### PR TITLE
chore: improve daft.yml hooks for full worktree automation

### DIFF
--- a/daft.yml
+++ b/daft.yml
@@ -1,5 +1,25 @@
 hooks:
+  post-clone:
+    jobs:
+      - name: mise-trust
+        run: mise trust
+      - name: mise-install
+        run: mise install
+        needs: [mise-trust]
+      - name: dev-setup
+        run: mise run dev-setup
+        needs: [mise-install]
+      - name: lefthook-install
+        run: lefthook install
+        needs: [mise-install]
+
   worktree-post-create:
     jobs:
       - name: mise-trust
         run: mise trust
+      - name: mise-install
+        run: mise install
+        needs: [mise-trust]
+      - name: dev-setup
+        run: mise run dev-setup
+        needs: [mise-install]


### PR DESCRIPTION
## Summary
- Add `post-clone` hook with `mise-trust`, `mise-install`, `dev-setup`, and `lefthook-install` jobs for first-time clone setup
- Expand `worktree-post-create` hook with `mise-install` and `dev-setup` jobs (no lefthook since `.git/hooks/` is shared)
- Set proper `needs` dependencies so jobs run in parallel where possible while respecting the dependency chain

## Test plan
- [ ] Clone the repo fresh via `git worktree-clone` and verify all post-clone jobs run in order
- [ ] Create a new worktree via `git worktree-checkout-branch` and verify post-create jobs run
- [ ] Verify `lefthook install` only runs on clone, not on worktree creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)