### PR TITLE
feat(clone): add -b/--branch option to specify checkout branch

### DIFF
--- a/src/commands/clone.rs
+++ b/src/commands/clone.rs
@@ -184,12 +184,6 @@ fn run_clone(args: &Args, output: &mut dyn Output) -> Result<()> {
         // Continue execution - upstream tracking may not work but worktrees will
     }
 
-    // Set up remote HEAD reference for better default branch detection
-    if let Err(e) = git.remote_set_head_auto(&config.remote_name) {
-        output.warning(&format!("Could not set remote HEAD: {e}"));
-        // Continue execution - this is not critical
-    }
-
     if !args.no_checkout && branch_exists {
         if args.all_branches {
             create_all_worktrees(&git, &config, &default_branch, output)?;
@@ -215,6 +209,11 @@ fn run_clone(args: &Args, output: &mut dyn Output) -> Result<()> {
         ));
         if let Err(e) = git.fetch(&config.remote_name, false) {
             output.warning(&format!("Could not fetch from remote: {e}"));
+        }
+
+        // Set up remote HEAD reference (must be after fetch so refs exist)
+        if let Err(e) = git.remote_set_head_auto(&config.remote_name) {
+            output.warning(&format!("Could not set remote HEAD: {e}"));
         }
 
         // Set up upstream tracking for the target branch


### PR DESCRIPTION
## Summary
- Added `-b, --branch` option to `git-worktree-clone` to specify which branch to checkout
- If the specified branch doesn't exist on remote, clone succeeds but no worktree is created (graceful failure)
- User ends up in repo root directory when branch doesn't exist
- New flag conflicts with `--all-branches` and `--no-checkout` (validated at startup)
- Default behavior unchanged: auto-detects and uses remote's default branch

## Usage
```bash
# Checkout specific branch
git worktree-clone -b develop git@github.com:user/repo.git

# Branch doesn't exist - clone succeeds, no worktree created
git worktree-clone -b nonexistent git@github.com:user/repo.git
# warning: Branch 'nonexistent' does not exist on remote
# Cloned 'repo' (branch 'nonexistent' not found, no worktree created)
```

## Test plan
- [x] All 11 clone integration tests pass
- [x] All 30 unit tests pass
- [x] Manual test: `-b master` clones and checks out master with proper tracking
- [x] Manual test: `-b nonexistent` clones bare repo, warns, stays in repo root
- [x] Manual test: default behavior (no `-b`) unchanged
- [x] Clippy passes with no warnings
- [x] Formatting check passes

Fixes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)