### PR TITLE
fix: add retry logic for release PR detection in man page update

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -76,10 +76,21 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          # Get the release PR branch name
-          PR_BRANCH=$(gh pr list --label release --json headRefName --jq '.[0].headRefName')
+          # Wait briefly for GitHub to propagate the PR and labels
+          sleep 5
+
+          # Get the release PR branch name with retry logic
+          for i in 1 2 3; do
+            PR_BRANCH=$(gh pr list --label release --json headRefName --jq '.[0].headRefName')
+            if [ -n "$PR_BRANCH" ]; then
+              break
+            fi
+            echo "Attempt $i: Release PR not found yet, waiting..."
+            sleep 5
+          done
+
           if [ -z "$PR_BRANCH" ]; then
-            echo "No release PR found, skipping man page update"
+            echo "No release PR found after retries, skipping man page update"
             exit 0
           fi
 


### PR DESCRIPTION
## Summary
Adds retry logic to the man page update step in the release-plz workflow to handle GitHub API propagation delays.

## Problem
In PR #115, we added a step to automatically regenerate man pages when release-plz creates a release PR. However, the step runs immediately after the PR is created, before GitHub has fully propagated the labels. This caused the `gh pr list --label release` command to return empty.

This resulted in PR #116 (v1.0.15) being created without the man page regeneration, requiring manual intervention.

## Solution
- Add initial 5 second delay to let GitHub propagate
- Add retry logic (3 attempts with 5 second delays)
- Better logging for debugging

## Test plan
- [ ] CI passes
- [ ] Next release PR should have man pages automatically regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)