### PR TITLE
feat: add one-time shell integration hint for new users

### DIFF
--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -3,6 +3,7 @@ use clap::Parser;
 use daft::{
     get_git_common_dir, get_project_root,
     git::GitCommand,
+    hints::maybe_show_shell_hint,
     hooks::{HookContext, HookExecutor, HookType, HooksConfig},
     is_git_repository,
     logging::init_logging,
@@ -135,6 +136,7 @@ fn run_checkout(args: &Args, settings: &DaftSettings, output: &mut dyn Output) -
             args.branch_name
         ));
         output.cd_path(&get_current_directory()?);
+        maybe_show_shell_hint(output)?;
         return Ok(());
     }
 
@@ -342,6 +344,7 @@ fn run_checkout(args: &Args, settings: &DaftSettings, output: &mut dyn Output) -
     output.result(&format!("Prepared worktree '{}'", args.branch_name));
 
     output.cd_path(&get_current_directory()?);
+    maybe_show_shell_hint(output)?;
 
     Ok(())
 }

--- a/src/commands/checkout_branch.rs
+++ b/src/commands/checkout_branch.rs
@@ -4,6 +4,7 @@ use daft::{
     config::git::{COMMITS_AHEAD_THRESHOLD, DEFAULT_COMMIT_COUNT},
     get_current_branch, get_git_common_dir, get_project_root,
     git::GitCommand,
+    hints::maybe_show_shell_hint,
     hooks::{HookContext, HookExecutor, HookType, HooksConfig},
     is_git_repository, logging,
     multi_remote::path::{calculate_worktree_path, resolve_remote_for_branch},
@@ -339,6 +340,7 @@ fn run_checkout_branch(
     ));
 
     output.cd_path(&get_current_directory()?);
+    maybe_show_shell_hint(output)?;
 
     Ok(())
 }

--- a/src/commands/clone.rs
+++ b/src/commands/clone.rs
@@ -3,6 +3,7 @@ use clap::Parser;
 use daft::{
     check_dependencies, extract_repo_name,
     git::GitCommand,
+    hints::maybe_show_shell_hint,
     hooks::{HookContext, HookExecutor, HookType, HooksConfig, TrustLevel},
     logging::init_logging,
     multi_remote::path::calculate_worktree_path,
@@ -372,6 +373,7 @@ fn run_clone(args: &Args, settings: &DaftSettings, output: &mut dyn Output) -> R
         )?;
 
         output.cd_path(&current_dir);
+        maybe_show_shell_hint(output)?;
     } else if !args.no_checkout && !branch_exists {
         // Branch was specified but doesn't exist - stay in repo root
         let current_dir = get_current_directory()?;
@@ -380,6 +382,7 @@ fn run_clone(args: &Args, settings: &DaftSettings, output: &mut dyn Output) -> R
             target_branch
         ));
         output.cd_path(&current_dir);
