### PR TITLE
feat: add multi-remote workflow support

### DIFF
--- a/src/commands/branch.rs
+++ b/src/commands/branch.rs
@@ -1,0 +1,354 @@
+//! Branch management command.
+//!
+//! Provides `git daft branch` subcommand for branch-related operations.
+
+use anyhow::{Context, Result};
+use clap::{Parser, Subcommand};
+use daft::{
+    get_project_root,
+    git::GitCommand,
+    is_git_repository,
+    multi_remote::path::calculate_worktree_path,
+    output::{CliOutput, Output, OutputConfig},
+    settings::DaftSettings,
+};
+use std::io::{self, Write};
+
+#[derive(Parser)]
+#[command(name = "branch")]
+#[command(about = "Branch and worktree management operations")]
+#[command(long_about = r#"
+Provides branch and worktree management operations, particularly useful
+in multi-remote workflows.
+
+The main subcommand is `move`, which moves a worktree to a different
+remote folder when multi-remote mode is enabled.
+"#)]
+pub struct Args {
+    #[command(subcommand)]
+    command: BranchCommand,
+}
+
+#[derive(Subcommand)]
+enum BranchCommand {
+    /// Move a worktree to a different remote folder
+    #[command(long_about = r#"
+Moves a worktree from one remote folder to another. This is useful when:
+
+- You forked a branch and want to organize it under a different remote
+- You're transferring a feature branch from your fork to upstream
+- You want to reorganize worktrees after adding a new remote
+
+The worktree is physically moved on disk, and git's internal worktree
+records are updated accordingly.
+
+Options like --set-upstream can update the branch's tracking configuration
+to match the new remote organization.
+"#)]
+    Move {
+        #[arg(help = "Branch name or worktree path to move")]
+        branch: String,
+
+        #[arg(long, help = "Target remote folder")]
+        to: String,
+
+        #[arg(
+            long,
+            help = "Also update the branch's upstream tracking to the new remote"
+        )]
+        set_upstream: bool,
+
+        #[arg(long, help = "Push the branch to the new remote")]
+        push: bool,
+
+        #[arg(long, help = "Delete the branch from the old remote after pushing")]
+        delete_old: bool,
+
+        #[arg(long, help = "Preview changes without executing")]
+        dry_run: bool,
+
+        #[arg(short = 'y', long, help = "Skip confirmation")]
+        yes: bool,
+    },
+}
+
+pub fn run() -> Result<()> {
+    // Skip "daft" and "branch" from args
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let args = Args::parse_from(args);
+
+    match args.command {
+        BranchCommand::Move {
+            branch,
+            to,
+            set_upstream,
+            push,
+            delete_old,
+            dry_run,
+            yes,
+        } => cmd_move(&branch, &to, set_upstream, push, delete_old, dry_run, yes),
+    }
+}
+
+/// Move a worktree to a different remote folder.
+#[allow(clippy::fn_params_excessive_bools)]
+fn cmd_move(
+    branch: &str,
+    to_remote: &str,
+    set_upstream: bool,
+    push: bool,
+    delete_old: bool,
+    dry_run: bool,
+    skip_confirm: bool,
+) -> Result<()> {
+    if !is_git_repository()? {
+        anyhow::bail!("Not in a git repository");
+    }
+
+    let settings = DaftSettings::load()?;
+    let config = OutputConfig::new(false, true);
+    let mut output = CliOutput::new(config);
+
+    let project_root = get_project_root()?;
+    let git = GitCommand::new(false);
+
+    // Verify multi-remote mode is enabled
+    if !settings.multi_remote_enabled {
+        anyhow::bail!(
+            "Multi-remote mode is not enabled.\n\
+             Run 'git daft multi-remote enable' first, or use regular git commands."
+        );
+    }
+
+    // Verify target remote exists
+    let remotes = git.remote_list()?;
+    if !remotes.contains(&to_remote.to_string()) {
+        anyhow::bail!(
+            "Remote '{}' does not exist. Available remotes: {}",
+            to_remote,
+            remotes.join(", ")
+        );
+    }
+
+    // Find the worktree for this branch
+    let worktree_path = git
+        .resolve_worktree_path(branch, &project_root)
+        .context(format!("Could not find worktree for branch '{}'", branch))?;
+
+    // Get branch name from worktree
+    let branch_name =
+        get_branch_name_for_worktree(&git, &worktree_path)?.unwrap_or_else(|| branch.to_string());
+
+    // Determine current remote (from path structure)
+    let current_remote = worktree_path
+        .strip_prefix(&project_root)
+        .ok()
+        .and_then(|p| p.components().next())
+        .and_then(|c| c.as_os_str().to_str())
+        .map(String::from);
+
+    output.step(&format!("Branch: {}", branch_name));
+    output.step(&format!("Current location: {}", worktree_path.display()));
+
+    if let Some(ref remote) = current_remote {
+        output.step(&format!("Current remote folder: {}", remote));
+    }
+    output.step(&format!("Target remote folder: {}", to_remote));
+
+    // Check if already in target location
+    if current_remote.as_deref() == Some(to_remote) {
+        output.result("Worktree is already in the target remote folder");
+        return Ok(());
+    }
+
+    // Calculate new path
+    let new_path = calculate_worktree_path(&project_root, &branch_name, to_remote, true);
+    output.step(&format!("New location: {}", new_path.display()));
+
+    // Check if target path already exists
+    if new_path.exists() {
+        anyhow::bail!(
+            "Target path already exists: {}\n\
+             Remove the existing worktree first or choose a different remote.",
+            new_path.display()
+        );
+    }
+
+    // Summary of actions
+    output.step("");
+    output.step("Actions to perform:");
+    output.step(&format!(
+        "  1. Move worktree: {} -> {}",
+        worktree_path.display(),
+        new_path.display()
+    ));
+
+    if set_upstream {
+        output.step(&format!("  2. Set upstream: {}/{}", to_remote, branch_name));
+    }
+
+    if push {
+        output.step(&format!("  3. Push to remote: {}", to_remote));
+    }
+
+    if delete_old {
+        if let Some(ref old_remote) = current_remote {
+            output.step(&format!(
+                "  4. Delete from old remote: {}/{}",
+                old_remote, branch_name
+            ));
+        }
+    }
+
+    if dry_run {
+        output.result("Dry run complete - no changes made");
+        return Ok(());
+    }
+
+    if !skip_confirm {
+        print!("\nProceed? [y/N] ");
+        io::stdout().flush()?;
+
+        let mut input = String::new();
+        io::stdin().read_line(&mut input)?;
+        let input = input.trim().to_lowercase();
+
+        if input != "y" && input != "yes" {
+            output.result("Aborted");
+            return Ok(());
+        }
+    }
+
+    // Execute the move
+    output.step("Moving worktree...");
+
+    // Ensure parent directory exists
+    if let Some(parent) = new_path.parent() {
+        if !parent.exists() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("Failed to create directory: {}", parent.display()))?;
+        }
+    }
+
+    git.worktree_move(&worktree_path, &new_path)
+        .context("Failed to move worktree")?;
+
+    // Set upstream if requested
+    if set_upstream {
+        output.step(&format!(
+            "Setting upstream to {}/{}...",
+            to_remote, branch_name
+        ));
+
+        // Need to change to the worktree directory to set upstream
+        let original_dir = std::env::current_dir()?;
+        std::env::set_current_dir(&new_path)?;
+
+        let result = git.set_upstream(to_remote, &branch_name);
+
+        // Restore original directory
+        std::env::set_current_dir(&original_dir)?;
+
+        if let Err(e) = result {
+            output.warning(&format!("Failed to set upstream: {}", e));
+        }
+    }
+
+    // Push if requested
+    if push {
+        output.step(&format!("Pushing to {}...", to_remote));
+
+        let original_dir = std::env::current_dir()?;
+        std::env::set_current_dir(&new_path)?;
+
+        let result = git.push_set_upstream(to_remote, &branch_name);
+
+        std::env::set_current_dir(&original_dir)?;
+
+        if let Err(e) = result {
+            output.warning(&format!("Failed to push: {}", e));
+        }
+    }
+
+    // Delete from old remote if requested
+    if delete_old {
+        if let Some(old_remote) = current_remote {
+            output.step(&format!(
+                "Deleting from old remote {}/{}...",
+                old_remote, branch_name
+            ));
+
+            let result = delete_remote_branch(&git, &old_remote, &branch_name);
+            if let Err(e) = result {
+                output.warning(&format!("Failed to delete from old remote: {}", e));
+            }
+        }
+    }
+
+    // Clean up empty remote directories
+    if let Some(old_remote) = worktree_path
+        .strip_prefix(&project_root)
+        .ok()
+        .and_then(|p| p.components().next())
+        .and_then(|c| c.as_os_str().to_str())
+    {
+        let old_remote_dir = project_root.join(old_remote);
+        if old_remote_dir.exists() {
+            if let Ok(mut entries) = std::fs::read_dir(&old_remote_dir) {
+                if entries.next().is_none() {
+                    // Directory is empty, remove it
+                    let _ = std::fs::remove_dir(&old_remote_dir);
+                }
+            }
+        }
+    }
+
+    output.result(&format!("Worktree moved to {}/{}", to_remote, branch_name));
+
+    Ok(())
+}
+
+/// Get the branch name for a worktree.
+fn get_branch_name_for_worktree(
+    git: &GitCommand,
+    worktree_path: &std::path::Path,
+) -> Result<Option<String>> {
+    let porcelain_output = git.worktree_list_porcelain()?;
+
+    let mut current_path: Option<std::path::PathBuf> = None;
+
+    for line in porcelain_output.lines() {
+        if let Some(path_str) = line.strip_prefix("worktree ") {
+            if let Some(prev_path) = current_path.take() {
+                if prev_path == worktree_path {
+                    // We've moved past this worktree without finding a branch
+                    return Ok(None);
+                }
+            }
+            current_path = Some(std::path::PathBuf::from(path_str));
+        } else if let Some(branch_ref) = line.strip_prefix("branch ") {
+            if current_path.as_ref() == Some(&worktree_path.to_path_buf()) {
+                return Ok(branch_ref.strip_prefix("refs/heads/").map(String::from));
+            }
+        }
+    }
+
+    Ok(None)
+}
+
+/// Delete a branch from a remote.
+fn delete_remote_branch(_git: &GitCommand, remote: &str, branch: &str) -> Result<()> {
+    use std::process::Command;
+
+    let output = Command::new("git")
+        .args(["push", remote, "--delete", branch])
+        .output()
+        .context("Failed to execute git push --delete")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("Failed to delete remote branch: {}", stderr);
+    }
+
+    Ok(())
+}

