### PR TITLE
fix: enable CD behavior for all shortcut styles

### DIFF
--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -5,6 +5,9 @@ use std::fs;
 use std::io::{self, Write};
 use std::path::PathBuf;
 
+use crate::commands::shortcuts::{detect_install_dir, enable_style};
+use crate::shortcuts::ShortcutStyle;
+
 #[derive(Debug, Clone, PartialEq)]
 enum Shell {
     Bash,
@@ -189,12 +192,28 @@ pub fn run() -> Result<()> {
     )?;
     writeln!(file, "{init_line}")?;
 
+    // Install git-style shortcuts
+    let shortcuts_installed = if let Ok(install_dir) = detect_install_dir() {
+        enable_style(ShortcutStyle::Git, &install_dir, false, false).is_ok()
+    } else {
+        false
+    };
+
     println!();
     println!("Done! Shell integration added to {}", config_file.display());
+    if shortcuts_installed {
+        println!("      Git-style shortcuts installed (gwtco, gwtcb, etc.)");
+    }
     println!();
     println!("To activate, either:");
     println!("  1. Restart your terminal, or");
     println!("  2. Run: source {}", config_file.display());
+    if shortcuts_installed {
+        println!();
+        println!("To use different shortcut styles:");
+        println!("  daft setup shortcuts only shell   # gwco, gwcob, gwcobd");
+        println!("  daft setup shortcuts only legacy  # gclone, gcw, gcbw, ...");
+    }
 
     Ok(())
 }

--- a/src/commands/shell_init.rs
+++ b/src/commands/shell_init.rs
@@ -138,6 +138,29 @@ git() {
             command git "$@" ;;
     esac
 }
+
+# Shortcut wrappers - these override symlinks to enable cd behavior
+# Git-style shortcuts
+gwtclone() { __daft_wrapper git-worktree-clone "$@"; }
+gwtinit() { __daft_wrapper git-worktree-init "$@"; }
+gwtco() { __daft_wrapper git-worktree-checkout "$@"; }
+gwtcb() { __daft_wrapper git-worktree-checkout-branch "$@"; }
+gwtcbm() { __daft_wrapper git-worktree-checkout-branch-from-default "$@"; }
+gwtprune() { __daft_wrapper git-worktree-prune "$@"; }
+gwtcarry() { __daft_wrapper git-worktree-carry "$@"; }
+gwtfetch() { __daft_wrapper git-worktree-fetch "$@"; }
+
+# Shell-style shortcuts
+gwco() { __daft_wrapper git-worktree-checkout "$@"; }
+gwcob() { __daft_wrapper git-worktree-checkout-branch "$@"; }
+gwcobd() { __daft_wrapper git-worktree-checkout-branch-from-default "$@"; }
+
+# Legacy-style shortcuts
+gclone() { __daft_wrapper git-worktree-clone "$@"; }
+gcw() { __daft_wrapper git-worktree-checkout "$@"; }
+gcbw() { __daft_wrapper git-worktree-checkout-branch "$@"; }
+gcbdw() { __daft_wrapper git-worktree-checkout-branch-from-default "$@"; }
+gprune() { __daft_wrapper git-worktree-prune "$@"; }
 "#;
 
 const BASH_ZSH_ALIASES: &str = r#"
@@ -255,6 +278,74 @@ function git --wraps git
         case '*'
             command git $argv
     end
+end
+
+# Shortcut wrappers - these override symlinks to enable cd behavior
+# Git-style shortcuts
+function gwtclone
+    __daft_wrapper git-worktree-clone $argv
+end
+
+function gwtinit
+    __daft_wrapper git-worktree-init $argv
+end
+
+function gwtco
+    __daft_wrapper git-worktree-checkout $argv
+end
+
+function gwtcb
+    __daft_wrapper git-worktree-checkout-branch $argv
+end
+
+function gwtcbm
+    __daft_wrapper git-worktree-checkout-branch-from-default $argv
+end
+
+function gwtprune
+    __daft_wrapper git-worktree-prune $argv
+end
+
+function gwtcarry
+    __daft_wrapper git-worktree-carry $argv
+end
+
+function gwtfetch
+    __daft_wrapper git-worktree-fetch $argv
+end
+
+# Shell-style shortcuts
+function gwco
+    __daft_wrapper git-worktree-checkout $argv
+end
+
+function gwcob
+    __daft_wrapper git-worktree-checkout-branch $argv
+end
+
+function gwcobd
+    __daft_wrapper git-worktree-checkout-branch-from-default $argv
+end
+
+# Legacy-style shortcuts
+function gclone
+    __daft_wrapper git-worktree-clone $argv
+end
+
+function gcw
+    __daft_wrapper git-worktree-checkout $argv
+end
+
+function gcbw
+    __daft_wrapper git-worktree-checkout-branch $argv
+end
+
+function gcbdw
+    __daft_wrapper git-worktree-checkout-branch-from-default $argv
+end
+
+function gprune
+    __daft_wrapper git-worktree-prune $argv
 end
 "#;
 


### PR DESCRIPTION
## Summary
- Add shell wrapper functions for all shortcuts (git, shell, legacy styles) to `daft shell-init` output
- Automatically install git-style shortcuts during `daft setup`
- Show hint about switching to other shortcut styles

## Problem
When using shortcut symlinks (`gwtco`, `gwtcb`, etc.), the CD behavior didn't work because symlinks bypass the shell wrapper functions that handle the `__DAFT_CD__` marker.

## Solution
1. **Shell wrappers for all shortcuts**: Shell functions take precedence over symlinks. By defining wrapper functions for all shortcuts in `daft shell-init`, CD behavior now works regardless of how commands are invoked.

2. **Auto-install shortcuts**: `daft setup` now automatically installs git-style shortcuts, so users get a complete setup in one command.

3. **Hint about alternatives**: After setup, users see how to switch to other shortcut styles if they prefer.

## What users see after `daft setup`
```
Done! Shell integration added to /Users/user/.zshrc
      Git-style shortcuts installed (gwtco, gwtcb, etc.)

To activate, either:
  1. Restart your terminal, or
  2. Run: source /Users/user/.zshrc

To use different shortcut styles:
  daft setup shortcuts only shell   # gwco, gwcob, gwcobd
  daft setup shortcuts only legacy  # gclone, gcw, gcbw, ...
```

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes
- [x] `just test-unit` passes (97 tests)
- [ ] Manual test: run `daft setup`, verify shortcuts installed and CD works

## Related
- Fixes #79
- Homebrew caveats PR: https://github.com/avihut/homebrew-daft/pull/1

🤖 Generated with [Claude Code](https://claude.com/claude-code)