### PR TITLE
feat: migrate Homebrew tap to avihut/homebrew-tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -284,7 +284,10 @@ jobs:
 
           gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
 
-  publish-homebrew-formula:
+  # DEPRECATED: Publishing to legacy homebrew-daft tap.
+  # This job will be removed once users have migrated to avihut/tap.
+  # To migrate: brew untap avihut/daft && brew install avihut/tap/daft
+  publish-homebrew-formula-legacy:
     needs:
       - plan
       - host
@@ -372,15 +375,107 @@ jobs:
           done
           git push
 
+  # WARNING: This job is manually maintained. Running `cargo dist generate` will
+  # overwrite it with the auto-generated version targeting only the tap in
+  # dist-workspace.toml. After regenerating, restore this job AND the legacy job above.
+  publish-homebrew-formula:
+    needs:
+      - plan
+      - host
+    runs-on: "ubuntu-22.04"
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PLAN: ${{ needs.plan.outputs.val }}
+      GITHUB_USER: "wheatley-the-moronic-ci-bot[bot]"
+      GITHUB_EMAIL: "wheatley-the-moronic-ci-bot[bot]@users.noreply.github.com"
+    if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: true
+          repository: "avihut/homebrew-tap"
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+      # So we have access to the formula
+      - name: Fetch homebrew formulae
+        uses: actions/download-artifact@v7
+        with:
+          pattern: artifacts-*
+          path: Formula/
+          merge-multiple: true
+      # Add man page installation and caveats to the formula
+      # cargo-dist doesn't support these natively
+      # IMPORTANT: Man pages must be installed in `install`, not `post_install`,
+      # because Homebrew only symlinks files created during `install`
+      - name: Add man pages and caveats to formula
+        run: |
+          FORMULA_FILE="Formula/daft.rb"
+          if [ -f "$FORMULA_FILE" ]; then
+            # Fix the formula to:
+            # 1. Exclude "man" from leftover_contents (so it doesn't get moved to pkgshare)
+            # 2. Install man pages BEFORE pkgshare.install
+            awk '
+            /leftover_contents = Dir\["\*"\] - doc_files/ {
+              # Replace the line to also exclude the man directory
+              print "    leftover_contents = Dir[\"*\"] - doc_files - [\"man\"]"
+              next
+            }
+            /pkgshare\.install.*unless leftover_contents\.empty\?/ {
+              # Insert man page installation BEFORE pkgshare.install
+              print ""
+              print "    # Install pre-generated man pages"
+              print "    man1.install Dir[buildpath/\"man/*.1\"]"
+              print ""
+              print $0
+              next
+            }
+            { print }
+            ' "$FORMULA_FILE" > "${FORMULA_FILE}.tmp" && mv "${FORMULA_FILE}.tmp" "$FORMULA_FILE"
+
+            # Remove the final 'end' and append caveats + end
+            sed -i '$ d' "$FORMULA_FILE"
+            # Append caveats method using printf to avoid heredoc YAML issues
+            printf '\n  def caveats\n    <<~EOS\n' >> "$FORMULA_FILE"
+            printf '      To complete setup (shell integration + shortcuts), run:\n' >> "$FORMULA_FILE"
+            printf '        daft setup\n\n' >> "$FORMULA_FILE"
+            printf '      This enables automatic cd into new worktrees and installs\n' >> "$FORMULA_FILE"
+            printf '      git-style shortcuts (gwtco, gwtcb, gwtcbm, etc.)\n\n' >> "$FORMULA_FILE"
+            printf '      For more information:\n' >> "$FORMULA_FILE"
+            printf '        daft --help\n' >> "$FORMULA_FILE"
+            printf '    EOS\n  end\nend\n' >> "$FORMULA_FILE"
+            echo "Added pre-generated man pages to install block and caveats to $FORMULA_FILE"
+          fi
+      # This is extra complex because you can make your Formula name not match your app name
+      # so we need to find releases with a *.rb file, and publish with that filename.
+      - name: Commit formula files
+        run: |
+          git config --global user.name "${GITHUB_USER}"
+          git config --global user.email "${GITHUB_EMAIL}"
+
+          for release in $(echo "$PLAN" | jq --compact-output '.releases[] | select([.artifacts[] | endswith(".rb")] | any)'); do
+            filename=$(echo "$release" | jq '.artifacts[] | select(endswith(".rb"))' --raw-output)
+            name=$(echo "$filename" | sed "s/\.rb$//")
+            version=$(echo "$release" | jq .app_version --raw-output)
+
+            export PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"
+            brew update
+            # We avoid reformatting user-provided data such as the app description and homepage.
+            brew style --except-cops FormulaAudit/Homepage,FormulaAudit/Desc,FormulaAuditStrict --fix "Formula/${filename}" || true
+
+            git add "Formula/${filename}"
+            git commit -m "${name} ${version}"
+          done
+          git push
+
   announce:
     needs:
       - plan
       - host
       - publish-homebrew-formula
