### PR TITLE
feat(update-check): throttle new version notification to once per 24h

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -112,8 +112,9 @@ fn main() -> Result<()> {
     };
 
     // Show update notification after command output (if available)
-    if let Some(notification) = update_notification {
-        daft::update_check::print_notification(&notification);
+    if let Some(ref notification) = update_notification {
+        daft::update_check::print_notification(notification);
+        daft::update_check::record_notification_shown(&notification.latest_version);
     }
 
     result


### PR DESCRIPTION
## Summary

- Throttle the "new version available" banner to show at most once every 24 hours for the same version
- If a *different* newer version appears in the cache, show the banner again immediately
- Track notification state in a separate file (`~/.config/daft/update-notification.json`) to avoid race conditions with the background update check process

## Implementation

- Added `NotificationState` struct and persistence helpers in `src/update_check.rs`
- Pure throttling logic in `should_suppress_for_state()` (testable without filesystem)
- `record_notification_shown()` called from `main.rs` after displaying the notification
- 6 new unit tests covering all throttling scenarios (no prior state, different version, same version recent/expired, future timestamp)

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy -- -D warnings` passes with zero warnings
- [x] `just test-unit` — all 189 tests pass (including 6 new notification throttling tests)
- [ ] Manual test: run daft command twice, first shows notification (if newer version cached), second suppresses

Fixes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)