### PR TITLE
fix: exclude prerelease tags when finding latest version

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -23,8 +23,8 @@ jobs:
       - name: Get latest version tag
         id: get-version
         run: |
-          # Get latest semver tag, default to v0.0.0 if none exist
-          LATEST=$(git tag -l 'v*.*.*' | sort -V | tail -n1)
+          # Get latest stable semver tag (exclude prereleases with hyphens)
+          LATEST=$(git tag -l 'v*.*.*' | grep -v '-' | sort -V | tail -n1)
           if [ -z "$LATEST" ]; then
             LATEST="v0.0.0"
           fi


### PR DESCRIPTION
## Summary
Fixes bump-version workflow to exclude prerelease tags (canary, beta) when determining the latest stable version.

**Problem:** The workflow was using `git tag -l 'v*.*.*' | sort -V | tail -n1` which included prerelease tags like `v0.2.0-canary.3`. This caused the version to jump from `v0.1.28` to `v0.2.1` unexpectedly.

**Solution:** Add `grep -v '-'` to filter out tags containing hyphens (prerelease indicators).

```diff
- LATEST=$(git tag -l 'v*.*.*' | sort -V | tail -n1)
+ LATEST=$(git tag -l 'v*.*.*' | grep -v '-' | sort -V | tail -n1)
```

## Test plan
- [ ] After merge, next stable release should increment from v0.2.1 to v0.2.2 (not pick up canary/beta tags)

🤖 Generated with [Claude Code](https://claude.com/claude-code)