### PR TITLE
fix: sync man page versions with release workflow

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -63,8 +63,47 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Run release-plz release-pr
+        id: release-plz
         uses: release-plz/action@v0.5
         with:
           command: release-pr
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      # Regenerate man pages to match the new version in Cargo.toml
+      - name: Update man pages in release PR
+        if: steps.release-plz.outputs.prs_created == 'true'
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          # Get the release PR branch name
+          PR_BRANCH=$(gh pr list --label release --json headRefName --jq '.[0].headRefName')
+          if [ -z "$PR_BRANCH" ]; then
+            echo "No release PR found, skipping man page update"
+            exit 0
+          fi
+
+          echo "Found release PR branch: $PR_BRANCH"
+
+          # Configure git
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Checkout the release PR branch
+          git fetch origin "$PR_BRANCH"
+          git checkout "$PR_BRANCH"
+
+          # Regenerate man pages with new version
+          cargo run --package xtask -- gen-man --output-dir=man
+
+          # Check if man pages changed
+          if git diff --quiet man/; then
+            echo "Man pages are already up to date"
+            exit 0
+          fi
+
+          # Commit and push the updated man pages
+          git add man/
+          git commit -m "chore: regenerate man pages for new version"
+          git push origin "$PR_BRANCH"
+          echo "Man pages updated in release PR"

--- a/man/daft-release-notes.1
+++ b/man/daft-release-notes.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH daft-release-notes 1  "daft-release-notes 1.0.13" 
+.TH daft-release-notes 1  "daft-release-notes 1.0.14" 
 .SH NAME
 daft\-release\-notes \- Display release notes from the changelog
 .SH SYNOPSIS
@@ -40,4 +40,4 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 [\fIVERSION\fR]
 Show notes for a specific version (e.g., "1.0.5" or "v1.0.5")
 .SH VERSION
-v1.0.13
+v1.0.14

--- a/man/git-worktree-carry.1
+++ b/man/git-worktree-carry.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-carry 1  "git-worktree-carry 1.0.13" 
+.TH git-worktree-carry 1  "git-worktree-carry 1.0.14" 
 .SH NAME
 git\-worktree\-carry \- Transfer uncommitted changes to other worktrees
 .SH SYNOPSIS
@@ -38,4 +38,4 @@ Print version
 <\fITARGETS\fR>
 Target worktree(s) by directory name or branch name
 .SH VERSION
-v1.0.13
+v1.0.14

