### PR TITLE
feat: add multi-style command shortcuts system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,7 +231,8 @@ src/
 │   ├── carry.rs         # git-worktree-carry implementation
 │   ├── hooks.rs         # git-daft hooks subcommand
 │   ├── man.rs           # daft man - man page generation
-│   └── shell_init.rs    # daft shell-init implementation
+│   ├── shell_init.rs    # daft shell-init implementation
+│   └── shortcuts.rs     # daft setup shortcuts - shortcut management
 ├── hooks/               # Hooks system
 │   ├── mod.rs           # Hook types and configuration
 │   ├── executor.rs      # Hook execution logic
@@ -240,6 +241,7 @@ src/
 ├── lib.rs               # Shared library code (includes output_cd_path for shell integration)
 ├── git.rs               # Git operations wrapper
 ├── remote.rs            # Remote repository handling
+├── shortcuts.rs         # Shortcut aliases and resolution
 ├── utils.rs             # Utility functions
 └── config.rs            # Configuration handling
 ```
@@ -274,6 +276,44 @@ daft shell-init fish | source
 # With short aliases (gwco, gwcob, etc.)
 eval "$(daft shell-init bash --aliases)"
 ```
+
+### Command Shortcuts
+
+daft supports three shortcut styles for frequently used commands:
+
+| Style | Shortcuts | Description |
+|-------|-----------|-------------|
+| **Git** (default) | `gwtclone`, `gwtinit`, `gwtco`, `gwtcb`, `gwtcbm`, `gwtprune`, `gwtcarry`, `gwtfetch` | Git worktree focused |
+| **Shell** | `gwco`, `gwcob`, `gwcobd` | Shell-friendly minimal |
+| **Legacy** | `gclone`, `gcw`, `gcbw`, `gcbdw`, `gprune` | Older style aliases |
+
+**How it works:**
+1. Shortcuts are resolved in `src/shortcuts.rs` before command routing in `main.rs`
+2. The binary detects the invocation name and maps shortcuts to their full command names
+3. Symlinks are managed via `daft setup shortcuts`
+
+**Managing shortcuts:**
+```bash
+daft setup shortcuts list            # List all styles and mappings
+daft setup shortcuts status          # Show installed shortcuts
+daft setup shortcuts enable git      # Enable git-style shortcuts
+daft setup shortcuts disable legacy  # Disable legacy shortcuts
+daft setup shortcuts only shell      # Enable only shell shortcuts
+daft setup shortcuts only git --dry-run  # Preview changes
+```
+
+**Complete shortcut mapping:**
+
+| Full Command | Git Style | Shell Style | Legacy Style |
+|--------------|-----------|-------------|--------------|
+| `git-worktree-clone` | `gwtclone` | - | `gclone` |
+| `git-worktree-init` | `gwtinit` | - | - |
+| `git-worktree-checkout` | `gwtco` | `gwco` | `gcw` |
+| `git-worktree-checkout-branch` | `gwtcb` | `gwcob` | `gcbw` |
+| `git-worktree-checkout-branch-from-default` | `gwtcbm` | `gwcobd` | `gcbdw` |
+| `git-worktree-prune` | `gwtprune` | - | `gprune` |
+| `git-worktree-carry` | `gwtcarry` | - | - |
+| `git-worktree-fetch` | `gwtfetch` | - | - |
 
 ## Usage
 

--- a/HOMEBREW.md
+++ b/HOMEBREW.md
@@ -17,7 +17,11 @@ daft uses a **single binary with multiple symlinks** (like BusyBox):
   - `git-worktree-checkout-branch-from-default` → `daft`
   - `git-worktree-init` → `daft`
   - `git-worktree-prune` → `daft`
+  - `git-worktree-carry` → `daft`
+  - `git-worktree-fetch` → `daft`
   - `git-daft` → `daft`
+- Git-style shortcuts (default):
+  - `gwtclone`, `gwtinit`, `gwtco`, `gwtcb`, `gwtcbm`, `gwtprune`, `gwtcarry`, `gwtfetch`
 
 ## Formula Customization
 
@@ -74,7 +78,18 @@ def install
   bin.install_symlink bin/"daft" => "git-worktree-init"
   bin.install_symlink bin/"daft" => "git-worktree-prune"
   bin.install_symlink bin/"daft" => "git-worktree-carry"
+  bin.install_symlink bin/"daft" => "git-worktree-fetch"
   bin.install_symlink bin/"daft" => "git-daft"