+      - publish-homebrew-formula-legacy
     # use "always() && ..." to allow us to wait for all publish jobs while
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
-    if: ${{ always() && needs.host.result == 'success' && (needs.publish-homebrew-formula.result == 'skipped' || needs.publish-homebrew-formula.result == 'success') }}
+    if: ${{ always() && needs.host.result == 'success' && (needs.publish-homebrew-formula.result == 'skipped' || needs.publish-homebrew-formula.result == 'success') && (needs.publish-homebrew-formula-legacy.result == 'skipped' || needs.publish-homebrew-formula-legacy.result == 'success') }}
     runs-on: "ubuntu-22.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-homebrew.yml
+++ b/.github/workflows/test-homebrew.yml
@@ -1,9 +1,9 @@
 name: Test Homebrew Installation
 
 on:
-  # Triggered by homebrew-daft repo when formula is updated
+  # Triggered by homebrew-tap repo when formula is updated
   repository_dispatch:
-    types: [homebrew-formula-updated]
+    types: [homebrew-tap-formula-updated]
   # Allow manual triggering for testing
   workflow_dispatch:
     inputs:
@@ -35,8 +35,8 @@ jobs:
           echo "Installing daft (expecting version $EXPECTED)..."
 
           # Tap and install
-          brew tap avihut/daft
-          brew install avihut/daft/daft
+          brew tap avihut/tap
+          brew install avihut/tap/daft
 
           # Verify correct version was installed
           INSTALLED=$(daft --version | awk '{print $2}')

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -525,7 +525,7 @@ Runs on every PR to catch installation issues early:
 
 #### 2. Real Homebrew Installation (`test-homebrew.yml`)
 Runs after successful releases via `workflow_run` trigger:
-- Installs via `brew tap avihut/daft && brew install avihut/daft/daft`
+- Installs via `brew tap avihut/tap && brew install avihut/tap/daft`
 - Includes retry logic for tap propagation delays
 - Verifies all commands are in PATH
 - Verifies man pages are installed

--- a/HOMEBREW.md
+++ b/HOMEBREW.md
@@ -284,14 +284,12 @@ After the formula is in place, users can install with:
 
 ```bash
 # Install from tap
-brew install avihut/daft
+brew install avihut/tap/daft
 
 # Or tap first, then install
-brew tap avihut/daft
+brew tap avihut/tap
 brew install daft
 ```
