### PR TITLE
docs: rewrite CLAUDE.md following best practices

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ IMPORTANT: Before committing, always run `cargo fmt`, `cargo clippy -- -D warnin
 ## Branch Naming & PRs
 
 - Branch names: `daft-<issue number>/<shortened issue name>`
-- PRs target `master`
+- PRs target `master` and are always **squash merged** (linear history required)
 - PR titles use conventional commit format: `feat: add dark mode toggle`
 - Issue references go in PR body, not title: `Fixes #42`
 


### PR DESCRIPTION
## Summary

- Rewrites CLAUDE.md from 700 lines to 68 lines (~90% reduction) following [Claude Code best practices](https://code.claude.com/docs/en/best-practices#write-an-effective-claude-md)
- Removes content Claude can infer from code: directory listings, workflow tutorials, shortcut mapping tables, implementation details, changelog
- Keeps only what Claude can't figure out on its own: critical rules, build/test/lint commands, architecture decisions, PR conventions, new command checklist

## Test plan

- [x] Verified `cargo fmt -- --check` passes
- [x] Verified `cargo clippy -- -D warnings` passes
- [x] Verified `just test-unit` passes (206 tests)
- [ ] Verify Claude Code sessions use the new CLAUDE.md effectively

Fixes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)