### PR TITLE
feat(prune): add streaming per-branch output in git-remote-prune style

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -799,6 +799,23 @@ impl GitCommand {
         Ok(stdout.trim() == "true")
     }
 
+    /// Get the URL of a remote.
+    pub fn remote_get_url(&self, remote: &str) -> Result<String> {
+        let output = Command::new("git")
+            .args(["remote", "get-url", remote])
+            .output()
+            .context("Failed to execute git remote get-url command")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("Git remote get-url failed: {}", stderr);
+        }
+
+        String::from_utf8(output.stdout)
+            .context("Failed to parse git remote get-url output")
+            .map(|s| s.trim().to_string())
+    }
+
     /// Move a worktree to a new location.
     pub fn worktree_move(&self, from: &Path, to: &Path) -> Result<()> {
         let mut cmd = Command::new("git");


### PR DESCRIPTION
## Summary

- Refactor `git-worktree-prune` output to match `git remote prune origin` style with a `Pruning origin` / `URL:` header, per-branch ` * [pruned]` lines with `(worktree removed)` annotation, and a pluralized summary
- Add `GitCommand::remote_get_url()` for fetching remote URLs
- Refactor `delete_branch()` to return `bool` and introduce `PruneResult` struct from `remove_worktree_and_delete_branch()` for cleaner control flow at call sites

Fixes #147

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy -- -D warnings` passes (zero warnings)
- [x] `just test-unit` passes (157 tests)
- [x] `just test-integration-prune` passes (all 19 tests)
- [ ] Manual test: bare-layout repo with branches deleted on remote → verify output matches target format
- [ ] Manual test: same with `--verbose` flag
- [ ] Manual test: nothing to prune → verify silence

🤖 Generated with [Claude Code](https://claude.com/claude-code)