+
+  # Create git-style shortcuts (default)
+  bin.install_symlink bin/"daft" => "gwtclone"
+  bin.install_symlink bin/"daft" => "gwtinit"
+  bin.install_symlink bin/"daft" => "gwtco"
+  bin.install_symlink bin/"daft" => "gwtcb"
+  bin.install_symlink bin/"daft" => "gwtcbm"
+  bin.install_symlink bin/"daft" => "gwtprune"
+  bin.install_symlink bin/"daft" => "gwtcarry"
+  bin.install_symlink bin/"daft" => "gwtfetch"
 
   # Generate and install man pages
   system bin/"daft", "man", "--output-dir=#{buildpath}/man"
@@ -149,7 +164,18 @@ class Daft < Formula
     bin.install_symlink bin/"daft" => "git-worktree-init"
     bin.install_symlink bin/"daft" => "git-worktree-prune"
     bin.install_symlink bin/"daft" => "git-worktree-carry"
+    bin.install_symlink bin/"daft" => "git-worktree-fetch"
     bin.install_symlink bin/"daft" => "git-daft"
+
+    # Create git-style shortcuts (default)
+    bin.install_symlink bin/"daft" => "gwtclone"
+    bin.install_symlink bin/"daft" => "gwtinit"
+    bin.install_symlink bin/"daft" => "gwtco"
+    bin.install_symlink bin/"daft" => "gwtcb"
+    bin.install_symlink bin/"daft" => "gwtcbm"
+    bin.install_symlink bin/"daft" => "gwtprune"
+    bin.install_symlink bin/"daft" => "gwtcarry"
+    bin.install_symlink bin/"daft" => "gwtfetch"
 
     # Generate and install man pages
     system bin/"daft", "man", "--output-dir=#{buildpath}/man"
@@ -170,7 +196,11 @@ class Daft < Formula
         git worktree-init <repo-name>
         git worktree-prune
 
+      Shortcuts are also available:
+        gwtclone, gwtco, gwtcb, gwtcbm, gwtprune, gwtinit, gwtcarry, gwtfetch
+
       Run 'git daft' for full documentation.
+      Run 'daft setup shortcuts list' to see all shortcut styles.
 
       RECOMMENDED: For automatic cd into new worktrees, run:
 

