### PR TITLE
feat: integrate git-cliff for automated changelog generation

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -22,6 +22,11 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
+      - name: Install git-cliff
+        run: |
+          curl -sSfL https://github.com/orhun/git-cliff/releases/latest/download/git-cliff-x86_64-unknown-linux-gnu.tar.gz | tar xz
+          sudo mv git-cliff /usr/local/bin/
+
       - name: Check for changes since last beta
         id: check-changes
         run: |
@@ -56,27 +61,57 @@ jobs:
           BETA_NUM="${{ steps.check-changes.outputs.beta_number }}"
           BETA_TAG="v${VERSION}-beta.${BETA_NUM}"
 
+          # Generate release notes with git-cliff
+          echo "Generating release notes..."
+
+          # Find reference point for changelog
+          LAST_BETA=$(git tag -l "v${VERSION}-beta.*" | sort -V | tail -n1)
+          LAST_STABLE=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]' | grep -v '-' | sort -V | tail -n1)
+
+          if [ -n "$LAST_BETA" ]; then
+            echo "Generating changelog from $LAST_BETA to HEAD"
+            git cliff --config cliff-prerelease.toml "${LAST_BETA}"..HEAD > /tmp/cliff_notes.md || echo ""
+          elif [ -n "$LAST_STABLE" ]; then
+            echo "Generating changelog from $LAST_STABLE to HEAD"
+            git cliff --config cliff-prerelease.toml "${LAST_STABLE}"..HEAD > /tmp/cliff_notes.md || echo ""
+          else
+            echo "Generating changelog for all commits"
+            git cliff --config cliff-prerelease.toml --unreleased > /tmp/cliff_notes.md || echo ""
+          fi
+
+          # Build final release notes
+          cat > /tmp/release_notes.md << EOF
+Beta release from \`develop\` branch.
+
+**This is a pre-release for testing purposes.**
+
+To install this beta version:
+\`\`\`bash
+cargo install --git https://github.com/avihut/daft --tag $BETA_TAG
+\`\`\`
+
+Commit: ${{ github.sha }}
+
+EOF
+
+          # Append git-cliff output if it has content
+          if [ -s /tmp/cliff_notes.md ]; then
+            echo "---" >> /tmp/release_notes.md
+            echo "" >> /tmp/release_notes.md
+            echo "## Changes" >> /tmp/release_notes.md
+            echo "" >> /tmp/release_notes.md
+            cat /tmp/cliff_notes.md >> /tmp/release_notes.md
+          fi
+
           git config user.name "wheatley-the-moronic-ci-bot[bot]"
           git config user.email "wheatley-the-moronic-ci-bot[bot]@users.noreply.github.com"
           git tag -a "$BETA_TAG" -m "Beta release $BETA_TAG"
           git push origin "$BETA_TAG"
 
-          # Create GitHub prerelease (no binaries)
+          # Create GitHub prerelease
           gh release create "$BETA_TAG" \
             --prerelease \
             --title "Beta: $BETA_TAG" \
-            --notes "$(cat <<EOF
-          Beta release from \`develop\` branch.
-
-          **This is a pre-release for testing purposes.**
-
-          To install this beta version:
-          \`\`\`bash
-          cargo install --git https://github.com/avihut/daft --tag $BETA_TAG
-          \`\`\`
-
-          Commit: ${{ github.sha }}
-          EOF
-          )"
+            --notes-file /tmp/release_notes.md
 
           echo "Created beta release: $BETA_TAG"

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -80,6 +80,18 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Final version: $VERSION"
 
+      - name: Install git-cliff
+        run: |
+          curl -sSfL https://github.com/orhun/git-cliff/releases/latest/download/git-cliff-x86_64-unknown-linux-gnu.tar.gz | tar xz
+          sudo mv git-cliff /usr/local/bin/
+
+      - name: Update CHANGELOG.md
+        run: |
+          VERSION="${{ steps.final.outputs.version }}"
+          echo "Generating changelog for $VERSION"
+          git cliff --config cliff.toml --tag "$VERSION" -o CHANGELOG.md
+          echo "CHANGELOG.md updated"
+
       - name: Update Cargo.toml and create tag
         run: |
           VERSION="${{ steps.final.outputs.version }}"
@@ -92,12 +104,21 @@ jobs:
           # Update version in Cargo.toml
           sed -i "s/^version = .*/version = \"$CARGO_VERSION\"/" Cargo.toml
 
-          # Only commit if Cargo.toml actually changed
+          # Stage CHANGELOG.md (always updated by git-cliff)
+          git add CHANGELOG.md
+
+          # Only commit Cargo.toml if it actually changed
           # (it won't change if this is a manual/major version bump from develop)
           if git diff --quiet Cargo.toml; then
-            echo "Cargo.toml already at $CARGO_VERSION, skipping commit"
+            echo "Cargo.toml already at $CARGO_VERSION, skipping Cargo.toml"
           else
             git add Cargo.toml
+          fi
+
+          # Commit if there are staged changes
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
             git commit -m "chore: release $VERSION [skip ci]"
             git push origin master
           fi

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -20,6 +20,11 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
+      - name: Install git-cliff
+        run: |
+          curl -sSfL https://github.com/orhun/git-cliff/releases/latest/download/git-cliff-x86_64-unknown-linux-gnu.tar.gz | tar xz
+          sudo mv git-cliff /usr/local/bin/
+
       - name: Create canary tag and release
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -28,27 +33,43 @@ jobs:
           VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
           CANARY_TAG="v${VERSION}-canary.${{ github.run_number }}"
 
+          # Generate release notes with git-cliff
+          echo "Generating release notes..."
+          git cliff --config cliff-prerelease.toml --unreleased > /tmp/cliff_notes.md || echo ""
+
+          # Build final release notes
+          cat > /tmp/release_notes.md << EOF
+Canary release from \`develop\` branch.
+
+**This is a pre-release for testing purposes.**
+
+To install this canary version:
+\`\`\`bash
+cargo install --git https://github.com/avihut/daft --tag $CANARY_TAG
+\`\`\`
+
+Commit: ${{ github.sha }}
+
+EOF
+
+          # Append git-cliff output if it has content
+          if [ -s /tmp/cliff_notes.md ]; then
+            echo "---" >> /tmp/release_notes.md
+            echo "" >> /tmp/release_notes.md
+            echo "## Changes" >> /tmp/release_notes.md
+            echo "" >> /tmp/release_notes.md
+            cat /tmp/cliff_notes.md >> /tmp/release_notes.md
+          fi
+
           git config user.name "wheatley-the-moronic-ci-bot[bot]"
           git config user.email "wheatley-the-moronic-ci-bot[bot]@users.noreply.github.com"
           git tag -a "$CANARY_TAG" -m "Canary release $CANARY_TAG"
           git push origin "$CANARY_TAG"
 
-          # Create GitHub prerelease (no binaries)
+          # Create GitHub prerelease
           gh release create "$CANARY_TAG" \
             --prerelease \
             --title "Canary: $CANARY_TAG" \
-            --notes "$(cat <<EOF
-          Canary release from \`develop\` branch.
-
-          **This is a pre-release for testing purposes.**
-
-          To install this canary version:
-          \`\`\`bash
-          cargo install --git https://github.com/avihut/daft --tag $CANARY_TAG
-          \`\`\`
-
-          Commit: ${{ github.sha }}
-          EOF
-          )"
+            --notes-file /tmp/release_notes.md
 
           echo "Created canary release: $CANARY_TAG"

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -50,6 +50,11 @@ jobs:
           # Push updated master
           git push origin master
 
+      - name: Install git-cliff
+        run: |
+          curl -sSfL https://github.com/orhun/git-cliff/releases/latest/download/git-cliff-x86_64-unknown-linux-gnu.tar.gz | tar xz
+          sudo mv git-cliff /usr/local/bin/
+
       - name: Generate release notes
         id: notes
         run: |
@@ -59,10 +64,11 @@ jobs:
           echo "## What's Changed in v${{ steps.version.outputs.version }}" > release_notes.md
           echo "" >> release_notes.md
 
+          # Use git-cliff for structured release notes
           if [ -n "$LAST_STABLE" ]; then
-            git log ${LAST_STABLE}..HEAD --pretty=format:"- %s" >> release_notes.md
+            git cliff --config cliff-prerelease.toml "${LAST_STABLE}"..HEAD >> release_notes.md || echo "No categorized changes."
           else
-            git log --pretty=format:"- %s" >> release_notes.md
+            git cliff --config cliff-prerelease.toml >> release_notes.md || echo "No categorized changes."
           fi
 
           echo "" >> release_notes.md
@@ -89,7 +95,7 @@ jobs:
 
       - name: Create milestone for next version
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           NEXT_VERSION="${{ inputs.next_version }}"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+<!-- git-cliff will prepend new releases here -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,50 @@ git push origin develop --force-with-lease
 | Beta | `beta.yml` | Monthly schedule or manual |
 | Promote | `promote-release.yml` | Manual with next_version input |
 
+## Commit Message Convention
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/) for automatic changelog generation via git-cliff.
+
+### Format
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer - e.g., "Fixes #42"]
+```
+
+### Types
+
+| Type | Description | Changelog Section |
+|------|-------------|-------------------|
+| `feat` | New feature | Features |
+| `fix` | Bug fix | Bug Fixes |
+| `docs` | Documentation changes | Documentation |
+| `style` | Code style (no logic change) | Styling |
+| `refactor` | Code refactoring | Refactoring |
+| `perf` | Performance improvement | Performance |
+| `test` | Adding/updating tests | Testing |
+| `chore` | Maintenance tasks | Miscellaneous |
+| `ci` | CI/CD changes | CI/CD |
+
+### Examples
+
+```bash
+feat: add shell completion generation
+fix(clone): handle repositories with special characters
+docs: update installation instructions
+refactor(git): extract common git operations
+chore: upgrade dependencies
+```
+
+### Changelog Generation
+
+- **Stable releases**: CHANGELOG.md is automatically updated when releasing to master
+- **Canary/Beta**: Release notes are generated but CHANGELOG.md is not modified
+- Configuration files: `cliff.toml` (stable), `cliff-prerelease.toml` (prereleases)
+
 ## Overview
 
 This is **daft** - a comprehensive Git extensions toolkit built in Rust. While the project currently focuses on worktree workflow management with both Rust binaries and legacy shell scripts, the vision extends far beyond: daft aims to provide a suite of Git extensions that enhance modern development workflows.
