### PR TITLE
ci: remove redundant push trigger from test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,6 @@
 name: Test Git Worktree Workflow
 
 on:
-  push:
-    branches: [ main, master ]
-    paths-ignore:
-      - '*.md'
-      - 'docs/**'
   pull_request:
     branches: [ main, master ]
     paths-ignore:


### PR DESCRIPTION
## Summary

- Remove `push` trigger from test.yml workflow
- Tests already run on PRs and block merging until they pass
- Running again on push to master is redundant

## Test plan

- [x] Verify workflow still triggers on pull requests (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)