### PR TITLE
refactor(cli): separate daft go/start from git-worktree-checkout

### DIFF
--- a/docs/plans/2026-02-24-separate-daft-go-start-design.md
+++ b/docs/plans/2026-02-24-separate-daft-go-start-design.md
@@ -1,0 +1,64 @@
+# Separate `daft go` / `daft start` from `git-worktree-checkout`
+
+## Problem
+
+`daft start` and `daft go` reuse the `git-worktree-checkout` clap `Args` struct.
+This causes:
+
+- `daft start --help` shows `git-worktree-checkout` help with irrelevant flags
+  (`-b`, `--start`, `-` previous worktree)
+- `daft go --help` shows `-b` (a git-style flag) and base-branch positional arg
+  that only applies with `-b`
+- `daft start` works by injecting `-b` into raw args before clap parsing, a
+  brittle hack
+
+`daft remove` and `daft rename` already solved this problem in
+`worktree_branch.rs` with dedicated `RemoveArgs` and `RenameArgs` structs. This
+design applies the same pattern to `checkout.rs`.
+
+## Design
+
+### New structs in `checkout.rs`
+
+**`GoArgs`** (for `daft go`):
+
+- `branch_name: String` — positional, allows `-` for previous worktree
+- `-b` / `--create-branch` — create a new branch
+- `base_branch_name: Option<String>` — positional, base branch (only with `-b`)
+- `-s` / `--start` — auto-create if branch doesn't exist
+- `-c` / `--carry`, `--no-carry`
+- `-r` / `--remote`
+- `--no-cd`
+- `-x` / `--exec`
+- `-q` / `-v`
+- `#[command(name = "daft go")]` with tailored help text
+
+**`StartArgs`** (for `daft start`):
+
+- `new_branch_name: String` — positional, required
+- `base_branch_name: Option<String>` — positional, optional
+- `-c` / `--carry`, `--no-carry`
+- `-r` / `--remote`
+- `--no-cd`
+- `-x` / `--exec`
+- `-q` / `-v`
+- `#[command(name = "daft start")]` with tailored help text
+- No `-b`, no `--start`, no `-` support
+
+### Entry points
+
+- `run()` — unchanged, parses `Args` for `git-worktree-checkout`
+- `run_go()` — new, parses `GoArgs`, delegates to shared helpers
+- `run_create()` — rewritten, parses `StartArgs`, delegates to shared helpers
+
+### Routing changes in `main.rs`
+
+- `"go"` routes to `commands::checkout::run_go()` (was `run()`)
+- `"start"` routes to `commands::checkout::run_create()` (unchanged target, new
+  implementation)
+
+### What stays the same
+
+- Core logic in `core/worktree/checkout.rs` and `checkout_branch.rs`
+- `git-worktree-checkout` `Args` struct and behavior
+- Shell completions (flag names unchanged for go/start)

