### PR TITLE
ci: run Rust integration tests and clippy on test code in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,14 +24,17 @@ jobs:
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@v2
 
+    - name: Install mise
+      uses: jdx/mise-action@v2
+
     - name: Check Rust formatting
-      run: cargo fmt -- --check
+      run: mise run fmt-check
 
     - name: Run Rust clippy
-      run: cargo clippy -- -D warnings
+      run: mise run clippy
 
     - name: Run Rust unit tests
-      run: cargo test --lib
+      run: mise run test-unit
 
   # Cross-platform integration tests + Homebrew simulation on macOS
   integration-tests:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,10 +3,10 @@ pre-commit:
   commands:
     fmt-check:
       glob: "*.rs"
-      run: cargo fmt -- --check
+      run: mise run fmt-check
     clippy:
       glob: "*.rs"
-      run: cargo clippy -- -D warnings
+      run: mise run clippy
     verify-man:
       glob: "*.rs"
       run: mise run verify-man
@@ -33,4 +33,4 @@ pre-push:
   commands:
     unit-tests:
       glob: "*.rs"
-      run: cargo test --lib
+      run: mise run test-unit

--- a/mise.toml
+++ b/mise.toml
@@ -99,7 +99,7 @@ run = 'echo "Running all tests (unit + integration)..."'
 description = "Run Rust unit tests"
 run = """
 echo "Running Rust unit tests..."
-cargo test --lib
+cargo test --lib --tests
 """
 
 [tasks.test-rust]
@@ -371,7 +371,7 @@ run = "cargo fmt -- --check"
 
 [tasks.clippy]
 description = "Run Rust clippy linter (zero warnings)"
-run = "cargo clippy -- -D warnings"
+run = "cargo clippy --tests -- -D warnings"
 
 [tasks.lint]
 description = "Run all linting tools"
@@ -385,7 +385,7 @@ run = """
 #!/usr/bin/env bash
 set -euo pipefail
 echo "Running Rust linting..."
-cargo clippy -- -D warnings
+cargo clippy --tests -- -D warnings
 cargo fmt --check
 if command -v shellcheck >/dev/null 2>&1; then
     shellcheck tests/integration/*.sh

--- a/src/hooks/executor.rs
+++ b/src/hooks/executor.rs
@@ -597,8 +597,10 @@ mod tests {
 
         create_test_hook(&worktree, "worktree-post-create", "#!/bin/bash\necho test");
 
-        let mut config = HooksConfig::default();
-        config.enabled = false;
+        let config = HooksConfig {
+            enabled: false,
+            ..Default::default()
+        };
 
         let executor = HookExecutor::with_trust_db(config, TrustDatabase::default());
         let mut output = TestOutput::default();

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -898,8 +898,10 @@ mod tests {
             fs::write(&user_hook, "@echo off\necho user").unwrap();
         }
 
-        let mut config = HooksConfig::default();
-        config.user_directory = user_hooks_dir.clone();
+        let config = HooksConfig {
+            user_directory: user_hooks_dir.clone(),
+            ..Default::default()
+        };
 
         let discovery = find_hooks(HookType::PostCreate, &worktree, &config);
         assert_eq!(discovery.hooks.len(), 1);
@@ -938,8 +940,10 @@ mod tests {
             fs::write(&user_hook, "@echo off\necho user").unwrap();
         }
 
-        let mut config = HooksConfig::default();
-        config.user_directory = user_hooks_dir.clone();
+        let config = HooksConfig {
+            user_directory: user_hooks_dir.clone(),
+            ..Default::default()
+        };
 
         let discovery = find_hooks(HookType::PostCreate, &worktree, &config);
         // Should find both hooks, project first then user

--- a/tests/test_concurrency.rs
+++ b/tests/test_concurrency.rs
@@ -243,10 +243,7 @@ fn test_concurrent_worktree_operations() -> Result<()> {
                     .args(["worktree", "list", "--porcelain"])
                     .output();
 
-                match result {
-                    Ok(_) => {}
-                    Err(_) => {}
-                }
+                let _ = result;
 
                 thread::sleep(Duration::from_millis(2));
             }


### PR DESCRIPTION
## Summary
- CI lint job ran `cargo test --lib` and `cargo clippy` without `--tests`, so `tests/*.rs` files (9 tests across `test_concurrency.rs` and `test_security.rs`) were never compiled or linted
- Add `--tests` to `test-unit` and `clippy` mise tasks, and align CI + lefthook to use mise tasks instead of raw cargo commands
- Fix 4 clippy warnings on master exposed by `--tests` (`field_reassign_with_default`, `single_match`)

## Test plan
- [x] `mise run fmt-check` passes
- [x] `mise run clippy` passes (now includes `--tests`)
- [x] `mise run test-unit` passes — all 298 tests (289 lib + 3 concurrency + 6 security)
- [x] Pre-commit hooks pass (fmt-check, clippy, verify-man, verify-cli-docs)
- [ ] CI lint job installs mise and runs all three tasks
- [ ] CI lint job compiles and runs `tests/*.rs` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)