### PR TITLE
fix: display full branch path for worktrees with slashes

### DIFF
--- a/src/commands/carry.rs
+++ b/src/commands/carry.rs
@@ -136,8 +136,9 @@ fn run_carry(args: &Args, settings: &DaftSettings, output: &mut dyn Output) -> R
     // Apply to each target
     for target_path in &resolved_targets {
         let target_name = target_path
-            .file_name()
-            .and_then(|n| n.to_str())
+            .strip_prefix(&project_root)
+            .ok()
+            .and_then(|p| p.to_str())
             .unwrap_or("unknown");
 
         println!("--> Applying changes to '{}'...", target_name);

--- a/src/commands/fetch.rs
+++ b/src/commands/fetch.rs
@@ -134,8 +134,9 @@ fn run_fetch(args: &Args, settings: &DaftSettings) -> Result<()> {
 
     for target_path in &targets {
         let worktree_name = target_path
-            .file_name()
-            .and_then(|n| n.to_str())
+            .strip_prefix(&project_root)
+            .ok()
+            .and_then(|p| p.to_str())
             .unwrap_or("unknown")
             .to_string();
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -696,12 +696,11 @@ impl GitCommand {
             worktrees.push((path, current_branch.take()));
         }
 
-        // First, check if target matches a worktree name (directory name)
+        // First, check if target is a path relative to project root (most precise)
+        let potential_path = project_root.join(target);
         for (path, _) in &worktrees {
-            if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-                if name == target {
-                    return Ok(path.clone());
-                }
+            if path == &potential_path {
+                return Ok(path.clone());
             }
         }
 
@@ -714,11 +713,12 @@ impl GitCommand {
             }
         }
 
-        // Third, check if target is a path relative to project root
-        let potential_path = project_root.join(target);
+        // Third, check if target matches a worktree directory name (convenience shorthand)
         for (path, _) in &worktrees {
-            if path == &potential_path {
-                return Ok(path.clone());
+            if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                if name == target {
+                    return Ok(path.clone());
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- Fix worktree display names in `fetch` and `carry` commands to show the full relative path (e.g., `feature/test-feature`) instead of just the last component (`test-feature`) when branch names contain slashes
- Reorder `resolve_worktree_path` matching to prefer relative-path matching first (most precise) over `file_name()` matching (convenience shorthand), preventing ambiguous matches

## Test plan
- [x] `cargo fmt` -- passes
- [x] `cargo clippy -- -D warnings` -- passes
- [x] `just test-unit` -- 140 tests pass
- [x] `just test-integration-fetch` -- 15 tests pass, including `fetch_multiple_worktrees` which uses `feature/test-feature`

Fixes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)