--- a/docs/plans/2026-02-24-separate-daft-go-start-plan.md
+++ b/docs/plans/2026-02-24-separate-daft-go-start-plan.md
@@ -1,0 +1,493 @@
+# Separate `daft go` / `daft start` from `git-worktree-checkout` — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to
+> implement this plan task-by-task.
+
+**Goal:** Give `daft go` and `daft start` their own clap Args structs and entry
+points so their `--help` output is tailored and they don't leak irrelevant flags
+from `git-worktree-checkout`.
+
+**Architecture:** Follow the pattern already established by
+`RemoveArgs`/`RenameArgs` in `worktree_branch.rs`. Add `GoArgs` and `StartArgs`
+to `checkout.rs`, each with dedicated `run_go()`/`run_create()` entry points
+that parse their own args and delegate to the existing shared helper functions
+(`run_checkout`, `run_create_branch`, `run_go_previous`). Update routing,
+completions, and man page generation.
+
+**Tech Stack:** Rust, clap derive, shell completion generators
+(bash/zsh/fish/fig)
+
+---
+
+### Task 1: Add `GoArgs` struct and `run_go()` entry point
+
+**Files:**
+
+- Modify: `src/commands/checkout.rs`
+
+**Step 1: Add the `GoArgs` struct after the existing `Args` struct (after
+line 112)**
+
+```rust
+/// Daft-style args for `daft go`. Separate from `Args` so that `--help`
+/// shows only the flags relevant to navigating worktrees.
+#[derive(Parser)]
+#[command(name = "daft go")]
+#[command(version = crate::VERSION)]
+#[command(about = "Open an existing branch in a worktree")]
+#[command(long_about = r#"
+Opens a worktree for an existing local or remote branch. The worktree is
+placed at the project root level as a sibling to other worktrees, using the
+branch name as the directory name.
+
+If the branch exists only on the remote, a local tracking branch is created
+automatically. If the branch exists both locally and on the remote, the local
+branch is checked out and upstream tracking is configured.
+
+If a worktree for the specified branch already exists, no new worktree is
+created; the working directory is changed to the existing worktree instead.
+
+Use '-' as the branch name to switch to the previous worktree, similar to
+'cd -'. Repeated 'daft go -' toggles between the two most recent worktrees.
+
+With -b, creates a new branch and worktree in a single operation. The new
+branch is based on the current branch, or on <base-branch> if specified.
+Prefer 'daft start' for creating new branches.
+
+With -s (--start), if the specified branch does not exist locally or on the
+remote, a new branch and worktree are created automatically. This can also
+be enabled permanently with the daft.go.autoStart git config option.
+
+Lifecycle hooks from .daft/hooks/ are executed if the repository is trusted.
+See daft-hooks(1) for hook management.
+"#)]
+pub struct GoArgs {
+    #[arg(
+        help = "Branch to open; use '-' for previous worktree",
+        allow_hyphen_values = true
+    )]
+    branch_name: String,
+
+    #[arg(
+        help = "Base branch for -b (defaults to current branch)"
+    )]
+    base_branch_name: Option<String>,
+
+    #[arg(
+        short = 'b',
+        long = "create-branch",
+        help = "Create a new branch (prefer 'daft start' instead)"
+    )]
+    create_branch: bool,
+
+    #[arg(
+        short = 's',
+        long = "start",
+        help = "Create a new worktree if the branch does not exist"
+    )]
+    start: bool,
+
+    #[arg(short, long, help = "Operate quietly; suppress progress reporting")]
+    quiet: bool,
+
+    #[arg(short, long, help = "Be verbose; show detailed progress")]
+    verbose: bool,
+
+    #[arg(
+        short = 'c',
+        long = "carry",
+        help = "Apply uncommitted changes from the current worktree to the new one"
+    )]
+    carry: bool,
+
+    #[arg(long, help = "Do not carry uncommitted changes")]
+    no_carry: bool,
+
+    #[arg(
+        short = 'r',
+        long = "remote",
+        help = "Remote for worktree organization (multi-remote mode)"
+    )]
+    remote: Option<String>,
+
+    #[arg(long, help = "Do not change directory to the new worktree")]
+    no_cd: bool,
+
+    #[arg(
+        short = 'x',
+        long = "exec",
+        help = "Run a command in the worktree after setup completes (repeatable)"
+    )]
+    exec: Vec<String>,
+}
+```
+
+**Step 2: Add the `run_go()` entry point**
+
+Replace the existing `run()` comment at line 114 to keep it for
+`git-worktree-checkout` only. Add a new `run_go()` function:
+
+```rust
+/// Entry point for `daft go`.
+pub fn run_go() -> Result<()> {
+    let mut raw = crate::get_clap_args("daft-go");
+    raw[0] = "daft go".to_string();
+    let go_args = GoArgs::parse_from(raw);
+
+    // Validate: base_branch_name only valid with -b
+    if go_args.base_branch_name.is_some() && !go_args.create_branch {
+        anyhow::bail!("<BASE_BRANCH_NAME> can only be used with -b/--create-branch");
+    }
+
+    // Convert to the internal Args and delegate
+    let args = Args {
+        branch_name: go_args.branch_name,
+        base_branch_name: go_args.base_branch_name,
+        create_branch: go_args.create_branch,
+        quiet: go_args.quiet,
+        verbose: go_args.verbose,
+        carry: go_args.carry,
+        no_carry: go_args.no_carry,
+        remote: go_args.remote,
+        no_cd: go_args.no_cd,
+        exec: go_args.exec,
+        start: go_args.start,
+    };
+    run_with_args(args)
+}
+```
+
+**Step 3: Build to verify it compiles**
+
+Run: `cargo build 2>&1 | head -20` Expected: compiles successfully
+
+**Step 4: Commit**
+
+```
+feat(go): add dedicated GoArgs for daft go
+```
+
+---
+
+### Task 2: Add `StartArgs` struct and rewrite `run_create()`
+
+**Files:**
+
+- Modify: `src/commands/checkout.rs`
+
+**Step 1: Add the `StartArgs` struct after `GoArgs`**
+
+```rust
+/// Daft-style args for `daft start`. Separate from `Args` so that `--help`
+/// shows only the flags relevant to creating new branches.
+#[derive(Parser)]
+#[command(name = "daft start")]
+#[command(version = crate::VERSION)]
+#[command(about = "Create a new branch and worktree")]
+#[command(long_about = r#"
+Creates a new branch and a corresponding worktree in a single operation. The
+worktree is placed at the project root level as a sibling to other worktrees,
+using the branch name as the directory name.
+
+The new branch is based on the current branch, or on <base-branch> if
+specified. After creating the branch locally, it is pushed to the remote and
+upstream tracking is configured (unless disabled via daft.checkoutBranch.push).
+
+This command can be run from anywhere within the repository.
+
+Lifecycle hooks from .daft/hooks/ are executed if the repository is trusted.
+See daft-hooks(1) for hook management.
+"#)]
+pub struct StartArgs {
+    #[arg(help = "Name of the new branch to create")]
+    new_branch_name: String,
+
+    #[arg(help = "Branch to use as the base (defaults to current branch)")]
+    base_branch_name: Option<String>,
+
+    #[arg(short, long, help = "Operate quietly; suppress progress reporting")]
+    quiet: bool,
+
+    #[arg(short, long, help = "Be verbose; show detailed progress")]
+    verbose: bool,
+
+    #[arg(
+        short = 'c',
+        long = "carry",
+        help = "Apply uncommitted changes from the current worktree to the new one"
+    )]
+    carry: bool,
+
+    #[arg(long, help = "Do not carry uncommitted changes")]
+    no_carry: bool,
+
+    #[arg(
+        short = 'r',
+        long = "remote",
+        help = "Remote for worktree organization (multi-remote mode)"
+    )]
+    remote: Option<String>,
+
+    #[arg(long, help = "Do not change directory to the new worktree")]
+    no_cd: bool,
+
+    #[arg(
+        short = 'x',
+        long = "exec",
+        help = "Run a command in the worktree after setup completes (repeatable)"
+    )]
+    exec: Vec<String>,
+}
+```
+
+**Step 2: Rewrite `run_create()` to parse `StartArgs` instead of injecting
+`-b`**
+
+```rust
+/// Entry point for `daft start`.
+pub fn run_create() -> Result<()> {
+    let mut raw = crate::get_clap_args("daft-start");
+    raw[0] = "daft start".to_string();
+    let start_args = StartArgs::parse_from(raw);
+
+    // Convert to the internal Args and delegate
+    let args = Args {
+        branch_name: start_args.new_branch_name,
+        base_branch_name: start_args.base_branch_name,
+        create_branch: true, // daft start always creates
+        quiet: start_args.quiet,
+        verbose: start_args.verbose,
+        carry: start_args.carry,
+        no_carry: start_args.no_carry,
+        remote: start_args.remote,
+        no_cd: start_args.no_cd,
+        exec: start_args.exec,
+        start: false, // Not applicable for start
+    };
+    run_with_args(args)
+}
+```
+
+**Step 3: Build to verify it compiles**
+
+Run: `cargo build 2>&1 | head -20` Expected: compiles successfully
+
+**Step 4: Commit**
+
+```
+feat(start): add dedicated StartArgs for daft start
+```
+
+---
+
+### Task 3: Update routing in `main.rs`
+
+**Files:**
+
+- Modify: `src/main.rs`
+
+**Step 1: Change the `"go"` route from `run()` to `run_go()`**
+
+At line 89, change:
+
+```rust
+"go" => commands::checkout::run_go(),
+```
+
+The `"start"` line (90) already calls `run_create()` which is now rewritten.
+
+**Step 2: Build and smoke test**
+
+Run: `cargo build && cargo run -- start --help` Expected: shows `daft start`
+help with `new_branch_name` and `base_branch_name` positionals, no `-b`, no
+`--start`
+
+Run: `cargo run -- go --help` Expected: shows `daft go` help with branch name,
+`-s`/`--start`, `-b`, no mention of `git-worktree-checkout`
+
+**Step 3: Commit**
+
+```
+refactor: route daft go/start to dedicated entry points
+```
+
+---
+
+### Task 4: Update shell completions
+
+**Files:**
+
+- Modify: `src/commands/completions/mod.rs`
+- Modify: `src/commands/completions/bash.rs`
+- Modify: `src/commands/completions/zsh.rs`
+- Modify: `src/commands/completions/fish.rs`
+
+**Step 1: Update `VERB_ALIAS_GROUPS` in `mod.rs` (line 28)**
+
+Change:
+
+```rust
+(&["go", "start"], "git-worktree-checkout"),
+```
+
+to separate entries:
+
+```rust
+(&["go"], "daft-go"),
+(&["start"], "daft-start"),
+```
+
+**Step 2: Add `"daft-go"` and `"daft-start"` to the `COMMANDS` array (line 37)**
+
+Add after the existing entries:
+
+```rust
+"daft-go",
+"daft-start",
+```
+
+**Step 3: Add entries in `get_command_for_name` (line 52)**
+
+```rust
+"daft-go" => Some(crate::commands::checkout::GoArgs::command()),
+"daft-start" => Some(crate::commands::checkout::StartArgs::command()),
+```
+
+**Step 4: Update bash completions in `bash.rs`**
+
+At line 135-139, change the `go|start)` case to separate cases:
+
+```bash
+go)
+    COMP_WORDS=("daft-go" "${COMP_WORDS[@]:2}")
+    COMP_CWORD=$((COMP_CWORD - 1))
+    _daft_go
+    return 0
+    ;;
+start)
+    COMP_WORDS=("daft-start" "${COMP_WORDS[@]:2}")
+    COMP_CWORD=$((COMP_CWORD - 1))
+    _daft_start
+    return 0
+    ;;
+```
+
+**Step 5: Update zsh completions in `zsh.rs`**
+
+At line 148-152, change the `go|start)` case to separate cases:
+
+```zsh
+go)
+    words=("daft-go" "${(@)words[3,-1]}")
+    CURRENT=$((CURRENT - 1))
+    __daft_go_impl
+    return
+    ;;
+start)
+    words=("daft-start" "${(@)words[3,-1]}")
+    CURRENT=$((CURRENT - 1))
+    __daft_start_impl
+    return
+    ;;
+```
+
+**Step 6: Update fish completions in `fish.rs`**
+
+At line 173, change:
+
+```fish
+complete -c daft -n '__fish_seen_subcommand_from go start carry update' -f -a "(daft __complete git-worktree-checkout '' 2>/dev/null)"
+```
+
+to:
+
+```fish
+complete -c daft -n '__fish_seen_subcommand_from go' -f -a "(daft __complete daft-go '' 2>/dev/null)"
+complete -c daft -n '__fish_seen_subcommand_from start' -f -a "(daft __complete daft-start '' 2>/dev/null)"
+complete -c daft -n '__fish_seen_subcommand_from carry update' -f -a "(daft __complete git-worktree-checkout '' 2>/dev/null)"
+```
+
+Also update the `needs_branch_completion` match at line 9 to include `"daft-go"`
+and `"daft-start"`.
+
+**Step 7: Build to verify**
+
+Run: `cargo build 2>&1 | head -20` Expected: compiles successfully
+
+**Step 8: Commit**
+
+```
+refactor(completions): separate go/start completion targets
+```
+
+---
+
+### Task 5: Update xtask man page generation
+
+**Files:**
+
+- Modify: `xtask/src/main.rs`
+
+**Step 1: Add `"daft-go"` and `"daft-start"` to the xtask
+`get_command_for_name`**
+
+At line 141, before `_ => None`, add:
+
+```rust
+"daft-go" => Some(daft::commands::checkout::GoArgs::command()),
+"daft-start" => Some(daft::commands::checkout::StartArgs::command()),
+```
+
+**Step 2: Verify man page generation picks up the new structs**
+
+The `DAFT_VERBS` entries for `daft-go` and `daft-start` already exist (lines
+53-62). The man page generation logic at line 337 already checks
+`get_command_for_name(verb.daft_name)` first and uses the dedicated Args struct
+if found. So adding `daft-go` and `daft-start` to `get_command_for_name` is
+sufficient — no changes to `DAFT_VERBS` needed.
+
+**Step 3: Generate man pages and verify**
+
+Run: `mise run man:gen`
+
+Verify `daft-go --help` and `daft-start --help` look correct: Run:
+`cargo run -- go --help` Run: `cargo run -- start --help`
+
+**Step 4: Commit**
+
+```
+refactor(man): generate dedicated man pages for daft go/start
+```
+
+---
+
+### Task 6: Run tests and lint
+
+**Files:** None (verification only)
+
+**Step 1: Format**
+
+Run: `mise run fmt`
+
+**Step 2: Clippy**
+
+Run: `mise run clippy` Expected: zero warnings
+
+**Step 3: Unit tests**
+
+Run: `mise run test:unit` Expected: all pass
+
+**Step 4: Integration tests**
+
+Run: `mise run test:integration` Expected: all pass (existing tests exercise
+`git-worktree-checkout` which is unchanged)
+
+**Step 5: Man page verification**
+
+Run: `mise run man:verify` Expected: all man pages up-to-date
+
+**Step 6: Final commit if any fixups were needed**
+
+```
+fix: address lint/test issues from go/start separation
+```

