### PR TITLE
feat(shell-init): add daft() shell wrapper for cd into worktrees

### DIFF
--- a/src/commands/shell_init.rs
+++ b/src/commands/shell_init.rs
@@ -156,6 +156,34 @@ git() {
     esac
 }
 
+# daft wrapper to intercept "daft worktree-*" subcommands
+daft() {
+    case "$1" in
+        worktree-clone)
+            shift; __daft_wrapper git-worktree-clone "$@" ;;
+        worktree-init)
+            shift; __daft_wrapper git-worktree-init "$@" ;;
+        worktree-checkout)
+            shift; __daft_wrapper git-worktree-checkout "$@" ;;
+        worktree-checkout-branch)
+            shift; __daft_wrapper git-worktree-checkout-branch "$@" ;;
+        worktree-checkout-branch-from-default)
+            shift; __daft_wrapper git-worktree-checkout-branch-from-default "$@" ;;
+        worktree-carry)
+            shift; __daft_wrapper git-worktree-carry "$@" ;;
+        worktree-prune)
+            shift; __daft_wrapper git-worktree-prune "$@" ;;
+        worktree-fetch)
+            shift; __daft_wrapper git-worktree-fetch "$@" ;;
+        worktree-flow-adopt)
+            shift; __daft_wrapper git-worktree-flow-adopt "$@" ;;
+        worktree-flow-eject)
+            shift; __daft_wrapper git-worktree-flow-eject "$@" ;;
+        *)
+            command daft "$@" ;;
+    esac
+}
+
 # Shortcut wrappers - these override symlinks to enable cd behavior
 # Git-style shortcuts
 gwtclone() { __daft_wrapper git-worktree-clone "$@"; }
@@ -300,6 +328,34 @@ function git --wraps git
             __daft_wrapper git-worktree-flow-eject $argv[2..-1]
         case '*'
             command git $argv
+    end
+end
+
+# daft wrapper to intercept "daft worktree-*" subcommands
+function daft --wraps daft
+    switch $argv[1]
+        case worktree-clone
+            __daft_wrapper git-worktree-clone $argv[2..-1]
+        case worktree-init
+            __daft_wrapper git-worktree-init $argv[2..-1]
+        case worktree-checkout
+            __daft_wrapper git-worktree-checkout $argv[2..-1]
+        case worktree-checkout-branch
+            __daft_wrapper git-worktree-checkout-branch $argv[2..-1]
+        case worktree-checkout-branch-from-default
+            __daft_wrapper git-worktree-checkout-branch-from-default $argv[2..-1]
+        case worktree-carry
+            __daft_wrapper git-worktree-carry $argv[2..-1]
+        case worktree-prune
+            __daft_wrapper git-worktree-prune $argv[2..-1]
+        case worktree-fetch
+            __daft_wrapper git-worktree-fetch $argv[2..-1]
+        case worktree-flow-adopt
+            __daft_wrapper git-worktree-flow-adopt $argv[2..-1]
+        case worktree-flow-eject
+            __daft_wrapper git-worktree-flow-eject $argv[2..-1]
+        case '*'
+            command daft $argv
     end
 end
 


### PR DESCRIPTION
## Summary
- Add `daft()` wrapper function for bash/zsh that intercepts `daft worktree-*` subcommands and routes them through `__daft_wrapper` for automatic cd behavior
- Add equivalent `function daft --wraps daft` wrapper for fish shell
- All non-worktree `daft` subcommands pass through to `command daft` unchanged
- Add integration tests verifying the wrapper exists, passes through regular commands, and is defined as a function

Fixes #164

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy -- -D warnings` — zero warnings
- [x] `just test-unit` — 183 passed, 0 failed
- [x] `just test-integration-shell-init` — all 3 new daft wrapper tests pass
- [ ] Manual: `eval "$(cargo run -- shell-init bash)" && type daft` shows it's a function
- [ ] Manual: `daft worktree-checkout <branch>` actually cd's into the new worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)