### PR TITLE
fix: use $SHELL -i for exec commands to support aliases and shell functions

### DIFF
--- a/src/exec.rs
+++ b/src/exec.rs
@@ -6,7 +6,9 @@ use crate::output::Output;
 pub fn run_exec_commands(commands: &[String], output: &mut dyn Output) -> Result<()> {
     for cmd in commands {
         output.step(&format!("Executing: {cmd}"));
-        let status = Command::new("sh")
+        let shell = std::env::var("SHELL").unwrap_or_else(|_| "sh".to_string());
+        let status = Command::new(&shell)
+            .arg("-i")
             .arg("-c")
             .arg(cmd)
             .stdin(std::process::Stdio::inherit())


### PR DESCRIPTION
## Summary

- `-x`/`--exec` commands were run with `sh -c`, a non-interactive POSIX shell that doesn't source the user's rc files
- Changed to use `$SHELL -i -c` so aliases, shell functions, and other rc-defined shortcuts are available
- Falls back to `sh` if `$SHELL` is not set

## Test Plan
- [ ] Run a command with `-x` using a shell alias (e.g. `alias g=git`) and verify it works
- [ ] Verify `-x` still works normally for plain commands without aliases

Fixes #244