### PR TITLE
feat: add `daft doctor` diagnostic command

### DIFF
--- a/man/daft-doctor.1
+++ b/man/daft-doctor.1
@@ -1,0 +1,28 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH daft-doctor 1  "daft-doctor " 
+.SH NAME
+daft\-doctor \- Diagnose daft installation and configuration issues
+.SH SYNOPSIS
+\fBdaft\-doctor\fR [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-\-fix\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+.SH DESCRIPTION
+Diagnose daft installation and configuration issues.
+.PP
+Runs health checks on your daft installation, repository setup,
+and hooks configuration. Reports issues with actionable suggestions.
+.PP
+When run outside a git repository, only installation checks are performed.
+Inside a daft\-managed repository, repository and hooks checks run too.
+.SH OPTIONS
+.TP
+\fB\-v\fR, \fB\-\-verbose\fR
+Show detailed output for each check
+.TP
+\fB\-\-fix\fR
+Auto\-fix issues that can be resolved automatically
+.TP
+\fB\-q\fR, \fB\-\-quiet\fR
+Only show warnings and errors
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help (see a summary with \*(Aq\-h\*(Aq)

--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -8,8 +8,8 @@ use std::path::Path;
 
 use crate::commands::{
     branch, carry, checkout, checkout_branch, checkout_branch_from_default, clone, completions,
-    fetch, flow_adopt, flow_eject, hooks, init, multi_remote, prune, release_notes, shell_init,
-    shortcuts,
+    doctor, fetch, flow_adopt, flow_eject, hooks, init, multi_remote, prune, release_notes,
+    shell_init, shortcuts,
 };
 
 /// A category of commands with a title and list of commands.
@@ -107,6 +107,10 @@ fn get_command_categories() -> Vec<CommandCategory> {
                 CommandEntry {
                     display_name: "daft shell-init",
                     command: shell_init::Args::command(),
+                },
+                CommandEntry {
+                    display_name: "daft doctor",
+                    command: doctor::Args::command(),
                 },
                 CommandEntry {
                     display_name: "daft completions",

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -1,0 +1,224 @@
+//! `daft doctor` command — diagnose installation and configuration issues.
+//!
+//! Inspects daft installation, repository configuration, and hooks setup,
+//! reporting issues with actionable suggestions and optional auto-fix.
+
+use anyhow::Result;
+use clap::Parser;
+
+use crate::doctor::{
+    hooks_checks, installation, repository, status_symbol, CheckCategory, CheckStatus,
+    DoctorSummary,
+};
+use crate::styles::{bold, dim, green, red, yellow};
+
+fn long_about() -> String {
+    [
+        "Diagnose daft installation and configuration issues.",
+        "",
+        "Runs health checks on your daft installation, repository setup,",
+        "and hooks configuration. Reports issues with actionable suggestions.",
+        "",
+        "When run outside a git repository, only installation checks are performed.",
+        "Inside a daft-managed repository, repository and hooks checks run too.",
+    ]
+    .join("\n")
+}
+
+#[derive(Parser)]
+#[command(name = "daft-doctor")]
+#[command(about = "Diagnose daft installation and configuration issues")]
+#[command(long_about = long_about())]
+pub struct Args {
+    /// Show detailed output for each check
+    #[arg(short, long, help = "Show detailed output for each check")]
+    verbose: bool,
+
+    /// Auto-fix issues that can be resolved automatically
+    #[arg(long, help = "Auto-fix issues that can be resolved automatically")]
+    fix: bool,
+
+    /// Only show warnings and errors
+    #[arg(short, long, help = "Only show warnings and errors")]
+    quiet: bool,
+}
+
+pub fn run() -> Result<()> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let args = Args::parse_from(args);
+
+    let mut categories = Vec::new();
+
+    // Installation checks (always run)
+    categories.push(run_installation_checks());
+
+    // Repository checks (only inside a daft-managed repo)
+    if let Some(ctx) = repository::get_repo_context() {
+        categories.push(run_repository_checks(&ctx));
+
+        // Hooks checks (only when hooks exist)
+        if hooks_checks::has_hooks(&ctx.project_root) {
+            categories.push(run_hooks_checks(&ctx));
+        }
+    }
+
+    // Apply fixes if requested
+    if args.fix {
+        apply_fixes(&categories);
+        // Re-run checks after fixes
+        categories.clear();
+        categories.push(run_installation_checks());
+        if let Some(ctx) = repository::get_repo_context() {
+            categories.push(run_repository_checks(&ctx));
+            if hooks_checks::has_hooks(&ctx.project_root) {
+                categories.push(run_hooks_checks(&ctx));
+            }
+        }
+    }
+
+    // Display results
+    print_results(&categories, args.verbose, args.quiet);
+
+    // Print summary
+    let summary = DoctorSummary::from_categories(&categories);
+    println!();
+    print_summary(&summary);
+
+    if summary.has_failures() {
+        std::process::exit(1);
+    }
+
+    Ok(())
+}
+
+fn run_installation_checks() -> CheckCategory {
+    CheckCategory {
+        title: "Installation".to_string(),
+        results: vec![
+            installation::check_binary_in_path(),
+            installation::check_command_symlinks(),
+            installation::check_git(),
+            installation::check_man_pages(),
+            installation::check_shell_integration(),
+        ],
+    }
+}
+
+fn run_repository_checks(ctx: &repository::RepoContext) -> CheckCategory {
+    CheckCategory {
+        title: "Repository".to_string(),
+        results: vec![
+            repository::check_worktree_layout(ctx),
+            repository::check_worktree_consistency(ctx),
+            repository::check_fetch_refspec(ctx),
+            repository::check_remote_head(ctx),
+        ],
+    }
+}
+
+fn run_hooks_checks(ctx: &repository::RepoContext) -> CheckCategory {
+    CheckCategory {
+        title: "Hooks".to_string(),
+        results: vec![
+            hooks_checks::check_hooks_executable(&ctx.project_root),
+            hooks_checks::check_deprecated_names(&ctx.project_root),
+            hooks_checks::check_trust_level(&ctx.git_common_dir),
+        ],
+    }
+}
+
+fn apply_fixes(categories: &[CheckCategory]) {
+    println!("{}", bold("Applying fixes..."));
+    println!();
+
+    for category in categories {
+        for result in &category.results {
+            if result.fixable && matches!(result.status, CheckStatus::Warning | CheckStatus::Fail) {
+                print!("  Fixing: {} ... ", result.name);
+                let fix_result = apply_single_fix(&result.name);
+                match fix_result {
+                    Ok(()) => println!("{}", green("done")),
+                    Err(e) => println!("{}", red(&format!("failed: {e}"))),
+                }
+            }
+        }
+    }
+    println!();
+}
+
+fn apply_single_fix(check_name: &str) -> Result<(), String> {
+    match check_name {
+        "Command symlinks" => installation::fix_command_symlinks(),
+        "Worktree consistency" => repository::fix_worktree_consistency(),
+        "Fetch refspec" => repository::fix_fetch_refspec(),
+        "Remote HEAD" => repository::fix_remote_head(),
+        "Hooks executable" => {
+            if let Some(ctx) = repository::get_repo_context() {
+                hooks_checks::fix_hooks_executable(&ctx.project_root)
+            } else {
+                Err("Not in a git repository".to_string())
+            }
+        }
+        "Hook names" => {
+            if let Some(ctx) = repository::get_repo_context() {
+                hooks_checks::fix_deprecated_names(&ctx.project_root)
+            } else {
+                Err("Not in a git repository".to_string())
+            }
+        }
+        _ => Err(format!("No fix available for '{check_name}'")),
+    }
+}
+
+fn print_results(categories: &[CheckCategory], verbose: bool, quiet: bool) {
+    println!("{}", bold("Doctor summary:"));
+
+    for category in categories {
+        println!();
+        println!("{}", bold(&category.title));
+
+        for result in &category.results {
+            // In quiet mode, skip passing and skipped checks
+            if quiet && matches!(result.status, CheckStatus::Pass | CheckStatus::Skipped) {
+                continue;
+            }
+
+            let symbol = status_symbol(result.status);
+            println!("  {symbol} {}", result.message);
+
+            // Show suggestion for warnings and failures
+            if let Some(ref suggestion) = result.suggestion {
+                if matches!(result.status, CheckStatus::Warning | CheckStatus::Fail) {
+                    println!("      {}", dim(suggestion));
+                }
+            }
+
+            // Show details in verbose mode
+            if verbose && !result.details.is_empty() {
+                for detail in &result.details {
+                    println!("      {}", dim(detail));
+                }
+            }
+        }
+    }
+}
+
+fn print_summary(summary: &DoctorSummary) {
+    let parts: Vec<String> = [
+        (summary.passed, "passed", green as fn(&str) -> String),
+        (summary.warnings, "warnings", yellow),
+        (summary.failures, "failures", red),
+    ]
+    .iter()
+    .filter(|(count, _, _)| *count > 0)
+    .map(|(count, label, style)| style(&format!("{count} {label}")))
+    .collect();
+
+    let summary_text = if parts.is_empty() {
+        dim("No checks performed")
+    } else {
+        parts.join(", ")
+    };
+
+    println!("Summary: {summary_text}");
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -11,6 +11,7 @@ pub mod clone;
 pub mod complete;
 pub mod completions;
 pub mod docs;
+pub mod doctor;
 pub mod fetch;
 pub mod flow_adopt;
 pub mod flow_eject;

--- a/src/doctor/hooks_checks.rs
+++ b/src/doctor/hooks_checks.rs
@@ -1,0 +1,320 @@
+//! Hook checks for `daft doctor`.
+//!
+//! Verifies hook configuration: executability, deprecated names, trust level.
+
+use crate::doctor::CheckResult;
+use crate::hooks::{HookType, TrustDatabase, TrustLevel, PROJECT_HOOKS_DIR};
+use std::path::{Path, PathBuf};
+
+/// Find the hooks directory by scanning worktrees under the project root.
+///
+/// Returns the first `.daft/hooks/` directory found in any worktree.
+fn find_hooks_dir(project_root: &Path) -> Option<PathBuf> {
+    let entries = std::fs::read_dir(project_root).ok()?;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() && path.file_name().map(|n| n != ".git").unwrap_or(false) {
+            let hooks_dir = path.join(PROJECT_HOOKS_DIR);
+            if hooks_dir.exists() && hooks_dir.is_dir() {
+                return Some(hooks_dir);
+            }
+        }
+    }
+    None
+}
+
+/// List hook files in a hooks directory.
+fn list_hook_files(hooks_dir: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(hooks_dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_file() {
+                files.push(path);
+            }
+        }
+    }
+    files.sort();
+    files
+}
+
+/// Check if hooks directory exists. Returns None if no hooks to check.
+pub fn has_hooks(project_root: &Path) -> bool {
+    find_hooks_dir(project_root).is_some()
+}
+
+/// Check that all hook files are executable.
+pub fn check_hooks_executable(project_root: &Path) -> CheckResult {
+    let hooks_dir = match find_hooks_dir(project_root) {
+        Some(dir) => dir,
+        None => return CheckResult::skipped("Hooks executable", "no hooks found"),
+    };
+
+    let files = list_hook_files(&hooks_dir);
+    if files.is_empty() {
+        return CheckResult::skipped("Hooks executable", "no hook files");
+    }
+
+    let mut non_executable = Vec::new();
+
+    for file in &files {
+        if !is_executable(file) {
+            if let Some(name) = file.file_name() {
+                non_executable.push(name.to_string_lossy().to_string());
+            }
+        }
+    }
+
+    if non_executable.is_empty() {
+        CheckResult::pass(
+            "Hooks executable",
+            &format!("all {} hooks executable", files.len()),
+        )
+    } else {
+        let details: Vec<String> = non_executable
+            .iter()
+            .map(|n| format!("Not executable: {n}"))
+            .collect();
+        CheckResult::warning(
+            "Hooks executable",
+            &format!("{} hook(s) not executable", non_executable.len()),
+        )
+        .with_suggestion("Run 'chmod +x' on the listed hooks")
+        .with_fixable(true)
+        .with_details(details)
+    }
+}
+
+/// Fix non-executable hooks by adding execute permission.
+pub fn fix_hooks_executable(project_root: &Path) -> Result<(), String> {
+    let hooks_dir =
+        find_hooks_dir(project_root).ok_or_else(|| "No hooks directory found".to_string())?;
+
+    let files = list_hook_files(&hooks_dir);
+    for file in &files {
+        if !is_executable(file) {
+            set_executable(file)?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Check for deprecated hook filenames.
+pub fn check_deprecated_names(project_root: &Path) -> CheckResult {
+    let hooks_dir = match find_hooks_dir(project_root) {
+        Some(dir) => dir,
+        None => return CheckResult::skipped("Hook names", "no hooks found"),
+    };
+
+    let files = list_hook_files(&hooks_dir);
+    let mut deprecated = Vec::new();
+
+    for file in &files {
+        if let Some(name) = file.file_name().and_then(|n| n.to_str()) {
+            if let Some(hook_type) = HookType::from_filename(name) {
+                if let Some(old_name) = hook_type.deprecated_filename() {
+                    if name == old_name {
+                        deprecated.push((old_name, hook_type.filename()));
+                    }
+                }
+            }
+        }
+    }
+
+    if deprecated.is_empty() {
+        CheckResult::pass("Hook names", "no deprecated names")
+    } else {
+        let details: Vec<String> = deprecated
+            .iter()
+            .map(|(old, new)| format!("{old} -> {new}"))
+            .collect();
+        CheckResult::warning(
+            "Hook names",
+            &format!("{} deprecated name(s)", deprecated.len()),
+        )
+        .with_suggestion("Run 'git daft hooks migrate'")
+        .with_fixable(true)
+        .with_details(details)
+    }
+}
+
+/// Fix deprecated hook names by renaming them.
+pub fn fix_deprecated_names(project_root: &Path) -> Result<(), String> {
+    let hooks_dir =
+        find_hooks_dir(project_root).ok_or_else(|| "No hooks directory found".to_string())?;
+
+    let files = list_hook_files(&hooks_dir);
+    for file in &files {
+        if let Some(name) = file.file_name().and_then(|n| n.to_str()) {
+            if let Some(hook_type) = HookType::from_filename(name) {
+                if let Some(old_name) = hook_type.deprecated_filename() {
+                    if name == old_name {
+                        let new_path = hooks_dir.join(hook_type.filename());
+                        if !new_path.exists() {
+                            std::fs::rename(file, &new_path)
+                                .map_err(|e| format!("Failed to rename {old_name}: {e}"))?;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Check the trust level for the current repository.
+pub fn check_trust_level(git_common_dir: &Path) -> CheckResult {
+    let db = match TrustDatabase::load() {
+        Ok(db) => db,
+        Err(e) => {
+            return CheckResult::warning(
+                "Trust level",
+                &format!("could not load trust database: {e}"),
+            );
+        }
+    };
+
+    let level = db.get_trust_level(git_common_dir);
+
+    match level {
+        TrustLevel::Allow => CheckResult::pass("Trust level", "allow"),
+        TrustLevel::Prompt => CheckResult::pass("Trust level", "prompt"),
+        TrustLevel::Deny => CheckResult::warning("Trust level", "deny (hooks will not run)")
+            .with_suggestion("Run 'git daft hooks trust' to allow hook execution"),
+    }
+}
+
+/// Check if a file is executable (Unix).
+#[cfg(unix)]
+fn is_executable(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    path.metadata()
+        .map(|m| m.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn is_executable(_path: &Path) -> bool {
+    true
+}
+
+/// Set executable permission on a file.
+#[cfg(unix)]
+fn set_executable(path: &Path) -> Result<(), String> {
+    use std::os::unix::fs::PermissionsExt;
+    let metadata = path
+        .metadata()
+        .map_err(|e| format!("Could not read metadata for {}: {e}", path.display()))?;
+    let mut perms = metadata.permissions();
+    let mode = perms.mode();
+    perms.set_mode(mode | 0o111);
+    std::fs::set_permissions(path, perms)
+        .map_err(|e| format!("Could not set permissions for {}: {e}", path.display()))?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn set_executable(_path: &Path) -> Result<(), String> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::doctor::CheckStatus;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_has_hooks_no_hooks_dir() {
+        let temp = tempdir().unwrap();
+        assert!(!has_hooks(temp.path()));
+    }
+
+    #[test]
+    fn test_has_hooks_with_hooks_dir() {
+        let temp = tempdir().unwrap();
+        let worktree = temp.path().join("main");
+        let hooks_dir = worktree.join(PROJECT_HOOKS_DIR);
+        std::fs::create_dir_all(&hooks_dir).unwrap();
+        assert!(has_hooks(temp.path()));
+    }
+
+    #[test]
+    fn test_check_hooks_executable_no_hooks() {
+        let temp = tempdir().unwrap();
+        let result = check_hooks_executable(temp.path());
+        assert_eq!(result.status, CheckStatus::Skipped);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_check_hooks_executable_all_ok() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempdir().unwrap();
+        let worktree = temp.path().join("main");
+        let hooks_dir = worktree.join(PROJECT_HOOKS_DIR);
+        std::fs::create_dir_all(&hooks_dir).unwrap();
+
+        let hook = hooks_dir.join("post-clone");
+        std::fs::write(&hook, "#!/bin/bash").unwrap();
+        let mut perms = hook.metadata().unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&hook, perms).unwrap();
+
+        let result = check_hooks_executable(temp.path());
+        assert_eq!(result.status, CheckStatus::Pass);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_check_hooks_executable_missing_permission() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempdir().unwrap();
+        let worktree = temp.path().join("main");
+        let hooks_dir = worktree.join(PROJECT_HOOKS_DIR);
+        std::fs::create_dir_all(&hooks_dir).unwrap();
+
+        let hook = hooks_dir.join("post-clone");
+        std::fs::write(&hook, "#!/bin/bash").unwrap();
+        let mut perms = hook.metadata().unwrap().permissions();
+        perms.set_mode(0o644);
+        std::fs::set_permissions(&hook, perms).unwrap();
+
+        let result = check_hooks_executable(temp.path());
+        assert_eq!(result.status, CheckStatus::Warning);
+        assert!(result.fixable);
+    }
+
+    #[test]
+    fn test_check_deprecated_names_no_deprecated() {
+        let temp = tempdir().unwrap();
+        let worktree = temp.path().join("main");
+        let hooks_dir = worktree.join(PROJECT_HOOKS_DIR);
+        std::fs::create_dir_all(&hooks_dir).unwrap();
+
+        // Use canonical name
+        std::fs::write(hooks_dir.join("worktree-post-create"), "#!/bin/bash").unwrap();
+
+        let result = check_deprecated_names(temp.path());
+        assert_eq!(result.status, CheckStatus::Pass);
+    }
+
+    #[test]
+    fn test_check_deprecated_names_found() {
+        let temp = tempdir().unwrap();
+        let worktree = temp.path().join("main");
+        let hooks_dir = worktree.join(PROJECT_HOOKS_DIR);
+        std::fs::create_dir_all(&hooks_dir).unwrap();
+
+        // Use deprecated name
+        std::fs::write(hooks_dir.join("post-create"), "#!/bin/bash").unwrap();
+
+        let result = check_deprecated_names(temp.path());
+        assert_eq!(result.status, CheckStatus::Warning);
+        assert!(result.fixable);
+    }
+}

--- a/src/doctor/installation.rs
+++ b/src/doctor/installation.rs
@@ -1,0 +1,305 @@
+//! Installation checks for `daft doctor`.
+//!
+//! Verifies that daft and its dependencies are correctly installed:
+//! binary in PATH, command symlinks, git, man pages, shell integration.
+
+use crate::doctor::CheckResult;
+use std::path::{Path, PathBuf};
+
+/// Expected command symlinks that should point to the daft binary.
+const EXPECTED_SYMLINKS: &[&str] = &[
+    "git-worktree-clone",
+    "git-worktree-init",
+    "git-worktree-checkout",
+    "git-worktree-checkout-branch",
+    "git-worktree-checkout-branch-from-default",
+    "git-worktree-prune",
+    "git-worktree-carry",
+    "git-worktree-fetch",
+    "git-worktree-flow-adopt",
+    "git-worktree-flow-eject",
+    "git-daft",
+];
+
+/// Check that the daft binary is in PATH.
+pub fn check_binary_in_path() -> CheckResult {
+    match which::which("daft") {
+        Ok(path) => {
+            let version = crate::VERSION;
+            CheckResult::pass(
+                "daft binary in PATH",
+                &format!("{} v{version}", path.display()),
+            )
+        }
+        Err(_) => CheckResult::fail("daft binary in PATH", "daft not found in PATH")
+            .with_suggestion("Add the directory containing 'daft' to your PATH"),
+    }
+}
+
+/// Check that all expected command symlinks are present and point to daft.
+pub fn check_command_symlinks() -> CheckResult {
+    let install_dir = match crate::commands::shortcuts::detect_install_dir() {
+        Ok(dir) => dir,
+        Err(_) => {
+            return CheckResult::warning(
+                "Command symlinks",
+                "Could not detect installation directory",
+            );
+        }
+    };
+
+    let mut present = Vec::new();
+    let mut missing = Vec::new();
+
+    for &name in EXPECTED_SYMLINKS {
+        let path = install_dir.join(name);
+        if is_valid_symlink(&path, &install_dir) {
+            present.push(name);
+        } else {
+            missing.push(name);
+        }
+    }
+
+    let total = EXPECTED_SYMLINKS.len();
+    let found = present.len();
+
+    if missing.is_empty() {
+        CheckResult::pass("Command symlinks", &format!("{found}/{total} present"))
+    } else {
+        let details: Vec<String> = missing.iter().map(|n| format!("Missing: {n}")).collect();
+        CheckResult::warning(
+            "Command symlinks",
+            &format!("{found}/{total} present, {} missing", missing.len()),
+        )
+        .with_suggestion("Run 'daft setup' to create missing symlinks")
+        .with_fixable(true)
+        .with_details(details)
+    }
+}
+
+/// Fix missing command symlinks by creating them.
+pub fn fix_command_symlinks() -> Result<(), String> {
+    let install_dir = crate::commands::shortcuts::detect_install_dir()
+        .map_err(|e| format!("Could not detect installation directory: {e}"))?;
+
+    for &name in EXPECTED_SYMLINKS {
+        let path = install_dir.join(name);
+        if !is_valid_symlink(&path, &install_dir) {
+            create_symlink(name, &install_dir)?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Check that git is installed and report its version.
+pub fn check_git() -> CheckResult {
+    match which::which("git") {
+        Ok(_) => match std::process::Command::new("git").arg("--version").output() {
+            Ok(output) if output.status.success() => {
+                let version_str = String::from_utf8_lossy(&output.stdout);
+                let version = version_str
+                    .trim()
+                    .strip_prefix("git version ")
+                    .unwrap_or(version_str.trim());
+                CheckResult::pass("git", &format!("version {version}"))
+            }
+            _ => CheckResult::pass("git", "installed (could not determine version)"),
+        },
+        Err(_) => CheckResult::fail("git", "not found in PATH").with_suggestion("Install git"),
+    }
+}
+
+/// Check that man pages are installed.
+pub fn check_man_pages() -> CheckResult {
+    let man_dirs = get_man_search_paths();
+
+    // Check for a representative man page
+    let test_pages = ["git-worktree-clone.1", "git-worktree-checkout.1"];
+    let mut found_in: Option<PathBuf> = None;
+
+    for dir in &man_dirs {
+        let man1_dir = dir.join("man1");
+        if man1_dir.exists() && test_pages.iter().all(|page| man1_dir.join(page).exists()) {
+            found_in = Some(man1_dir);
+            break;
+        }
+    }
+
+    match found_in {
+        Some(dir) => CheckResult::pass("Man pages installed", &format!("{}", dir.display())),
+        None => CheckResult::warning("Man pages not installed", "man pages not found")
+            .with_suggestion("Run 'just install-man' to install man pages"),
+    }
+}
+
+/// Check that shell integration is configured.
+pub fn check_shell_integration() -> CheckResult {
+    let shell_name = match std::env::var("SHELL") {
+        Ok(shell_path) => {
+            if shell_path.contains("zsh") {
+                "zsh"
+            } else if shell_path.contains("bash") {
+                "bash"
+            } else if shell_path.contains("fish") {
+                "fish"
+            } else {
+                return CheckResult::skipped("Shell integration", "unsupported shell");
+            }
+        }
+        Err(_) => {
+            return CheckResult::skipped("Shell integration", "$SHELL not set");
+        }
+    };
+
+    let home = match std::env::var("HOME") {
+        Ok(h) => h,
+        Err(_) => {
+            return CheckResult::skipped("Shell integration", "$HOME not set");
+        }
+    };
+
+    let config_file = match shell_name {
+        "bash" => PathBuf::from(&home).join(".bashrc"),
+        "zsh" => PathBuf::from(&home).join(".zshrc"),
+        "fish" => PathBuf::from(&home)
+            .join(".config")
+            .join("fish")
+            .join("config.fish"),
+        _ => unreachable!(),
+    };
+
+    if !config_file.exists() {
+        return CheckResult::warning(
+            "Shell integration",
+            &format!("{} not found", config_file.display()),
+        )
+        .with_suggestion("Run 'daft setup' to configure shell integration");
+    }
+
+    match std::fs::read_to_string(&config_file) {
+        Ok(content) if content.contains("daft shell-init") => {
+            CheckResult::pass("Shell integration", &format!("configured ({shell_name})"))
+        }
+        Ok(_) => CheckResult::warning(
+            "Shell integration",
+            &format!("not configured ({shell_name})"),
+        )
+        .with_suggestion("Run 'daft setup' to add shell integration"),
+        Err(_) => CheckResult::warning(
+            "Shell integration",
+            &format!("could not read {}", config_file.display()),
+        ),
+    }
+}
+
+/// Check if a path is a symlink pointing to the daft binary.
+fn is_valid_symlink(path: &Path, install_dir: &Path) -> bool {
+    if path.is_symlink() {
+        if let Ok(target) = std::fs::read_link(path) {
+            // Check relative ("daft") or absolute path targets
+            if target == Path::new("daft") || target == install_dir.join("daft") {
+                return true;
+            }
+            // Canonicalize for other target formats
+            if let Some(parent) = path.parent() {
+                if let (Ok(resolved), Ok(expected)) = (
+                    parent.join(&target).canonicalize(),
+                    install_dir.join("daft").canonicalize(),
+                ) {
+                    return resolved == expected;
+                }
+            }
+        }
+        return false;
+    }
+
+    // On non-Unix platforms, could be a copy rather than a symlink
+    #[cfg(not(unix))]
+    if path.exists() {
+        let daft_path = install_dir.join("daft");
+        if let (Ok(meta_link), Ok(meta_daft)) = (path.metadata(), daft_path.metadata()) {
+            return meta_link.len() == meta_daft.len();
+        }
+    }
+
+    false
+}
+
+/// Create a symlink for a command.
+fn create_symlink(alias: &str, install_dir: &Path) -> Result<(), String> {
+    let link_path = install_dir.join(alias);
+
+    // Remove existing file/symlink if present
+    if link_path.exists() || link_path.is_symlink() {
+        std::fs::remove_file(&link_path)
+            .map_err(|e| format!("Failed to remove existing {alias}: {e}"))?;
+    }
+
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink("daft", &link_path)
+            .map_err(|e| format!("Failed to create symlink for {alias}: {e}"))?;
+    }
+
+    #[cfg(not(unix))]
+    {
+        let daft_binary = install_dir.join("daft");
+        std::fs::copy(&daft_binary, &link_path)
+            .map_err(|e| format!("Failed to copy daft binary to {alias}: {e}"))?;
+    }
+
+    Ok(())
+}
+
+/// Get standard man page search paths.
+fn get_man_search_paths() -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+
+    // Check MANPATH environment variable first
+    if let Ok(manpath) = std::env::var("MANPATH") {
+        for path in manpath.split(':') {
+            if !path.is_empty() {
+                paths.push(PathBuf::from(path));
+            }
+        }
+    }
+
+    // User-local man directory
+    if let Some(home) = dirs::home_dir() {
+        paths.push(home.join(".local").join("share").join("man"));
+    }
+
+    // Homebrew paths
+    paths.push(PathBuf::from("/opt/homebrew/share/man"));
+    paths.push(PathBuf::from("/usr/local/share/man"));
+
+    // System paths
+    paths.push(PathBuf::from("/usr/share/man"));
+
+    paths
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_expected_symlinks_count() {
+        assert_eq!(EXPECTED_SYMLINKS.len(), 11);
+    }
+
+    #[test]
+    fn test_check_git_passes() {
+        // git should be installed in test environments
+        let result = check_git();
+        assert_eq!(result.status, crate::doctor::CheckStatus::Pass);
+        assert!(result.message.contains("version"));
+    }
+
+    #[test]
+    fn test_get_man_search_paths_not_empty() {
+        let paths = get_man_search_paths();
+        assert!(!paths.is_empty());
+    }
+}

--- a/src/doctor/mod.rs
+++ b/src/doctor/mod.rs
@@ -1,0 +1,234 @@
+//! Diagnostic check framework for `daft doctor`.
+//!
+//! Provides types and display helpers for running health checks on
+//! daft installation, repository configuration, and hooks setup.
+
+pub mod hooks_checks;
+pub mod installation;
+pub mod repository;
+
+/// Status of a single diagnostic check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CheckStatus {
+    Pass,
+    Warning,
+    Fail,
+    Skipped,
+}
+
+/// Result of a single diagnostic check.
+#[derive(Debug, Clone)]
+pub struct CheckResult {
+    pub name: String,
+    pub status: CheckStatus,
+    pub message: String,
+    /// Additional details shown in --verbose mode.
+    pub details: Vec<String>,
+    /// Actionable suggestion shown on Warning/Fail.
+    pub suggestion: Option<String>,
+    /// Whether this issue can be auto-fixed with --fix.
+    pub fixable: bool,
+}
+
+impl CheckResult {
+    pub fn pass(name: &str, message: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            status: CheckStatus::Pass,
+            message: message.to_string(),
+            details: Vec::new(),
+            suggestion: None,
+            fixable: false,
+        }
+    }
+
+    pub fn warning(name: &str, message: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            status: CheckStatus::Warning,
+            message: message.to_string(),
+            details: Vec::new(),
+            suggestion: None,
+            fixable: false,
+        }
+    }
+
+    pub fn fail(name: &str, message: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            status: CheckStatus::Fail,
+            message: message.to_string(),
+            details: Vec::new(),
+            suggestion: None,
+            fixable: false,
+        }
+    }
+
+    pub fn skipped(name: &str, message: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            status: CheckStatus::Skipped,
+            message: message.to_string(),
+            details: Vec::new(),
+            suggestion: None,
+            fixable: false,
+        }
+    }
+
+    pub fn with_suggestion(mut self, suggestion: &str) -> Self {
+        self.suggestion = Some(suggestion.to_string());
+        self
+    }
+
+    pub fn with_fixable(mut self, fixable: bool) -> Self {
+        self.fixable = fixable;
+        self
+    }
+
+    pub fn with_details(mut self, details: Vec<String>) -> Self {
+        self.details = details;
+        self
+    }
+}
+
+/// A category of checks with a title and results.
+pub struct CheckCategory {
+    pub title: String,
+    pub results: Vec<CheckResult>,
+}
+
+/// Summary counts for all checks.
+pub struct DoctorSummary {
+    pub passed: usize,
+    pub warnings: usize,
+    pub failures: usize,
+    pub skipped: usize,
+}
+
+impl DoctorSummary {
+    pub fn from_categories(categories: &[CheckCategory]) -> Self {
+        let mut passed = 0;
+        let mut warnings = 0;
+        let mut failures = 0;
+        let mut skipped = 0;
+
+        for category in categories {
+            for result in &category.results {
+                match result.status {
+                    CheckStatus::Pass => passed += 1,
+                    CheckStatus::Warning => warnings += 1,
+                    CheckStatus::Fail => failures += 1,
+                    CheckStatus::Skipped => skipped += 1,
+                }
+            }
+        }
+
+        Self {
+            passed,
+            warnings,
+            failures,
+            skipped,
+        }
+    }
+
+    pub fn has_failures(&self) -> bool {
+        self.failures > 0
+    }
+}
+
+/// Returns the status symbol for a check result.
+pub fn status_symbol(status: CheckStatus) -> String {
+    use crate::styles::{dim, green, red, yellow};
+    match status {
+        CheckStatus::Pass => green("\u{2713}"), // ✓
+        CheckStatus::Warning => yellow("!"),    // !
+        CheckStatus::Fail => red("\u{2717}"),   // ✗
+        CheckStatus::Skipped => dim("-"),       // -
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_check_result_pass() {
+        let result = CheckResult::pass("test", "everything ok");
+        assert_eq!(result.status, CheckStatus::Pass);
+        assert_eq!(result.name, "test");
+        assert_eq!(result.message, "everything ok");
+        assert!(result.suggestion.is_none());
+        assert!(!result.fixable);
+    }
+
+    #[test]
+    fn test_check_result_warning_with_suggestion() {
+        let result = CheckResult::warning("test", "something off")
+            .with_suggestion("fix it")
+            .with_fixable(true);
+        assert_eq!(result.status, CheckStatus::Warning);
+        assert_eq!(result.suggestion.as_deref(), Some("fix it"));
+        assert!(result.fixable);
+    }
+
+    #[test]
+    fn test_check_result_fail() {
+        let result = CheckResult::fail("test", "broken");
+        assert_eq!(result.status, CheckStatus::Fail);
+    }
+
+    #[test]
+    fn test_check_result_skipped() {
+        let result = CheckResult::skipped("test", "not applicable");
+        assert_eq!(result.status, CheckStatus::Skipped);
+    }
+
+    #[test]
+    fn test_check_result_with_details() {
+        let result =
+            CheckResult::pass("test", "ok").with_details(vec!["detail1".into(), "detail2".into()]);
+        assert_eq!(result.details.len(), 2);
+    }
+
+    #[test]
+    fn test_doctor_summary() {
+        let categories = vec![
+            CheckCategory {
+                title: "Test".to_string(),
+                results: vec![
+                    CheckResult::pass("a", "ok"),
+                    CheckResult::pass("b", "ok"),
+                    CheckResult::warning("c", "warn"),
+                ],
+            },
+            CheckCategory {
+                title: "Test2".to_string(),
+                results: vec![
+                    CheckResult::fail("d", "fail"),
+                    CheckResult::skipped("e", "skip"),
+                ],
+            },
+        ];
+
+        let summary = DoctorSummary::from_categories(&categories);
+        assert_eq!(summary.passed, 2);
+        assert_eq!(summary.warnings, 1);
+        assert_eq!(summary.failures, 1);
+        assert_eq!(summary.skipped, 1);
+        assert!(summary.has_failures());
+    }
+
+    #[test]
+    fn test_doctor_summary_no_failures() {
+        let categories = vec![CheckCategory {
+            title: "Test".to_string(),
+            results: vec![
+                CheckResult::pass("a", "ok"),
+                CheckResult::warning("b", "warn"),
+            ],
+        }];
+
+        let summary = DoctorSummary::from_categories(&categories);
+        assert!(!summary.has_failures());
+    }
+}

--- a/src/doctor/repository.rs
+++ b/src/doctor/repository.rs
@@ -1,0 +1,201 @@
+//! Repository checks for `daft doctor`.
+//!
+//! Verifies that the current repository is configured correctly for daft:
+//! worktree layout, worktree consistency, fetch refspec, remote HEAD.
+
+use crate::doctor::CheckResult;
+use crate::git::GitCommand;
+use std::path::{Path, PathBuf};
+
+/// Context for repository checks - gathered once and shared.
+pub struct RepoContext {
+    pub git_common_dir: PathBuf,
+    pub project_root: PathBuf,
+    pub is_bare: bool,
+}
+
+/// Try to build a RepoContext for the current directory.
+/// Returns None if not in a git repository.
+pub fn get_repo_context() -> Option<RepoContext> {
+    if !crate::is_git_repository().ok()? {
+        return None;
+    }
+
+    let git_common_dir = crate::get_git_common_dir().ok()?;
+    let project_root = git_common_dir.parent()?.to_path_buf();
+
+    let git = GitCommand::new(true);
+    let is_bare = git.rev_parse_is_bare_repository().unwrap_or(false);
+
+    Some(RepoContext {
+        git_common_dir,
+        project_root,
+        is_bare,
+    })
+}
+
+/// Check that the repository uses a daft-compatible worktree layout.
+pub fn check_worktree_layout(ctx: &RepoContext) -> CheckResult {
+    let git = GitCommand::new(true);
+
+    if !ctx.is_bare {
+        return CheckResult::warning(
+            "Worktree layout",
+            "Regular (non-bare) repository",
+        )
+        .with_suggestion(
+            "daft works best with bare repos created via 'git worktree-clone' or 'git worktree-init'",
+        );
+    }
+
+    // Count worktrees
+    let worktree_count = match git.worktree_list_porcelain() {
+        Ok(output) => output
+            .lines()
+            .filter(|line| line.starts_with("worktree "))
+            .count(),
+        Err(_) => 0,
+    };
+
+    CheckResult::pass(
+        "Worktree layout",
+        &format!("bare repo + {worktree_count} worktrees"),
+    )
+}
+
+/// Check that all worktree paths exist on disk.
+pub fn check_worktree_consistency(ctx: &RepoContext) -> CheckResult {
+    let git = GitCommand::new(true);
+
+    let porcelain = match git.worktree_list_porcelain() {
+        Ok(output) => output,
+        Err(e) => {
+            return CheckResult::warning(
+                "Worktree consistency",
+                &format!("Could not list worktrees: {e}"),
+            );
+        }
+    };
+
+    let mut orphaned = Vec::new();
+    let mut total = 0;
+
+    for line in porcelain.lines() {
+        if let Some(path_str) = line.strip_prefix("worktree ") {
+            total += 1;
+            let path = Path::new(path_str);
+            // Skip the bare repo itself (it's a valid "worktree" entry)
+            if path == ctx.git_common_dir {
+                continue;
+            }
+            if !path.exists() {
+                orphaned.push(path_str.to_string());
+            }
+        }
+    }
+
+    if orphaned.is_empty() {
+        CheckResult::pass(
+            "Worktree consistency",
+            &format!("{total} worktrees consistent"),
+        )
+    } else {
+        let details: Vec<String> = orphaned
+            .iter()
+            .map(|p| format!("Missing path: {p}"))
+            .collect();
+        CheckResult::warning(
+            "Worktree consistency",
+            &format!("{} orphaned worktree entries", orphaned.len()),
+        )
+        .with_suggestion("Run 'git worktree prune' to clean up orphaned entries")
+        .with_fixable(true)
+        .with_details(details)
+    }
+}
+
+/// Fix orphaned worktree entries by running git worktree prune.
+pub fn fix_worktree_consistency() -> Result<(), String> {
+    let output = std::process::Command::new("git")
+        .args(["worktree", "prune"])
+        .output()
+        .map_err(|e| format!("Failed to run 'git worktree prune': {e}"))?;
+
+    if output.status.success() {
+        Ok(())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        Err(format!("git worktree prune failed: {stderr}"))
+    }
+}
+
+/// Check that the fetch refspec is configured correctly for bare repos.
+pub fn check_fetch_refspec(ctx: &RepoContext) -> CheckResult {
+    if !ctx.is_bare {
+        return CheckResult::skipped("Fetch refspec", "not a bare repository");
+    }
+
+    let git = GitCommand::new(true);
+    let expected = "+refs/heads/*:refs/remotes/origin/*";
+
+    match git.config_get("remote.origin.fetch") {
+        Ok(Some(refspec)) if refspec == expected => {
+            CheckResult::pass("Fetch refspec", "correctly configured")
+        }
+        Ok(Some(refspec)) => {
+            CheckResult::warning("Fetch refspec", &format!("unexpected value: {refspec}"))
+                .with_suggestion(
+                    "Run 'git config remote.origin.fetch \"+refs/heads/*:refs/remotes/origin/*\"'",
+                )
+                .with_fixable(true)
+        }
+        Ok(None) => {
+            // Check if origin remote exists
+            match git.remote_exists("origin") {
+                Ok(true) => CheckResult::warning("Fetch refspec", "not configured")
+                    .with_suggestion("Run 'git config remote.origin.fetch \"+refs/heads/*:refs/remotes/origin/*\"'")
+                    .with_fixable(true),
+                _ => CheckResult::skipped("Fetch refspec", "no origin remote"),
+            }
+        }
+        Err(e) => CheckResult::warning("Fetch refspec", &format!("could not read config: {e}")),
+    }
+}
+
+/// Fix the fetch refspec by setting the correct value.
+pub fn fix_fetch_refspec() -> Result<(), String> {
+    let git = GitCommand::new(true);
+    git.setup_fetch_refspec("origin")
+        .map_err(|e| format!("Failed to set fetch refspec: {e}"))
+}
+
+/// Check that remote HEAD (refs/remotes/origin/HEAD) is set.
+pub fn check_remote_head(ctx: &RepoContext) -> CheckResult {
+    if !ctx.is_bare {
+        return CheckResult::skipped("Remote HEAD", "not a bare repository");
+    }
+
+    let git = GitCommand::new(true);
+
+    // Check if origin remote exists first
+    match git.remote_exists("origin") {
+        Ok(false) => return CheckResult::skipped("Remote HEAD", "no origin remote"),
+        Err(_) => return CheckResult::skipped("Remote HEAD", "could not check remotes"),
+        Ok(true) => {}
+    }
+
+    match git.show_ref_exists("refs/remotes/origin/HEAD") {
+        Ok(true) => CheckResult::pass("Remote HEAD", "set"),
+        Ok(false) => CheckResult::warning("Remote HEAD", "not set")
+            .with_suggestion("Run 'git remote set-head origin --auto'")
+            .with_fixable(true),
+        Err(e) => CheckResult::warning("Remote HEAD", &format!("could not check: {e}")),
+    }
+}
+
+/// Fix remote HEAD by running git remote set-head origin --auto.
+pub fn fix_remote_head() -> Result<(), String> {
+    let git = GitCommand::new(true);
+    git.remote_set_head_auto("origin")
+        .map_err(|e| format!("Failed to set remote HEAD: {e}"))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,7 @@ pub fn get_clap_args(expected_cmd: &str) -> Vec<String> {
 
 pub mod commands;
 pub mod config;
+pub mod doctor;
 pub mod git;
 pub mod git_oxide;
 pub mod hints;

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,6 +62,7 @@ fn main() -> Result<()> {
                     "--help" | "-h" => commands::docs::run(),
                     "branch" => commands::branch::run(),
                     "completions" => commands::completions::run(),
+                    "doctor" => commands::doctor::run(),
                     "__complete" => commands::complete::run(),
                     "__check-update" => {
                         let _ = daft::update_check::run_check_update();

--- a/src/suggest.rs
+++ b/src/suggest.rs
@@ -7,6 +7,7 @@
 pub const DAFT_SUBCOMMANDS: &[&str] = &[
     "branch",
     "completions",
+    "doctor",
     "hooks",
     "multi-remote",
     "release-notes",

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -21,6 +21,7 @@ const COMMANDS: &[&str] = &[
     "git-worktree-fetch",
     "git-worktree-flow-adopt",
     "git-worktree-flow-eject",
+    "daft-doctor",
     "daft-release-notes",
 ];
 
@@ -40,6 +41,7 @@ fn get_command_for_name(command_name: &str) -> Option<clap::Command> {
         "git-worktree-fetch" => Some(daft::commands::fetch::Args::command()),
         "git-worktree-flow-adopt" => Some(daft::commands::flow_adopt::Args::command()),
         "git-worktree-flow-eject" => Some(daft::commands::flow_eject::Args::command()),
+        "daft-doctor" => Some(daft::commands::doctor::Args::command()),
         "daft-release-notes" => Some(daft::commands::release_notes::Args::command()),
         _ => None,
     }


### PR DESCRIPTION
## Summary

- Add `daft doctor` command that inspects daft installation, repository configuration, and hooks setup
- Reports issues with colored status symbols (✓/!/✗/-) and actionable suggestions
- 12 health checks across 3 categories: Installation (5), Repository (4), Hooks (3)
- Supports `--verbose` (detailed output), `--quiet` (warnings only), and `--fix` (auto-fix)
- Auto-fix can create missing symlinks, prune orphaned worktrees, configure fetch refspec, set remote HEAD, fix hook permissions, and rename deprecated hooks

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy -- -D warnings` passes clean
- [x] `just test-unit` — 206 tests pass (17 new doctor tests)
- [x] `just gen-man` + `just verify-man` — man pages up to date
- [x] Manual: `daft doctor` outside a repo (installation checks only)
- [x] Manual: `daft doctor` inside a repo (all applicable checks)
- [x] Manual: `daft doctor --verbose` shows detailed per-check info
- [x] Manual: `daft doctor --quiet` only shows warnings/errors
- [x] Manual: `daft doctor --help` shows proper help text
- [x] `daft --help` includes doctor in command list

Fixes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)