### PR TITLE
docs: add comprehensive documentation and CLI reference generation

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -104,17 +104,18 @@ jobs:
           git fetch origin "$PR_BRANCH"
           git checkout "$PR_BRANCH"
 
-          # Regenerate man pages with new version
+          # Regenerate man pages and CLI docs with new version
           cargo run --package xtask -- gen-man --output-dir=man
+          cargo run --package xtask -- gen-cli-docs --output-dir=docs/cli
 
-          # Check if man pages changed
-          if git diff --quiet man/; then
-            echo "Man pages are already up to date"
+          # Check if anything changed
+          if git diff --quiet man/ docs/cli/; then
+            echo "Man pages and CLI docs are already up to date"
             exit 0
           fi
 
-          # Commit and push the updated man pages
-          git add man/
-          git commit -m "chore: regenerate man pages for new version"
+          # Commit and push the updated files
+          git add man/ docs/cli/
+          git commit -m "chore: regenerate man pages and CLI docs for new version"
           git push origin "$PR_BRANCH"
-          echo "Man pages updated in release PR"
+          echo "Man pages and CLI docs updated in release PR"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -420,5 +420,50 @@ jobs:
         fi
         echo "Committed man pages are up-to-date!"
 
+    - name: Test xtask gen-cli-docs
+      run: |
+        mkdir -p /tmp/cli-docs-test
+        cargo run --package xtask -- gen-cli-docs --output-dir=/tmp/cli-docs-test
+
+        # Verify all expected CLI docs were generated
+        for page in git-worktree-clone git-worktree-init git-worktree-checkout \
+                    git-worktree-checkout-branch git-worktree-checkout-branch-from-default \
+                    git-worktree-prune git-worktree-carry git-worktree-fetch \
+                    git-worktree-flow-adopt git-worktree-flow-eject \
+                    daft-doctor daft-release-notes; do
+          if [ ! -f "/tmp/cli-docs-test/${page}.md" ]; then
+            echo "FAILED: Missing CLI doc: ${page}.md"
+            exit 1
+          fi
+          # Verify it has valid markdown structure (frontmatter and Usage section)
+          if ! head -5 "/tmp/cli-docs-test/${page}.md" | grep -q '^---'; then
+            echo "FAILED: CLI doc missing frontmatter: ${page}.md"
+            exit 1
+          fi
+          if ! grep -q '## Usage' "/tmp/cli-docs-test/${page}.md"; then
+            echo "FAILED: CLI doc missing Usage section: ${page}.md"
+            exit 1
+          fi
+          echo "  ${page}.md - OK"
+        done
+        echo "All CLI docs generated and validated!"
+
+    - name: Verify committed CLI docs are up-to-date
+      run: |
+        # Skip verification on release PRs - release-plz bumps version in Cargo.toml
+        # which causes CLI docs (that embed version) to appear outdated
+        if [[ "${{ github.head_ref }}" == release-plz-* ]]; then
+          echo "Skipping CLI docs verification on release PR (version bump expected)"
+          exit 0
+        fi
+
+        cargo run --package xtask -- gen-cli-docs --output-dir=docs/cli
+        if ! git diff --exit-code docs/cli/; then
+          echo "FAILED: Committed CLI docs are out of date!"
+          echo "Run 'just gen-cli-docs' locally and commit the changes."
+          exit 1
+        fi
+        echo "Committed CLI docs are up-to-date!"
+
     - name: Run xtask unit tests
       run: cargo test --package xtask