--- a/README.md
+++ b/README.md
@@ -224,6 +224,45 @@ git worktree-checkout feature/auth    # spaces - works with shell integration
 git-worktree-checkout feature/auth    # hyphens - also works
 ```
 
+### Command Shortcuts
+
+daft provides short aliases for frequently used commands. Three styles are available:
+
+| Style | Shortcuts | Description |
+|-------|-----------|-------------|
+| **Git** (default) | `gwtclone`, `gwtinit`, `gwtco`, `gwtcb`, `gwtcbm`, `gwtprune`, `gwtcarry`, `gwtfetch` | Git worktree focused |
+| **Shell** | `gwco`, `gwcob`, `gwcobd` | Shell-friendly minimal |
+| **Legacy** | `gclone`, `gcw`, `gcbw`, `gcbdw`, `gprune` | Older style aliases |
+
+**Managing shortcuts:**
+```bash
+# List all shortcut styles and their mappings
+daft setup shortcuts list
+
+# Show currently installed shortcuts
+daft setup shortcuts status
+
+# Enable a specific style
+daft setup shortcuts enable git      # Enable git-style shortcuts
+daft setup shortcuts enable shell    # Enable shell-style shortcuts
+
+# Disable a style
+daft setup shortcuts disable legacy
+
+# Use only one style (disable others)
+daft setup shortcuts only shell
+
+# Preview changes without modifying
+daft setup shortcuts only git --dry-run
+```
+
+**Example usage with shortcuts:**
+```bash
+gwtco feature/auth           # Same as: git worktree-checkout feature/auth
+gwtcb feature/new-feature    # Same as: git worktree-checkout-branch feature/new-feature
+gwtprune                     # Same as: git worktree-prune
+```
+
 ## Commands
 
 ### Core Commands

--- a/install.sh
+++ b/install.sh
@@ -57,6 +57,8 @@ symlinks=(
     "git-worktree-checkout-branch"
     "git-worktree-checkout-branch-from-default"
     "git-worktree-prune"
+    "git-worktree-carry"
+    "git-worktree-fetch"
     "git-daft"
 )
 
@@ -68,6 +70,30 @@ for symlink in "${symlinks[@]}"; do
     fi
     ln -s "$INSTALL_DIR/daft" "$target"
     info "Created symlink: $symlink -> daft"
+done
+
+# Create git-style shortcuts (default)
+info "Creating git-style shortcuts..."
+
+shortcuts=(
+    "gwtclone"
+    "gwtinit"
+    "gwtco"
+    "gwtcb"
+    "gwtcbm"
+    "gwtprune"
+    "gwtcarry"
+    "gwtfetch"
+)
+
+for shortcut in "${shortcuts[@]}"; do
+    target="$INSTALL_DIR/$shortcut"
+    if [ -L "$target" ] || [ -f "$target" ]; then
+        warn "Removing existing $shortcut"
+        rm "$target"
+    fi
+    ln -s "$INSTALL_DIR/daft" "$target"
+    info "Created shortcut: $shortcut -> daft"
 done
 
 # Check if install directory is in PATH
@@ -87,12 +113,18 @@ info ""
 info "Installed:"
 info "  - daft binary: $INSTALL_DIR/daft"
 info "  - Git extensions: git worktree-clone, git worktree-checkout, etc."
+info "  - Shortcuts: gwtclone, gwtco, gwtcb, gwtcbm, gwtprune, gwtcarry, gwtfetch, gwtinit"
 info "  - Documentation: git daft"
 info ""
 info "Test the installation:"
 info "  daft                         # Show documentation"
 info "  git daft                     # Show documentation (via Git)"
 info "  git worktree-clone --help    # Show clone command help"
+info "  gwtco --help                 # Show checkout help (shortcut)"
+info ""
+info "Manage shortcuts:"
+info "  daft setup shortcuts list    # List all shortcut styles"
+info "  daft setup shortcuts status  # Show installed shortcuts"
 info ""
 
 # Binary size info

--- a/justfile
+++ b/justfile
@@ -52,7 +52,10 @@ dev-clean:
         git-worktree-prune \
         git-worktree-carry \
         git-worktree-fetch \
-        git-daft
+        git-daft \
+        gwtclone gwtinit gwtco gwtcb gwtcbm gwtprune gwtcarry gwtfetch \
+        gwco gwcob gwcobd \
+        gclone gcw gcbw gcbdw gprune
     @echo "Symlinks removed (binary preserved)"
 
 # Verify dev setup is working
@@ -195,6 +198,7 @@ setup-rust: build
     chmod +x {{integration_tests_dir}}/*.sh
     echo "Creating symlinks in target/release/..."
     cd target/release
+    # Core command symlinks
     ln -sf daft git-worktree-clone
     ln -sf daft git-worktree-init
     ln -sf daft git-worktree-checkout
@@ -204,6 +208,15 @@ setup-rust: build
     ln -sf daft git-worktree-carry
     ln -sf daft git-worktree-fetch
     ln -sf daft git-daft
+    # Git-style shortcuts (default for development)
+    ln -sf daft gwtclone
+    ln -sf daft gwtinit
+    ln -sf daft gwtco
+    ln -sf daft gwtcb
+    ln -sf daft gwtcbm
+    ln -sf daft gwtprune
+    ln -sf daft gwtcarry
+    ln -sf daft gwtfetch
     cd ../..
     echo "Development environment ready!"
     echo ""
@@ -221,6 +234,7 @@ setup-rust: build
     echo "Quick test:"
     echo "  ./target/release/daft"
     echo "  ./target/release/git-worktree-clone --help"
+    echo "  ./target/release/gwtco --help  # Git-style shortcut"
 
 # ============================================================================
 # Validation Recipes

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -17,3 +17,4 @@ pub mod man;
 pub mod prune;
 pub mod setup;
 pub mod shell_init;
+pub mod shortcuts;

--- a/src/commands/shortcuts.rs
+++ b/src/commands/shortcuts.rs
@@ -1,0 +1,377 @@
+//! Shortcut management command for daft.
+//!
+//! This module provides the `daft setup shortcuts` command for managing
+//! command shortcut symlinks.
+
+use anyhow::{anyhow, Context, Result};
+use clap::{Parser, Subcommand};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::shortcuts::{shortcuts_for_style, ShortcutStyle, SHORTCUTS};
+
+#[derive(Parser)]
+#[command(name = "shortcuts")]
+#[command(about = "Manage command shortcut symlinks")]
+#[command(long_about = r#"
+Manage shortcut symlinks for daft commands.
+
+Shortcuts provide short aliases for frequently used commands:
+  - Git style:    gwtclone, gwtco, gwtcb, gwtcbm, gwtprune, gwtcarry, gwtfetch, gwtinit
+  - Shell style:  gwco, gwcob, gwcobd
+  - Legacy style: gclone, gcw, gcbw, gcbdw, gprune
+
+Examples:
+  daft setup shortcuts                    # Show current status
+  daft setup shortcuts list               # List all shortcut styles
+  daft setup shortcuts enable git         # Enable git-style shortcuts
+  daft setup shortcuts disable legacy     # Disable legacy shortcuts
+  daft setup shortcuts only shell         # Enable only shell shortcuts
+"#)]
+pub struct Args {
+    #[command(subcommand)]
+    command: Option<ShortcutsCommand>,
+}
+
+#[derive(Subcommand)]
+enum ShortcutsCommand {
+    /// List all shortcut styles and their aliases
+    List,
+    /// Show currently installed shortcuts (default)
+    Status,
+    /// Enable a shortcut style (creates symlinks)
+    Enable {
+        /// The style to enable (git, shell, or legacy)
+        style: String,
+        /// Override installation directory
+        #[arg(long)]
+        install_dir: Option<PathBuf>,
+        /// Preview without making changes
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Disable a shortcut style (removes symlinks)
+    Disable {
+        /// The style to disable (git, shell, or legacy)
+        style: String,
+        /// Override installation directory
+        #[arg(long)]
+        install_dir: Option<PathBuf>,
+        /// Preview without making changes
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Enable only the specified style (disables others)
+    Only {
+        /// The style to enable exclusively (git, shell, or legacy)
+        style: String,
+        /// Override installation directory
+        #[arg(long)]
+        install_dir: Option<PathBuf>,
+        /// Preview without making changes
+        #[arg(long)]
+        dry_run: bool,
+    },
+}
+
+pub fn run() -> Result<()> {
+    // Skip "daft", "setup", and "shortcuts" from args
+    let args: Vec<String> = std::env::args().skip(3).collect();
+    let args = Args::parse_from(std::iter::once("shortcuts".to_string()).chain(args));
+
+    match args.command {
+        None | Some(ShortcutsCommand::Status) => cmd_status(),
+        Some(ShortcutsCommand::List) => cmd_list(),
+        Some(ShortcutsCommand::Enable {
+            style,
+            install_dir,
+            dry_run,
+        }) => cmd_enable(&style, install_dir, dry_run),
+        Some(ShortcutsCommand::Disable {
+            style,
+            install_dir,
+            dry_run,
+        }) => cmd_disable(&style, install_dir, dry_run),
+        Some(ShortcutsCommand::Only {
+            style,
+            install_dir,
+            dry_run,
+        }) => cmd_only(&style, install_dir, dry_run),
+    }
+}
+
+/// Detect the installation directory by finding where the daft binary is located.
+fn detect_install_dir() -> Result<PathBuf> {
+    let exe_path =
+        std::env::current_exe().context("Failed to determine current executable path")?;
+    let install_dir = exe_path
+        .parent()
+        .ok_or_else(|| anyhow!("Failed to determine installation directory"))?;
+    Ok(install_dir.to_path_buf())
+}
+
+/// Get the path to the daft binary in the given directory.
+fn get_daft_binary(install_dir: &Path) -> PathBuf {
+    install_dir.join("daft")
+}
+
+/// Check if a path is a symlink pointing to the daft binary.
+fn is_daft_symlink(path: &Path, install_dir: &Path) -> bool {
+    if !path.is_symlink() {
+        return false;
+    }
+
+    if let Ok(target) = fs::read_link(path) {
+        let daft_binary = get_daft_binary(install_dir);
+        // Check if target matches daft (absolute or relative)
+        target == daft_binary || target == Path::new("daft")
+    } else {
+        false
+    }
+}
+
+/// Get installed shortcuts in the given directory.
+fn get_installed_shortcuts(install_dir: &Path) -> Vec<(&'static str, ShortcutStyle)> {
+    let mut installed = Vec::new();
+
+    for shortcut in SHORTCUTS {
+        let path = install_dir.join(shortcut.alias);
+        if is_daft_symlink(&path, install_dir) {
+            installed.push((shortcut.alias, shortcut.style));
+        }
+    }
+
+    installed
+}
+
+/// Create a symlink for a shortcut.
+fn create_symlink(alias: &str, install_dir: &Path, dry_run: bool) -> Result<()> {
+    let link_path = install_dir.join(alias);
+
+    if dry_run {
+        println!("  Would create: {alias} -> daft");
+        return Ok(());
+    }
+
+    // Remove existing file/symlink if present
+    if link_path.exists() || link_path.is_symlink() {
+        fs::remove_file(&link_path)
+            .with_context(|| format!("Failed to remove existing {alias}"))?;
+    }
+
+    // Create symlink (using relative path for portability)
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink("daft", &link_path)
+            .with_context(|| format!("Failed to create symlink for {alias}"))?;
+    }
+
+    #[cfg(not(unix))]
+    {
+        // On non-Unix, copy the binary instead
+        let daft_binary = get_daft_binary(install_dir);
+        fs::copy(&daft_binary, &link_path)
+            .with_context(|| format!("Failed to copy daft binary to {alias}"))?;
+    }
+
+    println!("  Created: {alias} -> daft");
+    Ok(())
+}
+
+/// Remove a shortcut symlink.
+fn remove_symlink(alias: &str, install_dir: &Path, dry_run: bool) -> Result<()> {
+    let link_path = install_dir.join(alias);
+
+    if !link_path.exists() && !link_path.is_symlink() {
+        return Ok(()); // Already doesn't exist
+    }
+
+    if dry_run {
+        println!("  Would remove: {alias}");
+        return Ok(());
+    }
+
+    fs::remove_file(&link_path).with_context(|| format!("Failed to remove {alias}"))?;
+
+    println!("  Removed: {alias}");
+    Ok(())
+}
+
+/// Check write permission to a directory.
+fn check_write_permission(dir: &Path) -> Result<()> {
+    let test_file = dir.join(".daft-write-test");
+    fs::write(&test_file, "test")
+        .with_context(|| format!("Cannot write to {}. Check permissions.", dir.display()))?;
+    fs::remove_file(&test_file).ok();
+    Ok(())
+}
+
+/// Show status of installed shortcuts.
+fn cmd_status() -> Result<()> {
+    let install_dir = detect_install_dir()?;
+    let installed = get_installed_shortcuts(&install_dir);
+
+    println!("Installation directory: {}", install_dir.display());
+    println!();
+
+    if installed.is_empty() {
+        println!("No shortcuts currently installed.");
+        println!();
+        println!("Enable shortcuts with:");
+        println!("  daft setup shortcuts enable git     # Enable git-style shortcuts");
+        println!("  daft setup shortcuts enable shell   # Enable shell-style shortcuts");
+        println!("  daft setup shortcuts enable legacy  # Enable legacy shortcuts");
+    } else {
+        println!("Installed shortcuts:");
+        println!();
+
+        // Group by style
+        for style in ShortcutStyle::all() {
+            let style_shortcuts: Vec<_> = installed.iter().filter(|(_, s)| s == style).collect();
+            if !style_shortcuts.is_empty() {
+                println!("  {} style:", style.name());
+                for (alias, _) in style_shortcuts {
+                    println!("    {}", alias);
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// List all available shortcut styles and their aliases.
+fn cmd_list() -> Result<()> {
+    println!("Available shortcut styles:");
+    println!();
+
+    for style in ShortcutStyle::all() {
+        println!("{} - {}", style.name(), style.description());
+        println!();
+
+        let shortcuts = shortcuts_for_style(*style);
+        println!("  {:20} {:40}", "SHORTCUT", "COMMAND");
+        println!("  {:20} {:40}", "--------", "-------");
+        for shortcut in shortcuts {
+            println!("  {:20} {}", shortcut.alias, shortcut.command);
+        }
+        println!();
+    }
+
+    Ok(())
+}
+
+/// Enable shortcuts for a style.
+fn cmd_enable(style_name: &str, install_dir: Option<PathBuf>, dry_run: bool) -> Result<()> {
+    let style: ShortcutStyle = style_name
+        .parse()
+        .map_err(|_| anyhow!("Unknown style: {}. Use: git, shell, or legacy", style_name))?;
+
+    let install_dir = install_dir.map(Ok).unwrap_or_else(detect_install_dir)?;
+
+    if !dry_run {
+        check_write_permission(&install_dir)?;
+    }
+
+    let shortcuts = shortcuts_for_style(style);
+
+    if dry_run {
+        println!("[dry-run] Would enable {} style shortcuts:", style.name());
+    } else {
+        println!("Enabling {} style shortcuts:", style.name());
+    }
+    println!();
+
+    for shortcut in shortcuts {
+        create_symlink(shortcut.alias, &install_dir, dry_run)?;
+    }
+
+    if !dry_run {
+        println!();
+        println!("Done! {} shortcuts enabled.", style.name());
+    }
+
+    Ok(())
+}
+
+/// Disable shortcuts for a style.
+fn cmd_disable(style_name: &str, install_dir: Option<PathBuf>, dry_run: bool) -> Result<()> {
+    let style: ShortcutStyle = style_name
+        .parse()
+        .map_err(|_| anyhow!("Unknown style: {}. Use: git, shell, or legacy", style_name))?;
+
+    let install_dir = install_dir.map(Ok).unwrap_or_else(detect_install_dir)?;
+
+    if !dry_run {
+        check_write_permission(&install_dir)?;
+    }
+
+    let shortcuts = shortcuts_for_style(style);
+
+    if dry_run {
+        println!("[dry-run] Would disable {} style shortcuts:", style.name());
+    } else {
+        println!("Disabling {} style shortcuts:", style.name());
+    }
+    println!();
+
+    for shortcut in shortcuts {
+        remove_symlink(shortcut.alias, &install_dir, dry_run)?;
+    }
+
+    if !dry_run {
+        println!();
+        println!("Done! {} shortcuts disabled.", style.name());
+    }
+
+    Ok(())
+}
+
+/// Enable only the specified style (disable all others).
+fn cmd_only(style_name: &str, install_dir: Option<PathBuf>, dry_run: bool) -> Result<()> {
+    let style: ShortcutStyle = style_name
+        .parse()
+        .map_err(|_| anyhow!("Unknown style: {}. Use: git, shell, or legacy", style_name))?;
+
+    let install_dir = install_dir.map(Ok).unwrap_or_else(detect_install_dir)?;
+
+    if !dry_run {
+        check_write_permission(&install_dir)?;
+    }
+
+    if dry_run {
+        println!(
+            "[dry-run] Would enable only {} style shortcuts:",
+            style.name()
+        );
+    } else {
+        println!("Enabling only {} style shortcuts:", style.name());
+    }
+    println!();
+
+    // Remove all other styles
+    for other_style in ShortcutStyle::all() {
+        if *other_style != style {
+            let shortcuts = shortcuts_for_style(*other_style);
+            for shortcut in shortcuts {
+                let path = install_dir.join(shortcut.alias);
+                if is_daft_symlink(&path, &install_dir) {
+                    remove_symlink(shortcut.alias, &install_dir, dry_run)?;
+                }
+            }
+        }
+    }
+
+    // Enable the requested style
+    let shortcuts = shortcuts_for_style(style);
+    for shortcut in shortcuts {
+        create_symlink(shortcut.alias, &install_dir, dry_run)?;
+    }
+
+    if !dry_run {
+        println!();
+        println!("Done! Only {} shortcuts are now enabled.", style.name());
+    }
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ pub mod logging;
 pub mod output;
 pub mod remote;
 pub mod settings;
+pub mod shortcuts;
 pub mod utils;
 
 pub use settings::DaftSettings;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use anyhow::Result;
 use std::path::Path;
 
 mod commands;
+mod shortcuts;
 
 fn main() -> Result<()> {
     // Detect how we were invoked by checking argv[0]
@@ -17,8 +18,11 @@ fn main() -> Result<()> {
         .and_then(|n| n.to_str())
         .unwrap_or("daft");
 
+    // Resolve shortcut aliases to full command names
+    let resolved = shortcuts::resolve(program_name);
+
     // Route to the appropriate command based on invocation name
-    match program_name {
+    match resolved {
         // Git worktree extension commands (via symlinks)
         "git-worktree-clone" => commands::clone::run(),
         "git-worktree-init" => commands::init::run(),
@@ -55,7 +59,14 @@ fn main() -> Result<()> {
                     "__complete" => commands::complete::run(),
                     "hooks" => commands::hooks::run(),
                     "man" => commands::man::run(),
-                    "setup" => commands::setup::run(),
+                    "setup" => {
+                        // Check for setup subcommands
+                        if args.len() > 2 && args[2] == "shortcuts" {
+                            commands::shortcuts::run()
+                        } else {
+                            commands::setup::run()
+                        }
+                    }
                     "shell-init" => commands::shell_init::run(),
                     _ => commands::docs::run(),
                 }

--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -1,0 +1,306 @@
+//! Shortcut definitions and utilities for daft commands.
+//!
+//! This module provides centralized shortcut aliases for daft commands.
+//! Shortcuts come in three styles:
+//!
+//! - **Git style** (default): `gwtclone`, `gwtco`, `gwtcb`, etc.
+//! - **Shell style**: `gwco`, `gwcob`, `gwcobd`
+//! - **Legacy style**: `gclone`, `gcw`, `gcbw`, etc.
+//!
+//! Users can enable/disable styles via `daft setup shortcuts`.
+
+use std::fmt;
+use std::str::FromStr;
+
+/// Available shortcut styles.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ShortcutStyle {
+    /// Git-focused style: gwtclone, gwtco, gwtcb, etc.
+    Git,
+    /// Shell-focused style: gwco, gwcob, gwcobd
+    Shell,
+    /// Legacy style from older versions: gclone, gcw, gcbw, etc.
+    Legacy,
+}
+
+impl ShortcutStyle {
+    /// Returns all available shortcut styles.
+    pub fn all() -> &'static [ShortcutStyle] {
+        &[
+            ShortcutStyle::Git,
+            ShortcutStyle::Shell,
+            ShortcutStyle::Legacy,
+        ]
+    }
+
+    /// Returns the style name as a string.
+    pub fn name(&self) -> &'static str {
+        match self {
+            ShortcutStyle::Git => "git",
+            ShortcutStyle::Shell => "shell",
+            ShortcutStyle::Legacy => "legacy",
+        }
+    }
+
+    /// Returns a description of the style.
+    pub fn description(&self) -> &'static str {
+        match self {
+            ShortcutStyle::Git => "Git worktree focused (gwtclone, gwtco, gwtcb, ...)",
+            ShortcutStyle::Shell => "Shell-friendly short aliases (gwco, gwcob, gwcobd)",
+            ShortcutStyle::Legacy => "Legacy style from older versions (gclone, gcw, gcbw, ...)",
+        }
+    }
+}
+
+impl fmt::Display for ShortcutStyle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.name())
+    }
+}
+
+impl FromStr for ShortcutStyle {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "git" => Ok(ShortcutStyle::Git),
+            "shell" => Ok(ShortcutStyle::Shell),
+            "legacy" => Ok(ShortcutStyle::Legacy),
+            _ => Err(format!("Unknown shortcut style: {s}")),
+        }
+    }
+}
+
+/// A shortcut alias mapping.
+#[derive(Debug, Clone)]
+pub struct Shortcut {
+    /// The alias name (e.g., "gwtco")
+    pub alias: &'static str,
+    /// The full command name (e.g., "git-worktree-checkout")
+    pub command: &'static str,
+    /// The style this shortcut belongs to
+    pub style: ShortcutStyle,
+}
+
+/// All available shortcuts across all styles.
+pub const SHORTCUTS: &[Shortcut] = &[
+    // Git style (8 shortcuts)
+    Shortcut {
+        alias: "gwtclone",
+        command: "git-worktree-clone",
+        style: ShortcutStyle::Git,
+    },
+    Shortcut {
+        alias: "gwtinit",
+        command: "git-worktree-init",
+        style: ShortcutStyle::Git,
+    },
+    Shortcut {
+        alias: "gwtco",
+        command: "git-worktree-checkout",
+        style: ShortcutStyle::Git,
+    },
+    Shortcut {
+        alias: "gwtcb",
+        command: "git-worktree-checkout-branch",
+        style: ShortcutStyle::Git,
+    },
+    Shortcut {
+        alias: "gwtcbm",
+        command: "git-worktree-checkout-branch-from-default",
+        style: ShortcutStyle::Git,
+    },
+    Shortcut {
+        alias: "gwtprune",
+        command: "git-worktree-prune",
+        style: ShortcutStyle::Git,
+    },
+    Shortcut {
+        alias: "gwtcarry",
+        command: "git-worktree-carry",
+        style: ShortcutStyle::Git,
+    },
+    Shortcut {
+        alias: "gwtfetch",
+        command: "git-worktree-fetch",
+        style: ShortcutStyle::Git,
+    },
+    // Shell style (3 shortcuts)
+    Shortcut {
+        alias: "gwco",
+        command: "git-worktree-checkout",
+        style: ShortcutStyle::Shell,
+    },
+    Shortcut {
+        alias: "gwcob",
+        command: "git-worktree-checkout-branch",
+        style: ShortcutStyle::Shell,
+    },
+    Shortcut {
+        alias: "gwcobd",
+        command: "git-worktree-checkout-branch-from-default",
+        style: ShortcutStyle::Shell,
+    },
+    // Legacy style (5 shortcuts)
+    Shortcut {
+        alias: "gclone",
+        command: "git-worktree-clone",
+        style: ShortcutStyle::Legacy,
+    },
+    Shortcut {
+        alias: "gcw",
+        command: "git-worktree-checkout",
+        style: ShortcutStyle::Legacy,
+    },
+    Shortcut {
+        alias: "gcbw",
+        command: "git-worktree-checkout-branch",
+        style: ShortcutStyle::Legacy,
+    },
+    Shortcut {
+        alias: "gcbdw",
+        command: "git-worktree-checkout-branch-from-default",
+        style: ShortcutStyle::Legacy,
+    },
+    Shortcut {
+        alias: "gprune",
+        command: "git-worktree-prune",
+        style: ShortcutStyle::Legacy,
+    },
+];
+
+/// Resolves a shortcut alias to its full command name.
+///
+/// Returns the original name if no shortcut matches.
+pub fn resolve(name: &str) -> &str {
+    for shortcut in SHORTCUTS {
+        if shortcut.alias == name {
+            return shortcut.command;
+        }
+    }
+    name
+}
+
+/// Returns all shortcuts for a given style.
+pub fn shortcuts_for_style(style: ShortcutStyle) -> Vec<&'static Shortcut> {
+    SHORTCUTS.iter().filter(|s| s.style == style).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn test_resolve_git_style() {
+        assert_eq!(resolve("gwtclone"), "git-worktree-clone");
+        assert_eq!(resolve("gwtco"), "git-worktree-checkout");
+        assert_eq!(resolve("gwtcb"), "git-worktree-checkout-branch");
+        assert_eq!(
+            resolve("gwtcbm"),
+            "git-worktree-checkout-branch-from-default"
+        );
+        assert_eq!(resolve("gwtprune"), "git-worktree-prune");
+        assert_eq!(resolve("gwtcarry"), "git-worktree-carry");
+        assert_eq!(resolve("gwtfetch"), "git-worktree-fetch");
+        assert_eq!(resolve("gwtinit"), "git-worktree-init");
+    }
+
+    #[test]
+    fn test_resolve_shell_style() {
+        assert_eq!(resolve("gwco"), "git-worktree-checkout");
+        assert_eq!(resolve("gwcob"), "git-worktree-checkout-branch");
+        assert_eq!(
+            resolve("gwcobd"),
+            "git-worktree-checkout-branch-from-default"
+        );
+    }
+
+    #[test]
+    fn test_resolve_legacy_style() {
+        assert_eq!(resolve("gclone"), "git-worktree-clone");
+        assert_eq!(resolve("gcw"), "git-worktree-checkout");
+        assert_eq!(resolve("gcbw"), "git-worktree-checkout-branch");
+        assert_eq!(
+            resolve("gcbdw"),
+            "git-worktree-checkout-branch-from-default"
+        );
+        assert_eq!(resolve("gprune"), "git-worktree-prune");
+    }
+
+    #[test]
+    fn test_resolve_unknown() {
+        assert_eq!(resolve("unknown"), "unknown");
+        assert_eq!(resolve("git-worktree-clone"), "git-worktree-clone");
+        assert_eq!(resolve("daft"), "daft");
+    }
+
+    #[test]
+    fn test_no_duplicate_aliases() {
+        let aliases: Vec<&str> = SHORTCUTS.iter().map(|s| s.alias).collect();
+        let unique: HashSet<&str> = aliases.iter().copied().collect();
+        assert_eq!(
+            aliases.len(),
+            unique.len(),
+            "Found duplicate aliases in SHORTCUTS"
+        );
+    }
+
+    #[test]
+    fn test_all_shortcuts_map_to_valid_commands() {
+        let valid_commands = [
+            "git-worktree-clone",
+            "git-worktree-init",
+            "git-worktree-checkout",
+            "git-worktree-checkout-branch",
+            "git-worktree-checkout-branch-from-default",
+            "git-worktree-prune",
+            "git-worktree-carry",
+            "git-worktree-fetch",
+        ];
+
+        for shortcut in SHORTCUTS {
+            assert!(
+                valid_commands.contains(&shortcut.command),
+                "Shortcut '{}' maps to invalid command '{}'",
+                shortcut.alias,
+                shortcut.command
+            );
+        }
+    }
+
+    #[test]
+    fn test_shortcuts_for_style() {
+        let git_shortcuts = shortcuts_for_style(ShortcutStyle::Git);
+        assert_eq!(git_shortcuts.len(), 8);
+
+        let shell_shortcuts = shortcuts_for_style(ShortcutStyle::Shell);
+        assert_eq!(shell_shortcuts.len(), 3);
+
+        let legacy_shortcuts = shortcuts_for_style(ShortcutStyle::Legacy);
+        assert_eq!(legacy_shortcuts.len(), 5);
+    }
+
+    #[test]
+    fn test_style_from_str() {
+        assert_eq!(ShortcutStyle::from_str("git").unwrap(), ShortcutStyle::Git);
+        assert_eq!(ShortcutStyle::from_str("Git").unwrap(), ShortcutStyle::Git);
+        assert_eq!(ShortcutStyle::from_str("GIT").unwrap(), ShortcutStyle::Git);
+        assert_eq!(
+            ShortcutStyle::from_str("shell").unwrap(),
+            ShortcutStyle::Shell
+        );
+        assert_eq!(
+            ShortcutStyle::from_str("legacy").unwrap(),
+            ShortcutStyle::Legacy
+        );
+        assert!(ShortcutStyle::from_str("invalid").is_err());
+    }
+
+    #[test]
+    fn test_style_display() {
+        assert_eq!(ShortcutStyle::Git.to_string(), "git");
+        assert_eq!(ShortcutStyle::Shell.to_string(), "shell");
+        assert_eq!(ShortcutStyle::Legacy.to_string(), "legacy");
+    }
+}


### PR DESCRIPTION
## Summary

- Add support for three shortcut styles for frequently used commands:
  - **Git style** (default): `gwtclone`, `gwtco`, `gwtcb`, `gwtcbm`, `gwtprune`, `gwtcarry`, `gwtfetch`, `gwtinit`
  - **Shell style**: `gwco`, `gwcob`, `gwcobd`
  - **Legacy style**: `gclone`, `gcw`, `gcbw`, `gcbdw`, `gprune`
- Add `daft setup shortcuts` command for managing shortcut symlinks
- Shortcuts are resolved in the multicall binary before command routing

## Test plan

- [x] Unit tests pass (87 tests)
- [x] Integration tests pass (143 tests)
- [x] Clippy passes with no warnings
- [x] Code formatting verified
- [x] Shortcut resolution tested (`gwtco --help` shows checkout help)
- [x] Management commands tested (`daft setup shortcuts list/status/enable/disable/only`)
- [x] Dry-run mode verified

Fixes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)