### PR TITLE
docs: add missing CLI reference pages and fill documentation gaps

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -289,11 +289,18 @@ export default defineConfig({
             items: [
               { text: "doctor", link: "/cli/daft-doctor" },
               { text: "release-notes", link: "/cli/daft-release-notes" },
+              { text: "shell-init", link: "/cli/daft-shell-init" },
+              { text: "completions", link: "/cli/daft-completions" },
+              { text: "setup", link: "/cli/daft-setup" },
             ],
           },
           {
             text: "Configuration",
-            items: [{ text: "daft-hooks", link: "/cli/git-daft-hooks" }],
+            items: [
+              { text: "daft-hooks", link: "/cli/git-daft-hooks" },
+              { text: "branch", link: "/cli/daft-branch" },
+              { text: "multi-remote", link: "/cli/daft-multi-remote" },
+            ],
           },
         ],
       },

--- a/docs/cli/daft-branch.md
+++ b/docs/cli/daft-branch.md
@@ -1,0 +1,82 @@
+---
+title: daft-branch
+description: Branch and worktree management operations
+---
+
+# daft branch
+
+Branch and worktree management operations
+
+## Description
+
+Provides branch and worktree management operations, particularly useful in
+multi-remote workflows.
+
+The main subcommand is `move`, which moves a worktree to a different remote
+folder when multi-remote mode is enabled.
+
+## Usage
+
+```
+daft branch <SUBCOMMAND>
+```
+
+## Subcommands
+
+### move
+
+Move a worktree to a different remote folder.
+
+```
+daft branch move <BRANCH> --to <REMOTE> [OPTIONS]
+```
+
+Moves a worktree from one remote folder to another. This is useful when:
+
+- You forked a branch and want to organize it under a different remote
+- You're transferring a feature branch from your fork to upstream
+- You want to reorganize worktrees after adding a new remote
+
+The worktree is physically moved on disk, and git's internal worktree records
+are updated accordingly.
+
+Requires multi-remote mode to be enabled. See
+[multi-remote](./daft-multi-remote.md).
+
+| Argument / Option    | Description                                            | Required |
+| -------------------- | ------------------------------------------------------ | -------- |
+| `<BRANCH>`           | Branch name or worktree path to move                   | Yes      |
+| `--to <REMOTE>`      | Target remote folder                                   | Yes      |
+| `--set-upstream`     | Also update the branch's upstream tracking to the new remote |    |
+| `--push`             | Push the branch to the new remote                      |          |
+| `--delete-old`       | Delete the branch from the old remote after pushing    |          |
+| `--dry-run`          | Preview changes without executing                      |          |
+| `-f, --force`        | Skip confirmation                                      |          |
+
+### Examples
+
+```bash
+# Move feature/auth from origin to upstream
+daft branch move feature/auth --to upstream
+
+# Move and update tracking + push
+daft branch move feature/auth --to upstream --set-upstream --push
+
+# Full transfer: move, push to new, delete from old
+daft branch move feature/auth --to upstream --push --delete-old --force
+
+# Preview what would happen
+daft branch move feature/auth --to upstream --dry-run
+```
+
+## Global Options
+
+| Option            | Description               |
+| ----------------- | ------------------------- |
+| `-h`, `--help`    | Print help information    |
+| `-V`, `--version` | Print version information |
+
+## See Also
+
+- [daft-multi-remote](./daft-multi-remote.md)
+- [Multi-Remote guide](../guide/multi-remote.md)

