### PR TITLE
feat: add lefthook git hooks for local code quality checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ Thumbs.db
 # Claude Code settings
 .claude/settings.*
 .aider*
+
+# Lefthook local overrides
+.lefthook-local.yml

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,36 @@
+pre-commit:
+  parallel: true
+  commands:
+    fmt-check:
+      glob: "*.rs"
+      run: cargo fmt -- --check
+    clippy:
+      glob: "*.rs"
+      run: cargo clippy -- -D warnings
+    verify-man:
+      glob: "*.rs"
+      run: mise run verify-man
+    verify-cli-docs:
+      glob: "*.rs"
+      run: mise run verify-cli-docs
+
+commit-msg:
+  commands:
+    conventional-commit:
+      run: |
+        message=$(head -1 {1})
+        if ! echo "$message" | grep -qE '^(feat|fix|docs|style|refactor|perf|test|chore|ci|deps)(\(.+\))?!?: .+'; then
+          echo "ERROR: Commit message must follow Conventional Commits format."
+          echo ""
+          echo "  <type>[scope]: <description>"
+          echo "  Types: feat, fix, docs, style, refactor, perf, test, chore, ci, deps"
+          echo ""
+          echo "  Got: $message"
+          exit 1
+        fi
+
+pre-push:
+  commands:
+    unit-tests:
+      glob: "*.rs"
+      run: cargo test --lib

--- a/mise.toml
+++ b/mise.toml
@@ -3,6 +3,7 @@
 
 [tools]
 rust = "stable"
+lefthook = "latest"
 
 [env]
 INTEGRATION_TESTS_DIR = "tests/integration"
@@ -272,7 +273,13 @@ cd tests/integration && time ./test_all.sh
 [tasks.setup]
 description = "Setup development environment"
 depends = ["setup-rust"]
-run = 'echo "Development environment setup completed"'
+run = """
+#!/usr/bin/env bash
+set -euo pipefail
+echo "Installing lefthook git hooks..."
+lefthook install
+echo "Development environment setup completed"
+"""
 
 [tasks.setup-rust]
 description = "Setup Rust development environment"


### PR DESCRIPTION
## Summary

- Add `lefthook.yml` with pre-commit (fmt, clippy, man page & CLI docs freshness), commit-msg (conventional commits validation), and pre-push (unit tests) hooks
- Add lefthook as a mise tool and run `lefthook install` during `mise run setup`
- Add `.lefthook-local.yml` to `.gitignore` for developer-local overrides

## Details

The project enforces code quality via CI but had no local git hooks. Lefthook automates the same checks locally for faster feedback:

- **pre-commit** (parallel): `cargo fmt -- --check`, `cargo clippy -- -D warnings`, `mise run verify-man`, `mise run verify-cli-docs` — all gated on `*.rs` glob so non-Rust commits skip them
- **commit-msg**: Validates conventional commit format (feat, fix, docs, style, refactor, perf, test, chore, ci, deps)
- **pre-push**: Runs `cargo test --lib` unit tests, also gated on `*.rs` glob

No CI changes needed — CI already runs the same checks.

Fixes #172

## Test plan

- [ ] `mise install` fetches lefthook
- [ ] `mise run setup` runs `lefthook install` and activates hooks
- [ ] Commit with bad message (e.g., `git commit -m "bad"`) is rejected by commit-msg hook
- [ ] Commit with valid message (e.g., `git commit -m "chore: test"`) passes commit-msg hook
- [ ] Commit with staged `.rs` files triggers fmt-check + clippy + verify-man + verify-cli-docs
- [ ] Commit with only `.md` files skips all pre-commit checks (glob filter)
- [ ] `git push` with `.rs` changes triggers unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)