@@ -211,7 +255,18 @@ When working on project tickets, branch names should follow this convention daft
 
 ### PRs
 
-When opening a PR, the name should follow this convention [DAFT-<issue number>] <type: Feature / Bugfix / Enhancement / etc.>: <short description>
+PR titles should follow the conventional commit format:
+
+```
+feat: add dark mode toggle
+fix: resolve authentication timeout
+docs: update API documentation
+```
+
+Issue references should be in the PR body or commit footer, not the title. Example:
+```
+Fixes #42
+```
 
 ## Worktree Workflow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,130 @@
+# Contributing to daft
+
+Thank you for your interest in contributing to daft! This document provides guidelines for contributing to the project.
+
+## Commit Message Convention
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/) for automatic changelog generation via git-cliff.
+
+### Format
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+### Types
+
+| Type | Description | Changelog Section |
+|------|-------------|-------------------|
+| `feat` | A new feature | Features |
+| `fix` | A bug fix | Bug Fixes |
+| `docs` | Documentation only changes | Documentation |
+| `style` | Code style changes (formatting, etc.) | Styling |
+| `refactor` | Code changes that neither fix bugs nor add features | Refactoring |
+| `perf` | Performance improvements | Performance |
+| `test` | Adding or correcting tests | Testing |
+| `chore` | Maintenance tasks, dependency updates | Miscellaneous |
+| `ci` | CI/CD configuration changes | CI/CD |
+
+### Examples
+
+```bash
+# Feature with scope
+feat(checkout): add --force flag for overwriting worktrees
+
+# Bug fix
+fix: resolve branch name parsing for names with slashes
+
+# Documentation
+docs: update installation instructions for Windows
+
+# With issue reference in footer
+feat: implement branch search in checkout command
+
+Fixes #42
+
+# Breaking change (note the ! after type)
+feat!: change default branch detection algorithm
+
+BREAKING CHANGE: Now checks remote HEAD instead of hardcoded "main"
+```
+
+## Branch Naming
+
+Follow the convention: `daft-<issue-number>/<short-description>`
+
+```bash
+# Examples
+daft-42/dark-mode
+daft-15/branch-search
+hotfix/critical-bug
+```
+
+## Pull Request Titles
+
+Use conventional commit format for PR titles:
+
+```
+feat: add dark mode toggle
+fix: resolve login timeout
+docs: update installation guide
+```
+
+Issue references should be in the PR body, not the title.
+
+## Development Workflow
+
+1. **Fork the repository** (external contributors)
+
+2. **Create a feature branch**:
+   ```bash
+   git worktree-checkout-branch daft-XX/feature-name
+   ```
+
+3. **Make changes** following the commit conventions above
+
+4. **Run quality checks**:
+   ```bash
+   cargo fmt
+   cargo clippy -- -D warnings
+   make test
+   ```
+
+5. **Submit a pull request** with a conventional commit title
+
+## Code Quality Requirements
+
+Before submitting, ensure:
+
+- [ ] All tests pass: `make test`
+- [ ] No clippy warnings: `cargo clippy -- -D warnings`
+- [ ] Code is formatted: `cargo fmt --check`
+- [ ] Documentation is updated if needed
+
+## Testing
+
+The project has a three-tier testing architecture:
+
+```bash
+# Run all tests
+make test
+
+# Run specific test suites
+make test-unit          # Rust unit tests
+make test-integration   # End-to-end tests
+make test-legacy        # Legacy shell script tests
+```
+
+## Getting Help
+
+- Open an issue for bugs or feature requests
+- Check existing issues before creating new ones
+- For questions, use GitHub Discussions
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the MIT License.

