### PR TITLE
fix: include man pages in binary distribution archives

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -5,6 +5,8 @@ members = ["cargo:."]
 [dist]
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
 cargo-dist-version = "0.30.0"
+# Include man pages in distribution archives
+include = ["./man/"]
 # CI backends to support
 ci = "github"
 # The installers to generate for each app

--- a/man/daft-release-notes.1
+++ b/man/daft-release-notes.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH daft-release-notes 1  "daft-release-notes 1.0.11" 
+.TH daft-release-notes 1  "daft-release-notes 1.0.12" 
 .SH NAME
 daft\-release\-notes \- Display release notes from the changelog
 .SH SYNOPSIS
@@ -40,4 +40,4 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 [\fIVERSION\fR]
 Show notes for a specific version (e.g., "1.0.5" or "v1.0.5")
 .SH VERSION
-v1.0.11
+v1.0.12

--- a/man/git-worktree-carry.1
+++ b/man/git-worktree-carry.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-carry 1  "git-worktree-carry 1.0.11" 
+.TH git-worktree-carry 1  "git-worktree-carry 1.0.12" 
 .SH NAME
 git\-worktree\-carry \- Transfer uncommitted changes to other worktrees
 .SH SYNOPSIS
@@ -38,4 +38,4 @@ Print version
 <\fITARGETS\fR>
 Target worktree(s) by directory name or branch name
 .SH VERSION
-v1.0.11
+v1.0.12