--- a/man/git-worktree-checkout-branch-from-default.1
+++ b/man/git-worktree-checkout-branch-from-default.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-checkout-branch-from-default 1  "git-worktree-checkout-branch-from-default 1.0.13" 
+.TH git-worktree-checkout-branch-from-default 1  "git-worktree-checkout-branch-from-default 1.0.14" 
 .SH NAME
 git\-worktree\-checkout\-branch\-from\-default \- Create a worktree with a new branch based on the remote\*(Aqs default branch
 .SH SYNOPSIS
@@ -41,4 +41,4 @@ Print version
 <\fINEW_BRANCH_NAME\fR>
 Name for the new branch (also used as the worktree directory name)
 .SH VERSION
-v1.0.13
+v1.0.14

--- a/man/git-worktree-checkout-branch.1
+++ b/man/git-worktree-checkout-branch.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-checkout-branch 1  "git-worktree-checkout-branch 1.0.13" 
+.TH git-worktree-checkout-branch 1  "git-worktree-checkout-branch 1.0.14" 
 .SH NAME
 git\-worktree\-checkout\-branch \- Create a worktree with a new branch
 .SH SYNOPSIS
@@ -48,4 +48,4 @@ Name for the new branch (also used as the worktree directory name)
 [\fIBASE_BRANCH_NAME\fR]
 Branch to use as the base for the new branch; defaults to the current branch
 .SH VERSION
-v1.0.13
+v1.0.14

--- a/man/git-worktree-checkout.1
+++ b/man/git-worktree-checkout.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-checkout 1  "git-worktree-checkout 1.0.13" 
+.TH git-worktree-checkout 1  "git-worktree-checkout 1.0.14" 
 .SH NAME
 git\-worktree\-checkout \- Create a worktree for an existing branch
 .SH SYNOPSIS
@@ -44,4 +44,4 @@ Print version
 <\fIBRANCH_NAME\fR>
 Name of the branch to check out
 .SH VERSION
-v1.0.13
+v1.0.14

--- a/man/git-worktree-clone.1
+++ b/man/git-worktree-clone.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-clone 1  "git-worktree-clone 1.0.13" 
+.TH git-worktree-clone 1  "git-worktree-clone 1.0.14" 
 .SH NAME
 git\-worktree\-clone \- Clone a repository into a worktree\-based directory structure
 .SH SYNOPSIS
@@ -55,4 +55,4 @@ Print version
 <\fIREPOSITORY_URL\fR>
 The repository URL to clone (HTTPS or SSH)
 .SH VERSION
-v1.0.13
+v1.0.14

--- a/man/git-worktree-fetch.1
+++ b/man/git-worktree-fetch.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-fetch 1  "git-worktree-fetch 1.0.13" 
+.TH git-worktree-fetch 1  "git-worktree-fetch 1.0.14" 
 .SH NAME
 git\-worktree\-fetch \- Update worktree branches from their remote tracking branches
 .SH SYNOPSIS
@@ -62,4 +62,4 @@ Target worktree(s) by directory name or branch name
 [\fIPULL_ARGS\fR]
 Additional arguments to pass to git pull
 .SH VERSION
-v1.0.13
+v1.0.14

--- a/man/git-worktree-flow-adopt.1
+++ b/man/git-worktree-flow-adopt.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-flow-adopt 1  "git-worktree-flow-adopt 1.0.13" 
+.TH git-worktree-flow-adopt 1  "git-worktree-flow-adopt 1.0.14" 
 .SH NAME
 git\-worktree\-flow\-adopt \- Convert a traditional repository to worktree\-based layout
 .SH SYNOPSIS
@@ -92,4 +92,4 @@ Print version
 [\fIREPOSITORY_PATH\fR]
 Path to the repository to convert (defaults to current directory)
 .SH VERSION
-v1.0.13
+v1.0.14

--- a/man/git-worktree-flow-eject.1
+++ b/man/git-worktree-flow-eject.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-flow-eject 1  "git-worktree-flow-eject 1.0.13" 
+.TH git-worktree-flow-eject 1  "git-worktree-flow-eject 1.0.14" 
 .SH NAME
 git\-worktree\-flow\-eject \- Convert a worktree\-based repository back to traditional layout
 .SH SYNOPSIS
@@ -67,4 +67,4 @@ Print version
 [\fIREPOSITORY_PATH\fR]
 Path to the repository to convert (defaults to current directory)
 .SH VERSION
-v1.0.13
+v1.0.14

--- a/man/git-worktree-init.1
+++ b/man/git-worktree-init.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-init 1  "git-worktree-init 1.0.13" 
+.TH git-worktree-init 1  "git-worktree-init 1.0.14" 
 .SH NAME
 git\-worktree\-init \- Initialize a new repository in the worktree\-based directory structure
 .SH SYNOPSIS
@@ -48,4 +48,4 @@ Print version
 <\fIREPOSITORY_NAME\fR>
 Name for the new repository directory
 .SH VERSION
-v1.0.13
+v1.0.14

--- a/man/git-worktree-prune.1
+++ b/man/git-worktree-prune.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-prune 1  "git-worktree-prune 1.0.13" 
+.TH git-worktree-prune 1  "git-worktree-prune 1.0.14" 
 .SH NAME
 git\-worktree\-prune \- Remove worktrees and branches for deleted remote branches
 .SH SYNOPSIS
@@ -29,4 +29,4 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 \fB\-V\fR, \fB\-\-version\fR
 Print version
 .SH VERSION
-v1.0.13
+v1.0.14


### PR DESCRIPTION
## Summary
- Update man pages to show v1.0.14 (matching Cargo.toml)
- Add step in release-plz workflow to auto-regenerate man pages when creating release PRs

## Problem
After installing daft v1.0.14 via Homebrew, `man git-worktree-clone` showed version 1.0.13. This happened because:
1. PR #113 was created with Cargo.toml at v1.0.13
2. release-plz created PR #114 that bumped version to v1.0.14
3. But release-plz only updates Cargo.toml and CHANGELOG - not man pages
4. So v1.0.14 was released with man pages showing v1.0.13

## Solution
1. **Immediate fix**: Regenerate man pages to show v1.0.14
2. **Prevent future issues**: Add a step in the release-plz workflow that automatically regenerates man pages after creating/updating a release PR

The new workflow step:
- Runs after release-plz creates a PR
- Checks out the release PR branch
- Regenerates man pages with the new version
- Commits and pushes the updated man pages

## Test plan
- [ ] CI passes (verifies man pages are valid)
- [ ] After merge, verify next release PR includes regenerated man pages
- [ ] After next release, verify installed man pages show correct version

🤖 Generated with [Claude Code](https://claude.com/claude-code)