### PR TITLE
fix: install man pages before pkgshare.install in Homebrew formula

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -308,24 +308,34 @@ jobs:
           pattern: artifacts-*
           path: Formula/
           merge-multiple: true
-      # Add man page generation to install block and caveats to the formula
+      # Add man page installation and caveats to the formula
       # cargo-dist doesn't support these natively
-      # IMPORTANT: Man pages must be generated in `install`, not `post_install`,
+      # IMPORTANT: Man pages must be installed in `install`, not `post_install`,
       # because Homebrew only symlinks files created during `install`
       - name: Add man pages and caveats to formula
         run: |
           FORMULA_FILE="Formula/daft.rb"
           if [ -f "$FORMULA_FILE" ]; then
-            # Insert pre-generated man page installation before the end of the install method
-            # Use awk to insert after the pkgshare.install line
-            awk '/pkgshare\.install.*unless leftover_contents\.empty\?/ {
-              print
+            # Fix the formula to:
+            # 1. Exclude "man" from leftover_contents (so it doesn't get moved to pkgshare)
+            # 2. Install man pages BEFORE pkgshare.install
+            awk '
+            /leftover_contents = Dir\["\*"\] - doc_files/ {
+              # Replace the line to also exclude the man directory
+              print "    leftover_contents = Dir[\"*\"] - doc_files - [\"man\"]"
+              next
+            }
+            /pkgshare\.install.*unless leftover_contents\.empty\?/ {
+              # Insert man page installation BEFORE pkgshare.install
               print ""
               print "    # Install pre-generated man pages"
               print "    man1.install Dir[buildpath/\"man/*.1\"]"
+              print ""
+              print $0
               next
             }
-            { print }' "$FORMULA_FILE" > "${FORMULA_FILE}.tmp" && mv "${FORMULA_FILE}.tmp" "$FORMULA_FILE"
+            { print }
+            ' "$FORMULA_FILE" > "${FORMULA_FILE}.tmp" && mv "${FORMULA_FILE}.tmp" "$FORMULA_FILE"
 
             # Remove the final 'end' and append caveats + end
             sed -i '$ d' "$FORMULA_FILE"

--- a/man/daft-release-notes.1
+++ b/man/daft-release-notes.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH daft-release-notes 1  "daft-release-notes 1.0.12" 
+.TH daft-release-notes 1  "daft-release-notes 1.0.13" 
 .SH NAME
 daft\-release\-notes \- Display release notes from the changelog
 .SH SYNOPSIS
@@ -40,4 +40,4 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 [\fIVERSION\fR]
 Show notes for a specific version (e.g., "1.0.5" or "v1.0.5")
 .SH VERSION
-v1.0.12
+v1.0.13

--- a/man/git-worktree-carry.1
+++ b/man/git-worktree-carry.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-carry 1  "git-worktree-carry 1.0.12" 
+.TH git-worktree-carry 1  "git-worktree-carry 1.0.13" 
 .SH NAME
 git\-worktree\-carry \- Transfer uncommitted changes to other worktrees
 .SH SYNOPSIS
@@ -38,4 +38,4 @@ Print version
 <\fITARGETS\fR>
 Target worktree(s) by directory name or branch name
 .SH VERSION
-v1.0.12
+v1.0.13

