### PR TITLE
fix: correctly detect bare repo root to suppress carry warning

### DIFF
--- a/src/commands/checkout_branch.rs
+++ b/src/commands/checkout_branch.rs
@@ -236,8 +236,11 @@ fn run_checkout_branch(
                 false
             }
         }
-    } else {
+    } else if !should_carry {
         output.step("Skipping carry (--no-carry flag set or carry disabled in config)");
+        false
+    } else {
+        output.step("Skipping carry (not inside a worktree)");
         false
     };
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -405,7 +405,25 @@ impl GitCommand {
             .output()
             .context("Failed to execute git rev-parse command")?;
 
-        // Git rev-parse --is-inside-work-tree returns exit code 0 when inside work tree
+        if !output.status.success() {
+            return Ok(false);
+        }
+
+        // In a bare repo root, git exits 0 but prints "false" to stdout.
+        // We must check the actual output, not just the exit code.
+        let stdout =
+            String::from_utf8(output.stdout).context("Failed to parse git rev-parse output")?;
+        Ok(stdout.trim() == "true")
+    }
+
+    /// Check if current directory is inside any Git repository (work tree or bare)
+    pub fn is_inside_git_repo(&self) -> Result<bool> {
+        let output = Command::new("git")
+            .args(["rev-parse", "--git-dir"])
+            .stderr(std::process::Stdio::null())
+            .output()
+            .context("Failed to execute git rev-parse command")?;
+
         Ok(output.status.success())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@ impl Default for WorktreeConfig {
 
 pub fn is_git_repository() -> Result<bool> {
     let git = git::GitCommand::new(true); // Use quiet mode for this check
-    git.rev_parse_is_inside_work_tree()
+    git.is_inside_git_repo()
 }
 
 pub fn get_git_common_dir() -> Result<PathBuf> {


### PR DESCRIPTION
## Summary
- Fixed `rev_parse_is_inside_work_tree()` to check stdout content (`"true"`/`"false"`) instead of only the exit code — in a bare repo root, git exits 0 but prints `"false"`, causing the method to incorrectly report being inside a worktree
- Added `is_inside_git_repo()` method using `git rev-parse --git-dir` so that `is_git_repository()` correctly recognizes bare repo roots as valid git contexts
- Improved the "skipping carry" message in `checkout_branch` to distinguish between carry disabled by config/flag vs not being inside a worktree

## Test plan
- [ ] Run `gwtcb <branch>` from the bare repo root directory — should no longer produce the `warning: Could not check for uncommitted changes` message
- [ ] Run `gwtcb <branch>` from inside a worktree with uncommitted changes — carry should still work as before
- [ ] Run `gwtcb --no-carry <branch>` — should show "Skipping carry (--no-carry flag set or carry disabled in config)"
- [ ] Run `gwtcb <branch>` from bare repo root — should show "Skipping carry (not inside a worktree)"
- [ ] Verify `just test-unit` passes
- [ ] Verify `cargo clippy -- -D warnings` passes

Fixes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)