### PR TITLE
fix: cd to safe directory when branch-delete removes current worktree

### DIFF
--- a/src/commands/shell_init.rs
+++ b/src/commands/shell_init.rs
@@ -119,11 +119,15 @@ __daft_wrapper() {
     fi
     exit_code=$?
 
-    if [ $exit_code -eq 0 ] && [ -s "$cd_file" ]; then
+    # Always check cd_file regardless of exit code. If the binary wrote a
+    # cd target, the user MUST be moved there — their old CWD may have been
+    # removed (e.g., worktree-branch-delete may remove the worktree but still
+    # exit non-zero due to partial errors like remote branch deletion failure).
+    if [ -s "$cd_file" ]; then
         local cd_path
         cd_path=$(cat "$cd_file")
         if [ -n "$cd_path" ] && [ -d "$cd_path" ]; then
-            cd "$cd_path" || exit_code=$?
+            cd "$cd_path" || true
         fi
     fi
 
@@ -304,7 +308,8 @@ function __daft_wrapper
     end
     set -l exit_code $status
 
-    if test $exit_code -eq 0; and test -s "$cd_file"
+    # Always check cd_file regardless of exit code — see bash wrapper comment.
+    if test -s "$cd_file"
         set -l cd_path (cat "$cd_file")
         if test -n "$cd_path"; and test -d "$cd_path"
             cd $cd_path


### PR DESCRIPTION
## Summary
- Shell wrapper (bash/zsh/fish) now always checks `DAFT_CD_FILE` regardless of exit code — previously it only checked on success, so partial errors (e.g., remote branch deletion failure) would leave the user stranded in a deleted directory
- Made current-worktree detection in `branch_delete` more robust with path canonicalization and branch name fallback (matching the pattern used in `prune`)
- Added integration tests for deleting from inside the current worktree with both `cdTarget=root` and `cdTarget=default-branch`

## Test plan
- [x] `mise run fmt-check` — passes
- [x] `mise run clippy` — passes  
- [x] `mise run test-unit` — 333 passed
- [x] Integration tests: all 10 branch_delete tests pass (both default and gitoxide matrices)
- [x] All 19 prune tests still pass (shell wrapper change is backwards compatible)
- [x] Manual test: `git worktree-branch-delete` from inside worktree correctly cd's to safe directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)