### PR TITLE
feat: add --no-cd flag to worktree-creating commands

### DIFF
--- a/man/git-worktree-checkout-branch-from-default.1
+++ b/man/git-worktree-checkout-branch-from-default.1
@@ -4,7 +4,7 @@
 .SH NAME
 git\-worktree\-checkout\-branch\-from\-default \- Create a worktree with a new branch based on the remote\*(Aqs default branch
 .SH SYNOPSIS
-\fBgit\-worktree\-checkout\-branch\-from\-default\fR [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-c\fR|\fB\-\-carry\fR] [\fB\-\-no\-carry\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fINEW_BRANCH_NAME\fR> 
+\fBgit\-worktree\-checkout\-branch\-from\-default\fR [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-c\fR|\fB\-\-carry\fR] [\fB\-\-no\-carry\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-\-no\-cd\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fINEW_BRANCH_NAME\fR> 
 .SH DESCRIPTION
 .PP
 Creates a new branch based on the remote\*(Aqs default branch (typically main or
@@ -31,6 +31,9 @@ Do not carry uncommitted changes to the new worktree
 .TP
 \fB\-r\fR, \fB\-\-remote\fR \fI<REMOTE>\fR
 Remote for worktree organization (multi\-remote mode)
+.TP
+\fB\-\-no\-cd\fR
+Do not change directory to the new worktree
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help (see a summary with \*(Aq\-h\*(Aq)

--- a/man/git-worktree-checkout-branch.1
+++ b/man/git-worktree-checkout-branch.1
@@ -4,7 +4,7 @@
 .SH NAME
 git\-worktree\-checkout\-branch \- Create a worktree with a new branch
 .SH SYNOPSIS
-\fBgit\-worktree\-checkout\-branch\fR [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-c\fR|\fB\-\-carry\fR] [\fB\-\-no\-carry\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fINEW_BRANCH_NAME\fR> [\fIBASE_BRANCH_NAME\fR] 
+\fBgit\-worktree\-checkout\-branch\fR [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-c\fR|\fB\-\-carry\fR] [\fB\-\-no\-carry\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-\-no\-cd\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fINEW_BRANCH_NAME\fR> [\fIBASE_BRANCH_NAME\fR] 
 .SH DESCRIPTION
 .PP
 Creates a new branch and a corresponding worktree in a single operation. The
@@ -35,6 +35,9 @@ Do not carry uncommitted changes to the new worktree
 .TP
 \fB\-r\fR, \fB\-\-remote\fR \fI<REMOTE>\fR
 Remote for worktree organization (multi\-remote mode)
+.TP
+\fB\-\-no\-cd\fR
+Do not change directory to the new worktree
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help (see a summary with \*(Aq\-h\*(Aq)

--- a/man/git-worktree-checkout.1
+++ b/man/git-worktree-checkout.1
@@ -4,7 +4,7 @@
 .SH NAME
 git\-worktree\-checkout \- Create a worktree for an existing branch
 .SH SYNOPSIS
-\fBgit\-worktree\-checkout\fR [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-c\fR|\fB\-\-carry\fR] [\fB\-\-no\-carry\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIBRANCH_NAME\fR> 
+\fBgit\-worktree\-checkout\fR [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-c\fR|\fB\-\-carry\fR] [\fB\-\-no\-carry\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-\-no\-cd\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIBRANCH_NAME\fR> 
 .SH DESCRIPTION
 .PP
 Creates a new worktree for an existing local or remote branch. The worktree
@@ -34,6 +34,9 @@ Do not carry uncommitted changes (this is the default)
 .TP
 \fB\-r\fR, \fB\-\-remote\fR \fI<REMOTE>\fR
 Remote for worktree organization (multi\-remote mode)
+.TP
+\fB\-\-no\-cd\fR
+Do not change directory to the new worktree
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help (see a summary with \*(Aq\-h\*(Aq)

--- a/man/git-worktree-clone.1
+++ b/man/git-worktree-clone.1
@@ -4,7 +4,7 @@
 .SH NAME
 git\-worktree\-clone \- Clone a repository into a worktree\-based directory structure
 .SH SYNOPSIS
-\fBgit\-worktree\-clone\fR [\fB\-b\fR|\fB\-\-branch\fR] [\fB\-n\fR|\fB\-\-no\-checkout\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-a\fR|\fB\-\-all\-branches\fR] [\fB\-\-trust\-hooks\fR] [\fB\-\-no\-hooks\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIREPOSITORY_URL\fR> 
+\fBgit\-worktree\-clone\fR [\fB\-b\fR|\fB\-\-branch\fR] [\fB\-n\fR|\fB\-\-no\-checkout\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-a\fR|\fB\-\-all\-branches\fR] [\fB\-\-trust\-hooks\fR] [\fB\-\-no\-hooks\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-\-no\-cd\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIREPOSITORY_URL\fR> 
 .SH DESCRIPTION
 .PP
 Clones a repository into a directory structure optimized for worktree\-based
@@ -45,6 +45,9 @@ Do not run any hooks from the repository
 .TP
 \fB\-r\fR, \fB\-\-remote\fR \fI<REMOTE>\fR
 Organize worktree under this remote folder (enables multi\-remote mode)
+.TP
+\fB\-\-no\-cd\fR
+Do not change directory to the new worktree
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help (see a summary with \*(Aq\-h\*(Aq)

--- a/man/git-worktree-init.1
+++ b/man/git-worktree-init.1
@@ -4,7 +4,7 @@
 .SH NAME
 git\-worktree\-init \- Initialize a new repository in the worktree\-based directory structure
 .SH SYNOPSIS
-\fBgit\-worktree\-init\fR [\fB\-\-bare\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-b\fR|\fB\-\-initial\-branch\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIREPOSITORY_NAME\fR> 
+\fBgit\-worktree\-init\fR [\fB\-\-bare\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-b\fR|\fB\-\-initial\-branch\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-\-no\-cd\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIREPOSITORY_NAME\fR> 
 .SH DESCRIPTION
 .PP
 Initializes a new Git repository using the same directory structure as
@@ -38,6 +38,9 @@ Use <name> as the initial branch instead of the configured default
 .TP
 \fB\-r\fR, \fB\-\-remote\fR \fI<REMOTE>\fR
 Organize worktree under this remote folder (enables multi\-remote mode)
+.TP
+\fB\-\-no\-cd\fR
+Do not change directory to the new worktree
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help (see a summary with \*(Aq\-h\*(Aq)

--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -58,6 +58,9 @@ pub struct Args {
         help = "Remote for worktree organization (multi-remote mode)"
     )]
     remote: Option<String>,
+
+    #[arg(long, help = "Do not change directory to the new worktree")]
+    no_cd: bool,
 }
 
 pub fn run() -> Result<()> {
@@ -73,7 +76,8 @@ pub fn run() -> Result<()> {
     // Load settings from git config
     let settings = DaftSettings::load()?;
 
-    let config = OutputConfig::with_autocd(false, args.verbose, settings.autocd);
+    let autocd = settings.autocd && !args.no_cd;
+    let config = OutputConfig::with_autocd(false, args.verbose, autocd);
     let mut output = CliOutput::new(config);
 
     let original_dir = get_current_directory()?;

--- a/src/commands/checkout_branch.rs
+++ b/src/commands/checkout_branch.rs
@@ -61,6 +61,9 @@ pub struct Args {
         help = "Remote for worktree organization (multi-remote mode)"
     )]
     remote: Option<String>,
+
+    #[arg(long, help = "Do not change directory to the new worktree")]
+    no_cd: bool,
 }
 
 pub fn run() -> Result<()> {
@@ -76,7 +79,8 @@ pub fn run() -> Result<()> {
     // Load settings from git config
     let settings = DaftSettings::load()?;
 
-    let config = OutputConfig::with_autocd(args.quiet, args.verbose, settings.autocd);
+    let autocd = settings.autocd && !args.no_cd;
+    let config = OutputConfig::with_autocd(args.quiet, args.verbose, autocd);
     let mut output = CliOutput::new(config);
 
     let original_dir = get_current_directory()?;

--- a/src/commands/checkout_branch_from_default.rs
+++ b/src/commands/checkout_branch_from_default.rs
@@ -51,6 +51,9 @@ pub struct Args {
         help = "Remote for worktree organization (multi-remote mode)"
     )]
     remote: Option<String>,
+
+    #[arg(long, help = "Do not change directory to the new worktree")]
+    no_cd: bool,
 }
 
 pub fn run() -> Result<()> {
@@ -68,7 +71,8 @@ pub fn run() -> Result<()> {
     // Load settings from git config
     let settings = DaftSettings::load()?;
 
-    let config = OutputConfig::with_autocd(false, args.verbose, settings.autocd);
+    let autocd = settings.autocd && !args.no_cd;
+    let config = OutputConfig::with_autocd(false, args.verbose, autocd);
     let mut output = CliOutput::new(config);
 
     let original_dir = get_current_directory()?;
@@ -127,6 +131,9 @@ fn run_checkout_branch_from_default(
     }
     if let Some(ref remote) = args.remote {
         cmd.arg("--remote").arg(remote);
+    }
+    if args.no_cd {
+        cmd.arg("--no-cd");
     }
 
     let status = cmd

--- a/src/commands/clone.rs
+++ b/src/commands/clone.rs
@@ -89,6 +89,9 @@ pub struct Args {
         help = "Organize worktree under this remote folder (enables multi-remote mode)"
     )]
     remote: Option<String>,
+
+    #[arg(long, help = "Do not change directory to the new worktree")]
+    no_cd: bool,
 }
 
 pub fn run() -> Result<()> {
@@ -116,7 +119,8 @@ pub fn run() -> Result<()> {
     // Load settings from global config only (repo doesn't exist yet)
     let settings = DaftSettings::load_global()?;
 
-    let config = OutputConfig::with_autocd(args.quiet, args.verbose, settings.autocd);
+    let autocd = settings.autocd && !args.no_cd;
+    let config = OutputConfig::with_autocd(args.quiet, args.verbose, autocd);
     let mut output = CliOutput::new(config);
 
     let original_dir = get_current_directory()?;

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -72,6 +72,9 @@ pub struct Args {
         help = "Organize worktree under this remote folder (enables multi-remote mode)"
     )]
     remote: Option<String>,
+
+    #[arg(long, help = "Do not change directory to the new worktree")]
+    no_cd: bool,
 }
 
 pub fn run() -> Result<()> {
@@ -83,7 +86,8 @@ pub fn run() -> Result<()> {
     // Load settings from global config only (repo doesn't exist yet)
     let settings = DaftSettings::load_global()?;
 
-    let config = OutputConfig::with_autocd(args.quiet, args.verbose, settings.autocd);
+    let autocd = settings.autocd && !args.no_cd;
+    let config = OutputConfig::with_autocd(args.quiet, args.verbose, autocd);
     let mut output = CliOutput::new(config);
 
     let original_dir = get_current_directory()?;
@@ -287,6 +291,7 @@ mod tests {
             verbose,
             initial_branch: Some("master".to_string()),
             remote: None,
+            no_cd: false,
         }
     }
 
@@ -352,6 +357,7 @@ mod tests {
             verbose: false,
             initial_branch: Some("master".to_string()),
             remote: None,
+            no_cd: false,
         };
         let mut output = TestOutput::new();
 
@@ -373,6 +379,7 @@ mod tests {
             verbose: false,
             initial_branch: Some("".to_string()),
             remote: None,
+            no_cd: false,
         };
         let mut output = TestOutput::new();
 


### PR DESCRIPTION
## Summary

- Add `--no-cd` CLI flag to all 5 worktree-creating commands (`clone`, `init`, `checkout`, `checkout-branch`, `checkout-branch-from-default`)
- The flag overrides the `daft.autocd` git config setting on a per-invocation basis, preventing the shell wrapper from cd-ing into the new worktree
- `checkout-branch-from-default` passes the flag through to its subprocess call to `checkout-branch`
- Man pages regenerated to include the new flag

Fixes #151

## Test plan

- [x] `cargo fmt` passes
- [x] `cargo clippy -- -D warnings` passes with zero warnings
- [x] `just test-unit` — 157 tests pass
- [x] `just gen-man` regenerates man pages with `--no-cd` in all 5 commands
- [ ] Verify `--no-cd` suppresses the `__DAFT_CD__` marker when `daft.autocd` is enabled
- [ ] Verify commands still cd normally without `--no-cd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)