--- a/cliff-prerelease.toml
+++ b/cliff-prerelease.toml
@@ -1,0 +1,54 @@
+# git-cliff configuration for prerelease notes (canary/beta)
+# Simpler format without header, includes catch-all for non-conventional commits
+
+[changelog]
+# No header for prerelease notes
+header = ""
+
+# Compact body format
+body = """
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for commit in commits %}
+- {% if commit.scope %}**{{ commit.scope }}**: {% endif %}{{ commit.message | upper_first }}
+{% endfor %}
+
+{% endfor %}
+"""
+
+# No footer
+footer = ""
+
+# Remove leading and trailing whitespace
+trim = true
+
+[git]
+# Parse conventional commits
+conventional_commits = true
+
+# Don't filter non-conventional commits (include them in "Other" group)
+filter_unconventional = false
+
+# Commit message parsers (with catch-all)
+commit_parsers = [
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Bug Fixes" },
+    { message = "^doc", group = "Documentation" },
+    { message = "^perf", group = "Performance" },
+    { message = "^refactor", group = "Refactoring" },
+    { message = "^style", group = "Styling" },
+    { message = "^test", group = "Testing" },
+    { message = "^chore\\(release\\)", skip = true },
+    { message = "^chore: release", skip = true },
+    { message = "^chore: begin", skip = true },
+    { message = "^chore", group = "Miscellaneous" },
+    { message = "^ci", group = "CI/CD" },
+    { message = "^deps", group = "Dependencies" },
+    { body = ".*", group = "Other" },
+]
+
+# Tag pattern
+tag_pattern = "v[0-9].*"
+
+# Sort commits by newest first
+sort_commits = "newest"

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,73 @@
+# git-cliff configuration for stable releases
+# See: https://git-cliff.org/docs/configuration
+
+[changelog]
+# Template for the changelog header
+header = """
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+"""
+
+# Template for the changelog body
+body = """
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+    ## [Unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+
+    ### {{ group | upper_first }}
+    {% for commit in commits %}
+        - {% if commit.scope %}**{{ commit.scope }}**: {% endif %}\
+            {{ commit.message | upper_first }}\
+    {% endfor %}
+{% endfor %}
+"""
+
+# Template for the changelog footer
+footer = ""
+
+# Remove leading and trailing whitespace
+trim = true
+
+[git]
+# Parse conventional commits
+conventional_commits = true
+
+# Filter out commits that don't match conventional commit spec
+filter_unconventional = true
+
+# Commit message parsers
+commit_parsers = [
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Bug Fixes" },
+    { message = "^doc", group = "Documentation" },
+    { message = "^perf", group = "Performance" },
+    { message = "^refactor", group = "Refactoring" },
+    { message = "^style", group = "Styling" },
+    { message = "^test", group = "Testing" },
+    { message = "^chore\\(release\\)", skip = true },
+    { message = "^chore: release", skip = true },
+    { message = "^chore: begin", skip = true },
+    { message = "^chore", group = "Miscellaneous" },
+    { message = "^ci", group = "CI/CD" },
+    { message = "^deps", group = "Dependencies" },
+]
+
+# Protect against breaking changes
+protect_breaking_commits = false
+
+# Filter commits by pattern
+filter_commits = false
+
+# Tag pattern for releases (matches v1.0.0, v0.3.2, etc.)
+tag_pattern = "v[0-9].*"
+
+# Skip prerelease tags in changelog generation
+skip_tags = ".*-(canary|beta).*"
+
+# Sort commits by newest first
+sort_commits = "newest"


