### PR TITLE
fix: backport workflow release creation to master

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -47,8 +47,10 @@ jobs:
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Create beta tag
+      - name: Create beta tag and release
         if: steps.check-changes.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           VERSION="${{ steps.check-changes.outputs.version }}"
           BETA_NUM="${{ steps.check-changes.outputs.beta_number }}"
@@ -58,5 +60,23 @@ jobs:
           git config user.email "wheatley-the-moronic-ci-bot[bot]@users.noreply.github.com"
           git tag -a "$BETA_TAG" -m "Beta release $BETA_TAG"
           git push origin "$BETA_TAG"
+
+          # Create GitHub prerelease (no binaries)
+          gh release create "$BETA_TAG" \
+            --prerelease \
+            --title "Beta: $BETA_TAG" \
+            --notes "$(cat <<EOF
+          Beta release from \`develop\` branch.
+
+          **This is a pre-release for testing purposes.**
+
+          To install this beta version:
+          \`\`\`bash
+          cargo install --git https://github.com/avihut/daft --tag $BETA_TAG
+          \`\`\`
+
+          Commit: ${{ github.sha }}
+          EOF
+          )"
 
           echo "Created beta release: $BETA_TAG"

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -20,7 +20,9 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
-      - name: Create canary tag
+      - name: Create canary tag and release
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           # Read target version from Cargo.toml
           VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
@@ -30,5 +32,23 @@ jobs:
           git config user.email "wheatley-the-moronic-ci-bot[bot]@users.noreply.github.com"
           git tag -a "$CANARY_TAG" -m "Canary release $CANARY_TAG"
           git push origin "$CANARY_TAG"
+
+          # Create GitHub prerelease (no binaries)
+          gh release create "$CANARY_TAG" \
+            --prerelease \
+            --title "Canary: $CANARY_TAG" \
+            --notes "$(cat <<EOF
+          Canary release from \`develop\` branch.
+
+          **This is a pre-release for testing purposes.**
+
+          To install this canary version:
+          \`\`\`bash
+          cargo install --git https://github.com/avihut/daft --tag $CANARY_TAG
+          \`\`\`
+
+          Commit: ${{ github.sha }}
+          EOF
+          )"
 
           echo "Created canary release: $CANARY_TAG"


### PR DESCRIPTION
## Summary
- Backports canary and beta workflow updates from develop to master
- Adds GitHub release creation to both workflows
- Required because `workflow_dispatch` runs workflows from the default branch

## Test plan
- [x] Canary workflow already tested on develop (v0.2.0-canary.2, v0.2.0-canary.3)
- [ ] After merge, re-trigger beta workflow to create v0.2.0-beta.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)