### PR TITLE
fix(fetch): check target worktree for dirty state instead of current worktree

### DIFF
--- a/src/commands/fetch.rs
+++ b/src/commands/fetch.rs
@@ -313,7 +313,7 @@ fn process_worktree(
     }
 
     // Check for uncommitted changes
-    match git.has_uncommitted_changes() {
+    match git.has_uncommitted_changes_in(target_path) {
         Ok(has_changes) => {
             if has_changes && !args.force {
                 output.warning(&format!(


### PR DESCRIPTION
## Summary

- Fixed `git worktree-fetch` incorrectly skipping clean target worktrees when the current worktree has uncommitted changes
- The dirty check now uses `has_uncommitted_changes_in(target_path)` which explicitly evaluates the target worktree, not the CWD
- Added regression tests for both directions: clean target from dirty CWD, and dirty target from clean CWD

Fixes #186

## Test Plan

- [x] `mise run clippy` passes with zero warnings
- [x] `mise run fmt` — no formatting changes needed
- [x] All 310 unit tests pass
- [x] All 17 fetch integration tests pass (including 2 new tests)
- [x] New test `fetch_clean_target_from_dirty_worktree` validates the exact bug scenario
- [x] New test `fetch_dirty_target_from_clean_worktree` validates the converse still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)