--- a/src/commands/checkout_branch.rs
+++ b/src/commands/checkout_branch.rs
@@ -6,6 +6,7 @@ use daft::{
     git::GitCommand,
     hooks::{HookContext, HookExecutor, HookType, HooksConfig},
     is_git_repository, logging,
+    multi_remote::path::{calculate_worktree_path, resolve_remote_for_branch},
     output::{CliOutput, Output, OutputConfig},
     settings::DaftSettings,
     utils::*,
@@ -52,6 +53,13 @@ pub struct Args {
 
     #[arg(long, help = "Do not carry uncommitted changes to the new worktree")]
     no_carry: bool,
+
+    #[arg(
+        short = 'r',
+        long = "remote",
+        help = "Remote for worktree organization (multi-remote mode)"
+    )]
+    remote: Option<String>,
 }
 
 pub fn run() -> Result<()> {
@@ -105,13 +113,28 @@ fn run_checkout_branch(
     let project_root = get_project_root()?;
     let git_dir = get_git_common_dir()?;
     let source_worktree = get_current_directory()?;
-    let worktree_path = project_root.join(&args.new_branch_name);
 
     let config = WorktreeConfig {
         remote_name: settings.remote.clone(),
         quiet: output.is_quiet(),
     };
     let git = GitCommand::new(output.is_quiet());
+
+    // Resolve remote for multi-remote mode
+    let remote_for_path = resolve_remote_for_branch(
+        &git,
+        &args.new_branch_name,
+        args.remote.as_deref(),
+        &settings.multi_remote_default,
+    )?;
+
+    // Calculate worktree path based on multi-remote mode
+    let worktree_path = calculate_worktree_path(
+        &project_root,
+        &args.new_branch_name,
+        &remote_for_path,
+        settings.multi_remote_enabled,
+    );
 
     // Fetch latest changes from remote to ensure we have the latest version of the base branch
     output.step(&format!(

--- a/src/commands/checkout_branch_from_default.rs
+++ b/src/commands/checkout_branch_from_default.rs
@@ -44,6 +44,13 @@ pub struct Args {
 
     #[arg(long, help = "Do not carry uncommitted changes to the new worktree")]
     no_carry: bool,
+
+    #[arg(
+        short = 'r',
+        long = "remote",
+        help = "Remote for worktree organization (multi-remote mode)"
+    )]
+    remote: Option<String>,
 }
 
 pub fn run() -> Result<()> {
@@ -115,6 +122,9 @@ fn run_checkout_branch_from_default(
     }
     if args.no_carry {
         cmd.arg("--no-carry");
+    }
+    if let Some(ref remote) = args.remote {
+        cmd.arg("--remote").arg(remote);
     }
 
     let status = cmd

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -2,6 +2,7 @@
 ///
 /// Each module represents a Git extension command that can be invoked
 /// either directly or via symlink detection in the multicall binary.
+pub mod branch;
 pub mod carry;
 pub mod checkout;
 pub mod checkout_branch;
@@ -14,6 +15,7 @@ pub mod fetch;
 pub mod hooks;
 pub mod init;
 pub mod man;
+pub mod multi_remote;
 pub mod prune;
 pub mod setup;
 pub mod shell_init;

--- a/src/commands/multi_remote.rs
+++ b/src/commands/multi_remote.rs
@@ -1,0 +1,408 @@
+//! Multi-remote management command.
+//!
+//! Provides `git daft multi-remote` subcommand for managing multi-remote mode.
+
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+use daft::{
+    get_project_root,
+    git::GitCommand,
+    is_git_repository,
+    multi_remote::{
+        config::{set_multi_remote_default, set_multi_remote_enabled},
+        migration::{list_worktrees, MigrationPlan},
+    },
+    output::{CliOutput, Output, OutputConfig},
+    settings::DaftSettings,
+};
+use std::io::{self, Write};
+
+#[derive(Parser)]
+#[command(name = "multi-remote")]
+#[command(about = "Manage multi-remote worktree organization")]
+#[command(long_about = r#"
+Manages multi-remote mode, which organizes worktrees by remote when working
+with multiple remotes (e.g., fork workflows with `origin` and `upstream`).
+
+When multi-remote mode is disabled (default), worktrees are placed directly
+under the project root:
+
+    project/
+    ├── .git/
+    ├── main/
+    └── feature/foo/
+
+When multi-remote mode is enabled, worktrees are organized by remote:
+
+    project/
+    ├── .git/
+    ├── origin/
+    │   ├── main/
+    │   └── feature/foo/
+    └── upstream/
+        └── main/
+
+Use `git daft multi-remote enable` to migrate existing worktrees to the
+multi-remote layout. Use `git daft multi-remote disable` to migrate back
+to the flat layout.
+"#)]
+pub struct Args {
+    #[command(subcommand)]
+    command: Option<MultiRemoteCommand>,
+}
+
+#[derive(Subcommand)]
+enum MultiRemoteCommand {
+    /// Enable multi-remote mode and migrate existing worktrees
+    #[command(long_about = r#"
+Enables multi-remote mode and migrates existing worktrees to the remote-prefixed
+directory structure.
+
+Each worktree is moved from `project/branch` to `project/remote/branch`, where
+the remote is determined by the branch's upstream tracking configuration or
+defaults to the specified default remote.
+
+Use --dry-run to preview the migration without making changes.
+"#)]
+    Enable {
+        #[arg(long, help = "Default remote for new branches (defaults to 'origin')")]
+        default: Option<String>,
+
+        #[arg(long, help = "Preview changes without executing")]
+        dry_run: bool,
+
+        #[arg(short = 'y', long, help = "Skip confirmation")]
+        yes: bool,
+    },
+
+    /// Disable multi-remote mode and flatten worktree structure
+    #[command(long_about = r#"
+Disables multi-remote mode and migrates worktrees back to the flat directory
+structure.
+
+Each worktree is moved from `project/remote/branch` back to `project/branch`.
+This command requires that only one remote is configured, as the flat structure
+cannot distinguish between worktrees from different remotes.
+
+Use --dry-run to preview the migration without making changes.
+"#)]
+    Disable {
+        #[arg(long, help = "Preview changes without executing")]
+        dry_run: bool,
+
+        #[arg(short = 'y', long, help = "Skip confirmation")]
+        yes: bool,
+    },
+
+    /// Show current multi-remote configuration
+    Status,
+
+    /// Change the default remote for new branches
+    SetDefault {
+        #[arg(help = "Remote name to use as default")]
+        remote: String,
+    },
+}
+
+pub fn run() -> Result<()> {
+    // Skip "daft" and "multi-remote" from args
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let args = Args::parse_from(args);
+
+    match args.command {
+        Some(MultiRemoteCommand::Enable {
+            default,
+            dry_run,
+            yes,
+        }) => cmd_enable(default, dry_run, yes),
+        Some(MultiRemoteCommand::Disable { dry_run, yes }) => cmd_disable(dry_run, yes),
+        Some(MultiRemoteCommand::Status) => cmd_status(),
+        Some(MultiRemoteCommand::SetDefault { remote }) => cmd_set_default(&remote),
+        None => cmd_status(), // Default to status
+    }
+}
+
+/// Enable multi-remote mode.
+fn cmd_enable(default_remote: Option<String>, dry_run: bool, skip_confirm: bool) -> Result<()> {
+    if !is_git_repository()? {
+        anyhow::bail!("Not in a git repository");
+    }
+
+    let settings = DaftSettings::load()?;
+    let config = OutputConfig::new(false, true);
+    let mut output = CliOutput::new(config);
+
+    let project_root = get_project_root()?;
+    let git = GitCommand::new(false);
+
+    // Check if already enabled
+    if settings.multi_remote_enabled {
+        output.result("Multi-remote mode is already enabled");
+        return Ok(());
+    }
+
+    // Get list of remotes
+    let remotes = git.remote_list()?;
+    if remotes.is_empty() {
+        anyhow::bail!("No remotes configured. Add a remote before enabling multi-remote mode.");
+    }
+
+    let default = default_remote.unwrap_or_else(|| "origin".to_string());
+    if !remotes.contains(&default) {
+        output.warning(&format!(
+            "Default remote '{}' does not exist. Available remotes: {}",
+            default,
+            remotes.join(", ")
+        ));
+    }
+
+    output.step(&format!("Project root: {}", project_root.display()));
+    output.step(&format!("Remotes: {}", remotes.join(", ")));
+    output.step(&format!("Default remote: {}", default));
+
+    // List existing worktrees
+    let worktrees = list_worktrees(&git, &project_root)?;
+    let worktree_count = worktrees
+        .iter()
+        .filter(|w| !w.path.ends_with(".git"))
+        .count();
+
+    output.step(&format!("Found {} worktrees to migrate", worktree_count));
+
+    // Create migration plan
+    let plan = MigrationPlan::for_enable(&project_root, &worktrees, &default);
+
+    if plan.is_empty() {
+        output.step("No migration needed");
+    } else {
+        plan.preview(&mut output);
+    }
+
+    if dry_run {
+        output.result("Dry run complete - no changes made");
+        return Ok(());
+    }
+
+    if !plan.is_empty() && !skip_confirm {
+        print!("\nProceed with migration? [y/N] ");
+        io::stdout().flush()?;
+
+        let mut input = String::new();
+        io::stdin().read_line(&mut input)?;
+        let input = input.trim().to_lowercase();
+
+        if input != "y" && input != "yes" {
+            output.result("Aborted");
+            return Ok(());
+        }
+    }
+
+    // Execute migration
+    if !plan.is_empty() {
+        output.step("Executing migration...");
+        plan.execute(&git, &mut output)?;
+    }
+
+    // Update config
+    output.step("Updating git config...");
+    set_multi_remote_enabled(&git, true)?;
+    set_multi_remote_default(&git, &default)?;
+
+    output.result(&format!(
+        "Multi-remote mode enabled (default remote: {})",
+        default
+    ));
+    Ok(())
+}
+
+/// Disable multi-remote mode.
+fn cmd_disable(dry_run: bool, skip_confirm: bool) -> Result<()> {
+    if !is_git_repository()? {
+        anyhow::bail!("Not in a git repository");
+    }
+
+    let settings = DaftSettings::load()?;
+    let config = OutputConfig::new(false, true);
+    let mut output = CliOutput::new(config);
+
+    let project_root = get_project_root()?;
+    let git = GitCommand::new(false);
+
+    // Check if already disabled
+    if !settings.multi_remote_enabled {
+        output.result("Multi-remote mode is already disabled");
+        return Ok(());
+    }
+
+    // Check number of remotes
+    let remotes = git.remote_list()?;
+    if remotes.len() > 1 {
+        output.warning(&format!(
+            "Multiple remotes configured: {}",
+            remotes.join(", ")
+        ));
+        output.warning("Disabling multi-remote mode with multiple remotes may cause confusion.");
+        output.warning("Consider removing unused remotes first.");
+    }
+
+    // List existing worktrees
+    let worktrees = list_worktrees(&git, &project_root)?;
+    let worktree_count = worktrees
+        .iter()
+        .filter(|w| !w.path.ends_with(".git"))
+        .count();
+
+    output.step(&format!("Found {} worktrees to migrate", worktree_count));
+
+    // Create migration plan
+    let plan = MigrationPlan::for_disable(&project_root, &worktrees)?;
+
+    if plan.is_empty() {
+        output.step("No migration needed");
+    } else {
+        plan.preview(&mut output);
+    }
+
+    if dry_run {
+        output.result("Dry run complete - no changes made");
+        return Ok(());
+    }
+
+    if !plan.is_empty() && !skip_confirm {
+        print!("\nProceed with migration? [y/N] ");
+        io::stdout().flush()?;
+
+        let mut input = String::new();
+        io::stdin().read_line(&mut input)?;
+        let input = input.trim().to_lowercase();
+
+        if input != "y" && input != "yes" {
+            output.result("Aborted");
+            return Ok(());
+        }
+    }
+
+    // Execute migration
+    if !plan.is_empty() {
+        output.step("Executing migration...");
+        plan.execute(&git, &mut output)?;
+    }
+
+    // Update config
+    output.step("Updating git config...");
+    set_multi_remote_enabled(&git, false)?;
+
+    output.result("Multi-remote mode disabled");
+    Ok(())
+}
+
+/// Show current status.
+fn cmd_status() -> Result<()> {
+    if !is_git_repository()? {
+        anyhow::bail!("Not in a git repository");
+    }
+
+    let settings = DaftSettings::load()?;
+    let project_root = get_project_root()?;
+    let git = GitCommand::new(true);
+
+    println!("Repository: {}", project_root.display());
+    println!();
+
+    // Multi-remote status
+    let status = if settings.multi_remote_enabled {
+        "enabled"
+    } else {
+        "disabled"
+    };
+    println!("Multi-remote mode: {status}");
+    println!("Default remote: {}", settings.multi_remote_default);
+    println!();
+
+    // List remotes
+    let remotes = git.remote_list()?;
+    println!("Configured remotes:");
+    if remotes.is_empty() {
+        println!("  (none)");
+    } else {
+        for remote in &remotes {
+            let marker = if remote == &settings.multi_remote_default {
+                " (default)"
+            } else {
+                ""
+            };
+            println!("  - {remote}{marker}");
+        }
+    }
+    println!();
+
+    // List worktrees
+    let worktrees = list_worktrees(&git, &project_root)?;
+    let regular_worktrees: Vec<_> = worktrees
+        .iter()
+        .filter(|w| !w.path.ends_with(".git"))
+        .collect();
+
+    println!("Worktrees:");
+    if regular_worktrees.is_empty() {
+        println!("  (none)");
+    } else {
+        for wt in &regular_worktrees {
+            let relative = wt
+                .path
+                .strip_prefix(&project_root)
+                .map(|p| p.display().to_string())
+                .unwrap_or_else(|_| wt.path.display().to_string());
+
+            let branch_info = wt
+                .branch
+                .as_ref()
+                .map(|b| format!(" [{b}]"))
+                .unwrap_or_default();
+
+            let remote_info = wt
+                .remote
+                .as_ref()
+                .map(|r| format!(" ({})", r))
+                .unwrap_or_default();
+
+            println!("  {relative}{branch_info}{remote_info}");
+        }
+    }
+    println!();
+
+    // Commands
+    if settings.multi_remote_enabled {
+        println!("To disable multi-remote mode:");
+        println!("  git daft multi-remote disable");
+    } else {
+        println!("To enable multi-remote mode:");
+        println!("  git daft multi-remote enable");
+    }
+
+    Ok(())
+}
+
+/// Set the default remote.
+fn cmd_set_default(remote: &str) -> Result<()> {
+    if !is_git_repository()? {
+        anyhow::bail!("Not in a git repository");
+    }
+
+    let git = GitCommand::new(true);
+
+    // Verify remote exists
+    let remotes = git.remote_list()?;
+    if !remotes.contains(&remote.to_string()) {
+        anyhow::bail!(
+            "Remote '{}' does not exist. Available remotes: {}",
+            remote,
+            remotes.join(", ")
+        );
+    }
+
+    set_multi_remote_default(&git, remote)?;
+    println!("Default remote set to: {remote}");
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ pub mod config;
 pub mod git;
 pub mod hooks;
 pub mod logging;
+pub mod multi_remote;
 pub mod output;
 pub mod remote;
 pub mod settings;

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,10 +55,12 @@ fn main() -> Result<()> {
             let args: Vec<String> = std::env::args().collect();
             if args.len() > 1 {
                 match args[1].as_str() {
+                    "branch" => commands::branch::run(),
                     "completions" => commands::completions::run(),
                     "__complete" => commands::complete::run(),
                     "hooks" => commands::hooks::run(),
                     "man" => commands::man::run(),
+                    "multi-remote" => commands::multi_remote::run(),
                     "setup" => {
                         // Check for setup subcommands
                         if args.len() > 2 && args[2] == "shortcuts" {

--- a/src/multi_remote/config.rs
+++ b/src/multi_remote/config.rs
@@ -1,0 +1,49 @@
+//! Configuration helpers for multi-remote mode.
+
+use crate::git::GitCommand;
+use crate::settings::keys;
+use anyhow::Result;
+
+/// Set multi-remote configuration in the local git config.
+pub fn set_multi_remote_enabled(git: &GitCommand, enabled: bool) -> Result<()> {
+    let value = if enabled { "true" } else { "false" };
+    git.config_set(keys::multi_remote::ENABLED, value)
+}
+
+/// Set the default remote for multi-remote mode.
+pub fn set_multi_remote_default(git: &GitCommand, remote: &str) -> Result<()> {
+    git.config_set(keys::multi_remote::DEFAULT_REMOTE, remote)
+}
+
+/// Clear multi-remote configuration from the local git config.
+pub fn clear_multi_remote_config(git: &GitCommand) -> Result<()> {
+    // Try to unset; ignore errors if key doesn't exist
+    let _ = git.config_unset(keys::multi_remote::ENABLED);
+    let _ = git.config_unset(keys::multi_remote::DEFAULT_REMOTE);
+    Ok(())
+}
+
+/// Check if multi-remote mode should be used based on settings and context.
+pub fn should_use_multi_remote(enabled: bool, remote_count: usize) -> bool {
+    // Multi-remote mode only makes sense with more than one remote
+    enabled && remote_count > 1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_should_use_multi_remote() {
+        // Disabled mode - never use multi-remote
+        assert!(!should_use_multi_remote(false, 0));
+        assert!(!should_use_multi_remote(false, 1));
+        assert!(!should_use_multi_remote(false, 2));
+
+        // Enabled mode - only with multiple remotes
+        assert!(!should_use_multi_remote(true, 0));
+        assert!(!should_use_multi_remote(true, 1));
+        assert!(should_use_multi_remote(true, 2));
+        assert!(should_use_multi_remote(true, 3));
+    }
+}

--- a/src/multi_remote/migration.rs
+++ b/src/multi_remote/migration.rs
@@ -1,0 +1,345 @@
+//! Migration logic for enabling and disabling multi-remote mode.
+//!
+//! Handles moving worktrees between flat and nested directory structures.
+
+use crate::git::GitCommand;
+use crate::output::Output;
+use anyhow::{Context, Result};
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Information about a worktree for migration purposes.
+#[derive(Debug, Clone)]
+pub struct WorktreeInfo {
+    /// Full path to the worktree directory.
+    pub path: PathBuf,
+    /// Branch name checked out in this worktree.
+    pub branch: Option<String>,
+    /// Remote associated with this worktree (for multi-remote mode).
+    pub remote: Option<String>,
+}
+
+/// A single migration operation.
+#[derive(Debug, Clone)]
+pub enum MigrationOp {
+    /// Create a directory.
+    CreateDir(PathBuf),
+    /// Move a worktree from one location to another.
+    MoveWorktree { from: PathBuf, to: PathBuf },
+    /// Remove an empty directory.
+    RemoveEmptyDir(PathBuf),
+}
+
+impl MigrationOp {
+    /// Get a human-readable description of this operation.
+    pub fn description(&self) -> String {
+        match self {
+            MigrationOp::CreateDir(path) => format!("mkdir -p {}", path.display()),
+            MigrationOp::MoveWorktree { from, to } => {
+                format!("mv {} {}", from.display(), to.display())
+            }
+            MigrationOp::RemoveEmptyDir(path) => format!("rmdir {}", path.display()),
+        }
+    }
+}
+
+/// A plan for migrating worktrees between single-remote and multi-remote layouts.
+#[derive(Debug)]
+pub struct MigrationPlan {
+    /// Operations to execute in order.
+    pub operations: Vec<MigrationOp>,
+}
+
+impl MigrationPlan {
+    /// Create a migration plan to enable multi-remote mode.
+    ///
+    /// Moves worktrees from `project/branch` to `project/remote/branch`.
+    pub fn for_enable(
+        project_root: &Path,
+        worktrees: &[WorktreeInfo],
+        default_remote: &str,
+    ) -> Self {
+        let mut operations = Vec::new();
+        let mut needed_dirs: std::collections::HashSet<PathBuf> = std::collections::HashSet::new();
+
+        for wt in worktrees {
+            // Skip the bare repo's .git directory
+            if wt.path.ends_with(".git") {
+                continue;
+            }
+
+            let remote = wt.remote.as_deref().unwrap_or(default_remote).to_string();
+            let remote_dir = project_root.join(&remote);
+
+            // Add directory creation if needed
+            if !needed_dirs.contains(&remote_dir) {
+                if !remote_dir.exists() {
+                    operations.push(MigrationOp::CreateDir(remote_dir.clone()));
+                }
+                needed_dirs.insert(remote_dir.clone());
+            }
+
+            // Calculate new path: move from project/branch to project/remote/branch
+            if let Ok(relative) = wt.path.strip_prefix(project_root) {
+                let new_path = remote_dir.join(relative);
+                if new_path != wt.path {
+                    operations.push(MigrationOp::MoveWorktree {
+                        from: wt.path.clone(),
+                        to: new_path,
+                    });
+                }
+            }
+        }
+
+        Self { operations }
+    }
+
+    /// Create a migration plan to disable multi-remote mode.
+    ///
+    /// Moves worktrees from `project/remote/branch` to `project/branch`.
+    pub fn for_disable(project_root: &Path, worktrees: &[WorktreeInfo]) -> Result<Self> {
+        let mut operations = Vec::new();
+        let mut remote_dirs_to_remove: std::collections::HashSet<PathBuf> =
+            std::collections::HashSet::new();
+
+        // Group worktrees by their remote directory
+        let mut worktrees_by_remote: HashMap<String, Vec<&WorktreeInfo>> = HashMap::new();
+        for wt in worktrees {
+            if wt.path.ends_with(".git") {
+                continue;
+            }
+
+            if let Some(remote) = &wt.remote {
+                worktrees_by_remote
+                    .entry(remote.clone())
+                    .or_default()
+                    .push(wt);
+                remote_dirs_to_remove.insert(project_root.join(remote));
+            }
+        }
+
+        for wt in worktrees {
+            if wt.path.ends_with(".git") {
+                continue;
+            }
+
+            // Extract branch path from project/remote/branch
+            if let Some(remote) = &wt.remote {
+                let remote_prefix = project_root.join(remote);
+                if let Ok(branch_path) = wt.path.strip_prefix(&remote_prefix) {
+                    let new_path = project_root.join(branch_path);
+                    if new_path != wt.path {
+                        operations.push(MigrationOp::MoveWorktree {
+                            from: wt.path.clone(),
+                            to: new_path,
+                        });
+                    }
+                }
+            }
+        }
+
+        // Add cleanup operations for empty remote directories
+        for dir in remote_dirs_to_remove {
+            operations.push(MigrationOp::RemoveEmptyDir(dir));
+        }
+
+        Ok(Self { operations })
+    }
+
+    /// Preview the migration plan without executing.
+    pub fn preview(&self, output: &mut dyn Output) {
+        if self.operations.is_empty() {
+            output.step("No migration needed");
+            return;
+        }
+
+        output.step("Migration plan:");
+        for op in &self.operations {
+            output.step(&format!("  {}", op.description()));
+        }
+    }
+
+    /// Execute the migration plan.
+    pub fn execute(&self, git: &GitCommand, output: &mut dyn Output) -> Result<()> {
+        for op in &self.operations {
+            output.step(&op.description());
+
+            match op {
+                MigrationOp::CreateDir(path) => {
+                    fs::create_dir_all(path).with_context(|| {
+                        format!("Failed to create directory: {}", path.display())
+                    })?;
+                }
+                MigrationOp::MoveWorktree { from, to } => {
+                    // Ensure parent directory exists
+                    if let Some(parent) = to.parent() {
+                        if !parent.exists() {
+                            fs::create_dir_all(parent).with_context(|| {
+                                format!("Failed to create parent directory: {}", parent.display())
+                            })?;
+                        }
+                    }
+
+                    // Use git worktree move for proper bookkeeping
+                    git.worktree_move(from, to).with_context(|| {
+                        format!(
+                            "Failed to move worktree from {} to {}",
+                            from.display(),
+                            to.display()
+                        )
+                    })?;
+                }
+                MigrationOp::RemoveEmptyDir(path) => {
+                    // Only remove if empty
+                    if path.exists() {
+                        let is_empty = fs::read_dir(path)
+                            .map(|mut entries| entries.next().is_none())
+                            .unwrap_or(false);
+
+                        if is_empty {
+                            fs::remove_dir(path).with_context(|| {
+                                format!("Failed to remove empty directory: {}", path.display())
+                            })?;
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Check if this plan has any operations.
+    pub fn is_empty(&self) -> bool {
+        self.operations.is_empty()
+    }
+}
+
+/// List all worktrees in a repository.
+pub fn list_worktrees(git: &GitCommand, project_root: &Path) -> Result<Vec<WorktreeInfo>> {
+    let porcelain_output = git.worktree_list_porcelain()?;
+    let mut worktrees = Vec::new();
+
+    let mut current_path: Option<PathBuf> = None;
+    let mut current_branch: Option<String> = None;
+
+    for line in porcelain_output.lines() {
+        if let Some(worktree_path) = line.strip_prefix("worktree ") {
+            // Save previous worktree if any
+            if let Some(path) = current_path.take() {
+                let remote = infer_remote_from_path(project_root, &path);
+                worktrees.push(WorktreeInfo {
+                    path,
+                    branch: current_branch.take(),
+                    remote,
+                });
+            }
+            current_path = Some(PathBuf::from(worktree_path));
+            current_branch = None;
+        } else if let Some(branch_ref) = line.strip_prefix("branch ") {
+            current_branch = branch_ref.strip_prefix("refs/heads/").map(String::from);
+        }
+    }
+
+    // Don't forget the last worktree
+    if let Some(path) = current_path.take() {
+        let remote = infer_remote_from_path(project_root, &path);
+        worktrees.push(WorktreeInfo {
+            path,
+            branch: current_branch.take(),
+            remote,
+        });
+    }
+
+    Ok(worktrees)
+}
+
+/// Infer the remote name from a worktree path in multi-remote layout.
+fn infer_remote_from_path(project_root: &Path, worktree_path: &Path) -> Option<String> {
+    if let Ok(relative) = worktree_path.strip_prefix(project_root) {
+        let components: Vec<_> = relative.components().collect();
+        // If path has structure like remote/branch, extract remote
+        if components.len() >= 2 {
+            if let Some(first) = components.first() {
+                let name = first.as_os_str().to_str()?;
+                // Check if this looks like a remote name (not .git or common branch patterns)
+                if name != ".git" && !name.contains('/') {
+                    return Some(name.to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_migration_plan_for_enable_empty() {
+        let project_root = Path::new("/home/user/project");
+        let worktrees: Vec<WorktreeInfo> = vec![];
+
+        let plan = MigrationPlan::for_enable(project_root, &worktrees, "origin");
+        assert!(plan.is_empty());
+    }
+
+    #[test]
+    fn test_migration_plan_for_enable_single_worktree() {
+        let project_root = Path::new("/home/user/project");
+        let worktrees = vec![WorktreeInfo {
+            path: PathBuf::from("/home/user/project/main"),
+            branch: Some("main".to_string()),
+            remote: None,
+        }];
+
+        let plan = MigrationPlan::for_enable(project_root, &worktrees, "origin");
+        assert!(!plan.is_empty());
+
+        // Should create origin dir and move the worktree
+        let mut has_create = false;
+        let mut has_move = false;
+        for op in &plan.operations {
+            match op {
+                MigrationOp::CreateDir(path) => {
+                    has_create = true;
+                    assert_eq!(path, &PathBuf::from("/home/user/project/origin"));
+                }
+                MigrationOp::MoveWorktree { from, to } => {
+                    has_move = true;
+                    assert_eq!(from, &PathBuf::from("/home/user/project/main"));
+                    assert_eq!(to, &PathBuf::from("/home/user/project/origin/main"));
+                }
+                _ => {}
+            }
+        }
+        assert!(has_create);
+        assert!(has_move);
+    }
+
+    #[test]
+    fn test_migration_plan_for_disable() {
+        let project_root = Path::new("/home/user/project");
+        let worktrees = vec![WorktreeInfo {
+            path: PathBuf::from("/home/user/project/origin/main"),
+            branch: Some("main".to_string()),
+            remote: Some("origin".to_string()),
+        }];
+
+        let plan = MigrationPlan::for_disable(project_root, &worktrees).unwrap();
+        assert!(!plan.is_empty());
+
+        // Should move worktree and remove empty dir
+        let mut has_move = false;
+        for op in &plan.operations {
+            if let MigrationOp::MoveWorktree { from, to } = op {
+                has_move = true;
+                assert_eq!(from, &PathBuf::from("/home/user/project/origin/main"));
+                assert_eq!(to, &PathBuf::from("/home/user/project/main"));
+            }
+        }
+        assert!(has_move);
+    }
+}

--- a/src/multi_remote/mod.rs
+++ b/src/multi_remote/mod.rs
@@ -1,0 +1,39 @@
+//! Multi-remote support for daft.
+//!
+//! This module provides functionality for organizing worktrees by remote
+//! when working with multiple remotes (e.g., fork workflows with `origin` and `upstream`).
+//!
+//! # Directory Structure
+//!
+//! When multi-remote mode is disabled (default):
+//! ```text
+//! project/
+//! ├── .git/
+//! ├── main/
+//! └── feature/foo/
+//! ```
+//!
+//! When multi-remote mode is enabled:
+//! ```text
+//! project/
+//! ├── .git/
+//! ├── origin/
+//! │   ├── main/
+//! │   └── feature/foo/
+//! └── upstream/
+//!     └── main/
+//! ```
+//!
+//! # Configuration
+//!
+//! Multi-remote mode is controlled by git config:
+//! - `daft.multiRemote.enabled` - Enable/disable remote-prefixed paths
+//! - `daft.multiRemote.defaultRemote` - Default remote for new branches
+
+pub mod config;
+pub mod migration;
+pub mod path;
+
+pub use config::*;
+pub use migration::*;
+pub use path::*;

--- a/src/multi_remote/path.rs
+++ b/src/multi_remote/path.rs
@@ -1,0 +1,166 @@
+//! Path calculation for multi-remote worktree organization.
+
+use crate::git::GitCommand;
+use anyhow::Result;
+use std::path::{Path, PathBuf};
+
+/// Calculate the worktree path based on multi-remote mode.
+///
+/// When multi-remote mode is disabled:
+///   `project_root/branch_name`
+///
+/// When multi-remote mode is enabled:
+///   `project_root/remote_name/branch_name`
+pub fn calculate_worktree_path(
+    project_root: &Path,
+    branch_name: &str,
+    remote_name: &str,
+    multi_remote_enabled: bool,
+) -> PathBuf {
+    if multi_remote_enabled {
+        project_root.join(remote_name).join(branch_name)
+    } else {
+        project_root.join(branch_name)
+    }
+}
+
+/// Resolve the remote to use for a branch.
+///
+/// Priority:
+/// 1. Explicit remote flag (if provided)
+/// 2. Branch's tracking remote (git config branch.<name>.remote)
+/// 3. Default remote from settings
+pub fn resolve_remote_for_branch(
+    git: &GitCommand,
+    branch_name: &str,
+    explicit_remote: Option<&str>,
+    default_remote: &str,
+) -> Result<String> {
+    // 1. Explicit --remote flag takes precedence
+    if let Some(remote) = explicit_remote {
+        return Ok(remote.to_string());
+    }
+
+    // 2. Try to get the branch's tracking remote
+    if let Ok(Some(tracking_remote)) = git.get_branch_tracking_remote(branch_name) {
+        if !tracking_remote.is_empty() {
+            return Ok(tracking_remote);
+        }
+    }
+
+    // 3. Fall back to default remote
+    Ok(default_remote.to_string())
+}
+
+/// Extract the remote name from an existing worktree path (when multi-remote is enabled).
+///
+/// For a path like `project/origin/feature/foo`, extracts `origin`.
+/// Returns None if the path doesn't have the expected structure.
+pub fn extract_remote_from_path(project_root: &Path, worktree_path: &Path) -> Option<String> {
+    let relative = worktree_path.strip_prefix(project_root).ok()?;
+    let components: Vec<_> = relative.components().collect();
+
+    // In multi-remote mode, first component should be the remote name
+    if components.len() >= 2 {
+        components
+            .first()
+            .and_then(|c| c.as_os_str().to_str())
+            .map(String::from)
+    } else {
+        None
+    }
+}
+
+/// Extract the branch name from a worktree path.
+///
+/// For single-remote mode: `project/feature/foo` -> `feature/foo`
+/// For multi-remote mode: `project/origin/feature/foo` -> `feature/foo`
+pub fn extract_branch_from_path(
+    project_root: &Path,
+    worktree_path: &Path,
+    multi_remote_enabled: bool,
+) -> Option<String> {
+    let relative = worktree_path.strip_prefix(project_root).ok()?;
+    let components: Vec<_> = relative.components().collect();
+
+    if multi_remote_enabled {
+        // Skip the first component (remote name)
+        if components.len() >= 2 {
+            let branch_components: Vec<_> = components.iter().skip(1).collect();
+            let branch_path: PathBuf = branch_components.iter().collect();
+            branch_path.to_str().map(String::from)
+        } else {
+            None
+        }
+    } else {
+        relative.to_str().map(String::from)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_calculate_worktree_path_single_remote() {
+        let project_root = Path::new("/home/user/project");
+        let result = calculate_worktree_path(project_root, "feature/foo", "origin", false);
+        assert_eq!(result, PathBuf::from("/home/user/project/feature/foo"));
+    }
+
+    #[test]
+    fn test_calculate_worktree_path_multi_remote() {
+        let project_root = Path::new("/home/user/project");
+        let result = calculate_worktree_path(project_root, "feature/foo", "origin", true);
+        assert_eq!(
+            result,
+            PathBuf::from("/home/user/project/origin/feature/foo")
+        );
+
+        let result = calculate_worktree_path(project_root, "main", "upstream", true);
+        assert_eq!(result, PathBuf::from("/home/user/project/upstream/main"));
+    }
+
+    #[test]
+    fn test_extract_remote_from_path() {
+        let project_root = Path::new("/home/user/project");
+
+        let worktree_path = Path::new("/home/user/project/origin/feature/foo");
+        assert_eq!(
+            extract_remote_from_path(project_root, worktree_path),
+            Some("origin".to_string())
+        );
+
+        let worktree_path = Path::new("/home/user/project/upstream/main");
+        assert_eq!(
+            extract_remote_from_path(project_root, worktree_path),
+            Some("upstream".to_string())
+        );
+
+        // Single component (not multi-remote structure)
+        let worktree_path = Path::new("/home/user/project/main");
+        assert_eq!(extract_remote_from_path(project_root, worktree_path), None);
+    }
+
+    #[test]
+    fn test_extract_branch_from_path_single_remote() {
+        let project_root = Path::new("/home/user/project");
+        let worktree_path = Path::new("/home/user/project/feature/foo");
+
+        assert_eq!(
+            extract_branch_from_path(project_root, worktree_path, false),
+            Some("feature/foo".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_branch_from_path_multi_remote() {
+        let project_root = Path::new("/home/user/project");
+        let worktree_path = Path::new("/home/user/project/origin/feature/foo");
+
+        assert_eq!(
+            extract_branch_from_path(project_root, worktree_path, true),
+            Some("feature/foo".to_string())
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Add support for organizing worktrees by remote when working with multiple remotes (e.g., fork workflows with `origin` and `upstream`)
- New `git daft multi-remote` command with enable/disable/status/set-default subcommands
- New `git daft branch move` command to move worktrees between remote folders
- Add `--remote` flag to checkout, clone, and init commands
- Automatic migration of existing worktrees when enabling/disabling multi-remote mode

When multi-remote mode is enabled, worktrees are organized as:
```
project/
├── .git/
├── origin/
│   ├── main/
│   └── feature/foo/
└── upstream/
    └── main/
```

## Test plan

- [ ] Run `just test-unit` - all 96 tests pass
- [ ] Run `cargo clippy -- -D warnings` - no warnings
- [ ] Run `cargo fmt -- --check` - formatting correct
- [ ] Manual testing:
  - [ ] `git daft multi-remote enable` migrates existing worktrees
  - [ ] `git daft multi-remote disable` flattens structure back
  - [ ] `git worktree-checkout --remote upstream main` creates worktree in upstream folder
  - [ ] `git daft branch move feature/foo --to upstream` moves worktree

Fixes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)