--- a/docs/WEBSITE-BOOTSTRAP.md
+++ b/docs/WEBSITE-BOOTSTRAP.md
@@ -1,0 +1,244 @@
+---
+title: Website Bootstrap Guide
+description: Guide for setting up the daft documentation website in a separate repository
+---
+
+# Website Bootstrap Guide
+
+This guide covers setting up a documentation website that renders the markdown content from `daft/docs/`.
+
+## Architecture
+
+- **Content lives here**: All markdown documentation lives in `daft/docs/` and is maintained alongside the code
+- **Website lives separately**: The static site generator and deployment config live in a separate repository
+- **CLI docs are auto-generated**: The `docs/cli/` files are generated from clap definitions and committed to this repo
+
+## Option A: VitePress
+
+[VitePress](https://vitepress.dev/) is a Vue-powered static site generator designed for documentation.
+
+### Setup
+
+```bash
+npm init vitepress@latest daft-docs
+cd daft-docs
+```
+
+### Configuration
+
+`.vitepress/config.ts`:
+
+```ts
+import { defineConfig } from 'vitepress'
+
+export default defineConfig({
+  title: 'daft',
+  description: 'Git Extensions Toolkit',
+  base: '/daft/',
+  themeConfig: {
+    nav: [
+      { text: 'Guide', link: '/getting-started/installation' },
+      { text: 'CLI Reference', link: '/cli/git-worktree-clone' },
+      { text: 'GitHub', link: 'https://github.com/avihut/daft' },
+    ],
+    sidebar: [
+      {
+        text: 'Getting Started',
+        items: [
+          { text: 'Installation', link: '/getting-started/installation' },
+          { text: 'Quick Start', link: '/getting-started/quick-start' },
+          { text: 'Shell Integration', link: '/getting-started/shell-integration' },
+        ],
+      },
+      {
+        text: 'Guide',
+        items: [
+          { text: 'Worktree Workflow', link: '/guide/worktree-workflow' },
+          { text: 'Adopting Existing Repos', link: '/guide/adopting-existing-repos' },
+          { text: 'Hooks', link: '/guide/hooks' },
+          { text: 'Shortcuts', link: '/guide/shortcuts' },
+          { text: 'Multi-Remote', link: '/guide/multi-remote' },
+          { text: 'Configuration', link: '/guide/configuration' },
+        ],
+      },
+      {
+        text: 'CLI Reference',
+        collapsed: false,
+        items: [
+          { text: 'Overview', items: [] },
+          {
+            text: 'Setup',
+            items: [
+              { text: 'worktree-clone', link: '/cli/git-worktree-clone' },
+              { text: 'worktree-init', link: '/cli/git-worktree-init' },
+              { text: 'flow-adopt', link: '/cli/git-worktree-flow-adopt' },
+            ],
+          },
+          {
+            text: 'Branching',
+            items: [
+              { text: 'worktree-checkout', link: '/cli/git-worktree-checkout' },
+              { text: 'worktree-checkout-branch', link: '/cli/git-worktree-checkout-branch' },
+              { text: 'worktree-checkout-branch-from-default', link: '/cli/git-worktree-checkout-branch-from-default' },
+            ],
+          },
+          {
+            text: 'Maintenance',
+            items: [
+              { text: 'worktree-prune', link: '/cli/git-worktree-prune' },
+              { text: 'worktree-fetch', link: '/cli/git-worktree-fetch' },
+              { text: 'worktree-carry', link: '/cli/git-worktree-carry' },
+              { text: 'flow-eject', link: '/cli/git-worktree-flow-eject' },
+            ],
+          },
+          {
+            text: 'Utilities',
+            items: [
+              { text: 'doctor', link: '/cli/daft-doctor' },
+              { text: 'release-notes', link: '/cli/daft-release-notes' },
+            ],
+          },
+        ],
+      },
+      {
+        text: 'Project',
+        items: [
+          { text: 'Contributing', link: '/contributing' },
+          { text: 'Changelog', link: '/changelog' },
+        ],
+      },
+    ],
+  },
+})
+```
+
+## Option B: Starlight (Astro)
+
+[Starlight](https://starlight.astro.build/) is an Astro-powered documentation framework.
+
+### Setup
+
+```bash
+npm create astro@latest -- --template starlight daft-docs
+cd daft-docs
+```
+
+### Configuration
+
+`astro.config.mjs`:
+
+```js
+import { defineConfig } from 'astro/config'
+import starlight from '@astrojs/starlight'
+
+export default defineConfig({
+  integrations: [
+    starlight({
+      title: 'daft',
+      social: { github: 'https://github.com/avihut/daft' },
+      sidebar: [
+        {
+          label: 'Getting Started',
+          items: [
+            { label: 'Installation', slug: 'getting-started/installation' },
+            { label: 'Quick Start', slug: 'getting-started/quick-start' },
+            { label: 'Shell Integration', slug: 'getting-started/shell-integration' },
+          ],
+        },
+        {
+          label: 'Guide',
+          items: [
+            { label: 'Worktree Workflow', slug: 'guide/worktree-workflow' },
+            { label: 'Adopting Existing Repos', slug: 'guide/adopting-existing-repos' },
+            { label: 'Hooks', slug: 'guide/hooks' },
+            { label: 'Shortcuts', slug: 'guide/shortcuts' },
+            { label: 'Multi-Remote', slug: 'guide/multi-remote' },
+            { label: 'Configuration', slug: 'guide/configuration' },
+          ],
+        },
+        {
+          label: 'CLI Reference',
+          autogenerate: { directory: 'cli' },
+        },
+        {
+          label: 'Project',
+          items: [
+            { label: 'Contributing', slug: 'contributing' },
+            { label: 'Changelog', slug: 'changelog' },
+          ],
+        },
+      ],
+    }),
+  ],
+})
+```
+
+## Content Sourcing
+
+The recommended approach is a CI-based copy: a GitHub Action in the docs repo clones the daft repo and copies `docs/` into the site's content directory.
+
+### CI Copy Approach (Recommended)
+
+In the docs repo, create `.github/workflows/deploy.yml`:
+
+```yaml
+name: Deploy Docs
+
+on:
+  push:
+    branches: [main]
+  repository_dispatch:
+    types: [docs-update]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Fetch docs content from daft
+        run: |
+          git clone --depth 1 https://github.com/avihut/daft.git /tmp/daft
+          # Copy docs content (adjust destination for your site generator)
+          cp -r /tmp/daft/docs/* src/content/docs/  # Starlight
+          # or: cp -r /tmp/daft/docs/* docs/        # VitePress
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Deploy
+        # Deploy to your hosting provider (GitHub Pages, Netlify, Vercel, etc.)
+```
+
+### Alternatives
+
+- **Git submodule**: Add `daft` as a submodule in the docs repo. Requires manual submodule updates.
+- **npm package**: Publish docs as an npm package. Adds complexity with little benefit.
+
+## Triggering Docs Rebuild from daft Releases
+
+Add a `repository_dispatch` step to daft's `release.yml` workflow:
+
+```yaml
+- name: Trigger docs rebuild
+  uses: peter-evans/repository-dispatch@v3
+  with:
+    token: ${{ secrets.DOCS_REPO_TOKEN }}
+    repository: avihut/daft-docs
+    event-type: docs-update
+    client-payload: '{"version": "${{ github.ref_name }}"}'
+```
+
+This ensures the docs site rebuilds whenever a new daft version is released.
+
+## Sidebar Structure
+
+The recommended sidebar organization groups content by user journey:
+
+1. **Getting Started** - Installation, Quick Start, Shell Integration
+2. **Guide** - Worktree Workflow, Adopting Repos, Hooks, Shortcuts, Multi-Remote, Configuration
+3. **CLI Reference** - 12 commands grouped by category (Setup, Branching, Maintenance, Utilities)
+4. **Project** - Contributing, Changelog

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,26 @@
+---
+title: Changelog
+description: Release history and notable changes
+---
+
+# Changelog
+
+The full changelog is maintained in the repository's [CHANGELOG.md](https://github.com/avihut/daft/blob/master/CHANGELOG.md) file, which is automatically updated by [release-plz](https://release-plz.dev/) with each release.
+
+You can also view release notes from the command line:
+
+```bash
+# View all release notes
+daft release-notes
+
+# View a specific version
+daft release-notes 1.0.20
+
+# List all versions
+daft release-notes --list
+
+# Show latest 5 releases
+daft release-notes --latest 5
+```
+
+See the [GitHub Releases](https://github.com/avihut/daft/releases) page for downloadable binaries and release notes.

--- a/docs/cli/daft-doctor.md
+++ b/docs/cli/daft-doctor.md
@@ -1,0 +1,45 @@
+---
+title: daft-doctor
+description: Diagnose daft installation and configuration issues
+---
+
+# daft doctor
+
+Diagnose daft installation and configuration issues
+
+## Description
+
+Diagnose daft installation and configuration issues.
+
+Runs health checks on your daft installation, repository setup,
+and hooks configuration. Reports issues with actionable suggestions.
+
+When run outside a git repository, only installation checks are performed.
+Inside a daft-managed repository, repository and hooks checks run too.
+
+## Usage
+
+```
+daft doctor [OPTIONS]
+```
+
+## Options
+
+| Option | Description | Default |
+|--------|-------------|----------|
+| `-v, --verbose` | Show detailed output for each check |  |
+| `--fix` | Auto-fix issues that can be resolved automatically |  |
+| `-q, --quiet` | Only show warnings and errors |  |
+
+## Global Options
+
+| Option | Description |
+|--------|-------------|
+| `-h`, `--help` | Print help information |
+| `-V`, `--version` | Print version information |
+
+## See Also
+
+- [git-worktree-clone](./git-worktree-clone.md)
+- [git-worktree-init](./git-worktree-init.md)
+

--- a/docs/cli/daft-release-notes.md
+++ b/docs/cli/daft-release-notes.md
@@ -1,0 +1,47 @@
+---
+title: daft-release-notes
+description: Display release notes from the changelog
+---
+
+# daft release-notes
+
+Display release notes from the changelog
+
+## Description
+
+Displays release notes from daft's changelog in a scrollable interface
+using the system pager (similar to how git displays man pages).
+
+By default, shows all release notes. Use the VERSION argument to show
+notes for a specific version, or use --list to see a summary of all
+available versions.
+
+The pager can be navigated using standard less commands:
+  - Space/Page Down: scroll down one page
+  - b/Page Up: scroll up one page
+  - /pattern: search for text
+  - n: find next match
+  - q: quit
+
+## Usage
+
+```
+daft release-notes [OPTIONS]
+```
+
+## Options
+
+| Option | Description | Default |
+|--------|-------------|----------|
+| `-l, --list` | List all versions without full notes |  |
+| `-n, --latest <N>` | Show only the latest N releases (default: all) |  |
+| `--json` | Output as JSON for scripting |  |
+| `--no-pager` | Disable pager, print directly to stdout |  |
+
+## Global Options
+
+| Option | Description |
+|--------|-------------|
+| `-h`, `--help` | Print help information |
+| `-V`, `--version` | Print version information |
+

--- a/docs/cli/git-worktree-carry.md
+++ b/docs/cli/git-worktree-carry.md
@@ -1,0 +1,58 @@
+---
+title: git-worktree-carry
+description: Transfer uncommitted changes to other worktrees
+---
+
+# git worktree-carry
+
+Transfer uncommitted changes to other worktrees
+
+## Description
+
+Transfers uncommitted changes (staged, unstaged, and untracked files) from
+the current worktree to one or more target worktrees.
+
+When a single target is specified without --copy, changes are moved: they
+are applied to the target worktree and removed from the source. When --copy
+is specified or multiple targets are given, changes are copied: they are
+applied to all targets while remaining in the source worktree.
+
+Targets may be specified by worktree directory name or by branch name. If
+both a worktree and a branch have the same name, the worktree takes
+precedence.
+
+After transferring changes, the working directory is changed to the last
+target worktree (or the only target, if just one was specified).
+
+## Usage
+
+```
+git worktree-carry [OPTIONS] <TARGETS>
+```
+
+## Arguments
+
+| Argument | Description | Required |
+|----------|-------------|----------|
+| `<TARGETS>` | Target worktree(s) by directory name or branch name | Yes |
+
+## Options
+
+| Option | Description | Default |
+|--------|-------------|----------|
+| `-c, --copy` | Copy changes instead of moving; changes remain in the source worktree |  |
+| `-v, --verbose` | Be verbose; show detailed progress |  |
+
+## Global Options
+
+| Option | Description |
+|--------|-------------|
+| `-h`, `--help` | Print help information |
+| `-V`, `--version` | Print version information |
+
+## See Also
+
+- [git-worktree-checkout](./git-worktree-checkout.md)
+- [git-worktree-checkout-branch](./git-worktree-checkout-branch.md)
+- [git-worktree-fetch](./git-worktree-fetch.md)
+

--- a/docs/cli/git-worktree-checkout-branch-from-default.md
+++ b/docs/cli/git-worktree-checkout-branch-from-default.md
@@ -1,0 +1,58 @@
+---
+title: git-worktree-checkout-branch-from-default
+description: Create a worktree with a new branch based on the remote's default branch
+---
+
+# git worktree-checkout-branch-from-default
+
+Create a worktree with a new branch based on the remote's default branch
+
+## Description
+
+Creates a new branch based on the remote's default branch (typically main or
+master) and a corresponding worktree. This is equivalent to running
+git-worktree-checkout-branch(1) with the default branch as the base.
+
+The default branch is determined by querying the remote's HEAD reference.
+This command is useful when the current branch has diverged from the mainline
+and a fresh starting point is needed.
+
+By default, uncommitted changes from the current worktree are carried to the
+new worktree; use --no-carry to disable this. The worktree is placed at the
+project root level as a sibling to other worktrees.
+
+## Usage
+
+```
+git worktree-checkout-branch-from-default [OPTIONS] <NEW_BRANCH_NAME>
+```
+
+## Arguments
+
+| Argument | Description | Required |
+|----------|-------------|----------|
+| `<NEW_BRANCH_NAME>` | Name for the new branch (also used as the worktree directory name) | Yes |
+
+## Options
+
+| Option | Description | Default |
+|--------|-------------|----------|
+| `-v, --verbose` | Be verbose; show detailed progress |  |
+| `-c, --carry` | Apply uncommitted changes to the new worktree (this is the default) |  |
+| `--no-carry` | Do not carry uncommitted changes to the new worktree |  |
+| `-r, --remote <REMOTE>` | Remote for worktree organization (multi-remote mode) |  |
+| `--no-cd` | Do not change directory to the new worktree |  |
+
+## Global Options
+
+| Option | Description |
+|--------|-------------|
+| `-h`, `--help` | Print help information |
+| `-V`, `--version` | Print version information |
+
+## See Also
+
+- [git-worktree-checkout](./git-worktree-checkout.md)
+- [git-worktree-checkout-branch](./git-worktree-checkout-branch.md)
+- [git-worktree-carry](./git-worktree-carry.md)
+

--- a/docs/cli/git-worktree-checkout-branch.md
+++ b/docs/cli/git-worktree-checkout-branch.md
@@ -1,0 +1,61 @@
+---
+title: git-worktree-checkout-branch
+description: Create a worktree with a new branch
+---
+
+# git worktree-checkout-branch
+
+Create a worktree with a new branch
+
+## Description
+
+Creates a new branch and a corresponding worktree in a single operation. The
+new branch is based on the current branch, or on <base-branch> if specified.
+The worktree is placed at the project root level as a sibling to other
+worktrees.
+
+After creating the branch locally, this command pushes it to the remote and
+configures upstream tracking. By default, uncommitted changes from the current
+worktree are carried to the new worktree; use --no-carry to disable this.
+
+This command can be run from anywhere within the repository. Lifecycle hooks
+from .daft/hooks/ are executed if the repository is trusted. See git-daft(1)
+for hook management.
+
+## Usage
+
+```
+git worktree-checkout-branch [OPTIONS] <NEW_BRANCH_NAME> [BASE_BRANCH_NAME]
+```
+
+## Arguments
+
+| Argument | Description | Required |
+|----------|-------------|----------|
+| `<NEW_BRANCH_NAME>` | Name for the new branch (also used as the worktree directory name) | Yes |
+| `<BASE_BRANCH_NAME>` | Branch to use as the base for the new branch; defaults to the current branch | No |
+
+## Options
+
+| Option | Description | Default |
+|--------|-------------|----------|
+| `-q, --quiet` | Operate quietly; suppress progress reporting |  |
+| `-v, --verbose` | Be verbose; show detailed progress |  |
+| `-c, --carry` | Apply uncommitted changes to the new worktree (this is the default) |  |
+| `--no-carry` | Do not carry uncommitted changes to the new worktree |  |
+| `-r, --remote <REMOTE>` | Remote for worktree organization (multi-remote mode) |  |
+| `--no-cd` | Do not change directory to the new worktree |  |
+
+## Global Options
+
+| Option | Description |
+|--------|-------------|
+| `-h`, `--help` | Print help information |
+| `-V`, `--version` | Print version information |
+
+## See Also
+
+- [git-worktree-checkout](./git-worktree-checkout.md)
+- [git-worktree-checkout-branch-from-default](./git-worktree-checkout-branch-from-default.md)
+- [git-worktree-carry](./git-worktree-carry.md)
+

--- a/docs/cli/git-worktree-checkout.md
+++ b/docs/cli/git-worktree-checkout.md
@@ -1,0 +1,61 @@
+---
+title: git-worktree-checkout
+description: Create a worktree for an existing branch
+---
+
+# git worktree-checkout
+
+Create a worktree for an existing branch
+
+## Description
+
+Creates a new worktree for an existing local or remote branch. The worktree
+is placed at the project root level as a sibling to other worktrees, using
+the branch name as the directory name.
+
+If the branch exists only on the remote, a local tracking branch is created
+automatically. If the branch exists both locally and on the remote, the local
+branch is checked out and upstream tracking is configured.
+
+This command can be run from anywhere within the repository. If a worktree
+for the specified branch already exists, no new worktree is created; the
+working directory is changed to the existing worktree instead.
+
+Lifecycle hooks from .daft/hooks/ are executed if the repository is trusted.
+See git-daft(1) for hook management.
+
+## Usage
+
+```
+git worktree-checkout [OPTIONS] <BRANCH_NAME>
+```
+
+## Arguments
+
+| Argument | Description | Required |
+|----------|-------------|----------|
+| `<BRANCH_NAME>` | Name of the branch to check out | Yes |
+
+## Options
+
+| Option | Description | Default |
+|--------|-------------|----------|
+| `-v, --verbose` | Be verbose; show detailed progress |  |
+| `-c, --carry` | Apply uncommitted changes from the current worktree to the new one |  |
+| `--no-carry` | Do not carry uncommitted changes (this is the default) |  |
+| `-r, --remote <REMOTE>` | Remote for worktree organization (multi-remote mode) |  |
+| `--no-cd` | Do not change directory to the new worktree |  |
+
+## Global Options
+
+| Option | Description |
+|--------|-------------|
+| `-h`, `--help` | Print help information |
+| `-V`, `--version` | Print version information |
+
+## See Also
+
+- [git-worktree-checkout-branch](./git-worktree-checkout-branch.md)
+- [git-worktree-checkout-branch-from-default](./git-worktree-checkout-branch-from-default.md)
+- [git-worktree-carry](./git-worktree-carry.md)
+

--- a/docs/cli/git-worktree-clone.md
+++ b/docs/cli/git-worktree-clone.md
@@ -1,0 +1,64 @@
+---
+title: git-worktree-clone
+description: Clone a repository into a worktree-based directory structure
+---
+
+# git worktree-clone
+
+Clone a repository into a worktree-based directory structure
+
+## Description
+
+Clones a repository into a directory structure optimized for worktree-based
+development. The resulting layout is:
+
+    <repository-name>/.git    (bare repository metadata)
+    <repository-name>/<branch>  (worktree for the checked-out branch)
+
+The command first queries the remote to determine the default branch (main,
+master, or other configured default), then performs a bare clone and creates
+the initial worktree. This structure allows multiple worktrees to be created
+as siblings, each containing a different branch.
+
+If the repository contains a .daft/hooks/ directory and the repository is
+trusted, lifecycle hooks are executed. See git-daft(1) for hook management.
+
+## Usage
+
+```
+git worktree-clone [OPTIONS] <REPOSITORY_URL>
+```
+
+## Arguments
+
+| Argument | Description | Required |
+|----------|-------------|----------|
+| `<REPOSITORY_URL>` | The repository URL to clone (HTTPS or SSH) | Yes |
+
+## Options
+
+| Option | Description | Default |
+|--------|-------------|----------|
+| `-b, --branch <BRANCH>` | Check out <branch> instead of the remote's default branch |  |
+| `-n, --no-checkout` | Perform a bare clone only; do not create any worktree |  |
+| `-q, --quiet` | Operate quietly; suppress progress reporting |  |
+| `-v, --verbose` | Be verbose; show detailed progress |  |
+| `-a, --all-branches` | Create a worktree for each remote branch, not just the default |  |
+| `--trust-hooks` | Trust the repository and allow hooks to run without prompting |  |
+| `--no-hooks` | Do not run any hooks from the repository |  |
+| `-r, --remote <REMOTE>` | Organize worktree under this remote folder (enables multi-remote mode) |  |
+| `--no-cd` | Do not change directory to the new worktree |  |
+
+## Global Options
+
+| Option | Description |
+|--------|-------------|
+| `-h`, `--help` | Print help information |
+| `-V`, `--version` | Print version information |
+
+## See Also
+
+- [git-worktree-init](./git-worktree-init.md)
+- [git-worktree-checkout](./git-worktree-checkout.md)
+- [git-worktree-flow-adopt](./git-worktree-flow-adopt.md)
+

--- a/docs/cli/git-worktree-fetch.md
+++ b/docs/cli/git-worktree-fetch.md
@@ -1,0 +1,65 @@
+---
+title: git-worktree-fetch
+description: Update worktree branches from their remote tracking branches
+---
+
+# git worktree-fetch
+
+Update worktree branches from their remote tracking branches
+
+## Description
+
+Updates worktree branches by pulling from their remote tracking branches.
+
+For each target worktree, the command navigates to that directory and runs
+`git pull` with the configured options. By default, only fast-forward updates
+are allowed (--ff-only).
+
+Targets can be specified by worktree directory name or branch name. If no
+targets are specified and --all is not used, the current worktree is updated.
+
+Worktrees with uncommitted changes are skipped unless --force is specified.
+Use --dry-run to preview what would be done without making changes.
+
+Arguments after -- are passed directly to git pull, allowing full control
+over the pull behavior.
+
+## Usage
+
+```
+git worktree-fetch [OPTIONS] [TARGETS] [PULL_ARGS]
+```
+
+## Arguments
+
+| Argument | Description | Required |
+|----------|-------------|----------|
+| `<TARGETS>` | Target worktree(s) by directory name or branch name | No |
+| `<PULL_ARGS>` | Additional arguments to pass to git pull | No |
+
+## Options
+
+| Option | Description | Default |
+|--------|-------------|----------|
+| `--all` | Update all worktrees |  |
+| `-f, --force` | Update even with uncommitted changes |  |
+| `--dry-run` | Show what would be done |  |
+| `--rebase` | Use git pull --rebase |  |
+| `--autostash` | Use git pull --autostash |  |
+| `--ff-only` | Only fast-forward (default) |  |
+| `--no-ff-only` | Allow merge commits |  |
+| `-v, --verbose` | Be verbose; show detailed progress |  |
+| `-q, --quiet` | Suppress non-error output |  |
+
+## Global Options
+
+| Option | Description |
+|--------|-------------|
+| `-h`, `--help` | Print help information |
+| `-V`, `--version` | Print version information |
+
+## See Also
+
+- [git-worktree-prune](./git-worktree-prune.md)
+- [git-worktree-carry](./git-worktree-carry.md)
+

--- a/docs/cli/git-worktree-flow-adopt.md
+++ b/docs/cli/git-worktree-flow-adopt.md
@@ -1,0 +1,106 @@
+---
+title: git-worktree-flow-adopt
+description: Convert a traditional repository to worktree-based layout
+---
+
+# git worktree-flow-adopt
+
+Convert a traditional repository to worktree-based layout
+
+## Description
+
+WHAT THIS COMMAND DOES
+
+Converts your existing Git repository from the traditional layout to daft's
+worktree-based layout. After conversion:
+
+  Before:                    After:
+  my-project/                my-project/
+  ├── .git/                  ├── .git/        (bare repository)
+  ├── src/                   └── main/        (worktree)
+  └── README.md                  ├── src/
+                                 └── README.md
+
+Your uncommitted changes (staged and unstaged) are preserved in the new
+worktree. The command is safe to run - if anything fails, your repository
+is restored to its original state.
+
+ABOUT THE WORKTREE WORKFLOW
+
+The worktree workflow eliminates Git branch switching friction by giving
+each branch its own directory. Instead of switching branches within a
+single directory, you navigate between directories - each containing
+a different branch.
+
+BENEFITS
+
+- No more stashing: Each branch has its own working directory
+- Parallel development: Work on multiple branches simultaneously
+- Persistent context: Each worktree keeps its own IDE state, terminal
+  history, and environment (.envrc, node_modules, etc.)
+- Instant switching: Just cd to another directory
+- Safe experimentation: Changes in one worktree never affect another
+
+HOW TO WORK WITH IT
+
+After adopting, use these commands:
+
+  git worktree-checkout <branch>
+      Check out an existing branch into a new worktree
+
+  git worktree-checkout-branch <new-branch>
+      Create a new branch and worktree from current branch
+
+  git worktree-checkout-branch-from-default <new-branch>
+      Create a new branch from the remote's default branch
+
+  git worktree-prune
+      Clean up worktrees for merged/deleted branches
+
+Your directory structure grows as you work:
+
+  my-project/
+  ├── .git/
+  ├── main/              # Default branch
+  ├── feature/auth/      # Feature branch
+  └── bugfix/login/      # Bugfix branch
+
+REVERTING
+
+To convert back to a traditional layout, use git-worktree-flow-eject(1).
+
+## Usage
+
+```
+git worktree-flow-adopt [OPTIONS] [REPOSITORY_PATH]
+```
+
+## Arguments
+
+| Argument | Description | Required |
+|----------|-------------|----------|
+| `<REPOSITORY_PATH>` | Path to the repository to convert (defaults to current directory) | No |
+
+## Options
+
+| Option | Description | Default |
+|--------|-------------|----------|
+| `-q, --quiet` | Operate quietly; suppress progress reporting |  |
+| `-v, --verbose` | Be verbose; show detailed progress |  |
+| `--trust-hooks` | Trust the repository and allow hooks to run without prompting |  |
+| `--no-hooks` | Do not run any hooks from the repository |  |
+| `--dry-run` | Show what would be done without making any changes |  |
+
+## Global Options
+
+| Option | Description |
+|--------|-------------|
+| `-h`, `--help` | Print help information |
+| `-V`, `--version` | Print version information |
+
+## See Also
+
+- [git-worktree-clone](./git-worktree-clone.md)
+- [git-worktree-init](./git-worktree-init.md)
+- [git-worktree-flow-eject](./git-worktree-flow-eject.md)
+

--- a/docs/cli/git-worktree-flow-eject.md
+++ b/docs/cli/git-worktree-flow-eject.md
@@ -1,0 +1,81 @@
+---
+title: git-worktree-flow-eject
+description: Convert a worktree-based repository back to traditional layout
+---
+
+# git worktree-flow-eject
+
+Convert a worktree-based repository back to traditional layout
+
+## Description
+
+WHAT THIS COMMAND DOES
+
+Converts your worktree-based repository back to a traditional Git layout.
+This removes all worktrees except one, and moves that worktree's files
+back to the repository root.
+
+  Before:                    After:
+  my-project/                my-project/
+  ├── .git/                  ├── .git/
+  ├── main/                  ├── src/
+  │   ├── src/               └── README.md
+  │   └── README.md
+  └── feature/auth/
+      └── ...
+
+By default, the remote's default branch (main, master, etc.) is kept.
+Use --branch to specify a different branch.
+
+HANDLING UNCOMMITTED CHANGES
+
+- Changes in the target branch's worktree are preserved
+- Other worktrees with uncommitted changes cause the command to fail
+- Use --force to delete dirty worktrees (changes will be lost!)
+
+EXAMPLES
+
+  git worktree-flow-eject
+      Eject to the default branch
+
+  git worktree-flow-eject -b feature/auth
+      Eject, keeping the feature/auth branch
+
+  git worktree-flow-eject --force
+      Eject even if other worktrees have uncommitted changes
+
+## Usage
+
+```
+git worktree-flow-eject [OPTIONS] [REPOSITORY_PATH]
+```
+
+## Arguments
+
+| Argument | Description | Required |
+|----------|-------------|----------|
+| `<REPOSITORY_PATH>` | Path to the repository to convert (defaults to current directory) | No |
+
+## Options
+
+| Option | Description | Default |
+|--------|-------------|----------|
+| `-b, --branch <BRANCH>` | Branch to keep (defaults to remote's default branch) |  |
+| `-f, --force` | Delete worktrees with uncommitted changes (changes will be lost!) |  |
+| `-q, --quiet` | Operate quietly; suppress progress reporting |  |
+| `-v, --verbose` | Be verbose; show detailed progress |  |
+| `--dry-run` | Show what would be done without making any changes |  |
+
+## Global Options
+
+| Option | Description |
+|--------|-------------|
+| `-h`, `--help` | Print help information |
+| `-V`, `--version` | Print version information |
+
+## See Also
+
+- [git-worktree-flow-adopt](./git-worktree-flow-adopt.md)
+- [git-worktree-prune](./git-worktree-prune.md)
+- [git-worktree-clone](./git-worktree-clone.md)
+

--- a/docs/cli/git-worktree-init.md
+++ b/docs/cli/git-worktree-init.md
@@ -1,0 +1,63 @@
+---
+title: git-worktree-init
+description: Initialize a new repository in the worktree-based directory structure
+---
+
+# git worktree-init
+
+Initialize a new repository in the worktree-based directory structure
+
+## Description
+
+Initializes a new Git repository using the same directory structure as
+git-worktree-clone(1). The resulting layout is:
+
+    <name>/.git      (bare repository metadata)
+    <name>/<branch>  (worktree for the initial branch)
+
+This structure is optimized for worktree-based development, allowing multiple
+branches to be checked out simultaneously as sibling directories.
+
+The initial branch name is determined by, in order of precedence: the -b
+option, the init.defaultBranch configuration value, or "master" as a fallback.
+
+If the repository contains a .daft/hooks/ directory (created manually after
+init) and is trusted, lifecycle hooks are executed. See git-daft(1) for hook
+management.
+
+## Usage
+
+```
+git worktree-init [OPTIONS] <REPOSITORY_NAME>
+```
+
+## Arguments
+
+| Argument | Description | Required |
+|----------|-------------|----------|
+| `<REPOSITORY_NAME>` | Name for the new repository directory | Yes |
+
+## Options
+
+| Option | Description | Default |
+|--------|-------------|----------|
+| `--bare` | Create only the bare repository; do not create an initial worktree |  |
+| `-q, --quiet` | Operate quietly; suppress progress reporting |  |
+| `-v, --verbose` | Be verbose; show detailed progress |  |
+| `-b, --initial-branch <INITIAL_BRANCH>` | Use <name> as the initial branch instead of the configured default |  |
+| `-r, --remote <REMOTE>` | Organize worktree under this remote folder (enables multi-remote mode) |  |
+| `--no-cd` | Do not change directory to the new worktree |  |
+
+## Global Options
+
+| Option | Description |
+|--------|-------------|
+| `-h`, `--help` | Print help information |
+| `-V`, `--version` | Print version information |
+
+## See Also
+
+- [git-worktree-clone](./git-worktree-clone.md)
+- [git-worktree-checkout-branch](./git-worktree-checkout-branch.md)
+- [git-worktree-flow-adopt](./git-worktree-flow-adopt.md)
+

--- a/docs/cli/git-worktree-prune.md
+++ b/docs/cli/git-worktree-prune.md
@@ -1,0 +1,54 @@
+---
+title: git-worktree-prune
+description: Remove worktrees and branches for deleted remote branches
+---
+
+# git worktree-prune
+
+Remove worktrees and branches for deleted remote branches
+
+## Description
+
+Removes local branches whose corresponding remote tracking branches have been
+deleted, along with any associated worktrees. This is useful for cleaning up
+after branches have been merged and deleted on the remote.
+
+The command first fetches from the remote with pruning enabled to update the
+list of remote tracking branches. It then identifies local branches that were
+tracking now-deleted remote branches, removes their worktrees (if any exist),
+and finally deletes the local branches.
+
+If you are currently inside a worktree that is about to be pruned, the command
+handles this gracefully. In a bare-repo worktree layout (created by daft), the
+current worktree is removed last and the shell is redirected to a safe location
+(project root by default, or the default branch worktree if configured via
+daft.prune.cdTarget). In a regular repository where the current branch is being
+pruned, the command checks out the default branch before deleting the old branch.
+
+Pre-remove and post-remove lifecycle hooks are executed for each worktree
+removal if the repository is trusted. See git-daft(1) for hook management.
+
+## Usage
+
+```
+git worktree-prune [OPTIONS]
+```
+
+## Options
+
+| Option | Description | Default |
+|--------|-------------|----------|
+| `-v, --verbose` | Be verbose; show detailed progress |  |
+
+## Global Options
+
+| Option | Description |
+|--------|-------------|
+| `-h`, `--help` | Print help information |
+| `-V`, `--version` | Print version information |
+
+## See Also
+
+- [git-worktree-fetch](./git-worktree-fetch.md)
+- [git-worktree-flow-eject](./git-worktree-flow-eject.md)
+

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,130 @@
+---
+title: Contributing
+description: Guidelines for contributing to daft
+---
+
+# Contributing
+
+Thank you for your interest in contributing to daft!
+
+## Development Setup
+
+1. **Clone the repository** using daft's worktree layout:
+
+   ```bash
+   git worktree-clone git@github.com:avihut/daft.git
+   ```
+
+2. **Build and set up the development environment:**
+
+   ```bash
+   just dev
+   ```
+
+   This builds the binary, creates all symlinks in `target/release/`, and verifies the setup.
+
+3. **Add the binary to your PATH:**
+
+   ```bash
+   export PATH="$PWD/target/release:$PATH"
+   ```
+
+## Development Workflow
+
+1. Create a feature branch:
+
+   ```bash
+   git worktree-checkout-branch daft-XX/feature-name
+   ```
+
+2. Make changes following the conventions below.
+
+3. Run quality checks before committing:
+
+   ```bash
+   cargo fmt
+   cargo clippy -- -D warnings
+   just test-unit
+   ```
+
+4. Submit a pull request targeting `master`.
+
+## Code Quality Requirements
+
+All PRs must pass these checks (enforced in CI):
+
+- **Formatting:** `cargo fmt -- --check`
+- **Linting:** `cargo clippy -- -D warnings` (zero warnings)
+- **Unit tests:** `cargo test --lib`
+- **Integration tests:** `just test-integration`
+
+Run the full CI simulation locally:
+
+```bash
+just ci
+```
+
+## Commit Messages
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/) for automatic changelog generation.
+
+Format: `<type>[scope]: <description>`
+
+| Type | Description |
+|------|-------------|
+| `feat` | New feature |
+| `fix` | Bug fix |
+| `docs` | Documentation changes |
+| `style` | Code style (no logic change) |
+| `refactor` | Code refactoring |
+| `perf` | Performance improvement |
+| `test` | Adding/updating tests |
+| `chore` | Maintenance tasks |
+| `ci` | CI/CD changes |
+
+Examples:
+
+```bash
+feat(checkout): add --force flag for overwriting worktrees
+fix: resolve branch name parsing for names with slashes
+docs: update installation instructions
+```
+
+## Pull Request Guidelines
+
+- PR titles use conventional commit format: `feat: add dark mode toggle`
+- Issue references go in the PR body, not the title: `Fixes #42`
+- All PRs target `master` and are squash-merged
+
+## Branch Naming
+
+Follow the convention: `daft-<issue-number>/<short-description>`
+
+```
+daft-42/dark-mode
+daft-15/branch-search
+```
+
+## Testing
+
+```bash
+just test              # Run all tests
+just test-unit         # Rust unit tests only
+just test-integration  # End-to-end tests
+```
+
+See [CLAUDE.md](https://github.com/avihut/daft/blob/master/CLAUDE.md) in the repository for the complete testing architecture.
+
+## Adding a New Command
+
+1. Create `src/commands/<name>.rs` with a clap `Args` struct (include `about`, `long_about`, `arg(help)` attributes)
+2. Add the module to `src/commands/mod.rs`
+3. Add routing in `src/main.rs`
+4. Add to `COMMANDS` array and `get_command_for_name()` in `xtask/src/main.rs`
+5. Add to help output in `src/commands/docs.rs` (`get_command_categories()`)
+6. Run `just gen-man` and `just gen-cli-docs` and commit the generated files
+7. Add integration tests in `tests/integration/`
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the MIT License.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,0 +1,100 @@
+---
+title: Installation
+description: Install daft on macOS, Linux, or Windows
+---
+
+# Installation
+
+## macOS (Homebrew)
+
+The recommended way to install on macOS:
+
+```bash
+brew install avihut/tap/daft
+```
+
+This installs the `daft` binary, all command symlinks, and man pages.
+
+## Windows
+
+Run the PowerShell installer:
+
+```powershell
+irm https://github.com/avihut/daft/releases/latest/download/daft-installer.ps1 | iex
+```
+
+## Linux
+
+Download the latest binary from [GitHub Releases](https://github.com/avihut/daft/releases/latest):
+
+```bash
+# Download and extract
+curl -fsSL https://github.com/avihut/daft/releases/latest/download/daft-x86_64-unknown-linux-gnu.tar.gz | tar xz
+
+# Move to a directory in your PATH
+sudo mv daft /usr/local/bin/
+
+# Create command symlinks
+cd /usr/local/bin
+for cmd in git-worktree-clone git-worktree-init git-worktree-checkout \
+           git-worktree-checkout-branch git-worktree-checkout-branch-from-default \
+           git-worktree-prune git-worktree-carry git-worktree-fetch \
+           git-worktree-flow-adopt git-worktree-flow-eject git-daft; do
+  sudo ln -sf daft "$cmd"
+done
+```
+
+## From Source
+
+Build from source using Cargo:
+
+```bash
+git clone https://github.com/avihut/daft.git
+cd daft
+cargo build --release
+```
+
+Add the binary directory to your PATH and create symlinks:
+
+```bash
+export PATH="$PWD/target/release:$PATH"
+
+# Create symlinks (or use the just recipe)
+just dev-setup
+```
+
+## Verify Installation
+
+After installing, verify everything is working:
+
+```bash
+daft doctor
+```
+
+This runs health checks on your installation and reports any issues with actionable suggestions.
+
+You can also verify individual commands:
+
+```bash
+daft --version
+git worktree-clone --help
+```
+
+## Post-Install: Shell Integration
+
+For the best experience, enable shell integration so that daft can automatically `cd` you into new worktrees:
+
+```bash
+# Bash/Zsh: Add to your shell config
+eval "$(daft shell-init bash)"
+
+# Fish
+daft shell-init fish | source
+```
+
+See [Shell Integration](./shell-integration.md) for full details.
+
+## Requirements
+
+- **Git** 2.5+ (for worktree support)
+- **Rust** 1.70+ (only needed when building from source)

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -1,0 +1,129 @@
+---
+title: Quick Start
+description: Get up and running with daft in minutes
+---
+
+# Quick Start
+
+This guide walks you through the core daft workflow: cloning a repo, creating branches, and cleaning up.
+
+## 1. Clone a Repository
+
+```bash
+git worktree-clone git@github.com:user/my-project.git
+```
+
+This creates a structured layout:
+
+```
+my-project/
+├── .git/           # Shared Git metadata
+└── main/           # Worktree for the default branch
+    └── ... (project files)
+```
+
+You're automatically placed in `my-project/main/`.
+
+## 2. Create a Feature Branch
+
+From anywhere inside the repository:
+
+```bash
+git worktree-checkout-branch feature/auth
+```
+
+This creates a new branch and worktree in one step:
+
+```
+my-project/
+├── .git/
+├── main/               # Default branch (untouched)
+└── feature/auth/       # New branch with its own worktree
+    └── ... (project files)
+```
+
+You're now in `my-project/feature/auth/`. Your `main/` directory is completely untouched.
+
+## 3. Switch Between Branches
+
+Each branch is just a directory. Open different terminals:
+
+```bash
+# Terminal 1 - working on feature
+cd my-project/feature/auth/
+npm run dev
+
+# Terminal 2 - checking main
+cd my-project/main/
+npm test
+```
+
+To check out an existing branch:
+
+```bash
+git worktree-checkout bugfix/login-issue
+```
+
+## 4. Branch From Default
+
+When you need a fresh branch from `main` (regardless of where you are):
+
+```bash
+git worktree-checkout-branch-from-default hotfix/critical-fix
+```
+
+Your directory structure becomes:
+
+```
+my-project/
+├── .git/
+├── main/
+├── feature/auth/
+├── bugfix/login-issue/
+└── hotfix/critical-fix/    # Branched from main, not current branch
+```
+
+## 5. Carry Changes Between Worktrees
+
+Move uncommitted work to another worktree:
+
+```bash
+# Move changes from current worktree to feature/auth
+git worktree-carry feature/auth
+
+# Or copy changes (keep them in both places)
+git worktree-carry --copy feature/auth main
+```
+
+## 6. Clean Up Merged Branches
+
+After branches are merged and deleted on the remote:
+
+```bash
+git worktree-prune
+```
+
+This automatically:
+- Fetches from remote and prunes stale tracking branches
+- Identifies local branches whose remotes were deleted
+- Removes associated worktrees
+- Deletes local branches
+
+## 7. Adopt an Existing Repository
+
+Already have a traditional repository? Convert it:
+
+```bash
+cd my-existing-project
+git worktree-flow-adopt
+```
+
+This restructures your repo into the worktree layout. Uncommitted changes are preserved.
+
+## What's Next
+
+- [Shell Integration](./shell-integration.md) - Enable auto-cd into new worktrees
+- [Worktree Workflow](../guide/worktree-workflow.md) - Deep dive into the worktree-centric approach
+- [Hooks](../guide/hooks.md) - Automate worktree lifecycle events
+- [Shortcuts](../guide/shortcuts.md) - Enable short command aliases
+- [Configuration](../guide/configuration.md) - Customize daft's behavior

--- a/docs/getting-started/shell-integration.md
+++ b/docs/getting-started/shell-integration.md
@@ -1,0 +1,92 @@
+---
+title: Shell Integration
+description: Enable automatic directory changes when creating worktrees
+---
+
+# Shell Integration
+
+## Why It's Needed
+
+When daft creates a new worktree, the Rust binary changes directory internally - but your parent shell stays in the original directory. Shell integration solves this by wrapping daft commands so the shell follows along.
+
+## Setup
+
+### Bash / Zsh
+
+Add to `~/.bashrc` or `~/.zshrc`:
+
+```bash
+eval "$(daft shell-init bash)"
+```
+
+### Fish
+
+Add to `~/.config/fish/config.fish`:
+
+```fish
+daft shell-init fish | source
+```
+
+### With Short Aliases
+
+Include short aliases like `gwco`, `gwcob`:
+
+```bash
+# Bash/Zsh
+eval "$(daft shell-init bash --aliases)"
+
+# Fish
+daft shell-init fish --aliases | source
+```
+
+## How It Works
+
+1. The shell wrappers set `DAFT_SHELL_WRAPPER=1` before calling the underlying command
+2. When this env var is set, commands output a `__DAFT_CD__:/path/to/worktree` marker
+3. The wrapper parses this marker and uses the shell's builtin `cd` to change directory
+
+This means the binary does the heavy lifting (cloning, branching, etc.) and the wrapper just handles the final `cd`.
+
+## Disabling Auto-CD
+
+If you prefer to stay in your current directory after creating worktrees:
+
+```bash
+# Disable globally
+git config --global daft.autocd false
+
+# Disable for a specific repository
+git config daft.autocd false
+```
+
+You can also use the `--no-cd` flag on individual commands:
+
+```bash
+git worktree-checkout-branch feature/auth --no-cd
+```
+
+## Shell Completions
+
+daft provides tab completions for all commands:
+
+```bash
+# Install completions for all shells
+daft completions bash --install
+daft completions zsh --install
+daft completions fish --install
+```
+
+Or generate to a specific location:
+
+```bash
+# Generate bash completions
+daft completions bash > /path/to/completions/daft.bash
+
+# Generate zsh completions
+daft completions zsh > /path/to/_daft
+
+# Generate fish completions
+daft completions fish > /path/to/completions/daft.fish
+```
+
+Restart your shell after installing completions.

--- a/docs/guide/adopting-existing-repos.md
+++ b/docs/guide/adopting-existing-repos.md
@@ -1,0 +1,106 @@
+---
+title: Adopting Existing Repositories
+description: Convert traditional repositories to the worktree-based layout
+---
+
+# Adopting Existing Repositories
+
+Already have a traditional Git repository? You can convert it to the worktree layout without losing any work.
+
+## What flow-adopt Does
+
+`git worktree-flow-adopt` restructures a traditional repository into daft's worktree layout:
+
+**Before:**
+```
+my-project/
+├── .git/            # Regular git directory
+├── src/
+├── package.json
+└── README.md
+```
+
+**After:**
+```
+my-project/
+├── .git/            # Bare repository
+└── main/            # Worktree for current branch
+    ├── src/
+    ├── package.json
+    └── README.md
+```
+
+## Running It
+
+```bash
+cd my-existing-project
+git worktree-flow-adopt
+```
+
+Or specify a path:
+
+```bash
+git worktree-flow-adopt /path/to/my-project
+```
+
+### Preview First
+
+Use `--dry-run` to see what would happen without making changes:
+
+```bash
+git worktree-flow-adopt --dry-run
+```
+
+## Uncommitted Changes Are Preserved
+
+Any staged, unstaged, or untracked changes in your working directory are carried into the new worktree. You won't lose any work.
+
+## Reverting with flow-eject
+
+If you decide the worktree layout isn't for you:
+
+```bash
+git worktree-flow-eject
+```
+
+This converts back to a traditional repository layout:
+
+**Before:**
+```
+my-project/
+├── .git/            # Bare repository
+├── main/
+│   ├── src/
+│   └── README.md
+└── feature/auth/
+    ├── src/
+    └── README.md
+```
+
+**After:**
+```
+my-project/
+├── .git/            # Regular git directory
+├── src/
+└── README.md
+```
+
+By default, `flow-eject` keeps the remote's default branch. Use `--branch` to specify a different one:
+
+```bash
+git worktree-flow-eject --branch feature/auth
+```
+
+Other worktrees are removed. If any have uncommitted changes, the command fails unless you pass `--force`.
+
+## When to Adopt vs Clone Fresh
+
+**Use `flow-adopt`** when:
+- You have an existing local repository with work in progress
+- You want to try the worktree workflow without re-cloning
+- You have local branches or stashes you want to preserve
+
+**Use `worktree-clone`** when:
+- Starting fresh from a remote repository
+- Setting up a new development environment
+- The repository has no local-only work to preserve

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1,0 +1,104 @@
+---
+title: Configuration
+description: All daft configuration options
+---
+
+# Configuration
+
+daft reads configuration from Git's config system. Settings are loaded with standard Git priority: repository-local config overrides global config, which overrides built-in defaults.
+
+## Setting Values
+
+```bash
+# Set for the current repository
+git config daft.autocd false
+
+# Set globally (all repositories)
+git config --global daft.autocd false
+```
+
+## General Settings
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `daft.autocd` | `true` | CD into new worktrees when using shell wrappers |
+| `daft.remote` | `"origin"` | Default remote name for all operations |
+| `daft.updateCheck` | `true` | Show notifications when a new daft version is available |
+| `daft.experimental.gitoxide` | `false` | Use gitoxide for supported Git operations |
+
+## Checkout Settings
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `daft.checkout.push` | `true` | Push new branches to remote after creation |
+| `daft.checkout.upstream` | `true` | Set upstream tracking for branches |
+| `daft.checkout.carry` | `false` | Carry uncommitted changes when checking out existing branches |
+| `daft.checkoutBranch.carry` | `true` | Carry uncommitted changes when creating new branches |
+
+## Fetch Settings
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `daft.fetch.args` | `"--ff-only"` | Default arguments passed to `git pull` in fetch operations |
+
+## Prune Settings
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `daft.prune.cdTarget` | `"root"` | Where to cd after pruning the current worktree. Values: `root` (project root) or `default-branch` (default branch worktree) |
+
+## Multi-Remote Settings
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `daft.multiRemote.enabled` | `false` | Enable multi-remote directory organization |
+| `daft.multiRemote.defaultRemote` | `"origin"` | Default remote for new branches in multi-remote mode |
+
+## Hooks Settings
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `daft.hooks.enabled` | `true` | Master switch for all hooks |
+| `daft.hooks.defaultTrust` | `"deny"` | Default trust level for unknown repositories (`deny`, `prompt`, or `allow`) |
+| `daft.hooks.userDirectory` | `~/.config/daft/hooks/` | Path to user-global hooks directory |
+| `daft.hooks.timeout` | `300` | Hook execution timeout in seconds |
+
+### Per-Hook Settings
+
+Each hook type can be configured individually. The hook name uses camelCase.
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `daft.hooks.<hookName>.enabled` | `true` | Enable/disable a specific hook type |
+| `daft.hooks.<hookName>.failMode` | varies | Behavior on failure: `abort` or `warn` |
+
+Hook names: `postClone`, `postInit`, `worktreePreCreate`, `worktreePostCreate`, `worktreePreRemove`, `worktreePostRemove`.
+
+Default fail modes:
+- `worktreePreCreate`: `abort` (setup must succeed before creating worktree)
+- All others: `warn` (don't block operations)
+
+## Examples
+
+```bash
+# Don't push new branches automatically
+git config daft.checkout.push false
+
+# Use a different remote
+git config daft.remote upstream
+
+# Disable auto-cd globally
+git config --global daft.autocd false
+
+# After pruning, cd to default branch worktree instead of root
+git config daft.prune.cdTarget default-branch
+
+# Use rebase-style fetch by default
+git config daft.fetch.args "--rebase"
+
+# Disable hooks globally
+git config --global daft.hooks.enabled false
+
+# Make post-create hooks abort on failure
+git config daft.hooks.worktreePostCreate.failMode abort
+```

--- a/docs/guide/hooks.md
+++ b/docs/guide/hooks.md
@@ -1,0 +1,207 @@
+---
+title: Hooks
+description: Automate worktree lifecycle events with project-managed hooks
+---
+
+# Hooks
+
+daft provides a hooks system that runs scripts at worktree lifecycle events. Hooks are stored in the repository and shared with your team, with a trust-based security model.
+
+## Overview
+
+Hooks are executable scripts placed in `.daft/hooks/` within your repository. They run automatically when worktrees are created, removed, or cloned.
+
+```
+my-project/
+├── .daft/
+│   └── hooks/
+│       ├── post-clone            # Runs after cloning the repo
+│       ├── worktree-post-create  # Runs after creating a worktree
+│       └── worktree-pre-remove   # Runs before removing a worktree
+└── src/
+```
+
+## Hook Types
+
+| Hook | Trigger | Runs From |
+|------|---------|-----------|
+| `post-clone` | After `git worktree-clone` completes | New default branch worktree |
+| `post-init` | After `git worktree-init` completes | New initial worktree |
+| `worktree-pre-create` | Before new worktree is added | Source worktree (where command runs) |
+| `worktree-post-create` | After new worktree is created | New worktree |
+| `worktree-pre-remove` | Before worktree is removed | Worktree being removed |
+| `worktree-post-remove` | After worktree is removed | Current worktree (where prune runs) |
+
+## Trust Model
+
+For security, hooks from untrusted repositories don't run automatically. Trust is managed per-repository.
+
+### Trust Levels
+
+| Level | Behavior |
+|-------|----------|
+| `deny` (default) | Hooks are never executed |
+| `prompt` | User is prompted before each hook execution |
+| `allow` | Hooks run without prompting |
+
+### Managing Trust
+
+```bash
+# Trust the current repository
+git daft hooks trust
+
+# Prompt before running hooks
+git daft hooks prompt
+
+# Revoke trust
+git daft hooks deny
+
+# Check current status
+git daft hooks status
+
+# List all trusted repositories
+git daft hooks list
+
+# Clear all trust settings
+git daft hooks reset-trust
+```
+
+## Writing a Hook
+
+Hooks are executable scripts. They can be written in any language.
+
+### Example: Auto-allow direnv
+
+```bash
+#!/bin/bash
+# .daft/hooks/worktree-post-create
+if [ -f ".envrc" ] && command -v direnv &>/dev/null; then
+    direnv allow .
+fi
+```
+
+### Example: Install dependencies
+
+```bash
+#!/bin/bash
+# .daft/hooks/worktree-post-create
+if [ -f "package.json" ]; then
+    npm install
+elif [ -f "Gemfile" ]; then
+    bundle install
+elif [ -f "requirements.txt" ]; then
+    pip install -r requirements.txt
+fi
+```
+
+### Example: Use correct Node version
+
+```bash
+#!/bin/bash
+# .daft/hooks/worktree-post-create
+if [ -f ".nvmrc" ] && command -v nvm &>/dev/null; then
+    nvm use
+fi
+```
+
+Make hooks executable:
+
+```bash
+chmod +x .daft/hooks/worktree-post-create
+```
+
+## Environment Variables
+
+Hooks receive context via environment variables:
+
+### Universal (all hooks)
+
+| Variable | Description |
+|----------|-------------|
+| `DAFT_HOOK` | Hook type (e.g., `worktree-post-create`) |
+| `DAFT_COMMAND` | Command that triggered the hook (e.g., `checkout-branch`) |
+| `DAFT_PROJECT_ROOT` | Repository root (parent of `.git` directory) |
+| `DAFT_GIT_DIR` | Path to the `.git` directory |
+| `DAFT_REMOTE` | Remote name (usually `origin`) |
+| `DAFT_SOURCE_WORKTREE` | Worktree where the command was invoked |
+
+### Worktree (creation and removal hooks)
+
+| Variable | Description |
+|----------|-------------|
+| `DAFT_WORKTREE_PATH` | Path to the target worktree |
+| `DAFT_BRANCH_NAME` | Branch name for the target worktree |
+
+### Creation (create hooks only)
+
+| Variable | Description |
+|----------|-------------|
+| `DAFT_IS_NEW_BRANCH` | `true` if the branch was newly created, `false` otherwise |
+| `DAFT_BASE_BRANCH` | Base branch (for `checkout-branch` commands) |
+
+### Clone (post-clone only)
+
+| Variable | Description |
+|----------|-------------|
+| `DAFT_REPOSITORY_URL` | The cloned repository URL |
+| `DAFT_DEFAULT_BRANCH` | The remote's default branch |
+
+### Removal (remove hooks only)
+
+| Variable | Description |
+|----------|-------------|
+| `DAFT_REMOVAL_REASON` | Why the worktree is being removed: `remote-deleted`, `manual`, or `ejecting` |
+
+## Fail Modes
+
+Each hook type has a default fail mode that determines what happens when a hook exits with a non-zero status:
+
+| Hook | Default Fail Mode | Behavior |
+|------|--------------------|----------|
+| `worktree-pre-create` | `abort` | Operation is cancelled |
+| All others | `warn` | Warning is shown, operation continues |
+
+Override per-hook:
+
+```bash
+# Make post-create hooks abort on failure
+git config daft.hooks.worktreePostCreate.failMode abort
+
+# Make pre-create hooks just warn
+git config daft.hooks.worktreePreCreate.failMode warn
+```
+
+## User-Global Hooks
+
+Place hooks in `~/.config/daft/hooks/` to run them for all repositories. Global hooks run after project hooks.
+
+Customize the directory:
+
+```bash
+git config --global daft.hooks.userDirectory ~/my-daft-hooks
+```
+
+## Configuration
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `daft.hooks.enabled` | `true` | Master switch for all hooks |
+| `daft.hooks.defaultTrust` | `deny` | Default trust level for unknown repos |
+| `daft.hooks.userDirectory` | `~/.config/daft/hooks/` | Path to user-global hooks |
+| `daft.hooks.timeout` | `300` | Hook execution timeout in seconds |
+| `daft.hooks.<hookName>.enabled` | `true` | Enable/disable a specific hook type |
+| `daft.hooks.<hookName>.failMode` | varies | `abort` or `warn` on hook failure |
+
+Hook name config keys use camelCase: `postClone`, `postInit`, `worktreePreCreate`, `worktreePostCreate`, `worktreePreRemove`, `worktreePostRemove`.
+
+## Migration from Deprecated Names
+
+In earlier versions, worktree hooks used shorter names (`pre-create`, `post-create`, `pre-remove`, `post-remove`). These were renamed with a `worktree-` prefix for clarity.
+
+Old names still work with deprecation warnings until v2.0.0. To migrate:
+
+```bash
+git daft hooks migrate
+```
+
+This renames hook files in the current worktree from old names to new names.

--- a/docs/guide/multi-remote.md
+++ b/docs/guide/multi-remote.md
@@ -1,0 +1,81 @@
+---
+title: Multi-Remote Mode
+description: Organize worktrees by remote for fork-based workflows
+---
+
+# Multi-Remote Mode
+
+When working with multiple remotes (e.g., a fork workflow with `origin` and `upstream`), multi-remote mode organizes worktrees into remote-prefixed directories.
+
+## Directory Layouts
+
+### Standard Layout (default)
+
+```
+my-project/
+├── .git/
+├── main/
+├── feature/auth/
+└── bugfix/login/
+```
+
+### Multi-Remote Layout
+
+```
+my-project/
+├── .git/
+├── origin/
+│   ├── main/
+│   ├── feature/auth/
+│   └── bugfix/login/
+└── upstream/
+    └── main/
+```
+
+## Enabling Multi-Remote Mode
+
+```bash
+# Enable for the current repository
+git daft multi-remote enable
+
+# Check current status
+git daft multi-remote status
+
+# Set the default remote
+git daft multi-remote set-default origin
+```
+
+Enabling migrates existing worktrees into the remote-prefixed layout.
+
+## Disabling Multi-Remote Mode
+
+```bash
+git daft multi-remote disable
+```
+
+This flattens the directory structure back to the standard layout.
+
+## Using --remote on Commands
+
+When multi-remote mode is enabled, you can specify which remote to organize under:
+
+```bash
+# Create worktree under origin/
+git worktree-checkout-branch feature/auth --remote origin
+
+# Create worktree under upstream/
+git worktree-checkout upstream-branch --remote upstream
+```
+
+You can also enable multi-remote mode during clone:
+
+```bash
+git worktree-clone git@github.com:user/project.git --remote origin
+```
+
+## Configuration
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `daft.multiRemote.enabled` | `false` | Enable multi-remote mode |
+| `daft.multiRemote.defaultRemote` | `origin` | Default remote for new branches |

--- a/docs/guide/shortcuts.md
+++ b/docs/guide/shortcuts.md
@@ -1,0 +1,87 @@
+---
+title: Shortcuts
+description: Short command aliases for frequently used daft commands
+---
+
+# Shortcuts
+
+daft supports short aliases for frequently used commands. Instead of typing `git worktree-checkout`, you can type `gwtco`.
+
+## Shortcut Styles
+
+Three styles are available. Enable the one that fits your preference.
+
+### Git Style (default)
+
+Prefix: `gwt` (Git Worktree)
+
+| Shortcut | Full Command |
+|----------|-------------|
+| `gwtclone` | `git-worktree-clone` |
+| `gwtinit` | `git-worktree-init` |
+| `gwtco` | `git-worktree-checkout` |
+| `gwtcb` | `git-worktree-checkout-branch` |
+| `gwtcbm` | `git-worktree-checkout-branch-from-default` |
+| `gwtprune` | `git-worktree-prune` |
+| `gwtcarry` | `git-worktree-carry` |
+| `gwtfetch` | `git-worktree-fetch` |
+
+### Shell Style
+
+Prefix: `gw` (shorter, shell-friendly)
+
+| Shortcut | Full Command |
+|----------|-------------|
+| `gwco` | `git-worktree-checkout` |
+| `gwcob` | `git-worktree-checkout-branch` |
+| `gwcobd` | `git-worktree-checkout-branch-from-default` |
+
+### Legacy Style
+
+From earlier versions of daft:
+
+| Shortcut | Full Command |
+|----------|-------------|
+| `gclone` | `git-worktree-clone` |
+| `gcw` | `git-worktree-checkout` |
+| `gcbw` | `git-worktree-checkout-branch` |
+| `gcbdw` | `git-worktree-checkout-branch-from-default` |
+| `gprune` | `git-worktree-prune` |
+
+## Managing Shortcuts
+
+```bash
+# List all available styles and mappings
+daft setup shortcuts list
+
+# Show which shortcuts are currently installed
+daft setup shortcuts status
+
+# Enable a style (creates symlinks)
+daft setup shortcuts enable git
+
+# Disable a style (removes symlinks)
+daft setup shortcuts disable legacy
+
+# Enable only one style (disable all others)
+daft setup shortcuts only shell
+
+# Preview changes without applying
+daft setup shortcuts only git --dry-run
+```
+
+## How They Work
+
+Shortcuts are implemented as symlinks that point to the `daft` binary. When the binary starts, it inspects `argv[0]` (how it was invoked) and maps the shortcut name to the corresponding full command.
+
+For example, `gwtco` is a symlink to `daft`. When invoked, the binary sees `argv[0] = "gwtco"`, resolves it to `git-worktree-checkout`, and runs that command.
+
+## Shell Integration Aliases
+
+Alternatively, `daft shell-init` can generate shell aliases with the `--aliases` flag:
+
+```bash
+eval "$(daft shell-init bash --aliases)"
+```
+
+This creates shell functions (not symlinks) for the shell-style shortcuts (`gwco`, `gwcob`, `gwcobd`) with proper cd behavior built in.

--- a/docs/guide/worktree-workflow.md
+++ b/docs/guide/worktree-workflow.md
@@ -1,0 +1,130 @@
+---
+title: Worktree Workflow
+description: Understanding the worktree-centric development approach
+---
+
+# Worktree Workflow
+
+## What Is a Git Worktree?
+
+A Git worktree is an additional working directory linked to the same repository. Git 2.5+ supports multiple worktrees sharing a single `.git` directory, so each branch can have its own files on disk simultaneously.
+
+daft structures this into a consistent layout and provides commands to manage the lifecycle.
+
+## The daft Directory Layout
+
+When you clone or init with daft, repositories use this structure:
+
+```
+my-project/
+├── .git/                    # Shared Git metadata (bare repository)
+├── main/                    # Worktree for the default branch
+│   ├── src/
+│   ├── package.json
+│   └── ...
+├── feature/auth/            # Worktree for feature branch
+│   ├── src/
+│   ├── package.json
+│   └── ...
+└── bugfix/login/            # Worktree for bugfix branch
+    ├── src/
+    ├── package.json
+    └── ...
+```
+
+Key properties:
+- `.git/` is a bare repository at the project root - it holds all shared Git data
+- Each branch lives in its own directory as a sibling to `.git/`
+- All worktrees share the same Git history, remotes, and configuration
+- Each worktree has its own working files, index, and HEAD
+
+## Why This Matters
+
+### No Context Switching
+
+Traditional Git requires `git checkout` to switch branches, which replaces all files in your working directory. With worktrees, branches coexist:
+
+```bash
+# Traditional: sequential, with context loss
+git stash
+git checkout feature-b
+# ... work ...
+git checkout feature-a
+git stash pop
+
+# Worktree: parallel, no context loss
+cd ../feature-b/
+# ... work ...
+cd ../feature-a/
+```
+
+### Full Isolation
+
+Each worktree has its own:
+- Working files and build artifacts (`node_modules/`, `target/`, etc.)
+- IDE state and configuration (`.vscode/`, `.idea/`)
+- Environment files (`.envrc`, `.env`)
+- Running processes (dev servers, watchers)
+
+### Parallel Development
+
+Run multiple branches simultaneously in separate terminals:
+
+```bash
+# Terminal 1: running dev server for feature work
+cd my-project/feature/auth/
+npm run dev  # http://localhost:3000
+
+# Terminal 2: running tests for bugfix
+cd my-project/bugfix/login/
+npm test
+
+# Terminal 3: code review
+cd my-project/review/teammate-pr/
+npm run lint
+```
+
+## Daily Development Flow
+
+### Starting a New Feature
+
+```bash
+# Creates branch + worktree, pushes to remote, sets upstream
+git worktree-checkout-branch feature/user-auth
+```
+
+### Checking Out a PR for Review
+
+```bash
+# Creates worktree for existing remote branch
+git worktree-checkout feature/teammate-work
+```
+
+### Branching from Default
+
+When your current branch has diverged and you need a fresh start:
+
+```bash
+# Always branches from origin's default branch (main/master/develop)
+git worktree-checkout-branch-from-default hotfix/critical-fix
+```
+
+### Moving Uncommitted Work
+
+Started work in the wrong branch? Move it:
+
+```bash
+git worktree-carry feature/correct-branch
+```
+
+### Cleaning Up
+
+After branches are merged and deleted on the remote:
+
+```bash
+git worktree-prune
+```
+
+## How Commands Find the Project Root
+
+daft commands use `git rev-parse --git-common-dir` to locate the shared `.git` directory regardless of which worktree you're in. This means you can run commands from any directory within any worktree - they always find the project root and create new worktrees as siblings.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,88 @@
+---
+title: daft - Git Extensions Toolkit
+description: Give each Git branch its own directory. No more stashing, no more context switching, no more waiting for builds to restart.
+layout: home
+hero:
+  name: daft
+  text: Git Extensions Toolkit
+  tagline: Give each Git branch its own directory. No more stashing, no more context switching.
+  actions:
+    - theme: brand
+      text: Get Started
+      link: /getting-started/installation
+    - theme: alt
+      text: View on GitHub
+      link: https://github.com/avihut/daft
+features:
+  - title: One Branch, One Directory
+    details: Each branch lives in its own directory. Run different branches in different terminals with full isolation.
+  - title: Zero Context Switching
+    details: No stashing, no rebuilding, no lost IDE state. Switch branches by switching directories.
+  - title: Seamless Git Integration
+    details: Works as native Git subcommands. Your existing Git knowledge applies - just add worktree power.
+  - title: Lifecycle Hooks
+    details: Project-managed hooks automate setup for each new worktree - direnv, nvm, custom scripts.
+---
+
+# daft - Git Extensions Toolkit
+
+> Stop switching branches. Work on multiple branches simultaneously.
+
+**daft** gives each Git branch its own directory. No more stashing, no more context switching, no more waiting for builds to restart.
+
+```
+my-project/
+├── .git/                    # Shared Git data
+├── main/                    # Stable branch
+├── feature/auth/            # Your feature work
+├── bugfix/login/            # Parallel bugfix
+└── review/teammate-pr/      # Code review
+```
+
+## Quick Start
+
+```bash
+# Install (macOS)
+brew install avihut/tap/daft
+
+# Clone a repo
+git worktree-clone git@github.com:user/my-project.git
+
+# Start a feature branch
+git worktree-checkout-branch feature/auth
+```
+
+Each directory is a full working copy. Run different branches in different terminals. Your IDE state, node_modules, build artifacts - all isolated per branch.
+
+## Why daft?
+
+**Traditional Git workflow:**
+```
+$ git stash
+$ git checkout feature-b
+$ npm install        # wait...
+$ npm run build      # wait...
+# context lost, IDE state gone
+$ git checkout feature-a
+$ git stash pop
+# where was I?
+```
+
+**With daft:**
+```
+Terminal 1 (feature-a/)     Terminal 2 (feature-b/)
+┌───────────────────────┐   ┌───────────────────────┐
+│ $ npm run dev         │   │ $ npm run dev         │
+│ Server on :3000       │   │ Server on :3001       │
+│ # full context        │   │ # full context        │
+└───────────────────────┘   └───────────────────────┘
+         ↓                           ↓
+    Both running simultaneously, isolated environments
+```
+
+## Next Steps
+
+- [Installation](./getting-started/installation.md) - Install daft on your system
+- [Quick Start](./getting-started/quick-start.md) - Get up and running in minutes
+- [Shell Integration](./getting-started/shell-integration.md) - Enable auto-cd into worktrees
+- [Worktree Workflow Guide](./guide/worktree-workflow.md) - Understand the worktree-centric approach

--- a/justfile
+++ b/justfile
@@ -420,6 +420,24 @@ verify-man:
     @echo "Man pages are up-to-date"
 
 # ============================================================================
+# CLI Docs Recipes
+# ============================================================================
+
+# Generate CLI reference docs to docs/cli/ directory using xtask
+gen-cli-docs:
+    @echo "Generating CLI reference docs..."
+    @mkdir -p docs/cli
+    cargo run --package xtask -- gen-cli-docs --output-dir=docs/cli
+    @echo "CLI docs generated in docs/cli/"
+
+# Verify CLI docs are up-to-date with source
+verify-cli-docs:
+    @echo "Verifying CLI docs are up-to-date..."
+    cargo run --package xtask -- gen-cli-docs --output-dir=docs/cli
+    @git diff --exit-code docs/cli/ || (echo "CLI docs out of date. Run 'just gen-cli-docs' and commit." && exit 1)
+    @echo "CLI docs are up-to-date"
+
+# ============================================================================
 # Cleanup Recipes
 # ============================================================================
 
@@ -516,6 +534,10 @@ help:
     @echo "  gen-man                           - Generate man pages to man/ using xtask"
     @echo "  install-man                       - Install pre-generated man pages to system location"
     @echo "  verify-man                        - Verify man pages are up-to-date with source"
+    @echo ""
+    @echo "CLI docs:"
+    @echo "  gen-cli-docs                      - Generate CLI reference docs to docs/cli/"
+    @echo "  verify-cli-docs                   - Verify CLI docs are up-to-date with source"
     @echo ""
     @echo "Cleanup:"
     @echo "  clean                             - Clean up all artifacts"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -47,6 +47,61 @@ fn get_command_for_name(command_name: &str) -> Option<clap::Command> {
     }
 }
 
+/// Command clusters for "See Also" links in CLI docs
+fn related_commands(command_name: &str) -> Vec<&'static str> {
+    match command_name {
+        // Setup cluster
+        "git-worktree-clone" => vec![
+            "git-worktree-init",
+            "git-worktree-checkout",
+            "git-worktree-flow-adopt",
+        ],
+        "git-worktree-init" => vec![
+            "git-worktree-clone",
+            "git-worktree-checkout-branch",
+            "git-worktree-flow-adopt",
+        ],
+        "git-worktree-flow-adopt" => vec![
+            "git-worktree-clone",
+            "git-worktree-init",
+            "git-worktree-flow-eject",
+        ],
+        // Branching cluster
+        "git-worktree-checkout" => vec![
+            "git-worktree-checkout-branch",
+            "git-worktree-checkout-branch-from-default",
+            "git-worktree-carry",
+        ],
+        "git-worktree-checkout-branch" => vec![
+            "git-worktree-checkout",
+            "git-worktree-checkout-branch-from-default",
+            "git-worktree-carry",
+        ],
+        "git-worktree-checkout-branch-from-default" => vec![
+            "git-worktree-checkout",
+            "git-worktree-checkout-branch",
+            "git-worktree-carry",
+        ],
+        // Maintenance cluster
+        "git-worktree-prune" => vec!["git-worktree-fetch", "git-worktree-flow-eject"],
+        "git-worktree-fetch" => vec!["git-worktree-prune", "git-worktree-carry"],
+        "git-worktree-carry" => vec![
+            "git-worktree-checkout",
+            "git-worktree-checkout-branch",
+            "git-worktree-fetch",
+        ],
+        "git-worktree-flow-eject" => vec![
+            "git-worktree-flow-adopt",
+            "git-worktree-prune",
+            "git-worktree-clone",
+        ],
+        // Config cluster
+        "daft-doctor" => vec!["git-worktree-clone", "git-worktree-init"],
+        "daft-release-notes" => vec![],
+        _ => vec![],
+    }
+}
+
 #[derive(Parser)]
 #[command(name = "xtask")]
 #[command(about = "Development automation tasks for daft")]
@@ -67,6 +122,17 @@ enum Commands {
         #[arg(long)]
         command: Option<String>,
     },
+
+    /// Generate CLI reference markdown docs for daft commands
+    GenCliDocs {
+        /// Output directory for CLI docs
+        #[arg(long, default_value = "docs/cli")]
+        output_dir: PathBuf,
+
+        /// Specific command to generate docs for (default: all commands)
+        #[arg(long)]
+        command: Option<String>,
+    },
 }
 
 fn main() -> Result<()> {
@@ -77,6 +143,10 @@ fn main() -> Result<()> {
             output_dir,
             command,
         } => generate_man_pages(&output_dir, command.as_deref()),
+        Commands::GenCliDocs {
+            output_dir,
+            command,
+        } => generate_cli_docs(&output_dir, command.as_deref()),
     }
 }
 
@@ -114,6 +184,225 @@ fn generate_man_pages(output_dir: &PathBuf, command: Option<&str>) -> Result<()>
 
     eprintln!("\nMan pages generated in: {}", output_dir.display());
     Ok(())
+}
+
+/// Generate CLI reference markdown docs and write to a directory
+fn generate_cli_docs(output_dir: &PathBuf, command: Option<&str>) -> Result<()> {
+    fs::create_dir_all(output_dir).with_context(|| {
+        format!(
+            "Failed to create output directory: {}",
+            output_dir.display()
+        )
+    })?;
+
+    let commands_to_generate: Vec<&str> = if let Some(cmd) = command {
+        vec![cmd]
+    } else {
+        COMMANDS.to_vec()
+    };
+
+    for command_name in commands_to_generate {
+        let cmd = get_command_for_name(command_name)
+            .with_context(|| format!("Unknown command: {command_name}"))?;
+
+        let markdown = render_command_markdown(command_name, &cmd);
+
+        let filename = format!("{command_name}.md");
+        let file_path = output_dir.join(&filename);
+
+        fs::write(&file_path, &markdown)
+            .with_context(|| format!("Failed to write CLI doc: {}", file_path.display()))?;
+
+        eprintln!("Generated: {}", file_path.display());
+    }
+
+    eprintln!("\nCLI docs generated in: {}", output_dir.display());
+    Ok(())
+}
+
+/// Render a clap Command to a markdown CLI reference page.
+fn render_command_markdown(command_name: &str, cmd: &clap::Command) -> String {
+    let mut md = String::new();
+
+    let about = cmd.get_about().map(|s| s.to_string()).unwrap_or_default();
+
+    let long_about = cmd
+        .get_long_about()
+        .map(|s| s.to_string())
+        .unwrap_or_default();
+
+    // Display name: convert "git-worktree-clone" → "git worktree-clone" for git commands,
+    // "daft-doctor" → "daft doctor" for daft commands
+    let display_name = if let Some(suffix) = command_name.strip_prefix("git-") {
+        format!("git {suffix}")
+    } else if let Some(suffix) = command_name.strip_prefix("daft-") {
+        format!("daft {suffix}")
+    } else {
+        command_name.to_string()
+    };
+
+    // Frontmatter
+    md.push_str("---\n");
+    md.push_str(&format!("title: {command_name}\n"));
+    md.push_str(&format!("description: {about}\n"));
+    md.push_str("---\n\n");
+
+    // Title
+    md.push_str(&format!("# {display_name}\n\n"));
+    md.push_str(&format!("{about}\n\n"));
+
+    // Description
+    let description = long_about.trim();
+    if !description.is_empty() {
+        md.push_str("## Description\n\n");
+        md.push_str(description);
+        md.push_str("\n\n");
+    }
+
+    // Usage line
+    md.push_str("## Usage\n\n");
+    md.push_str("```\n");
+    md.push_str(&build_usage_string(command_name, cmd, &display_name));
+    md.push_str("\n```\n\n");
+
+    // Positional arguments
+    let positionals: Vec<_> = cmd
+        .get_arguments()
+        .filter(|a| a.is_positional() && a.get_id() != "version" && a.get_id() != "help")
+        .collect();
+
+    if !positionals.is_empty() {
+        md.push_str("## Arguments\n\n");
+        md.push_str("| Argument | Description | Required |\n");
+        md.push_str("|----------|-------------|----------|\n");
+
+        for arg in &positionals {
+            let id = arg.get_id().as_str();
+            let value_name = arg
+                .get_value_names()
+                .and_then(|v| v.first().map(|s| s.to_string()))
+                .unwrap_or_else(|| id.to_uppercase());
+
+            let help = arg.get_help().map(|s| s.to_string()).unwrap_or_default();
+
+            let required = if arg.is_required_set() { "Yes" } else { "No" };
+
+            md.push_str(&format!("| `<{value_name}>` | {help} | {required} |\n"));
+        }
+        md.push('\n');
+    }
+
+    // Options (non-positional arguments)
+    let options: Vec<_> = cmd
+        .get_arguments()
+        .filter(|a| !a.is_positional() && a.get_id() != "version" && a.get_id() != "help")
+        .collect();
+
+    if !options.is_empty() {
+        md.push_str("## Options\n\n");
+        md.push_str("| Option | Description | Default |\n");
+        md.push_str("|--------|-------------|----------|\n");
+
+        for arg in &options {
+            let mut opt_str = String::new();
+            if let Some(short) = arg.get_short() {
+                opt_str.push_str(&format!("-{short}"));
+            }
+            if let Some(long) = arg.get_long() {
+                if !opt_str.is_empty() {
+                    opt_str.push_str(", ");
+                }
+                opt_str.push_str(&format!("--{long}"));
+            }
+
+            // Add value name if the option takes a value (skip for boolean flags)
+            let is_bool_flag = matches!(
+                arg.get_action(),
+                clap::ArgAction::SetTrue | clap::ArgAction::SetFalse | clap::ArgAction::Count
+            );
+            if !is_bool_flag {
+                if let Some(value_names) = arg.get_value_names() {
+                    if !value_names.is_empty() {
+                        let name = &value_names[0];
+                        opt_str.push_str(&format!(" <{name}>"));
+                    }
+                }
+            }
+
+            let help = arg.get_help().map(|s| s.to_string()).unwrap_or_default();
+
+            let defaults: Vec<_> = arg
+                .get_default_values()
+                .iter()
+                .map(|v| v.to_string_lossy().to_string())
+                .collect();
+            let default_str = if defaults.is_empty() {
+                String::new()
+            } else {
+                format!("`{}`", defaults.join(", "))
+            };
+
+            md.push_str(&format!("| `{opt_str}` | {help} | {default_str} |\n"));
+        }
+        md.push('\n');
+    }
+
+    // Global options
+    md.push_str("## Global Options\n\n");
+    md.push_str("| Option | Description |\n");
+    md.push_str("|--------|-------------|\n");
+    md.push_str("| `-h`, `--help` | Print help information |\n");
+    md.push_str("| `-V`, `--version` | Print version information |\n");
+    md.push('\n');
+
+    // See Also
+    let related = related_commands(command_name);
+    if !related.is_empty() {
+        md.push_str("## See Also\n\n");
+        for related_cmd in &related {
+            md.push_str(&format!("- [{related_cmd}](./{related_cmd}.md)\n"));
+        }
+        md.push('\n');
+    }
+
+    md
+}
+
+/// Build the usage string for a command.
+fn build_usage_string(command_name: &str, cmd: &clap::Command, display_name: &str) -> String {
+    let mut parts = vec![display_name.to_string()];
+
+    // Check if there are any non-positional, non-built-in options
+    let has_options = cmd
+        .get_arguments()
+        .any(|a| !a.is_positional() && a.get_id() != "version" && a.get_id() != "help");
+
+    if has_options {
+        parts.push("[OPTIONS]".to_string());
+    }
+
+    // Add positional arguments
+    for arg in cmd.get_arguments() {
+        if !arg.is_positional() || arg.get_id() == "version" || arg.get_id() == "help" {
+            continue;
+        }
+
+        let value_name = arg
+            .get_value_names()
+            .and_then(|v| v.first().map(|s| s.to_string()))
+            .unwrap_or_else(|| arg.get_id().as_str().to_uppercase());
+
+        if arg.is_required_set() {
+            parts.push(format!("<{value_name}>"));
+        } else {
+            parts.push(format!("[{value_name}]"));
+        }
+    }
+
+    // Check for trailing var arg (like fetch's -- PULL_ARGS)
+    let _ = command_name; // suppress unused warning; reserved for future use
+
+    parts.join(" ")
 }
 
 #[cfg(test)]