--- a/man/git-worktree-checkout-branch-from-default.1
+++ b/man/git-worktree-checkout-branch-from-default.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-checkout-branch-from-default 1  "git-worktree-checkout-branch-from-default 1.0.11" 
+.TH git-worktree-checkout-branch-from-default 1  "git-worktree-checkout-branch-from-default 1.0.12" 
 .SH NAME
 git\-worktree\-checkout\-branch\-from\-default \- Create a worktree with a new branch based on the remote\*(Aqs default branch
 .SH SYNOPSIS
@@ -41,4 +41,4 @@ Print version
 <\fINEW_BRANCH_NAME\fR>
 Name for the new branch (also used as the worktree directory name)
 .SH VERSION
-v1.0.11
+v1.0.12

--- a/man/git-worktree-checkout-branch.1
+++ b/man/git-worktree-checkout-branch.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-checkout-branch 1  "git-worktree-checkout-branch 1.0.11" 
+.TH git-worktree-checkout-branch 1  "git-worktree-checkout-branch 1.0.12" 
 .SH NAME
 git\-worktree\-checkout\-branch \- Create a worktree with a new branch
 .SH SYNOPSIS
@@ -48,4 +48,4 @@ Name for the new branch (also used as the worktree directory name)
 [\fIBASE_BRANCH_NAME\fR]
 Branch to use as the base for the new branch; defaults to the current branch
 .SH VERSION
-v1.0.11
+v1.0.12

--- a/man/git-worktree-checkout.1
+++ b/man/git-worktree-checkout.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-checkout 1  "git-worktree-checkout 1.0.11" 
+.TH git-worktree-checkout 1  "git-worktree-checkout 1.0.12" 
 .SH NAME
 git\-worktree\-checkout \- Create a worktree for an existing branch
 .SH SYNOPSIS
@@ -44,4 +44,4 @@ Print version
 <\fIBRANCH_NAME\fR>
 Name of the branch to check out
 .SH VERSION
-v1.0.11
+v1.0.12

--- a/man/git-worktree-clone.1
+++ b/man/git-worktree-clone.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-clone 1  "git-worktree-clone 1.0.11" 
+.TH git-worktree-clone 1  "git-worktree-clone 1.0.12" 
 .SH NAME
 git\-worktree\-clone \- Clone a repository into a worktree\-based directory structure
 .SH SYNOPSIS
@@ -55,4 +55,4 @@ Print version
 <\fIREPOSITORY_URL\fR>
 The repository URL to clone (HTTPS or SSH)
 .SH VERSION
-v1.0.11
+v1.0.12

--- a/man/git-worktree-fetch.1
+++ b/man/git-worktree-fetch.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-fetch 1  "git-worktree-fetch 1.0.11" 
+.TH git-worktree-fetch 1  "git-worktree-fetch 1.0.12" 
 .SH NAME
 git\-worktree\-fetch \- Update worktree branches from their remote tracking branches
 .SH SYNOPSIS
@@ -62,4 +62,4 @@ Target worktree(s) by directory name or branch name
 [\fIPULL_ARGS\fR]
 Additional arguments to pass to git pull
 .SH VERSION
-v1.0.11
+v1.0.12

--- a/man/git-worktree-flow-adopt.1
+++ b/man/git-worktree-flow-adopt.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-flow-adopt 1  "git-worktree-flow-adopt 1.0.11" 
+.TH git-worktree-flow-adopt 1  "git-worktree-flow-adopt 1.0.12" 
 .SH NAME
 git\-worktree\-flow\-adopt \- Convert a traditional repository to worktree\-based layout
 .SH SYNOPSIS
@@ -92,4 +92,4 @@ Print version
 [\fIREPOSITORY_PATH\fR]
 Path to the repository to convert (defaults to current directory)
 .SH VERSION
-v1.0.11
+v1.0.12

--- a/man/git-worktree-flow-eject.1
+++ b/man/git-worktree-flow-eject.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-flow-eject 1  "git-worktree-flow-eject 1.0.11" 
+.TH git-worktree-flow-eject 1  "git-worktree-flow-eject 1.0.12" 
 .SH NAME
 git\-worktree\-flow\-eject \- Convert a worktree\-based repository back to traditional layout
 .SH SYNOPSIS
@@ -67,4 +67,4 @@ Print version
 [\fIREPOSITORY_PATH\fR]
 Path to the repository to convert (defaults to current directory)
 .SH VERSION
-v1.0.11
+v1.0.12

--- a/man/git-worktree-init.1
+++ b/man/git-worktree-init.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-init 1  "git-worktree-init 1.0.11" 
+.TH git-worktree-init 1  "git-worktree-init 1.0.12" 
 .SH NAME
 git\-worktree\-init \- Initialize a new repository in the worktree\-based directory structure
 .SH SYNOPSIS
@@ -48,4 +48,4 @@ Print version
 <\fIREPOSITORY_NAME\fR>
 Name for the new repository directory
 .SH VERSION
-v1.0.11
+v1.0.12

--- a/man/git-worktree-prune.1
+++ b/man/git-worktree-prune.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-prune 1  "git-worktree-prune 1.0.11" 
+.TH git-worktree-prune 1  "git-worktree-prune 1.0.12" 
 .SH NAME
 git\-worktree\-prune \- Remove worktrees and branches for deleted remote branches
 .SH SYNOPSIS
@@ -29,4 +29,4 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 \fB\-V\fR, \fB\-\-version\fR
 Print version
 .SH VERSION
-v1.0.11
+v1.0.12


### PR DESCRIPTION
## Summary

- Adds `include = ["./man/"]` to cargo-dist configuration to include pre-generated man pages in binary tarballs

## Problem

The test-homebrew workflow failed after v1.0.12 release because man pages were missing from the Homebrew installation. 

**Root cause:** cargo-dist's binary tarballs only include the compiled binary and basic docs (README, LICENSE, CHANGELOG) by default. The Homebrew formula expected man pages at `buildpath/"man/*.1"` but that directory didn't exist in the downloaded archive.

## Solution

The cargo-dist `include` directive specifies additional files/directories to bundle in distribution archives. Adding `include = ["./man/"]` ensures the pre-generated man pages are included in all binary tarballs.

## Verification

Locally verified with `cargo dist build --artifacts=local --target=aarch64-apple-darwin`:

```
$ tar -tJf target/distrib/daft-aarch64-apple-darwin.tar.xz
daft-aarch64-apple-darwin/
daft-aarch64-apple-darwin/daft
daft-aarch64-apple-darwin/README.md
daft-aarch64-apple-darwin/CHANGELOG.md
daft-aarch64-apple-darwin/LICENSE
daft-aarch64-apple-darwin/man
daft-aarch64-apple-darwin/man/git-worktree-checkout.1
daft-aarch64-apple-darwin/man/git-worktree-flow-adopt.1
daft-aarch64-apple-darwin/man/git-worktree-clone.1
... (all 11 man pages)
```

## Test plan

- [x] Verify locally that man pages are included in tarball
- [ ] CI passes (unit tests, integration tests, homebrew-simulation)
- [ ] After merge → release → verify test-homebrew workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)