+        maybe_show_shell_hint(output)?;
     } else {
         // Git-like result message for no-checkout mode
         output.result(&format!("Cloned '{repo_name}' (bare)"));

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -3,6 +3,7 @@ use clap::Parser;
 use daft::{
     check_dependencies,
     git::GitCommand,
+    hints::maybe_show_shell_hint,
     hooks::{HookContext, HookExecutor, HookType, HooksConfig, TrustLevel},
     logging::init_logging,
     multi_remote::path::calculate_worktree_path,
@@ -226,6 +227,7 @@ pub fn run_with_output(args: &Args, output: &mut dyn Output) -> Result<()> {
         run_post_init_hook(&parent_dir, &git_dir, &current_dir, &initial_branch, output)?;
 
         output.cd_path(&current_dir);
+        maybe_show_shell_hint(output)?;
     } else {
         // Git-like result message for bare mode
         output.result(&format!(

--- a/src/hints.rs
+++ b/src/hints.rs
@@ -1,0 +1,206 @@
+//! First-run hints for improved user experience.
+//!
+//! This module provides a system for showing one-time hints to users
+//! who may not have completed setup for optional features like shell
+//! integration.
+
+use crate::output::Output;
+use crate::SHELL_WRAPPER_ENV;
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+/// Environment variable to suppress all hints.
+pub const NO_HINTS_ENV: &str = "DAFT_NO_HINTS";
+
+/// State file for tracking which hints have been shown.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HintsState {
+    /// Schema version for future migrations.
+    #[serde(default = "default_version")]
+    pub version: u32,
+    /// Set of hint IDs that have been shown.
+    #[serde(default)]
+    pub shown: HashSet<String>,
+}
+
+fn default_version() -> u32 {
+    1
+}
+
+impl Default for HintsState {
+    fn default() -> Self {
+        Self {
+            version: 1,
+            shown: HashSet::new(),
+        }
+    }
+}
+
+impl HintsState {
+    /// Load the hints state from the default location.
+    pub fn load() -> Result<Self> {
+        let path = Self::default_path()?;
+        Self::load_from(&path)
+    }
+
+    /// Load the hints state from a specific path.
+    pub fn load_from(path: &PathBuf) -> Result<Self> {
+        if !path.exists() {
+            return Ok(Self::default());
+        }
+
+        let contents = fs::read_to_string(path)
+            .with_context(|| format!("Failed to read hints state from {}", path.display()))?;
+
+        serde_json::from_str(&contents)
+            .with_context(|| format!("Failed to parse hints state from {}", path.display()))
+    }
+
+    /// Save the hints state to the default location.
+    pub fn save(&self) -> Result<()> {
+        let path = Self::default_path()?;
+        self.save_to(&path)
+    }
+
+    /// Save the hints state to a specific path.
+    pub fn save_to(&self, path: &PathBuf) -> Result<()> {
+        // Ensure parent directory exists
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("Failed to create directory {}", parent.display()))?;
+        }
+
+        let contents =
+            serde_json::to_string_pretty(self).context("Failed to serialize hints state")?;
+
+        fs::write(path, contents)
+            .with_context(|| format!("Failed to write hints state to {}", path.display()))?;
+
+        Ok(())
+    }
+
+    /// Get the default path for the hints state file.
+    pub fn default_path() -> Result<PathBuf> {
+        let config_dir = dirs::config_dir().context("Could not determine config directory")?;
+        Ok(config_dir.join("daft").join("hints.json"))
+    }
+
+    /// Check if a hint has been shown.
+    pub fn has_shown(&self, hint_id: &str) -> bool {
+        self.shown.contains(hint_id)
+    }
+
+    /// Mark a hint as shown.
+    pub fn mark_shown(&mut self, hint_id: &str) {
+        self.shown.insert(hint_id.to_string());
+    }
+}
+
+/// Hint identifier for shell integration.
+pub const SHELL_INTEGRATION_HINT: &str = "shell-integration";
+
+/// Check if hints are globally disabled via environment variable.
+pub fn hints_disabled() -> bool {
+    env::var(NO_HINTS_ENV).is_ok()
+}
+
+/// Check if the shell wrapper is active.
+pub fn shell_wrapper_active() -> bool {
+    env::var(SHELL_WRAPPER_ENV).is_ok()
+}
+
+/// Show the shell integration hint if appropriate.
+///
+/// This should be called after a successful worktree creation operation.
+/// The hint is shown only if:
+/// - Hints are not disabled via DAFT_NO_HINTS
+/// - The shell wrapper is not active (DAFT_SHELL_WRAPPER not set)
+/// - The hint hasn't been shown before
+/// - Quiet mode is not enabled
+///
+/// Returns Ok(true) if the hint was shown, Ok(false) otherwise.
+pub fn maybe_show_shell_hint(output: &mut dyn Output) -> Result<bool> {
+    // Skip if hints are disabled
+    if hints_disabled() {
+        return Ok(false);
+    }
+
+    // Skip if quiet mode
+    if output.is_quiet() {
+        return Ok(false);
+    }
+
+    // Skip if shell wrapper is already active - user has already set it up
+    if shell_wrapper_active() {
+        return Ok(false);
+    }
+
+    // Load state and check if we've shown this hint before
+    let mut state = HintsState::load().unwrap_or_default();
+    if state.has_shown(SHELL_INTEGRATION_HINT) {
+        return Ok(false);
+    }
+
+    // Show the hint
+    output.info("");
+    output.info("hint: Enable shell integration to auto-cd into new worktrees:");
+    output.info("  eval \"$(daft shell-init bash)\"   # Add to ~/.bashrc or ~/.zshrc");
+    output.info("  daft shell-init fish | source    # Add to ~/.config/fish/config.fish");
+    output.info("Run 'daft shell-init --help' for more options.");
+    output.info(&format!("To suppress hints: export {NO_HINTS_ENV}=1"));
+
+    // Mark as shown and save
+    state.mark_shown(SHELL_INTEGRATION_HINT);
+    // Don't fail the command if we can't save state - the hint might show again next time
+    // but that's acceptable behavior
+    let _ = state.save();
+
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_hints_state_default() {
+        let state = HintsState::default();
+        assert_eq!(state.version, 1);
+        assert!(state.shown.is_empty());
+    }
+
+    #[test]
+    fn test_hints_state_mark_shown() {
+        let mut state = HintsState::default();
+        assert!(!state.has_shown("test-hint"));
+        state.mark_shown("test-hint");
+        assert!(state.has_shown("test-hint"));
+    }
+
+    #[test]
+    fn test_hints_state_save_and_load() {
+        let temp_dir = tempdir().unwrap();
+        let path = temp_dir.path().join("hints.json");
+
+        let mut state = HintsState::default();
+        state.mark_shown("test-hint");
+        state.save_to(&path).unwrap();
+
+        let loaded = HintsState::load_from(&path).unwrap();
+        assert!(loaded.has_shown("test-hint"));
+    }
+
+    #[test]
+    fn test_hints_state_load_missing_file() {
+        let temp_dir = tempdir().unwrap();
+        let path = temp_dir.path().join("nonexistent.json");
+
+        let state = HintsState::load_from(&path).unwrap();
+        assert!(state.shown.is_empty());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ pub fn output_cd_path(path: &Path) {
 
 pub mod config;
 pub mod git;
+pub mod hints;
 pub mod hooks;
 pub mod logging;
 pub mod multi_remote;


### PR DESCRIPTION
## Summary

- Adds a one-time hint system that notifies users about shell integration when they run worktree commands without the shell wrapper active
- Hint is shown after successful worktree creation (clone, init, checkout, checkout-branch)
- Tracks which hints have been shown in `~/.config/daft/hints.json`
- Can be suppressed via `DAFT_NO_HINTS=1` environment variable

## Problem

After installing daft from Homebrew, users may miss the shell integration setup instructions. Without shell integration, commands like `git worktree-checkout-branch` work but don't auto-cd into the new worktree - leaving users in their original directory wondering why.

## Solution

After successful worktree operations, if the shell wrapper isn't active (`DAFT_SHELL_WRAPPER` env var not set), show a helpful one-time hint:

```
hint: Enable shell integration to auto-cd into new worktrees:
  eval "$(daft shell-init bash)"   # Add to ~/.bashrc or ~/.zshrc
  daft shell-init fish | source    # Add to ~/.config/fish/config.fish
Run 'daft shell-init --help' for more options.
To suppress hints: export DAFT_NO_HINTS=1
```

## Test plan

- [x] Unit tests for hint state management (save/load/mark shown)
- [x] All existing tests pass
- [x] Clippy passes with no warnings
- [x] Code is properly formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)