@@ -183,5 +472,88 @@ mod tests {
 
         // Clean up
         let _ = fs::remove_dir_all(&temp_dir);
+    }
+
+    #[test]
+    fn test_cli_docs_generation() {
+        let temp_dir = std::env::temp_dir().join("xtask-test-cli-docs");
+        let _ = fs::remove_dir_all(&temp_dir);
+        fs::create_dir_all(&temp_dir).unwrap();
+
+        // Test generating a single CLI doc
+        generate_cli_docs(&temp_dir, Some("git-worktree-clone")).unwrap();
+
+        let doc_file = temp_dir.join("git-worktree-clone.md");
+        assert!(doc_file.exists(), "CLI doc was not generated");
+
+        let content = fs::read_to_string(&doc_file).unwrap();
+        assert!(content.contains("---"), "CLI doc missing frontmatter");
+        assert!(
+            content.contains("# git worktree-clone"),
+            "CLI doc missing title"
+        );
+        assert!(
+            content.contains("## Usage"),
+            "CLI doc missing Usage section"
+        );
+        assert!(
+            content.contains("## Options"),
+            "CLI doc missing Options section"
+        );
+        assert!(
+            content.contains("## See Also"),
+            "CLI doc missing See Also section"
+        );
+
+        // Clean up
+        let _ = fs::remove_dir_all(&temp_dir);
+    }
+
+    #[test]
+    fn test_all_cli_docs_generation() {
+        let temp_dir = std::env::temp_dir().join("xtask-test-all-cli-docs");
+        let _ = fs::remove_dir_all(&temp_dir);
+        fs::create_dir_all(&temp_dir).unwrap();
+
+        // Test generating all CLI docs
+        generate_cli_docs(&temp_dir, None).unwrap();
+
+        // Verify all expected CLI docs exist
+        for command_name in COMMANDS {
+            let doc_file = temp_dir.join(format!("{command_name}.md"));
+            assert!(
+                doc_file.exists(),
+                "CLI doc for '{}' was not generated",
+                command_name
+            );
+
+            let content = fs::read_to_string(&doc_file).unwrap();
+            assert!(
+                content.contains("---"),
+                "CLI doc for '{}' missing frontmatter",
+                command_name
+            );
+            assert!(
+                content.contains("## Usage"),
+                "CLI doc for '{}' missing Usage section",
+                command_name
+            );
+        }
+
+        // Clean up
+        let _ = fs::remove_dir_all(&temp_dir);
+    }
+
+    #[test]
+    fn test_related_commands_returns_entries() {
+        let related = related_commands("git-worktree-clone");
+        assert!(!related.is_empty());
+        assert!(related.contains(&"git-worktree-init"));
+    }
+
+    #[test]
+    fn test_related_commands_unknown_returns_empty() {
+        let related = related_commands("unknown-command");
+        assert!(related.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- Add `gen-cli-docs` xtask subcommand that generates markdown CLI reference pages from clap definitions (12 commands)
- Write hand-authored docs: landing page, getting started guides (installation, quick start, shell integration), usage guides (worktree workflow, adopting repos, hooks, shortcuts, multi-remote, configuration), contributing guide, and changelog page
- Add website bootstrap guide with VitePress and Starlight configurations
- Add Justfile recipes (`gen-cli-docs`, `verify-cli-docs`)
- Add CI integration: CLI docs verification in `test.yml`, auto-regeneration in `release-plz.yml` alongside man pages

## Test plan

- [ ] `cargo test --package xtask` passes (4 new tests for CLI docs generation)
- [ ] `just verify-cli-docs` confirms generated docs match source
- [ ] `just verify-man` confirms no man page regressions
- [ ] CI `xtask-test` job passes with new CLI docs steps
- [ ] Review hand-authored docs for accuracy against source code
- [ ] Spot-check generated CLI docs against `--help` output

Fixes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)