### PR TITLE
fix(hooks): resolve hooks not executing on first run after upgrade

### DIFF
--- a/src/core/progress.rs
+++ b/src/core/progress.rs
@@ -57,6 +57,11 @@ impl<'a> CommandBridge<'a> {
     pub fn new(output: &'a mut dyn Output, executor: HookExecutor) -> Self {
         Self { output, executor }
     }
+
+    /// Consume the bridge and return the hook executor.
+    pub fn into_executor(self) -> HookExecutor {
+        self.executor
+    }
 }
 
 impl ProgressSink for CommandBridge<'_> {

--- a/src/core/worktree/checkout.rs
+++ b/src/core/worktree/checkout.rs
@@ -2,7 +2,7 @@
 //!
 //! Creates a worktree for an existing branch.
 
-use crate::core::{HookRunner, ProgressSink};
+use crate::core::{HookOutcome, HookRunner, ProgressSink};
 use crate::git::GitCommand;
 use crate::hooks::{HookContext, HookType};
 use crate::multi_remote::path::{calculate_worktree_path, resolve_remote_for_branch};
@@ -44,6 +44,8 @@ pub struct CheckoutResult {
     pub stash_conflict: bool,
     pub upstream_set: bool,
     pub upstream_skipped: bool,
+    pub git_dir: PathBuf,
+    pub post_hook_outcome: HookOutcome,
 }
 
 /// Execute the checkout operation.
@@ -98,6 +100,12 @@ pub fn execute(
             stash_conflict: false,
             upstream_set: false,
             upstream_skipped: true,
+            git_dir,
+            post_hook_outcome: HookOutcome {
+                success: true,
+                skipped: true,
+                skip_reason: None,
+            },
         });
     }
 
@@ -202,7 +210,7 @@ pub fn execute(
     )
     .with_new_branch(false);
 
-    sink.run_hook(&post_hook_ctx)?;
+    let post_hook_outcome = sink.run_hook(&post_hook_ctx)?;
 
     Ok(CheckoutResult {
         branch_name: params.branch_name.clone(),
@@ -213,6 +221,8 @@ pub fn execute(
         stash_conflict,
         upstream_set,
         upstream_skipped,
+        git_dir,
+        post_hook_outcome,
     })
 }
 

--- a/src/core/worktree/checkout_branch.rs
+++ b/src/core/worktree/checkout_branch.rs
@@ -3,7 +3,7 @@
 //! Creates a worktree with a new branch.
 
 use crate::config::git::{COMMITS_AHEAD_THRESHOLD, DEFAULT_COMMIT_COUNT};
-use crate::core::{HookRunner, ProgressSink};
+use crate::core::{HookOutcome, HookRunner, ProgressSink};
 use crate::git::GitCommand;
 use crate::hooks::{HookContext, HookType};
 use crate::multi_remote::path::{calculate_worktree_path, resolve_remote_for_branch};
@@ -45,6 +45,8 @@ pub struct CheckoutBranchResult {
     pub stash_conflict: bool,
     pub push_set: bool,
     pub push_skipped: bool,
+    pub git_dir: PathBuf,
+    pub post_hook_outcome: HookOutcome,
 }
 
 /// Execute the checkout-branch operation.
@@ -150,7 +152,7 @@ pub fn execute(
     .with_new_branch(true)
     .with_base_branch(&base_branch);
 
-    sink.run_hook(&post_hook_ctx)?;
+    let post_hook_outcome = sink.run_hook(&post_hook_ctx)?;
 
     Ok(CheckoutBranchResult {
         new_branch_name: params.new_branch_name.clone(),
@@ -161,6 +163,8 @@ pub fn execute(
         stash_conflict,
         push_set,
         push_skipped,
+        git_dir,
+        post_hook_outcome,
     })
 }
 


### PR DESCRIPTION
## Summary

- Fix path canonicalization in checkout commands — replace private `resolve_git_dir()` with `get_git_common_dir()` from `repo.rs` which canonicalizes paths, fixing trust DB lookups on systems with symlinks (e.g. macOS `/var` -> `/private/var`)
- Fix `CommandBridge::run_hook()` propagating `result.stderr` instead of `result.skip_reason`, which lost the actual skip reason
- Add untrusted-hooks notice to `go`/`start` commands (previously only `clone` and `adopt` showed it)

## Test Plan
- [x] `mise run clippy` — zero warnings
- [x] `mise run fmt` — clean
- [x] `mise run test:unit` — 6/6 passed
- [x] `mise run test:integration` — 198/198 passed (default + gitoxide backends)

🤖 Generated with [Claude Code](https://claude.com/claude-code)