--- a/man/daft-go.1
+++ b/man/daft-go.1
@@ -1,50 +1,43 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH daft-go 1  "daft-go 1.0.31" 
+.TH "daft go" 1  "daft go 1.0.31" 
 .SH NAME
-daft\-go \- Open an existing branch in a worktree
+daft go \- Open a worktree for an existing branch, or create one with \-b
 .SH SYNOPSIS
-\fBdaft\-go\fR [\fB\-b\fR|\fB\-\-create\-branch\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-c\fR|\fB\-\-carry\fR] [\fB\-\-no\-carry\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-\-no\-cd\fR] [\fB\-x\fR|\fB\-\-exec\fR] [\fB\-s\fR|\fB\-\-start\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIBRANCH_NAME\fR> [\fIBASE_BRANCH_NAME\fR] 
+\fBdaft go\fR [\fB\-b\fR|\fB\-\-create\-branch\fR] [\fB\-s\fR|\fB\-\-start\fR] [\fB\-c\fR|\fB\-\-carry\fR] [\fB\-\-no\-carry\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-\-no\-cd\fR] [\fB\-x\fR|\fB\-\-exec\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIBRANCH_NAME\fR> [\fIBASE_BRANCH_NAME\fR] 
 .SH DESCRIPTION
 .PP
-Creates a new worktree for an existing local or remote branch. The worktree
-is placed at the project root level as a sibling to other worktrees, using
-the branch name as the directory name.
+Opens a worktree for an existing local or remote branch. The worktree is
+placed at the project root level as a sibling to other worktrees, using the
+branch name as the directory name.
 .PP
 If the branch exists only on the remote, a local tracking branch is created
 automatically. If the branch exists both locally and on the remote, the local
 branch is checked out and upstream tracking is configured.
 .PP
-With \-b, creates a new branch and a corresponding worktree in a single
-operation. The new branch is based on the current branch, or on <base\-branch>
-if specified. After creating the branch locally, it is pushed to the remote
-and upstream tracking is configured.
-.PP
-With \-\-start (or \-s), if the specified branch does not exist locally or on the
-remote, a new branch and worktree are created automatically, as if \*(Aqdaft start\*(Aq
-had been called. This can also be enabled permanently with the daft.go.autoStart
-git config option.
+If a worktree for the specified branch already exists, no new worktree is
+created; the working directory is changed to the existing worktree instead.
 .PP
 Use \*(Aq\-\*(Aq as the branch name to switch to the previous worktree, similar to
 \*(Aqcd \-\*(Aq. Repeated \*(Aqdaft go \-\*(Aq toggles between the two most recent worktrees.
-Cannot be combined with \-b/\-\-create\-branch.
 .PP
-This command can be run from anywhere within the repository. If a worktree
-for the specified branch already exists, no new worktree is created; the
-working directory is changed to the existing worktree instead.
+With \-b, creates a new branch and worktree in a single operation. The new
+branch is based on the current branch, or on <base\-branch> if specified.
+Prefer \*(Aqdaft start\*(Aq for creating new branches.
+.PP
+With \-s (\-\-start), if the specified branch does not exist locally or on the
+remote, a new branch and worktree are created automatically. This can also
+be enabled permanently with the daft.go.autoStart git config option.
 .PP
 Lifecycle hooks from .daft/hooks/ are executed if the repository is trusted.
-See git\-daft(1) for hook management.
+See daft\-hooks(1) for hook management.
 .SH OPTIONS
 .TP
 \fB\-b\fR, \fB\-\-create\-branch\fR
-Create a new branch instead of checking out an existing one
+Create a new branch (prefer \*(Aqdaft start\*(Aq instead)
 .TP
-\fB\-q\fR, \fB\-\-quiet\fR
-Operate quietly; suppress progress reporting
-.TP
-\fB\-v\fR, \fB\-\-verbose\fR
-Be verbose; show detailed progress
+\fB\-s\fR, \fB\-\-start\fR
+Create a new worktree if the branch does not exist
 .TP
 \fB\-c\fR, \fB\-\-carry\fR
 Apply uncommitted changes from the current worktree to the new one
@@ -61,8 +54,11 @@ Do not change directory to the new worktree
 \fB\-x\fR, \fB\-\-exec\fR \fI<EXEC>\fR
 Run a command in the worktree after setup completes (repeatable)
 .TP
-\fB\-s\fR, \fB\-\-start\fR
-Create a new worktree if the branch does not exist
+\fB\-q\fR, \fB\-\-quiet\fR
+Operate quietly; suppress progress reporting
+.TP
+\fB\-v\fR, \fB\-\-verbose\fR
+Be verbose; show detailed progress
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help (see a summary with \*(Aq\-h\*(Aq)
@@ -71,9 +67,9 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 Print version
 .TP
 <\fIBRANCH_NAME\fR>
-Name of the branch to check out (or create with \-b); use \*(Aq\-\*(Aq for previous worktree
+Branch to open; use \*(Aq\-\*(Aq for previous worktree
 .TP
 [\fIBASE_BRANCH_NAME\fR]
-Branch to use as the base for the new branch (only with \-b); defaults to the current branch
+Base branch for \-b (defaults to current branch)
 .SH VERSION
 v1.0.31

--- a/man/daft-start.1
+++ b/man/daft-start.1
@@ -1,50 +1,25 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH daft-start 1  "daft-start 1.0.31" 
+.TH "daft start" 1  "daft start 1.0.31" 
 .SH NAME
-daft\-start \- Create a new branch and worktree
+daft start \- Create a new branch and worktree
 .SH SYNOPSIS
-\fBdaft\-start\fR [\fB\-b\fR|\fB\-\-create\-branch\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-c\fR|\fB\-\-carry\fR] [\fB\-\-no\-carry\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-\-no\-cd\fR] [\fB\-x\fR|\fB\-\-exec\fR] [\fB\-s\fR|\fB\-\-start\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIBRANCH_NAME\fR> [\fIBASE_BRANCH_NAME\fR] 
+\fBdaft start\fR [\fB\-c\fR|\fB\-\-carry\fR] [\fB\-\-no\-carry\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-\-no\-cd\fR] [\fB\-x\fR|\fB\-\-exec\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fINEW_BRANCH_NAME\fR> [\fIBASE_BRANCH_NAME\fR] 
 .SH DESCRIPTION
 .PP
-Creates a new worktree for an existing local or remote branch. The worktree
-is placed at the project root level as a sibling to other worktrees, using
-the branch name as the directory name.
+Creates a new branch and a corresponding worktree in a single operation. The
+worktree is placed at the project root level as a sibling to other worktrees,
+using the branch name as the directory name.
 .PP
-If the branch exists only on the remote, a local tracking branch is created
-automatically. If the branch exists both locally and on the remote, the local
-branch is checked out and upstream tracking is configured.
+The new branch is based on the current branch, or on <base\-branch> if
+specified. After creating the branch locally, it is pushed to the remote and
+upstream tracking is configured (unless disabled via daft.checkoutBranch.push).
 .PP
-With \-b, creates a new branch and a corresponding worktree in a single
-operation. The new branch is based on the current branch, or on <base\-branch>
-if specified. After creating the branch locally, it is pushed to the remote
-and upstream tracking is configured.
-.PP
-With \-\-start (or \-s), if the specified branch does not exist locally or on the
-remote, a new branch and worktree are created automatically, as if \*(Aqdaft start\*(Aq
-had been called. This can also be enabled permanently with the daft.go.autoStart
-git config option.
-.PP
-Use \*(Aq\-\*(Aq as the branch name to switch to the previous worktree, similar to
-\*(Aqcd \-\*(Aq. Repeated \*(Aqdaft go \-\*(Aq toggles between the two most recent worktrees.
-Cannot be combined with \-b/\-\-create\-branch.
-.PP
-This command can be run from anywhere within the repository. If a worktree
-for the specified branch already exists, no new worktree is created; the
-working directory is changed to the existing worktree instead.
+This command can be run from anywhere within the repository.
 .PP
 Lifecycle hooks from .daft/hooks/ are executed if the repository is trusted.
-See git\-daft(1) for hook management.
+See daft\-hooks(1) for hook management.
 .SH OPTIONS
-.TP
-\fB\-b\fR, \fB\-\-create\-branch\fR
-Create a new branch instead of checking out an existing one
-.TP
-\fB\-q\fR, \fB\-\-quiet\fR
-Operate quietly; suppress progress reporting
-.TP
-\fB\-v\fR, \fB\-\-verbose\fR
-Be verbose; show detailed progress
 .TP
 \fB\-c\fR, \fB\-\-carry\fR
 Apply uncommitted changes from the current worktree to the new one
@@ -61,8 +36,11 @@ Do not change directory to the new worktree
 \fB\-x\fR, \fB\-\-exec\fR \fI<EXEC>\fR
 Run a command in the worktree after setup completes (repeatable)
 .TP
-\fB\-s\fR, \fB\-\-start\fR
-Create a new worktree if the branch does not exist
+\fB\-q\fR, \fB\-\-quiet\fR
+Operate quietly; suppress progress reporting
+.TP
+\fB\-v\fR, \fB\-\-verbose\fR
+Be verbose; show detailed progress
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help (see a summary with \*(Aq\-h\*(Aq)
@@ -70,10 +48,10 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 \fB\-V\fR, \fB\-\-version\fR
 Print version
 .TP
-<\fIBRANCH_NAME\fR>
-Name of the branch to check out (or create with \-b); use \*(Aq\-\*(Aq for previous worktree
+<\fINEW_BRANCH_NAME\fR>
+Name for the new branch
 .TP
 [\fIBASE_BRANCH_NAME\fR]
-Branch to use as the base for the new branch (only with \-b); defaults to the current branch
+Branch to use as the base; defaults to the current branch
 .SH VERSION
 v1.0.31

--- a/src/commands/complete.rs
+++ b/src/commands/complete.rs
@@ -79,6 +79,12 @@ fn complete(command: &str, position: usize, word: &str, verbose: bool) -> Result
         // git-worktree-branch: complete existing branch names for deletion
         ("git-worktree-branch", _) => complete_existing_branches(word, verbose),
 
+        // daft-go: complete existing branch names
+        ("daft-go", 1) => complete_existing_branches(word, verbose),
+
+        // daft-start: no dynamic completion for new branch names
+        ("daft-start", _) => Ok(vec![]),
+
         // daft-remove: complete existing branch names for deletion
         ("daft-remove", _) => complete_existing_branches(word, verbose),
 

--- a/src/commands/completions/bash.rs
+++ b/src/commands/completions/bash.rs
@@ -9,6 +9,8 @@ pub(super) fn generate_bash_completion_string(command_name: &str) -> Result<Stri
         "git-worktree-checkout"
             | "git-worktree-carry"
             | "git-worktree-fetch"
+            | "daft-go"
+            | "daft-start"
             | "daft-remove"
             | "daft-rename"
     );
@@ -132,10 +134,16 @@ _daft() {
     # verb aliases: delegate to underlying command completions
     if [[ $cword -ge 2 ]]; then
         case "${words[1]}" in
-            go|start)
-                COMP_WORDS=("git-worktree-checkout" "${COMP_WORDS[@]:2}")
+            go)
+                COMP_WORDS=("daft-go" "${COMP_WORDS[@]:2}")
                 COMP_CWORD=$((COMP_CWORD - 1))
-                _git_worktree_checkout
+                _daft_go
+                return 0
+                ;;
+            start)
+                COMP_WORDS=("daft-start" "${COMP_WORDS[@]:2}")
+                COMP_CWORD=$((COMP_CWORD - 1))
+                _daft_start
                 return 0
                 ;;
             carry)

--- a/src/commands/completions/fig.rs
+++ b/src/commands/completions/fig.rs
@@ -134,7 +134,13 @@ pub(super) fn generate_fig_completion_string(command_name: &str) -> Result<Strin
 
     let has_branches = matches!(
         command_name,
-        "git-worktree-checkout" | "git-worktree-carry" | "git-worktree-fetch"
+        "git-worktree-checkout"
+            | "git-worktree-carry"
+            | "git-worktree-fetch"
+            | "daft-go"
+            | "daft-start"
+            | "daft-remove"
+            | "daft-rename"
     );
 
     let about = cmd.get_about().map(|a| a.to_string());

--- a/src/commands/completions/fish.rs
+++ b/src/commands/completions/fish.rs
@@ -9,6 +9,8 @@ pub(super) fn generate_fish_completion_string(command_name: &str) -> Result<Stri
         "git-worktree-checkout"
             | "git-worktree-carry"
             | "git-worktree-fetch"
+            | "daft-go"
+            | "daft-start"
             | "daft-remove"
             | "daft-rename"
     );
@@ -170,7 +172,9 @@ complete -c daft -n '__fish_use_subcommand' -a 'remove' -d 'Delete branch and wo
 complete -c daft -n '__fish_use_subcommand' -a 'adopt' -d 'Convert repo to worktree layout'
 complete -c daft -n '__fish_use_subcommand' -a 'sync' -d 'Synchronize worktrees with remote'
 complete -c daft -n '__fish_use_subcommand' -a 'eject' -d 'Convert back to traditional layout'
-complete -c daft -n '__fish_seen_subcommand_from go start carry update' -f -a "(daft __complete git-worktree-checkout '' 2>/dev/null)"
+complete -c daft -n '__fish_seen_subcommand_from go' -f -a "(daft __complete daft-go '' 2>/dev/null)"
+complete -c daft -n '__fish_seen_subcommand_from start' -f -a "(daft __complete daft-start '' 2>/dev/null)"
+complete -c daft -n '__fish_seen_subcommand_from carry update' -f -a "(daft __complete git-worktree-checkout '' 2>/dev/null)"
 complete -c daft -n '__fish_seen_subcommand_from remove' -f -a "(daft __complete daft-remove '' 2>/dev/null)"
 complete -c daft -n '__fish_seen_subcommand_from rename' -f -a "(daft __complete daft-rename '' 2>/dev/null)"
 complete -c daft -n '__fish_seen_subcommand_from multi-remote; and not __fish_seen_subcommand_from enable disable status set-default move' -f -a 'enable disable status set-default move'

--- a/src/commands/completions/mod.rs
+++ b/src/commands/completions/mod.rs
@@ -25,7 +25,8 @@ pub(super) enum CompletionTarget {
 /// Each entry is (list of verb names, underlying command name).
 /// Used by completion generators to offer flag completions for verb aliases.
 pub(super) const VERB_ALIAS_GROUPS: &[(&[&str], &str)] = &[
-    (&["go", "start"], "git-worktree-checkout"),
+    (&["go"], "daft-go"),
+    (&["start"], "daft-start"),
     (&["carry"], "git-worktree-carry"),
     (&["update"], "git-worktree-fetch"),
     (&["remove"], "daft-remove"),
@@ -43,6 +44,8 @@ pub(super) const COMMANDS: &[&str] = &[
     "git-worktree-fetch",
     "git-worktree-flow-adopt",
     "git-worktree-flow-eject",
+    "daft-go",
+    "daft-start",
     "daft-remove",
     "daft-rename",
     "git-sync",
@@ -59,6 +62,8 @@ pub(super) fn get_command_for_name(command_name: &str) -> Option<Command> {
         "git-worktree-fetch" => Some(crate::commands::fetch::Args::command()),
         "git-worktree-flow-adopt" => Some(crate::commands::flow_adopt::Args::command()),
         "git-worktree-flow-eject" => Some(crate::commands::flow_eject::Args::command()),
+        "daft-go" => Some(crate::commands::checkout::GoArgs::command()),
+        "daft-start" => Some(crate::commands::checkout::StartArgs::command()),
         "daft-remove" => Some(crate::commands::worktree_branch::RemoveArgs::command()),
         "daft-rename" => Some(crate::commands::worktree_branch::RenameArgs::command()),
         "git-sync" => Some(crate::commands::sync::Args::command()),

--- a/src/commands/completions/zsh.rs
+++ b/src/commands/completions/zsh.rs
@@ -9,6 +9,8 @@ pub(super) fn generate_zsh_completion_string(command_name: &str) -> Result<Strin
         "git-worktree-checkout"
             | "git-worktree-carry"
             | "git-worktree-fetch"
+            | "daft-go"
+            | "daft-start"
             | "daft-remove"
             | "daft-rename"
     );
@@ -145,10 +147,16 @@ _daft() {
     # verb aliases: delegate to underlying command completions
     if (( CURRENT >= 3 )); then
         case "$words[2]" in
-            go|start)
-                words=("git-worktree-checkout" "${(@)words[3,-1]}")
+            go)
+                words=("daft-go" "${(@)words[3,-1]}")
                 CURRENT=$((CURRENT - 1))
-                __git_worktree_checkout_impl
+                __daft_go_impl
+                return
+                ;;
+            start)
+                words=("daft-start" "${(@)words[3,-1]}")
+                CURRENT=$((CURRENT - 1))
+                __daft_start_impl
                 return
                 ;;
             carry)

--- a/src/commands/shell_init.rs
+++ b/src/commands/shell_init.rs
@@ -180,10 +180,12 @@ daft() {
             shift; __daft_wrapper git-worktree-clone "$@" ;;
         worktree-init|init)
             shift; __daft_wrapper git-worktree-init "$@" ;;
-        worktree-checkout|go)
+        worktree-checkout)
             shift; __daft_wrapper git-worktree-checkout "$@" ;;
+        go)
+            shift; __daft_wrapper daft-go "$@" ;;
         start)
-            shift; __daft_wrapper git-worktree-checkout -b "$@" ;;
+            shift; __daft_wrapper daft-start "$@" ;;
         worktree-carry|carry)
             shift; __daft_wrapper git-worktree-carry "$@" ;;
         worktree-prune|prune)
@@ -406,10 +408,12 @@ function daft --wraps daft
             __daft_wrapper git-worktree-clone $argv[2..-1]
         case worktree-init init
             __daft_wrapper git-worktree-init $argv[2..-1]
-        case worktree-checkout go
+        case worktree-checkout
             __daft_wrapper git-worktree-checkout $argv[2..-1]
+        case go
+            __daft_wrapper daft-go $argv[2..-1]
         case start
-            __daft_wrapper git-worktree-checkout -b $argv[2..-1]
+            __daft_wrapper daft-start $argv[2..-1]
         case worktree-carry carry
             __daft_wrapper git-worktree-carry $argv[2..-1]
         case worktree-prune prune

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,8 @@ fn main() -> Result<()> {
         "git-sync" => commands::sync::run(),
 
         // Daft-style commands (via symlinks)
+        "daft-go" => commands::checkout::run_go(),
+        "daft-start" => commands::checkout::run_start(),
         "daft-remove" => commands::worktree_branch::run_remove(),
         "daft-rename" => commands::worktree_branch::run_rename(),
 
@@ -86,8 +88,8 @@ fn main() -> Result<()> {
                     // Daft verb aliases (short names)
                     "clone" => commands::clone::run(),
                     "init" => commands::init::run(),
-                    "go" => commands::checkout::run(),
-                    "start" => commands::checkout::run_create(),
+                    "go" => commands::checkout::run_go(),
+                    "start" => commands::checkout::run_start(),
                     "carry" => commands::carry::run(),
                     "update" => commands::fetch::run(),
                     "prune" => commands::prune::run(),

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -52,13 +52,13 @@ const DAFT_VERBS: &[DaftVerbEntry] = &[
     },
     DaftVerbEntry {
         daft_name: "daft-go",
-        source_command: "git-worktree-checkout",
-        about_override: Some("Open an existing branch in a worktree"),
+        source_command: "git-worktree-checkout", // fallback only; dedicated GoArgs used via get_command_for_name
+        about_override: None,
     },
     DaftVerbEntry {
         daft_name: "daft-start",
-        source_command: "git-worktree-checkout",
-        about_override: Some("Create a new branch and worktree"),
+        source_command: "git-worktree-checkout", // fallback only; dedicated StartArgs used via get_command_for_name
+        about_override: None,
     },
     DaftVerbEntry {
         daft_name: "daft-carry",
@@ -139,6 +139,8 @@ fn get_command_for_name(command_name: &str) -> Option<clap::Command> {
         "daft-release-notes" => Some(daft::commands::release_notes::Args::command()),
         "daft-remove" => Some(daft::commands::worktree_branch::RemoveArgs::command()),
         "daft-rename" => Some(daft::commands::worktree_branch::RenameArgs::command()),
+        "daft-go" => Some(daft::commands::checkout::GoArgs::command()),
+        "daft-start" => Some(daft::commands::checkout::StartArgs::command()),
         _ => None,
     }
 }


### PR DESCRIPTION
## Summary
- Give `daft go` and `daft start` their own clap Args structs (`GoArgs`, `StartArgs`) with tailored help text, following the pattern established by `RemoveArgs` and `RenameArgs`
- Update shell wrappers to route `daft go` → `daft-go` and `daft start` → `daft-start` instead of redirecting through `git-worktree-checkout`
- Update routing, shell completions, dynamic completions, fig spec, man page generation, and symlink dispatch

## Test plan
- [x] `command daft start --help` shows `Usage: daft start` with only relevant flags (no `-b`, `--start`)
- [x] `command daft go --help` shows `Usage: daft go` with tailored help
- [x] `git-worktree-checkout --help` still shows full original help
- [x] `mise run fmt` clean
- [x] `mise run clippy` zero warnings
- [x] `mise run test:unit` all pass
- [x] `mise run man:gen` + `mise run man:verify` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)