### PR DESCRIPTION
## Summary

Integrates git-cliff changelog generator into all release workflows for automated changelog generation.

### Changes

- **New files:**
  - `cliff.toml` - Configuration for stable release changelog (full format)
  - `cliff-prerelease.toml` - Configuration for canary/beta release notes (compact format)
  - `CHANGELOG.md` - Initial changelog file (will be auto-updated)
  - `CONTRIBUTING.md` - Contributor guidelines with commit conventions

- **Workflow updates:**
  - `bump-version.yml` - Now updates CHANGELOG.md when creating stable releases
  - `canary.yml` - Uses git-cliff to generate release notes
  - `beta.yml` - Uses git-cliff to generate release notes
  - `promote-release.yml` - Uses git-cliff instead of raw git log

- **Documentation:**
  - Added "Commit Message Convention" section to CLAUDE.md
  - Updated PR title convention to use conventional commits format

### Design Decisions

1. **Prereleases don't update CHANGELOG.md** - Only stable releases modify the changelog (less noise)
2. **Pure conventional commits** - PR titles use `feat:`, `fix:`, etc. format
3. **Issue refs in body/footer** - Not in PR titles

## Test plan

- [ ] Merge to master, verify bump-version workflow updates CHANGELOG.md
- [ ] Push to develop (after cherry-pick), verify canary release has git-cliff notes
- [ ] Manually trigger beta workflow, verify notes generation
- [ ] Run `git cliff --config cliff.toml --unreleased` locally to verify config

🤖 Generated with [Claude Code](https://claude.com/claude-code)