### PR TITLE
docs: update README hooks section to use daft.yml format

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,25 +156,32 @@ daft setup shortcuts list          # See all available shortcuts
 
 ## Hooks
 
-Automate worktree lifecycle events with project-managed hooks in `.daft/hooks/`:
+Automate worktree lifecycle events with a `daft.yml` configuration file:
 
 | Hook | Trigger |
 |------|---------|
 | `post-clone` | After repository clone |
-| `post-create` | After worktree created |
-| `pre-remove` | Before worktree removal |
+| `worktree-post-create` | After worktree created |
+| `worktree-pre-remove` | Before worktree removal |
 
-**Example** - auto-allow direnv in new worktrees:
+**Example** - install dependencies and auto-allow direnv in new worktrees:
+
+```yaml
+# daft.yml
+hooks:
+  worktree-post-create:
+    jobs:
+      - name: install-deps
+        run: npm install
+      - name: direnv-allow
+        run: direnv allow .
+```
 
 ```bash
-mkdir -p .daft/hooks
-echo '#!/bin/bash
-[ -f ".envrc" ] && command -v direnv &>/dev/null && direnv allow .' > .daft/hooks/post-create
-chmod +x .daft/hooks/post-create
 git daft hooks trust
 ```
 
-Hooks require explicit trust for security. See `git daft hooks --help` for details.
+Hooks require explicit trust for security. See the [hooks guide](https://avihu.dev/daft/guide/hooks) for details.
 
 ## AI Agent Skill
 


### PR DESCRIPTION
## Summary

- Replace the shell script hooks example (`.daft/hooks/`) with the recommended `daft.yml` YAML configuration format
- Update hook names from deprecated `post-create`/`pre-remove` to current `worktree-post-create`/`worktree-pre-remove`
- Link to the hooks guide for full documentation

## Test plan

- [ ] Verify the YAML example in the README renders correctly on GitHub
- [ ] Confirm the hooks guide link resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)