### PR TITLE
feat: add -x/--exec option to run commands in worktree after setup

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -123,6 +123,21 @@ these as `git` subcommands (e.g., `daft worktree-checkout` is
 All worktree commands can be run from **any directory** within any worktree.
 They find the project root automatically via `git rev-parse --git-common-dir`.
 
+### Post-setup Command Execution (`-x`/`--exec`)
+
+The `clone`, `init`, `checkout`, and `checkout-branch` commands support
+`-x`/`--exec` to run commands in the new worktree immediately after setup:
+
+```bash
+daft worktree-clone https://github.com/org/repo -x 'mise install' -x 'npm run dev'
+daft worktree-checkout-branch my-feature -x claude
+daft worktree-init my-project -x 'echo "ready"'
+```
+
+The option is repeatable -- commands run sequentially in the worktree directory,
+after hooks complete. Execution stops on first failure. Interactive programs
+(claude, vim) work because stdio is fully inherited.
+
 ## Shell Integration
 
 Shell integration is important because the daft binary creates worktrees

--- a/docs/cli/git-worktree-checkout-branch.md
+++ b/docs/cli/git-worktree-checkout-branch.md
@@ -45,6 +45,7 @@ git worktree-checkout-branch [OPTIONS] <NEW_BRANCH_NAME> [BASE_BRANCH_NAME]
 | `--no-carry` | Do not carry uncommitted changes to the new worktree |  |
 | `-r, --remote <REMOTE>` | Remote for worktree organization (multi-remote mode) |  |
 | `--no-cd` | Do not change directory to the new worktree |  |
+| `-x, --exec <EXEC>` | Run a command in the worktree after setup completes (repeatable) |  |
 
 ## Global Options
 

--- a/docs/cli/git-worktree-checkout.md
+++ b/docs/cli/git-worktree-checkout.md
@@ -45,6 +45,7 @@ git worktree-checkout [OPTIONS] <BRANCH_NAME>
 | `--no-carry` | Do not carry uncommitted changes (this is the default) |  |
 | `-r, --remote <REMOTE>` | Remote for worktree organization (multi-remote mode) |  |
 | `--no-cd` | Do not change directory to the new worktree |  |
+| `-x, --exec <EXEC>` | Run a command in the worktree after setup completes (repeatable) |  |
 
 ## Global Options
 

--- a/docs/cli/git-worktree-clone.md
+++ b/docs/cli/git-worktree-clone.md
@@ -48,6 +48,7 @@ git worktree-clone [OPTIONS] <REPOSITORY_URL>
 | `--no-hooks` | Do not run any hooks from the repository |  |
 | `-r, --remote <REMOTE>` | Organize worktree under this remote folder (enables multi-remote mode) |  |
 | `--no-cd` | Do not change directory to the new worktree |  |
+| `-x, --exec <EXEC>` | Run a command in the worktree after setup completes (repeatable) |  |
 
 ## Global Options
 

--- a/docs/cli/git-worktree-init.md
+++ b/docs/cli/git-worktree-init.md
@@ -47,6 +47,7 @@ git worktree-init [OPTIONS] <REPOSITORY_NAME>
 | `-b, --initial-branch <INITIAL_BRANCH>` | Use <name> as the initial branch instead of the configured default |  |
 | `-r, --remote <REMOTE>` | Organize worktree under this remote folder (enables multi-remote mode) |  |
 | `--no-cd` | Do not change directory to the new worktree |  |
+| `-x, --exec <EXEC>` | Run a command in the worktree after setup completes (repeatable) |  |
 
 ## Global Options
 

--- a/man/git-worktree-checkout-branch.1
+++ b/man/git-worktree-checkout-branch.1
@@ -4,7 +4,7 @@
 .SH NAME
 git\-worktree\-checkout\-branch \- Create a worktree with a new branch
 .SH SYNOPSIS
-\fBgit\-worktree\-checkout\-branch\fR [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-c\fR|\fB\-\-carry\fR] [\fB\-\-no\-carry\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-\-no\-cd\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fINEW_BRANCH_NAME\fR> [\fIBASE_BRANCH_NAME\fR] 
+\fBgit\-worktree\-checkout\-branch\fR [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-c\fR|\fB\-\-carry\fR] [\fB\-\-no\-carry\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-\-no\-cd\fR] [\fB\-x\fR|\fB\-\-exec\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fINEW_BRANCH_NAME\fR> [\fIBASE_BRANCH_NAME\fR] 
 .SH DESCRIPTION
 .PP
 Creates a new branch and a corresponding worktree in a single operation. The
@@ -38,6 +38,9 @@ Remote for worktree organization (multi\-remote mode)
 .TP
 \fB\-\-no\-cd\fR
 Do not change directory to the new worktree
+.TP
+\fB\-x\fR, \fB\-\-exec\fR \fI<EXEC>\fR
+Run a command in the worktree after setup completes (repeatable)
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help (see a summary with \*(Aq\-h\*(Aq)

--- a/man/git-worktree-checkout.1
+++ b/man/git-worktree-checkout.1
@@ -4,7 +4,7 @@
 .SH NAME
 git\-worktree\-checkout \- Create a worktree for an existing branch
 .SH SYNOPSIS
-\fBgit\-worktree\-checkout\fR [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-c\fR|\fB\-\-carry\fR] [\fB\-\-no\-carry\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-\-no\-cd\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIBRANCH_NAME\fR> 
+\fBgit\-worktree\-checkout\fR [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-c\fR|\fB\-\-carry\fR] [\fB\-\-no\-carry\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-\-no\-cd\fR] [\fB\-x\fR|\fB\-\-exec\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIBRANCH_NAME\fR> 
 .SH DESCRIPTION
 .PP
 Creates a new worktree for an existing local or remote branch. The worktree
@@ -37,6 +37,9 @@ Remote for worktree organization (multi\-remote mode)
 .TP
 \fB\-\-no\-cd\fR
 Do not change directory to the new worktree
+.TP
+\fB\-x\fR, \fB\-\-exec\fR \fI<EXEC>\fR
+Run a command in the worktree after setup completes (repeatable)
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help (see a summary with \*(Aq\-h\*(Aq)

--- a/man/git-worktree-clone.1
+++ b/man/git-worktree-clone.1
@@ -4,7 +4,7 @@
 .SH NAME
 git\-worktree\-clone \- Clone a repository into a worktree\-based directory structure
 .SH SYNOPSIS
-\fBgit\-worktree\-clone\fR [\fB\-b\fR|\fB\-\-branch\fR] [\fB\-n\fR|\fB\-\-no\-checkout\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-a\fR|\fB\-\-all\-branches\fR] [\fB\-\-trust\-hooks\fR] [\fB\-\-no\-hooks\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-\-no\-cd\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIREPOSITORY_URL\fR> 
+\fBgit\-worktree\-clone\fR [\fB\-b\fR|\fB\-\-branch\fR] [\fB\-n\fR|\fB\-\-no\-checkout\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-a\fR|\fB\-\-all\-branches\fR] [\fB\-\-trust\-hooks\fR] [\fB\-\-no\-hooks\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-\-no\-cd\fR] [\fB\-x\fR|\fB\-\-exec\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIREPOSITORY_URL\fR> 
 .SH DESCRIPTION
 .PP
 Clones a repository into a directory structure optimized for worktree\-based
@@ -48,6 +48,9 @@ Organize worktree under this remote folder (enables multi\-remote mode)
 .TP
 \fB\-\-no\-cd\fR
 Do not change directory to the new worktree
+.TP
+\fB\-x\fR, \fB\-\-exec\fR \fI<EXEC>\fR
+Run a command in the worktree after setup completes (repeatable)
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help (see a summary with \*(Aq\-h\*(Aq)

--- a/man/git-worktree-init.1
+++ b/man/git-worktree-init.1
@@ -4,7 +4,7 @@
 .SH NAME
 git\-worktree\-init \- Initialize a new repository in the worktree\-based directory structure
 .SH SYNOPSIS
-\fBgit\-worktree\-init\fR [\fB\-\-bare\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-b\fR|\fB\-\-initial\-branch\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-\-no\-cd\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIREPOSITORY_NAME\fR> 
+\fBgit\-worktree\-init\fR [\fB\-\-bare\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-b\fR|\fB\-\-initial\-branch\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-\-no\-cd\fR] [\fB\-x\fR|\fB\-\-exec\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIREPOSITORY_NAME\fR> 
 .SH DESCRIPTION
 .PP
 Initializes a new Git repository using the same directory structure as
@@ -41,6 +41,9 @@ Organize worktree under this remote folder (enables multi\-remote mode)
 .TP
 \fB\-\-no\-cd\fR
 Do not change directory to the new worktree
+.TP
+\fB\-x\fR, \fB\-\-exec\fR \fI<EXEC>\fR
+Run a command in the worktree after setup completes (repeatable)
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help (see a summary with \*(Aq\-h\*(Aq)

--- a/mise-tasks/test/integration/exec
+++ b/mise-tasks/test/integration/exec
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+#MISE description="Run integration exec tests"
+#MISE depends=["build"]
+set -euo pipefail
+
+echo "Running integration exec tests..."
+cd tests/integration && ./test_exec.sh

--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -61,6 +61,13 @@ pub struct Args {
 
     #[arg(long, help = "Do not change directory to the new worktree")]
     no_cd: bool,
+
+    #[arg(
+        short = 'x',
+        long = "exec",
+        help = "Run a command in the worktree after setup completes (repeatable)"
+    )]
+    exec: Vec<String>,
 }
 
 pub fn run() -> Result<()> {
@@ -138,8 +145,16 @@ fn run_checkout(args: &Args, settings: &DaftSettings, output: &mut dyn Output) -
         output.step("Changing to existing worktree...");
         change_directory(&existing_path)?;
         output.result(&format!("Switched to existing worktree '{}'", branch_name));
+
+        // Run exec commands (after cd, before cd_path)
+        let exec_result = crate::exec::run_exec_commands(&args.exec, output);
+
         output.cd_path(&get_current_directory()?);
         maybe_show_shell_hint(output)?;
+
+        // Propagate exec error after cd_path is written
+        exec_result?;
+
         return Ok(());
     }
 
@@ -348,8 +363,14 @@ fn run_checkout(args: &Args, settings: &DaftSettings, output: &mut dyn Output) -
         output,
     )?;
 
+    // Run exec commands (after hooks, before cd_path)
+    let exec_result = crate::exec::run_exec_commands(&args.exec, output);
+
     output.cd_path(&get_current_directory()?);
     maybe_show_shell_hint(output)?;
+
+    // Propagate exec error after cd_path is written
+    exec_result?;
 
     Ok(())
 }

--- a/src/commands/checkout_branch.rs
+++ b/src/commands/checkout_branch.rs
@@ -64,6 +64,13 @@ pub struct Args {
 
     #[arg(long, help = "Do not change directory to the new worktree")]
     no_cd: bool,
+
+    #[arg(
+        short = 'x',
+        long = "exec",
+        help = "Run a command in the worktree after setup completes (repeatable)"
+    )]
+    exec: Vec<String>,
 }
 
 pub fn run() -> Result<()> {
@@ -396,8 +403,14 @@ fn run_checkout_branch(
         output,
     )?;
 
+    // Run exec commands (after hooks, before cd_path)
+    let exec_result = crate::exec::run_exec_commands(&args.exec, output);
+
     output.cd_path(&get_current_directory()?);
     maybe_show_shell_hint(output)?;
+
+    // Propagate exec error after cd_path is written
+    exec_result?;
 
     Ok(())
 }

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -1,0 +1,22 @@
+use anyhow::Result;
+use std::process::Command;
+
+use crate::output::Output;
+
+pub fn run_exec_commands(commands: &[String], output: &mut dyn Output) -> Result<()> {
+    for cmd in commands {
+        output.step(&format!("Executing: {cmd}"));
+        let status = Command::new("sh")
+            .arg("-c")
+            .arg(cmd)
+            .stdin(std::process::Stdio::inherit())
+            .stdout(std::process::Stdio::inherit())
+            .stderr(std::process::Stdio::inherit())
+            .status()?;
+        if !status.success() {
+            let code = status.code().unwrap_or(1);
+            anyhow::bail!("Command '{}' exited with status {}", cmd, code);
+        }
+    }
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@ pub fn get_clap_args(expected_cmd: &str) -> Vec<String> {
 pub mod commands;
 pub mod config;
 pub mod doctor;
+pub mod exec;
 pub mod git;
 pub mod git_oxide;
 pub mod hints;

--- a/tests/integration/test_all.sh
+++ b/tests/integration/test_all.sh
@@ -17,6 +17,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/test_hooks.sh"
 source "$(dirname "${BASH_SOURCE[0]}")/test_flow_adopt.sh"
 source "$(dirname "${BASH_SOURCE[0]}")/test_flow_eject.sh"
 source "$(dirname "${BASH_SOURCE[0]}")/test_unknown_command.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/test_exec.sh"
 
 # Test framework self-tests
 test_integration_framework_assertions() {
@@ -303,6 +304,7 @@ run_all_integration_tests() {
     run_flow_adopt_tests
     run_flow_eject_tests
     run_unknown_command_tests
+    run_exec_tests
 
     # Integration tests
     run_test "integration_full_workflow" "test_integration_full_workflow"

--- a/tests/integration/test_exec.sh
+++ b/tests/integration/test_exec.sh
@@ -1,0 +1,198 @@
+#!/bin/bash
+
+# Integration tests for --exec (-x) option across worktree commands
+
+source "$(dirname "${BASH_SOURCE[0]}")/test_framework.sh"
+
+# Test single -x command runs in init worktree directory
+test_exec_init_single() {
+    git-worktree-init -x 'pwd > exec_output.txt' exec-init-repo || return 1
+
+    # We should be in the worktree now
+    cd exec-init-repo/master || return 1
+    assert_file_exists "exec_output.txt" "exec command should have created output file" || return 1
+
+    # The pwd output should contain the worktree path
+    local exec_pwd
+    exec_pwd=$(cat exec_output.txt)
+    if [[ "$exec_pwd" != *"exec-init-repo/master"* ]]; then
+        log_error "exec command ran in wrong directory: $exec_pwd"
+        return 1
+    fi
+    log_success "Single -x command ran in correct worktree directory"
+
+    return 0
+}
+
+# Test multiple -x commands run in order
+test_exec_init_multiple() {
+    git-worktree-init -x 'echo first > order.txt' -x 'echo second >> order.txt' exec-multi-repo || return 1
+
+    cd exec-multi-repo/master || return 1
+    assert_file_exists "order.txt" "exec commands should have created output file" || return 1
+
+    local content
+    content=$(cat order.txt)
+    if [[ "$content" != "first
+second" ]]; then
+        log_error "exec commands ran out of order or incorrectly: $content"
+        return 1
+    fi
+    log_success "Multiple -x commands ran in correct order"
+
+    return 0
+}
+
+# Test -x with failing command stops and propagates error
+test_exec_failing_command() {
+    # The command should fail because 'false' returns exit code 1
+    if git-worktree-init -x 'echo before > marker.txt' -x 'false' -x 'echo after >> marker.txt' exec-fail-repo 2>/dev/null; then
+        log_error "Command should have failed due to 'false'"
+        return 1
+    fi
+    log_success "Failing -x command propagated error"
+
+    # The second command (false) should have failed, so 'after' should NOT be in marker.txt
+    cd exec-fail-repo/master || return 1
+    assert_file_exists "marker.txt" "First exec command should have run" || return 1
+
+    if grep -q "after" marker.txt; then
+        log_error "Commands after the failing one should not have run"
+        return 1
+    fi
+    log_success "Commands after failure were not executed"
+
+    return 0
+}
+
+# Test -x with clone
+test_exec_clone_single() {
+    local remote_repo
+    remote_repo=$(create_test_remote "test-repo-exec-clone" "main")
+
+    git-worktree-clone "$remote_repo" -x 'pwd > exec_output.txt' || return 1
+
+    cd test-repo-exec-clone/main || return 1
+    assert_file_exists "exec_output.txt" "exec command should have created output file in clone worktree" || return 1
+
+    local exec_pwd
+    exec_pwd=$(cat exec_output.txt)
+    if [[ "$exec_pwd" != *"test-repo-exec-clone/main"* ]]; then
+        log_error "exec command ran in wrong directory: $exec_pwd"
+        return 1
+    fi
+    log_success "Single -x command ran in clone worktree directory"
+
+    return 0
+}
+
+# Test -x with checkout
+test_exec_checkout_single() {
+    local remote_repo
+    remote_repo=$(create_test_remote "test-repo-exec-co" "main")
+
+    # First clone the repository
+    git-worktree-clone "$remote_repo" || return 1
+    cd test-repo-exec-co || return 1
+
+    # Checkout with exec
+    git-worktree-checkout develop -x 'pwd > exec_output.txt' || return 1
+
+    cd develop || return 1
+    assert_file_exists "exec_output.txt" "exec command should have created output file in checkout worktree" || return 1
+
+    local exec_pwd
+    exec_pwd=$(cat exec_output.txt)
+    if [[ "$exec_pwd" != *"test-repo-exec-co/develop"* ]]; then
+        log_error "exec command ran in wrong directory: $exec_pwd"
+        return 1
+    fi
+    log_success "Single -x command ran in checkout worktree directory"
+
+    return 0
+}
+
+# Test -x with checkout-branch
+test_exec_checkout_branch_single() {
+    local remote_repo
+    remote_repo=$(create_test_remote "test-repo-exec-cb" "main")
+
+    # First clone the repository
+    git-worktree-clone "$remote_repo" || return 1
+    cd test-repo-exec-cb/main || return 1
+
+    # Checkout-branch with exec
+    git-worktree-checkout-branch my-new-branch -x 'pwd > exec_output.txt' || return 1
+
+    cd ../my-new-branch || return 1
+    assert_file_exists "exec_output.txt" "exec command should have created output file in new branch worktree" || return 1
+
+    local exec_pwd
+    exec_pwd=$(cat exec_output.txt)
+    if [[ "$exec_pwd" != *"test-repo-exec-cb/my-new-branch"* ]]; then
+        log_error "exec command ran in wrong directory: $exec_pwd"
+        return 1
+    fi
+    log_success "Single -x command ran in checkout-branch worktree directory"
+
+    return 0
+}
+
+# Test -x runs for checkout of existing worktree
+test_exec_checkout_existing_worktree() {
+    local remote_repo
+    remote_repo=$(create_test_remote "test-repo-exec-existing" "main")
+
+    # Clone and create a worktree for develop
+    git-worktree-clone "$remote_repo" || return 1
+    cd test-repo-exec-existing || return 1
+    git-worktree-checkout develop || return 1
+
+    # Now checkout develop again (existing worktree) with -x
+    cd main || return 1
+    git-worktree-checkout develop -x 'echo ran > exec_marker.txt' || return 1
+
+    cd ../develop || return 1
+    assert_file_exists "exec_marker.txt" "exec command should run even for existing worktree checkout" || return 1
+
+    local content
+    content=$(cat exec_marker.txt)
+    if [[ "$content" != "ran" ]]; then
+        log_error "exec command content wrong: $content"
+        return 1
+    fi
+    log_success "-x runs for checkout of existing worktree"
+
+    return 0
+}
+
+# Test -x with no commands (empty) works fine
+test_exec_no_commands() {
+    git-worktree-init exec-no-cmd-repo || return 1
+
+    assert_directory_exists "exec-no-cmd-repo/master" || return 1
+    assert_git_worktree "exec-no-cmd-repo/master" "master" || return 1
+    log_success "No -x commands works normally"
+
+    return 0
+}
+
+# --- Test runner ---
+run_exec_tests() {
+    run_test "exec_init_single" test_exec_init_single
+    run_test "exec_init_multiple" test_exec_init_multiple
+    run_test "exec_failing_command" test_exec_failing_command
+    run_test "exec_clone_single" test_exec_clone_single
+    run_test "exec_checkout_single" test_exec_checkout_single
+    run_test "exec_checkout_branch_single" test_exec_checkout_branch_single
+    run_test "exec_checkout_existing_worktree" test_exec_checkout_existing_worktree
+    run_test "exec_no_commands" test_exec_no_commands
+}
+
+# Main execution (when run directly)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    setup
+    run_exec_tests
+    print_summary
+    exit $?
+fi


### PR DESCRIPTION
## Summary

- Adds `-x`/`--exec` repeatable option to `checkout`, `checkout-branch`, `clone`, and `init` commands
- Commands run sequentially in the worktree directory after hooks complete, with full stdio inheritance (interactive apps like `claude` or `vim` work directly)
- On failure, stops execution and propagates the error, but always writes `cd_path` so the shell still lands in the worktree

## Usage

```bash
git worktree-checkout-branch my-feature -x claude
git worktree-clone https://github.com/org/repo -x 'mise install' -x 'npm run dev'
git worktree-init my-project -x 'echo setup complete'
```

## Test plan

- [x] Unit tests pass (349 tests)
- [x] Integration tests pass (8 new exec-specific tests covering single/multiple commands, failure propagation, all four commands, existing worktree case)
- [x] `mise run clippy` — zero warnings
- [x] `mise run fmt` — clean
- [x] Man pages regenerated and verified
- [x] CLI docs regenerated and verified
- [x] SKILL.md updated with exec option documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)