### PR TITLE
feat(output): add colored output to CLI and fetch/prune commands

### DIFF
--- a/src/output/cli.rs
+++ b/src/output/cli.rs
@@ -4,6 +4,7 @@
 //! ensuring backward compatibility during the migration.
 
 use super::{Output, OutputConfig};
+use crate::styles::{self, colors_enabled, colors_enabled_stderr};
 use crate::{CD_PATH_MARKER, SHELL_WRAPPER_ENV};
 use std::env;
 use std::path::Path;
@@ -53,39 +54,63 @@ impl Output for CliOutput {
 
     fn success(&mut self, msg: &str) {
         if !self.config.quiet {
-            println!("{msg}");
+            if colors_enabled() {
+                println!("{}{msg}{}", styles::GREEN, styles::RESET);
+            } else {
+                println!("{msg}");
+            }
         }
     }
 
     fn warning(&mut self, msg: &str) {
         // Warnings are always shown (not affected by quiet mode)
         // Git-like format: lowercase prefix
-        eprintln!("warning: {msg}");
+        if colors_enabled_stderr() {
+            eprintln!("{}warning:{} {msg}", styles::YELLOW, styles::RESET);
+        } else {
+            eprintln!("warning: {msg}");
+        }
     }
 
     fn error(&mut self, msg: &str) {
         // Errors are always shown (not affected by quiet mode)
         // Git-like format: lowercase prefix
-        eprintln!("error: {msg}");
+        if colors_enabled_stderr() {
+            eprintln!("{}error:{} {msg}", styles::RED, styles::RESET);
+        } else {
+            eprintln!("error: {msg}");
+        }
     }
 
     fn debug(&mut self, msg: &str) {
         if self.config.verbose {
-            println!("debug: {msg}");
+            if colors_enabled() {
+                println!("{}debug: {msg}{}", styles::DIM, styles::RESET);
+            } else {
+                println!("debug: {msg}");
+            }
         }
     }
 
     fn step(&mut self, msg: &str) {
         // Steps are only shown in verbose mode
         if self.config.verbose && !self.config.quiet {
-            println!("{msg}");
+            if colors_enabled() {
+                println!("{}{msg}{}", styles::DIM, styles::RESET);
+            } else {
+                println!("{msg}");
+            }
         }
     }
 
     fn result(&mut self, msg: &str) {
         // Result is the primary output - always shown unless quiet
         if !self.config.quiet {
-            println!("{msg}");
+            if colors_enabled() {
+                println!("{}{msg}{}", styles::BOLD, styles::RESET);
+            } else {
+                println!("{msg}");
+            }
         }
     }
 
@@ -102,7 +127,11 @@ impl Output for CliOutput {
 
     fn detail(&mut self, key: &str, value: &str) {
         if !self.config.quiet {
-            println!("  {key}: {value}");
+            if colors_enabled() {
+                println!("  {}{key}:{} {value}", styles::BOLD, styles::RESET);
+            } else {
+                println!("  {key}: {value}");
+            }
         }
     }
 

--- a/src/styles.rs
+++ b/src/styles.rs
@@ -3,6 +3,23 @@
 //! Provides clean abstractions for ANSI terminal styling, keeping escape codes
 //! isolated from application code.
 
+use std::io::IsTerminal;
+use std::sync::OnceLock;
+
+/// Whether colors are enabled for stdout (cached on first call).
+pub fn colors_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED
+        .get_or_init(|| std::io::stdout().is_terminal() && std::env::var_os("NO_COLOR").is_none())
+}
+
+/// Whether colors are enabled for stderr (cached on first call).
+pub fn colors_enabled_stderr() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED
+        .get_or_init(|| std::io::stderr().is_terminal() && std::env::var_os("NO_COLOR").is_none())
+}
+
 /// ANSI escape code for bold text.
 pub const BOLD: &str = "\x1b[1m";
 


### PR DESCRIPTION
## Summary

- Add TTY-aware color support with `NO_COLOR` compliance to daft's own CLI output, resolving the visual mismatch between plain daft output and git's native colored output
- Color `CliOutput` methods: `success` (green), `warning` (yellow prefix), `error` (red prefix), `result` (bold), `step`/`debug` (dim), `detail` (bold key)
- Color inline status tags in fetch (`[fetched]` green, `[skipped]` yellow, `[failed]` red, `[dry run]` dim) and prune (`[pruned]` green)

Fixes #204

## Test plan

- [x] `mise run fmt` -- clean
- [x] `mise run clippy` -- zero warnings
- [x] `mise run test-unit` -- 306 passed
- [x] `mise run test-integration` -- 175 passed (both default and gitoxide backends)
- [ ] Manual: run `gwtfetch --all` in a terminal and verify colored output
- [ ] Manual: run `gwtfetch --all | cat` and verify NO colors when piped
- [ ] Manual: `NO_COLOR=1 gwtfetch --all` and verify NO colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)