--- a/docs/cli/daft-completions.md
+++ b/docs/cli/daft-completions.md
@@ -1,0 +1,84 @@
+---
+title: daft-completions
+description: Generate shell completion scripts for daft commands
+---
+
+# daft completions
+
+Generate shell completion scripts for daft commands
+
+## Description
+
+Generate shell completion scripts that provide tab completion for daft commands,
+including static flag completions and dynamic branch name completions.
+
+Supported targets:
+
+- **bash** -- Bash completion scripts using `_init_completion`
+- **zsh** -- Zsh completion scripts using `compdef`/`compadd`
+- **fish** -- Fish completion scripts using `complete`
+- **fig** -- Fig/Amazon Q/Kiro completion specs (ESM format)
+
+By default, generates completions for all worktree commands. Use `--command` to
+generate for a specific command only.
+
+Shell completions are also included automatically in the output of
+`daft shell-init`, so most users do not need to run this command directly.
+
+## Usage
+
+```
+daft completions <TARGET> [OPTIONS]
+```
+
+## Arguments
+
+| Argument   | Description                                         | Required |
+| ---------- | --------------------------------------------------- | -------- |
+| `<TARGET>` | Target to generate completions for (bash, zsh, fish, fig) | Yes      |
+
+## Options
+
+| Option                   | Description                                              | Default |
+| ------------------------ | -------------------------------------------------------- | ------- |
+| `-c, --command <COMMAND>` | Specific command to generate completions for (default: all) |         |
+| `-i, --install`          | Install completions to standard locations                |         |
+
+## Global Options
+
+| Option         | Description               |
+| -------------- | ------------------------- |
+| `-h`, `--help` | Print help information    |
+| `-V`, `--version` | Print version information |
+
+## Installation Locations
+
+When using `--install`, completions are written to:
+
+| Shell | Location                                     |
+| ----- | -------------------------------------------- |
+| bash  | `$XDG_DATA_HOME/bash-completion/completions/` (or `~/.local/share/`) |
+| zsh   | `~/.zfunc/`                                  |
+| fish  | `$XDG_CONFIG_HOME/fish/completions/` (or `~/.config/fish/`) |
+| fig   | `~/.amazon-q/autocomplete/build/` or `~/.fig/autocomplete/build/` |
+
+## Examples
+
+```bash
+# Generate all bash completions
+daft completions bash
+
+# Generate completions for a specific command
+daft completions zsh --command git-worktree-checkout
+
+# Install completions to standard locations
+daft completions bash --install
+daft completions zsh --install
+daft completions fish --install
+daft completions fig --install
+```
+
+## See Also
+
+- [daft-shell-init](./daft-shell-init.md)
+- [daft-setup](./daft-setup.md)

