### PR TITLE
feat(go): add `daft go -` to toggle between previous worktrees

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -114,6 +114,7 @@ these as `git` subcommands (e.g., `daft worktree-checkout` is
 | `daft worktree-clone <url>`                     | Clone a remote repository into daft's worktree layout                             |
 | `daft worktree-init <name>`                     | Initialize a new local repository in worktree layout                              |
 | `daft worktree-checkout <branch>`               | Create a worktree for an existing local or remote branch                          |
+| `daft worktree-checkout -- -`                   | Switch to the previous worktree (`cd -` style toggle)                             |
 | `daft worktree-checkout -s <branch>`            | Same as above, but auto-creates branch if not found (also `daft.go.autoStart`)    |
 | `daft worktree-checkout -b <new-branch> [base]` | Create a new branch and worktree from current or specified base                   |
 | `daft worktree-branch -d <branch>`              | Safely delete a branch: its worktree, local branch, and remote tracking branch    |
@@ -533,6 +534,7 @@ When working in a daft-managed repository, apply these translations:
 | "Create a branch"     | `daft worktree-checkout -b <name>` -- creates branch + worktree + pushes                           |
 | "Branch from main"    | `daft worktree-checkout -b <name> main` -- branches from the specified base                        |
 | "Switch to branch X"  | Navigate to the worktree directory: `cd ../X/`                                                     |
+| "Go back"             | `daft worktree-checkout -- -` -- toggles to the previous worktree                                  |
 | "Check out a PR"      | `daft worktree-checkout <branch>` -- creates worktree for existing branch                          |
 | "Delete a branch"     | `daft worktree-branch -d <branch>` -- removes worktree, local branch, and remote tracking branch   |
 | "Clean up branches"   | `daft worktree-prune` -- removes worktrees for deleted remote branches                             |

--- a/docs/cli/daft-go.md
+++ b/docs/cli/daft-go.md
@@ -30,6 +30,21 @@ With `--start` (or `-s`), if the branch does not exist locally or on the
 remote, a new branch and worktree are created automatically. This can also be
 enabled permanently with `git config daft.go.autoStart true`.
 
+### Previous worktree (`-`)
+
+Use `-` as the branch name to switch to the previous worktree, similar to
+`cd -`. Each successful `daft go` or `daft start` records the source worktree,
+so repeated `daft go -` toggles between the two most recent worktrees.
+
+```
+daft go main        # switch to main
+daft go feature/x   # switch to feature/x (main is now "previous")
+daft go -           # back to main
+daft go -           # back to feature/x
+```
+
+Cannot be combined with `-b`/`--create-branch`.
+
 ## See Also
 
 - [daft start](./daft-start.md) to create a new branch

--- a/docs/cli/git-worktree-checkout.md
+++ b/docs/cli/git-worktree-checkout.md
@@ -33,6 +33,10 @@ remote, a new branch and worktree are created automatically, as if 'daft start'
 had been called. This can also be enabled permanently with the daft.go.autoStart
 git config option.
 
+Use '-' as the branch name to switch to the previous worktree, similar to
+'cd -'. Repeated 'daft go -' toggles between the two most recent worktrees.
+Cannot be combined with -b/--create-branch.
+
 This command can be run from anywhere within the repository. If a worktree
 for the specified branch already exists, no new worktree is created; the
 working directory is changed to the existing worktree instead.
@@ -50,7 +54,7 @@ git worktree-checkout [OPTIONS] <BRANCH_NAME> [BASE_BRANCH_NAME]
 
 | Argument | Description | Required |
 |----------|-------------|----------|
-| `<BRANCH_NAME>` | Name of the branch to check out (or create with -b) | Yes |
+| `<BRANCH_NAME>` | Name of the branch to check out (or create with -b); use '-' for previous worktree | Yes |
 | `<BASE_BRANCH_NAME>` | Branch to use as the base for the new branch (only with -b); defaults to the current branch | No |
 
 ## Options

--- a/man/daft-go.1
+++ b/man/daft-go.1
@@ -25,6 +25,10 @@ remote, a new branch and worktree are created automatically, as if \*(Aqdaft sta
 had been called. This can also be enabled permanently with the daft.go.autoStart
 git config option.
 .PP
+Use \*(Aq\-\*(Aq as the branch name to switch to the previous worktree, similar to
+\*(Aqcd \-\*(Aq. Repeated \*(Aqdaft go \-\*(Aq toggles between the two most recent worktrees.
+Cannot be combined with \-b/\-\-create\-branch.
+.PP
 This command can be run from anywhere within the repository. If a worktree
 for the specified branch already exists, no new worktree is created; the
 working directory is changed to the existing worktree instead.
@@ -67,7 +71,7 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 Print version
 .TP
 <\fIBRANCH_NAME\fR>
-Name of the branch to check out (or create with \-b)
+Name of the branch to check out (or create with \-b); use \*(Aq\-\*(Aq for previous worktree
 .TP
 [\fIBASE_BRANCH_NAME\fR]
 Branch to use as the base for the new branch (only with \-b); defaults to the current branch

--- a/man/daft-start.1
+++ b/man/daft-start.1
@@ -25,6 +25,10 @@ remote, a new branch and worktree are created automatically, as if \*(Aqdaft sta
 had been called. This can also be enabled permanently with the daft.go.autoStart
 git config option.
 .PP
+Use \*(Aq\-\*(Aq as the branch name to switch to the previous worktree, similar to
+\*(Aqcd \-\*(Aq. Repeated \*(Aqdaft go \-\*(Aq toggles between the two most recent worktrees.
+Cannot be combined with \-b/\-\-create\-branch.
+.PP
 This command can be run from anywhere within the repository. If a worktree
 for the specified branch already exists, no new worktree is created; the
 working directory is changed to the existing worktree instead.
@@ -67,7 +71,7 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 Print version
 .TP
 <\fIBRANCH_NAME\fR>
-Name of the branch to check out (or create with \-b)
+Name of the branch to check out (or create with \-b); use \*(Aq\-\*(Aq for previous worktree
 .TP
 [\fIBASE_BRANCH_NAME\fR]
 Branch to use as the base for the new branch (only with \-b); defaults to the current branch

--- a/man/git-worktree-checkout.1
+++ b/man/git-worktree-checkout.1
@@ -25,6 +25,10 @@ remote, a new branch and worktree are created automatically, as if \*(Aqdaft sta
 had been called. This can also be enabled permanently with the daft.go.autoStart
 git config option.
 .PP
+Use \*(Aq\-\*(Aq as the branch name to switch to the previous worktree, similar to
+\*(Aqcd \-\*(Aq. Repeated \*(Aqdaft go \-\*(Aq toggles between the two most recent worktrees.
+Cannot be combined with \-b/\-\-create\-branch.
+.PP
 This command can be run from anywhere within the repository. If a worktree
 for the specified branch already exists, no new worktree is created; the
 working directory is changed to the existing worktree instead.
@@ -67,7 +71,7 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 Print version
 .TP
 <\fIBRANCH_NAME\fR>
-Name of the branch to check out (or create with \-b)
+Name of the branch to check out (or create with \-b); use \*(Aq\-\*(Aq for previous worktree
 .TP
 [\fIBASE_BRANCH_NAME\fR]
 Branch to use as the base for the new branch (only with \-b); defaults to the current branch

--- a/src/core/worktree/mod.rs
+++ b/src/core/worktree/mod.rs
@@ -13,6 +13,7 @@ pub mod fetch;
 pub mod flow_adopt;
 pub mod flow_eject;
 pub mod init;
+pub mod previous;
 pub mod prune;
 
 /// Configuration for worktree operations.

--- a/src/core/worktree/previous.rs
+++ b/src/core/worktree/previous.rs
@@ -1,0 +1,125 @@
+//! Previous worktree state for `daft go -` navigation.
+//!
+//! Stores the absolute path of the last worktree the user switched away from,
+//! enabling `cd -`–style toggling between two worktrees. State is persisted
+//! per-repository at `<git-common-dir>/.daft/previous-worktree`.
+
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+
+const STATE_DIR: &str = ".daft";
+const STATE_FILE: &str = "previous-worktree";
+
+/// Load the previously visited worktree path, if any.
+///
+/// Returns `Ok(None)` when no previous worktree has been recorded (file
+/// missing or empty). Returns `Err` only on unexpected I/O failures.
+pub fn load(git_common_dir: &Path) -> Result<Option<PathBuf>> {
+    let file = git_common_dir.join(STATE_DIR).join(STATE_FILE);
+
+    match std::fs::read_to_string(&file) {
+        Ok(content) => {
+            let trimmed = content.trim();
+            if trimmed.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(PathBuf::from(trimmed)))
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e).with_context(|| {
+            format!(
+                "Failed to read previous worktree state from {}",
+                file.display()
+            )
+        }),
+    }
+}
+
+/// Save the worktree path as the "previous" for later `daft go -` use.
+///
+/// Creates the `.daft/` directory inside the git common dir if it does not
+/// already exist.
+pub fn save(git_common_dir: &Path, worktree_path: &Path) -> Result<()> {
+    let dir = git_common_dir.join(STATE_DIR);
+    if !dir.exists() {
+        std::fs::create_dir_all(&dir)
+            .with_context(|| format!("Failed to create state directory {}", dir.display()))?;
+    }
+
+    let file = dir.join(STATE_FILE);
+    std::fs::write(&file, worktree_path.to_string_lossy().as_bytes()).with_context(|| {
+        format!(
+            "Failed to write previous worktree state to {}",
+            file.display()
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_roundtrip() {
+        let dir = tempdir().unwrap();
+        let worktree = PathBuf::from("/projects/repo/feature-x");
+
+        save(dir.path(), &worktree).unwrap();
+        let loaded = load(dir.path()).unwrap();
+        assert_eq!(loaded, Some(worktree));
+    }
+
+    #[test]
+    fn test_no_file() {
+        let dir = tempdir().unwrap();
+        let loaded = load(dir.path()).unwrap();
+        assert_eq!(loaded, None);
+    }
+
+    #[test]
+    fn test_empty_file() {
+        let dir = tempdir().unwrap();
+        let state_dir = dir.path().join(STATE_DIR);
+        std::fs::create_dir_all(&state_dir).unwrap();
+        std::fs::write(state_dir.join(STATE_FILE), "").unwrap();
+
+        let loaded = load(dir.path()).unwrap();
+        assert_eq!(loaded, None);
+    }
+
+    #[test]
+    fn test_whitespace_only_file() {
+        let dir = tempdir().unwrap();
+        let state_dir = dir.path().join(STATE_DIR);
+        std::fs::create_dir_all(&state_dir).unwrap();
+        std::fs::write(state_dir.join(STATE_FILE), "  \n  ").unwrap();
+
+        let loaded = load(dir.path()).unwrap();
+        assert_eq!(loaded, None);
+    }
+
+    #[test]
+    fn test_overwrite() {
+        let dir = tempdir().unwrap();
+        let first = PathBuf::from("/projects/repo/main");
+        let second = PathBuf::from("/projects/repo/develop");
+
+        save(dir.path(), &first).unwrap();
+        save(dir.path(), &second).unwrap();
+
+        let loaded = load(dir.path()).unwrap();
+        assert_eq!(loaded, Some(second));
+    }
+
+    #[test]
+    fn test_creates_daft_directory() {
+        let dir = tempdir().unwrap();
+        let daft_dir = dir.path().join(STATE_DIR);
+        assert!(!daft_dir.exists());
+
+        save(dir.path(), &PathBuf::from("/some/path")).unwrap();
+        assert!(daft_dir.exists());
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `daft go -` (and `git worktree-checkout -- -`) to switch to the previous worktree, mirroring `cd -` behavior
- Every successful `daft go` or `daft start` saves the source worktree path at `<git-common-dir>/.daft/previous-worktree`
- Repeated `daft go -` toggles between the two most recent worktrees
- Cannot be combined with `-b`/`--create-branch`

## Test plan

- [x] Unit tests for `previous::load`/`save` (roundtrip, no file, empty file, overwrite, directory creation)
- [x] Integration test: `go -` with no previous errors correctly
- [x] Integration test: `go -` toggles between two worktrees via DAFT_CD_FILE
- [x] Integration test: `go -` errors when previous worktree was deleted
- [x] Integration test: `go -b -` is rejected
- [x] `mise run fmt` clean
- [x] `mise run clippy` zero warnings
- [x] `mise run test:unit` all 377 tests pass
- [x] Man pages regenerated and verified
- [x] CLI docs regenerated and verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)