### PR TITLE
fix: skip uncommitted changes check when not in a work tree

### DIFF
--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -206,7 +206,9 @@ fn run_checkout(args: &Args, settings: &DaftSettings, output: &mut dyn Output) -
     };
 
     // Check for uncommitted changes and stash them if should_carry is true
-    let stash_created = if should_carry {
+    // Skip the check if we're not inside a work tree (e.g., running from the bare repo root)
+    let in_worktree = git.rev_parse_is_inside_work_tree().unwrap_or(false);
+    let stash_created = if should_carry && in_worktree {
         match git.has_uncommitted_changes() {
             Ok(true) => {
                 output.step("Stashing uncommitted changes...");

--- a/src/commands/checkout_branch.rs
+++ b/src/commands/checkout_branch.rs
@@ -215,7 +215,9 @@ fn run_checkout_branch(
     };
 
     // Check for uncommitted changes and stash them if should_carry is true
-    let stash_created = if should_carry {
+    // Skip the check if we're not inside a work tree (e.g., running from the bare repo root)
+    let in_worktree = git.rev_parse_is_inside_work_tree().unwrap_or(false);
+    let stash_created = if should_carry && in_worktree {
         match git.has_uncommitted_changes() {
             Ok(true) => {
                 output.step("Stashing uncommitted changes...");


### PR DESCRIPTION
## Summary
- Skip the carry/uncommitted-changes check when running `git-worktree-checkout-branch` or `git-worktree-checkout` from the bare repository root (the parent directory containing `.git/` and worktree subdirectories)
- Uses the existing `rev_parse_is_inside_work_tree()` guard to detect this case, avoiding the confusing `git status` failure warning
- Also fixes `git-worktree-checkout-branch-from-default` since it delegates to `checkout-branch`

Fixes #90

## Test plan
- [ ] Run `gwtcb <branch>` from the bare repo root — verify no warning is emitted
- [ ] Run `gwtcb <branch>` from inside a worktree with uncommitted changes — verify carry still works
- [ ] Run `gwtco <branch>` from the bare repo root — verify no warning is emitted
- [ ] Run `gwtcbm <branch>` from the bare repo root — verify no warning is emitted
- [ ] Run `cargo clippy -- -D warnings` — passes
- [ ] Run `cargo test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)