### PR TITLE
refactor: unify git-daft and daft command routing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,9 @@ pub fn get_clap_args(expected_cmd: &str) -> Vec<String> {
             .and_then(|n| n.to_str())
             .unwrap_or("");
 
-        if program_name == "daft" && args[1].starts_with("worktree-") {
+        if (program_name == "daft" || program_name == "git-daft")
+            && args[1].starts_with("worktree-")
+        {
             // Reconstruct args with the expected command name
             let mut new_args = vec![expected_cmd.to_string()];
             new_args.extend(args.into_iter().skip(2));

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,8 +20,8 @@ fn main() -> Result<()> {
     // Resolve shortcut aliases to full command names
     let resolved = shortcuts::resolve(program_name);
 
-    // Handle --version/-V flag for the main daft command
-    if resolved == "daft" {
+    // Handle --version/-V flag for the main daft/git-daft command
+    if resolved == "daft" || resolved == "git-daft" {
         let args: Vec<String> = std::env::args().collect();
         if args.len() == 2 && (args[1] == "--version" || args[1] == "-V") {
             println!("daft {}", daft::VERSION);
@@ -45,27 +45,13 @@ fn main() -> Result<()> {
         "git-worktree-flow-adopt" => commands::flow_adopt::run(),
         "git-worktree-flow-eject" => commands::flow_eject::run(),
 
-        // Documentation command (via git-daft symlink or direct invocation)
-        "git-daft" => {
-            // Check for subcommands like `git daft hooks`
-            let args: Vec<String> = std::env::args().collect();
-            if args.len() > 1 {
-                match args[1].as_str() {
-                    "--help" | "-h" => commands::docs::run(),
-                    "hooks" => commands::hooks::run(),
-                    _ => daft::suggest::handle_unknown_subcommand(
-                        "git daft",
-                        args[1].as_str(),
-                        daft::suggest::GIT_DAFT_SUBCOMMANDS,
-                    ),
-                }
+        // Main daft / git-daft command - check for subcommands
+        "git-daft" | "daft" => {
+            let label = if resolved == "git-daft" {
+                "git daft"
             } else {
-                commands::docs::run()
-            }
-        }
-
-        // Main daft command - check for subcommands
-        "daft" => {
+                "daft"
+            };
             // Check if a subcommand was provided
             let args: Vec<String> = std::env::args().collect();
             if args.len() > 1 {
@@ -100,7 +86,7 @@ fn main() -> Result<()> {
                     "worktree-flow-adopt" => commands::flow_adopt::run(),
                     "worktree-flow-eject" => commands::flow_eject::run(),
                     _ => daft::suggest::handle_unknown_subcommand(
-                        "daft",
+                        label,
                         args[1].as_str(),
                         daft::suggest::DAFT_SUBCOMMANDS,
                     ),

--- a/src/suggest.rs
+++ b/src/suggest.rs
@@ -24,9 +24,6 @@ pub const DAFT_SUBCOMMANDS: &[&str] = &[
     "worktree-prune",
 ];
 
-/// Subcommands available via `git daft <subcmd>`.
-pub const GIT_DAFT_SUBCOMMANDS: &[&str] = &["hooks"];
-
 /// Compute Levenshtein edit distance between two strings.
 fn levenshtein_distance(a: &str, b: &str) -> usize {
     let a_len = a.len();
@@ -210,31 +207,10 @@ mod tests {
     }
 
     #[test]
-    fn test_git_daft_subcommands_sorted() {
-        let mut sorted = GIT_DAFT_SUBCOMMANDS.to_vec();
-        sorted.sort();
-        assert_eq!(
-            GIT_DAFT_SUBCOMMANDS,
-            &sorted[..],
-            "GIT_DAFT_SUBCOMMANDS should be in alphabetical order"
-        );
-    }
-
-    #[test]
     fn test_daft_subcommands_no_duplicates() {
         let mut seen = std::collections::HashSet::new();
         for cmd in DAFT_SUBCOMMANDS {
             assert!(seen.insert(cmd), "Duplicate subcommand: {cmd}");
-        }
-    }
-
-    #[test]
-    fn test_git_daft_subcommands_subset_of_daft() {
-        for cmd in GIT_DAFT_SUBCOMMANDS {
-            assert!(
-                DAFT_SUBCOMMANDS.contains(cmd),
-                "GIT_DAFT_SUBCOMMANDS entry '{cmd}' not found in DAFT_SUBCOMMANDS"
-            );
         }
     }
 }


### PR DESCRIPTION
## Summary
- Merges the separate `git-daft` and `daft` dispatch arms in `main.rs` into a single `"git-daft" | "daft"` match arm, so adding new subcommands only requires updating one place
- Updates `get_clap_args()` in `lib.rs` to handle `"git-daft"` as a program name, enabling `git daft worktree-checkout` and similar worktree subcommands
- Removes the now-unnecessary `GIT_DAFT_SUBCOMMANDS` constant and its associated tests from `suggest.rs`
- Extends the `--version` flag to work for both `daft --version` and `git daft --version`

Fixes #122

## Test plan
- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy -- -D warnings` passes with zero warnings
- [x] `just test-unit` passes (133 tests, 0 failures)
- [ ] Manual smoke test: `git daft hooks status`, `git daft --version`, `git daft completions --help`, `git daft unknown-cmd` (should suggest)
- [ ] Integration tests via CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)