--- a/docs/cli/daft-multi-remote.md
+++ b/docs/cli/daft-multi-remote.md
@@ -1,0 +1,149 @@
+---
+title: daft-multi-remote
+description: Manage multi-remote worktree organization
+---
+
+# daft multi-remote
+
+Manage multi-remote worktree organization
+
+## Description
+
+Manages multi-remote mode, which organizes worktrees by remote when working with
+multiple remotes (e.g., fork workflows with `origin` and `upstream`).
+
+When multi-remote mode is disabled (default), worktrees are placed directly
+under the project root:
+
+```
+project/
+├── .git/
+├── main/
+└── feature/foo/
+```
+
+When multi-remote mode is enabled, worktrees are organized by remote:
+
+```
+project/
+├── .git/
+├── origin/
+│   ├── main/
+│   └── feature/foo/
+└── upstream/
+    └── main/
+```
+
+Without a subcommand, shows the current multi-remote status.
+
+## Usage
+
+```
+daft multi-remote [SUBCOMMAND]
+```
+
+## Subcommands
+
+### enable
+
+Enable multi-remote mode and migrate existing worktrees.
+
+```
+daft multi-remote enable [OPTIONS]
+```
+
+Each worktree is moved from `project/branch` to `project/remote/branch`, where
+the remote is determined by the branch's upstream tracking configuration or
+defaults to the specified default remote.
+
+| Option                  | Description                                          |
+| ----------------------- | ---------------------------------------------------- |
+| `--default <REMOTE>`    | Default remote for new branches (defaults to 'origin') |
+| `--dry-run`             | Preview changes without executing                    |
+| `-f, --force`           | Skip confirmation                                    |
+
+### disable
+
+Disable multi-remote mode and flatten worktree structure.
+
+```
+daft multi-remote disable [OPTIONS]
+```
+
+Each worktree is moved from `project/remote/branch` back to `project/branch`.
+
+| Option        | Description                       |
+| ------------- | --------------------------------- |
+| `--dry-run`   | Preview changes without executing |
+| `-f, --force` | Skip confirmation                 |
+
+### status
+
+Show current multi-remote configuration (default when no subcommand given).
+
+```
+daft multi-remote status
+```
+
+Displays:
+
+- Whether multi-remote mode is enabled or disabled
+- The default remote
+- Configured remotes
+- Current worktrees and their organization
+
+### set-default
+
+Change the default remote for new branches.
+
+```
+daft multi-remote set-default <REMOTE>
+```
+
+| Argument   | Description                    | Required |
+| ---------- | ------------------------------ | -------- |
+| `<REMOTE>` | Remote name to use as default  | Yes      |
+
+## Configuration
+
+Multi-remote mode uses these git config keys:
+
+| Key                              | Default    | Description                                |
+| -------------------------------- | ---------- | ------------------------------------------ |
+| `daft.multiRemote.enabled`       | `false`    | Enable multi-remote directory organization |
+| `daft.multiRemote.defaultRemote` | `"origin"` | Default remote for new branches            |
+
+## Examples
+
+```bash
+# Check current status
+daft multi-remote
+
+# Enable with default settings
+daft multi-remote enable
+
+# Enable with upstream as default
+daft multi-remote enable --default upstream
+
+# Preview migration without making changes
+daft multi-remote enable --dry-run
+
+# Change default remote
+daft multi-remote set-default upstream
+
+# Disable and flatten back
+daft multi-remote disable
+```
+
+## Global Options
+
+| Option            | Description               |
+| ----------------- | ------------------------- |
+| `-h`, `--help`    | Print help information    |
+| `-V`, `--version` | Print version information |
+
+## See Also
+
+- [daft-branch](./daft-branch.md)
+- [Multi-Remote guide](../guide/multi-remote.md)
+- [Configuration](../guide/configuration.md)