-
-The tap name matches the repository name, so the short form `brew install avihut/daft` works without explicitly tapping.
 
 ## Man Pages
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Release](https://img.shields.io/github/v/release/avihut/daft?label=release)](https://github.com/avihut/daft/releases/latest)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Rust](https://img.shields.io/badge/rust-1.70%2B-orange.svg)](https://www.rust-lang.org/)
-[![Homebrew](https://img.shields.io/badge/homebrew-avihut%2Fdaft-blueviolet)](https://github.com/avihut/homebrew-daft)
+[![Homebrew](https://img.shields.io/badge/homebrew-avihut%2Ftap-blueviolet)](https://github.com/avihut/homebrew-tap)
 [![macOS](https://img.shields.io/badge/macOS-supported-success)](https://github.com/avihut/daft/releases)
 [![Linux](https://img.shields.io/badge/Linux-supported-success)](https://github.com/avihut/daft/releases)
 [![Windows](https://img.shields.io/badge/Windows-supported%20(WSL)-success)](https://github.com/avihut/daft/releases)
@@ -29,7 +29,7 @@ my-project/
 
 ```bash
 # Install (macOS)
-brew install avihut/daft/daft
+brew install avihut/tap/daft
 
 # Clone a repo (creates my-project/main/)
 git worktree-clone git@github.com:user/my-project.git
@@ -97,7 +97,7 @@ Terminal 1 (feature-a/)     Terminal 2 (feature-b/)
 ### macOS (Homebrew)
 
 ```bash
-brew install avihut/daft/daft
+brew install avihut/tap/daft
 ```
 
 ### Windows

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -168,7 +168,7 @@ After release, verify installations work:
 
 ```bash
 # Install from Homebrew
-brew install avihut/daft
+brew install avihut/tap/daft
 
 # Verify all commands
 daft --version
@@ -213,14 +213,14 @@ git-worktree-clone --help
 1. Verify GitHub secret is set: Settings → Secrets → Actions → `HOMEBREW_TAP_TOKEN`
 2. Check `dist-workspace.toml`:
    ```toml
-   tap = "avihut/daft"
+   tap = "avihut/homebrew-tap"
    formula = "Formula/daft.rb"
    ```
 3. Review publish-homebrew-formula job logs
 
 ### Installation Fails
 
-**Symptoms:** `brew install avihut/daft` fails with checksum mismatch
+**Symptoms:** `brew install avihut/tap/daft` fails with checksum mismatch
 
 **Cause:** Checksums in formula don't match downloaded artifacts
 

--- a/SETUP_RELEASE.md
+++ b/SETUP_RELEASE.md
@@ -116,7 +116,7 @@ installers = ["homebrew", "powershell", "msi"]
 targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-pc-windows-msvc"]
 pr-run-mode = "plan"
 publish-jobs = ["homebrew"]
-tap = "avihut/daft"
+tap = "avihut/homebrew-tap"
 formula = "Formula/daft.rb"
 ```
 
@@ -331,7 +331,7 @@ Test the complete installation workflow.
 
 ```bash
 # Install from Homebrew
-brew install avihut/daft
+brew install avihut/tap/daft
 
 # Verify version
 daft --version
@@ -415,7 +415,7 @@ The Homebrew formula symlinks will persist automatically!
 **Fix:**
 1. Verify `dist-workspace.toml`:
    ```toml
-   tap = "avihut/daft"
+   tap = "avihut/homebrew-tap"
    formula = "Formula/daft.rb"
    ```
 2. Check token permissions
@@ -424,7 +424,7 @@ The Homebrew formula symlinks will persist automatically!
 ### Installation Fails
 
 **Symptoms:**
-- `brew install avihut/daft` fails
+- `brew install avihut/tap/daft` fails
 - Checksum mismatch error
 
 **Fix:**
@@ -478,7 +478,7 @@ install-path = "~/bin"  # Or other path
 After completing this setup:
 - ✅ Releases are fully automated
 - ✅ Push a tag → binaries built → Homebrew formula updated → Release created
-- ✅ Users can install with `brew install avihut/daft` (macOS)
+- ✅ Users can install with `brew install avihut/tap/daft` (macOS)
 - ✅ Users can install with PowerShell script (Windows)
 - ✅ Zero manual intervention required for releases
 

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -18,7 +18,7 @@ pr-run-mode = "plan"
 # Publish jobs to run in CI
 publish-jobs = ["homebrew"]
 # A GitHub repo to push Homebrew formulas to
-tap = "avihut/homebrew-daft"
+tap = "avihut/homebrew-tap"
 # Skip checking whether the specified configuration files are up to date
 allow-dirty = ["ci"]
 # Path that installers should place binaries in


### PR DESCRIPTION
## Summary
- Migrates Homebrew formula publishing from `avihut/homebrew-daft` to `avihut/homebrew-tap` (a general-purpose tap)
- Dual-publishes to both taps during transition: legacy job kept as `publish-homebrew-formula-legacy`
- Updates `test-homebrew.yml` to trigger from the new tap's `homebrew-tap-formula-updated` dispatch event
- Updates all documentation (`README.md`, `CLAUDE.md`, `HOMEBREW.md`, `RELEASING.md`, `SETUP_RELEASE.md`) with new install commands (`brew install avihut/tap/daft`)

## Context
The old `avihut/homebrew-daft` tap only served `daft`. The new `avihut/homebrew-tap` is a general-purpose tap that can host multiple formulae. Users should migrate with:
```
brew untap avihut/daft && brew install avihut/tap/daft
```

## Test plan
- [ ] Verify `release.yml` YAML is valid (CI plan job runs)
- [ ] Verify `test-homebrew.yml` dispatches correctly from new tap
- [ ] Confirm dual-publish: both taps receive formula on next release
- [ ] Confirm `brew install avihut/tap/daft` works after next release

Fixes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)