--- a/man/git-worktree-checkout-branch-from-default.1
+++ b/man/git-worktree-checkout-branch-from-default.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-checkout-branch-from-default 1  "git-worktree-checkout-branch-from-default 1.0.12" 
+.TH git-worktree-checkout-branch-from-default 1  "git-worktree-checkout-branch-from-default 1.0.13" 
 .SH NAME
 git\-worktree\-checkout\-branch\-from\-default \- Create a worktree with a new branch based on the remote\*(Aqs default branch
 .SH SYNOPSIS
@@ -41,4 +41,4 @@ Print version
 <\fINEW_BRANCH_NAME\fR>
 Name for the new branch (also used as the worktree directory name)
 .SH VERSION
-v1.0.12
+v1.0.13

--- a/man/git-worktree-checkout-branch.1
+++ b/man/git-worktree-checkout-branch.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-checkout-branch 1  "git-worktree-checkout-branch 1.0.12" 
+.TH git-worktree-checkout-branch 1  "git-worktree-checkout-branch 1.0.13" 
 .SH NAME
 git\-worktree\-checkout\-branch \- Create a worktree with a new branch
 .SH SYNOPSIS
@@ -48,4 +48,4 @@ Name for the new branch (also used as the worktree directory name)
 [\fIBASE_BRANCH_NAME\fR]
 Branch to use as the base for the new branch; defaults to the current branch
 .SH VERSION
-v1.0.12
+v1.0.13

--- a/man/git-worktree-checkout.1
+++ b/man/git-worktree-checkout.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-checkout 1  "git-worktree-checkout 1.0.12" 
+.TH git-worktree-checkout 1  "git-worktree-checkout 1.0.13" 
 .SH NAME
 git\-worktree\-checkout \- Create a worktree for an existing branch
 .SH SYNOPSIS
@@ -44,4 +44,4 @@ Print version
 <\fIBRANCH_NAME\fR>
 Name of the branch to check out
 .SH VERSION
-v1.0.12
+v1.0.13

--- a/man/git-worktree-clone.1
+++ b/man/git-worktree-clone.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-clone 1  "git-worktree-clone 1.0.12" 
+.TH git-worktree-clone 1  "git-worktree-clone 1.0.13" 
 .SH NAME
 git\-worktree\-clone \- Clone a repository into a worktree\-based directory structure
 .SH SYNOPSIS
@@ -55,4 +55,4 @@ Print version
 <\fIREPOSITORY_URL\fR>
 The repository URL to clone (HTTPS or SSH)
 .SH VERSION
-v1.0.12
+v1.0.13

--- a/man/git-worktree-fetch.1
+++ b/man/git-worktree-fetch.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-fetch 1  "git-worktree-fetch 1.0.12" 
+.TH git-worktree-fetch 1  "git-worktree-fetch 1.0.13" 
 .SH NAME
 git\-worktree\-fetch \- Update worktree branches from their remote tracking branches
 .SH SYNOPSIS
@@ -62,4 +62,4 @@ Target worktree(s) by directory name or branch name
 [\fIPULL_ARGS\fR]
 Additional arguments to pass to git pull
 .SH VERSION
-v1.0.12
+v1.0.13

--- a/man/git-worktree-flow-adopt.1
+++ b/man/git-worktree-flow-adopt.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-flow-adopt 1  "git-worktree-flow-adopt 1.0.12" 
+.TH git-worktree-flow-adopt 1  "git-worktree-flow-adopt 1.0.13" 
 .SH NAME
 git\-worktree\-flow\-adopt \- Convert a traditional repository to worktree\-based layout
 .SH SYNOPSIS
@@ -92,4 +92,4 @@ Print version
 [\fIREPOSITORY_PATH\fR]
 Path to the repository to convert (defaults to current directory)
 .SH VERSION
-v1.0.12
+v1.0.13

--- a/man/git-worktree-flow-eject.1
+++ b/man/git-worktree-flow-eject.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-flow-eject 1  "git-worktree-flow-eject 1.0.12" 
+.TH git-worktree-flow-eject 1  "git-worktree-flow-eject 1.0.13" 
 .SH NAME
 git\-worktree\-flow\-eject \- Convert a worktree\-based repository back to traditional layout
 .SH SYNOPSIS
@@ -67,4 +67,4 @@ Print version
 [\fIREPOSITORY_PATH\fR]
 Path to the repository to convert (defaults to current directory)
 .SH VERSION
-v1.0.12
+v1.0.13

--- a/man/git-worktree-init.1
+++ b/man/git-worktree-init.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-init 1  "git-worktree-init 1.0.12" 
+.TH git-worktree-init 1  "git-worktree-init 1.0.13" 
 .SH NAME
 git\-worktree\-init \- Initialize a new repository in the worktree\-based directory structure
 .SH SYNOPSIS
@@ -48,4 +48,4 @@ Print version
 <\fIREPOSITORY_NAME\fR>
 Name for the new repository directory
 .SH VERSION
-v1.0.12
+v1.0.13

--- a/man/git-worktree-prune.1
+++ b/man/git-worktree-prune.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-prune 1  "git-worktree-prune 1.0.12" 
+.TH git-worktree-prune 1  "git-worktree-prune 1.0.13" 
 .SH NAME
 git\-worktree\-prune \- Remove worktrees and branches for deleted remote branches
 .SH SYNOPSIS
@@ -29,4 +29,4 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 \fB\-V\fR, \fB\-\-version\fR
 Print version
 .SH VERSION
-v1.0.12
+v1.0.13


### PR DESCRIPTION
## Summary

- Fixes the order of man page installation in the Homebrew formula modification

## Problem

After v1.0.13 was released with man pages included in the binary tarballs, the test-homebrew workflow still failed because man pages weren't being installed properly.

**Root cause:** The awk command in release.yml inserted `man1.install Dir[buildpath/"man/*.1"]` AFTER `pkgshare.install(*leftover_contents)`. But `leftover_contents` included the `man` directory, which got moved to pkgshare **before** `man1.install` could access it.

## Solution

Updated the awk command to:
1. Exclude "man" from `leftover_contents` so it doesn't get moved to pkgshare
2. Insert man page installation **BEFORE** `pkgshare.install` runs

### Before (broken):
```ruby
leftover_contents = Dir["*"] - doc_files
pkgshare.install(*leftover_contents) unless leftover_contents.empty?

# Install pre-generated man pages
man1.install Dir[buildpath/"man/*.1"]  # TOO LATE - man/ already moved!
```

### After (fixed):
```ruby
leftover_contents = Dir["*"] - doc_files - ["man"]

# Install pre-generated man pages
man1.install Dir[buildpath/"man/*.1"]  # man/ still exists here

pkgshare.install(*leftover_contents) unless leftover_contents.empty?
```

## Test plan

- [x] Verified awk command produces correct output locally
- [ ] CI passes
- [ ] After release → test-homebrew passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)