### PR TITLE
fix: prevent prune from deleting worktrees with uncommitted changes

### DIFF
--- a/docs/cli/git-worktree-prune.md
+++ b/docs/cli/git-worktree-prune.md
@@ -39,6 +39,7 @@ git worktree-prune [OPTIONS]
 | Option | Description | Default |
 |--------|-------------|----------|
 | `-v, --verbose` | Be verbose; show detailed progress |  |
+| `-f, --force` | Force removal of worktrees with uncommitted changes or untracked files |  |
 
 ## Global Options
 

--- a/man/git-worktree-prune.1
+++ b/man/git-worktree-prune.1
@@ -4,7 +4,7 @@
 .SH NAME
 git\-worktree\-prune \- Remove worktrees and branches for deleted remote branches
 .SH SYNOPSIS
-\fBgit\-worktree\-prune\fR [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] 
+\fBgit\-worktree\-prune\fR [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-f\fR|\fB\-\-force\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] 
 .SH DESCRIPTION
 .PP
 Removes local branches whose corresponding remote tracking branches have been
@@ -29,6 +29,9 @@ removal if the repository is trusted. See git\-daft(1) for hook management.
 .TP
 \fB\-v\fR, \fB\-\-verbose\fR
 Be verbose; show detailed progress
+.TP
+\fB\-f\fR, \fB\-\-force\fR
+Force removal of worktrees with uncommitted changes or untracked files
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help (see a summary with \*(Aq\-h\*(Aq)


### PR DESCRIPTION
## Summary

- `git-worktree-prune` now checks each worktree for uncommitted changes or untracked files before removing it
- Dirty worktrees are skipped with a warning message instead of silently deleted
- Added `--force` / `-f` flag to explicitly opt-in to removing dirty worktrees

Previously, prune unconditionally passed `--force` to `git worktree remove`, which silently destroyed any uncommitted work or untracked files in worktrees being pruned. This caused data loss with no recovery path.

## Test plan

- [x] `test_prune_skips_untracked_files` — verifies untracked files are preserved without `--force`
- [x] `test_prune_skips_uncommitted_changes` — verifies modified tracked files are preserved without `--force`
- [x] `test_prune_force_removes_dirty_worktree` — verifies `--force` removes dirty worktrees
- [x] `test_prune_removes_clean_worktree` — verifies clean worktrees still get removed normally
- [x] All 22 prune integration tests pass
- [x] All 350 unit tests pass
- [x] clippy, fmt, man page, and CLI docs verification all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)