--- a/docs/cli/daft-setup.md
+++ b/docs/cli/daft-setup.md
@@ -1,0 +1,163 @@
+---
+title: daft-setup
+description: Add daft shell integration to your shell config
+---
+
+# daft setup
+
+Add daft shell integration to your shell config
+
+## Description
+
+Automatically adds the `daft shell-init` line to your shell configuration file.
+This enables automatic cd into new worktrees when using daft commands.
+
+The command will:
+
+1. Detect your shell (bash, zsh, or fish)
+2. Find the appropriate config file (`~/.bashrc`, `~/.zshrc`, or
+   `~/.config/fish/config.fish`)
+3. Check if daft is already configured (won't add duplicates)
+4. Create a backup of your config file
+5. Append the shell-init line
+6. Install git-style shortcuts (gwtco, gwtcb, etc.)
+
+## Usage
+
+```
+daft setup [OPTIONS]
+```
+
+## Options
+
+| Option           | Description                                                | Default |
+| ---------------- | ---------------------------------------------------------- | ------- |
+| `-f, --force`    | Skip confirmation and re-add if already configured         |         |
+| `--dry-run`      | Show what would be done without making changes             |         |
+
+## Global Options
+
+| Option         | Description               |
+| -------------- | ------------------------- |
+| `-h`, `--help` | Print help information    |
+| `-V`, `--version` | Print version information |
+
+## Examples
+
+```bash
+# Interactive setup with confirmation
+daft setup
+
+# Skip confirmation
+daft setup --force
+
+# Preview without making changes
+daft setup --dry-run
+```
+
+---
+
+## Subcommand: shortcuts
+
+Manage command shortcut symlinks.
+
+### Usage
+
+```
+daft setup shortcuts [SUBCOMMAND]
+```
+
+Without a subcommand, shows the current shortcut installation status.
+
+### Shortcut Styles
+
+| Style    | Shortcuts                                                             |
+| -------- | --------------------------------------------------------------------- |
+| `git`    | gwtclone, gwtinit, gwtco, gwtcb, gwtbd, gwtprune, gwtcarry, gwtfetch |
+| `shell`  | gwco, gwcob                                                          |
+| `legacy` | gclone, gcw, gcbw, gprune                                           |
+
+Default-branch shortcuts (`gwtcm`, `gwtcbm`, `gwcobd`, `gcbdw`) are
+shell-only functions provided by `daft shell-init`, not managed here.
+
+### shortcuts list
+
+List all shortcut styles and their aliases.
+
+```
+daft setup shortcuts list
+```
+
+### shortcuts status
+
+Show currently installed shortcuts (default when no subcommand given).
+
+```
+daft setup shortcuts status
+```
+
+### shortcuts enable
+
+Enable a shortcut style by creating symlinks.
+
+```
+daft setup shortcuts enable <STYLE> [OPTIONS]
+```
+
+| Argument / Option          | Description                        |
+| -------------------------- | ---------------------------------- |
+| `<STYLE>`                  | Style to enable (git, shell, legacy) |
+| `--install-dir <DIR>`      | Override installation directory     |
+| `--dry-run`                | Preview without making changes     |
+
+### shortcuts disable
+
+Disable a shortcut style by removing its symlinks.
+
+```
+daft setup shortcuts disable <STYLE> [OPTIONS]
+```
+
+| Argument / Option          | Description                          |
+| -------------------------- | ------------------------------------ |
+| `<STYLE>`                  | Style to disable (git, shell, legacy) |
+| `--install-dir <DIR>`      | Override installation directory       |
+| `--dry-run`                | Preview without making changes       |
+
+### shortcuts only
+
+Enable only the specified style and disable all others.
+
+```
+daft setup shortcuts only <STYLE> [OPTIONS]
+```
+
+| Argument / Option          | Description                                     |
+| -------------------------- | ----------------------------------------------- |
+| `<STYLE>`                  | Style to enable exclusively (git, shell, legacy) |
+| `--install-dir <DIR>`      | Override installation directory                  |
+| `--dry-run`                | Preview without making changes                  |
+
+### Examples
+
+```bash
+# See what's installed
+daft setup shortcuts status
+
+# List all available styles
+daft setup shortcuts list
+
+# Enable git-style shortcuts
+daft setup shortcuts enable git
+
+# Switch to shell-style only
+daft setup shortcuts only shell
+
+# Preview changes
+daft setup shortcuts only git --dry-run
+```
+
+## See Also
+
+- [daft-shell-init](./daft-shell-init.md)
+- [Shortcuts guide](../guide/shortcuts.md)

--- a/docs/cli/daft-shell-init.md
+++ b/docs/cli/daft-shell-init.md
@@ -1,0 +1,88 @@
+---
+title: daft-shell-init
+description: Generate shell wrapper functions for daft commands
+---
+
+# daft shell-init
+
+Generate shell wrapper functions for daft commands
+
+## Description
+
+Generate shell wrapper functions that enable automatic cd into new worktrees.
+
+By default, when daft commands create or switch to a worktree, the process
+changes directory but the parent shell remains in the original directory. These
+wrappers solve this by reading the CD target from a temp file and using the
+shell's builtin cd.
+
+Add to your shell config:
+
+```bash
+# Bash (~/.bashrc)
+eval "$(daft shell-init bash)"
+
+# Zsh (~/.zshrc)
+eval "$(daft shell-init zsh)"
+
+# Fish (~/.config/fish/config.fish)
+daft shell-init fish | source
+```
+
+With short aliases (gwco, gwcob, etc.):
+
+```bash
+eval "$(daft shell-init bash --aliases)"
+```
+
+The generated output includes:
+
+- Shell wrapper functions for all `git-worktree-*` commands
+- A `git` wrapper that intercepts `git worktree-*` subcommands
+- A `daft` wrapper that intercepts `daft worktree-*` subcommands
+- Shortcut wrappers for all shortcut styles (gwtco, gwco, gclone, etc.)
+- Default-branch shortcuts (gwtcm, gwtcbm, gwcobd, gcbdw)
+- Shell completions for all commands
+
+## Usage
+
+```
+daft shell-init <SHELL> [OPTIONS]
+```
+
+## Arguments
+
+| Argument  | Description                    | Required |
+| --------- | ------------------------------ | -------- |
+| `<SHELL>` | Target shell (bash, zsh, fish) | Yes      |
+
+## Options
+
+| Option      | Description                            | Default |
+| ----------- | -------------------------------------- | ------- |
+| `--aliases` | Include short aliases (gwco, gwcob, etc.) |         |
+
+## Global Options
+
+| Option         | Description               |
+| -------------- | ------------------------- |
+| `-h`, `--help` | Print help information    |
+| `-V`, `--version` | Print version information |
+
+## How It Works
+
+The wrappers use a temp file mechanism for shell cd:
+
+1. Before running a daft command, the wrapper creates a temp file
+2. The temp file path is passed via the `DAFT_CD_FILE` environment variable
+3. The daft command writes the target directory to this file
+4. After the command finishes, the wrapper reads the file and calls `cd`
+5. The temp file is cleaned up
+
+This approach keeps stdout clean for normal command output.
+
+## See Also
+
+- [Shell Integration](../getting-started/shell-integration.md)
+- [daft-setup](./daft-setup.md)
+- [Shortcuts](../guide/shortcuts.md)

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -82,6 +82,14 @@ Default fail modes:
 - `worktreePreCreate`: `abort` (setup must succeed before creating worktree)
 - All others: `warn` (don't block operations)
 
+### Hook Output Settings
+
+| Key                            | Default | Description                             |
+| ------------------------------ | ------- | --------------------------------------- |
+| `daft.hooks.output.quiet`      | `false` | Suppress hook stdout/stderr             |
+| `daft.hooks.output.timerDelay` | `5`     | Seconds before showing elapsed timer    |
+| `daft.hooks.output.tailLines`  | `6`     | Rolling output lines per job (0 = none) |
+
 ### YAML Hooks Configuration
 
 Hooks can also be configured through a `daft.yml` file for richer features
@@ -115,3 +123,13 @@ git config --global daft.hooks.enabled false
 # Make post-create hooks abort on failure
 git config daft.hooks.worktreePostCreate.failMode abort
 ```
+
+## Environment Variables
+
+| Variable               | Description                                                               |
+| ---------------------- | ------------------------------------------------------------------------- |
+| `DAFT_CD_FILE`         | Temp file path for shell wrapper CD communication (set by shell wrappers) |
+| `DAFT_NO_HINTS`        | Set to suppress contextual hint messages                                  |
+| `DAFT_NO_UPDATE_CHECK` | Set to disable version update notifications                               |
+| `NO_COLOR`             | Standard variable to disable colored output                               |
+| `PAGER`                | Override the pager for `daft release-notes`                               |


### PR DESCRIPTION
## Summary

- Add 5 hand-written CLI reference pages for previously undocumented commands: `daft shell-init`, `daft completions`, `daft setup` (with full `shortcuts` subcommand docs), `daft branch`, and `daft multi-remote`
- Update VitePress sidebar to include all new pages under Utilities and Configuration categories
- Add missing hook output settings (`quiet`, `timerDelay`, `tailLines`) and environment variables section to the Configuration guide

## Test plan

- [x] `mise run test-unit` -- all 342 tests pass
- [x] `mise run clippy` -- zero warnings
- [x] `mise run verify-man` -- man pages up-to-date
- [x] `mise run docs:site-build` -- site builds with no broken links
- [ ] Visual review of new pages on docs site


🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)