### PR TITLE
feat: accept worktree paths as arguments in branch-delete

### DIFF
--- a/docs/cli/git-worktree-branch-delete.md
+++ b/docs/cli/git-worktree-branch-delete.md
@@ -13,6 +13,11 @@ Deletes one or more local branches along with their associated worktrees and
 remote tracking branches in a single operation. This is the inverse of
 git-worktree-checkout-branch(1).
 
+Arguments can be branch names or worktree paths. When a path is given
+(absolute, relative, or "."), the branch checked out in that worktree is
+resolved automatically. This is convenient when you are inside a worktree
+and want to delete it without remembering the branch name.
+
 Safety checks prevent accidental data loss. The command refuses to delete a
 branch that:
 
@@ -40,7 +45,7 @@ git worktree-branch-delete [OPTIONS] <BRANCHES>
 
 | Argument | Description | Required |
 |----------|-------------|----------|
-| `<BRANCHES>` | Branch names to delete | Yes |
+| `<BRANCHES>` | Branches to delete (names or worktree paths) | Yes |
 
 ## Options
 

--- a/man/git-worktree-branch-delete.1
+++ b/man/git-worktree-branch-delete.1
@@ -11,6 +11,11 @@ Deletes one or more local branches along with their associated worktrees and
 remote tracking branches in a single operation. This is the inverse of
 git\-worktree\-checkout\-branch(1).
 .PP
+Arguments can be branch names or worktree paths. When a path is given
+(absolute, relative, or "."), the branch checked out in that worktree is
+resolved automatically. This is convenient when you are inside a worktree
+and want to delete it without remembering the branch name.
+.PP
 Safety checks prevent accidental data loss. The command refuses to delete a
 branch that:
 .PP
@@ -45,6 +50,6 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 Print version
 .TP
 <\fIBRANCHES\fR>
-Branch names to delete
+Branches to delete (names or worktree paths)
 .SH VERSION
 v1.0.28


### PR DESCRIPTION
## Summary
- Allow `git-worktree-branch-delete` to accept worktree paths (absolute, relative, or `.`) in addition to branch names
- Paths are resolved to the branch checked out in the worktree, making it convenient to delete a branch without remembering its name (e.g., `git worktree-branch-delete .` from inside a worktree)
- Errors clearly when a worktree has a detached HEAD (no branch to infer)

## Test plan
- [x] Existing 11 integration tests continue to pass
- [x] New test: delete by relative worktree path
- [x] New test: delete by absolute worktree path
- [x] New test: delete by `.` (current directory)
- [x] Unit tests pass (350 tests)
- [x] Clippy clean, fmt clean, man pages and CLI docs regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)