### PR TITLE
docs: fill v1.0.32 documentation gaps

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -88,6 +88,8 @@ daft provides short verb aliases for common commands:
 | `daft update` | `daft worktree-fetch`       |
 | `daft prune`  | `daft worktree-prune`       |
 | `daft remove` | `daft worktree-branch -d`   |
+| `daft rename` | `daft worktree-branch -m`   |
+| `daft sync`   | `daft git-sync`             |
 | `daft adopt`  | `daft worktree-flow-adopt`  |
 | `daft eject`  | `daft worktree-flow-eject`  |
 
@@ -123,6 +125,8 @@ these as `git` subcommands (e.g., `daft worktree-checkout` is
 | `daft worktree-prune`                           | Remove worktrees whose remote branches have been deleted                          |
 | `daft worktree-carry <targets>`                 | Transfer uncommitted changes to one or more other worktrees                       |
 | `daft worktree-fetch [targets]`                 | Update worktree branches from remote (supports refspec syntax source:destination) |
+| `daft worktree-branch -m <source> <new-branch>` | Rename a branch, move its worktree, and rename the remote branch                  |
+| `daft git-sync`                                 | Synchronize all worktrees: prune stale + update all + optional rebase             |
 
 ### Adoption and Ejection
 
@@ -568,11 +572,11 @@ in one worktree must be committed and merged to propagate to other worktrees.
 
 daft supports three shortcut styles as symlink aliases for faster terminal use:
 
-| Style         | Shortcuts                                                                            | Example              |
-| ------------- | ------------------------------------------------------------------------------------ | -------------------- |
-| Git (default) | `gwtclone`, `gwtinit`, `gwtco`, `gwtcb`, `gwtbd`, `gwtprune`, `gwtcarry`, `gwtfetch` | `gwtco feature/auth` |
-| Shell         | `gwco`, `gwcob`                                                                      | `gwco feature/auth`  |
-| Legacy        | `gclone`, `gcw`, `gcbw`, `gprune`                                                    | `gcw feature/auth`   |
+| Style         | Shortcuts                                                                                                | Example              |
+| ------------- | -------------------------------------------------------------------------------------------------------- | -------------------- |
+| Git (default) | `gwtclone`, `gwtinit`, `gwtco`, `gwtcb`, `gwtbd`, `gwtprune`, `gwtcarry`, `gwtfetch`, `gwtls`, `gwtsync` | `gwtco feature/auth` |
+| Shell         | `gwco`, `gwcob`                                                                                          | `gwco feature/auth`  |
+| Legacy        | `gclone`, `gcw`, `gcbw`, `gprune`                                                                        | `gcw feature/auth`   |
 
 The `gwtcb`, `gwcob`, and `gcbw` shortcuts map to `git-worktree-checkout -b`
 (branch creation mode).
@@ -580,6 +584,9 @@ The `gwtcb`, `gwcob`, and `gcbw` shortcuts map to `git-worktree-checkout -b`
 Default-branch shortcuts (`gwtcm`, `gwtcbm`, `gwcobd`, `gcbdw`) are available
 via shell integration only (`daft shell-init`). They resolve the remote's
 default branch dynamically and use `git-worktree-checkout -b`.
+
+Shell integration also provides `gwtrn` (maps to `daft rename`) and `gwtsync`
+(maps to `git-sync`) as shell functions with cd behavior.
 
 Manage with `daft setup shortcuts list`, `enable <style>`, `disable <style>`,
 `only <style>`.

--- a/docs/cli/daft-go.md
+++ b/docs/cli/daft-go.md
@@ -13,9 +13,6 @@ Open an existing branch in a worktree
 daft go [OPTIONS] <BRANCH_NAME>
 ```
 
-This is equivalent to `git worktree-checkout`. All options and arguments are
-the same.
-
 ## Description
 
 Creates a new worktree for an existing local or remote branch. The worktree
@@ -45,7 +42,52 @@ daft go -           # back to feature/x
 
 Cannot be combined with `-b`/`--create-branch`.
 
+## Arguments
+
+| Argument | Description | Required |
+|----------|-------------|----------|
+| `<BRANCH_NAME>` | Name of the branch to check out; use `-` for previous worktree | Yes |
+
+## Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-s, --start` | Create a new worktree if the branch does not exist | |
+| `-x, --exec <EXEC>` | Run a command in the worktree after setup (repeatable) | |
+| `--no-cd` | Do not change directory to the new worktree | |
+| `-c, --carry` | Apply uncommitted changes from the current worktree | |
+| `--no-carry` | Do not carry uncommitted changes | |
+| `-r, --remote <REMOTE>` | Remote for worktree organization (multi-remote mode) | |
+| `-v, --verbose` | Be verbose; show detailed progress | |
+| `-q, --quiet` | Suppress non-error output | |
+
+## Global Options
+
+| Option | Description |
+|--------|-------------|
+| `-h`, `--help` | Print help information |
+| `-V`, `--version` | Print version information |
+
+## Examples
+
+```bash
+# Check out an existing branch
+daft go feature/auth
+
+# Switch to the previous worktree (toggle)
+daft go -
+
+# Check out a branch, auto-creating if it doesn't exist
+daft go -s feature/new-idea
+
+# Check out and run a command after setup
+daft go feature/auth -x 'npm install'
+
+# Check out without changing directory
+daft go feature/auth --no-cd
+```
+
 ## See Also
 
 - [daft start](./daft-start.md) to create a new branch
-- [git worktree-checkout](./git-worktree-checkout.md) for full options reference
+- [git worktree-checkout](./git-worktree-checkout.md) for the underlying git-native command

--- a/docs/cli/daft-list.md
+++ b/docs/cli/daft-list.md
@@ -13,9 +13,6 @@ List all worktrees with status information
 daft list [OPTIONS]
 ```
 
-This is equivalent to `git worktree-list`. All options and arguments are
-the same.
-
 ## Description
 
 Lists all worktrees in the current project with enriched status information
@@ -35,8 +32,37 @@ Each worktree is shown with:
 
 Ages use shorthand notation: `<1m`, `Xm`, `Xh`, `Xd`, `Xw`, `Xmo`, `Xy`.
 
-Use `--json` for machine-readable output suitable for scripting.
+Use `--json` for machine-readable output suitable for scripting. JSON output
+includes fields like `is_default_branch`, `staged`, `unstaged`, `untracked`,
+`remote_ahead`, `remote_behind`, and `branch_age`.
+
+## Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--json` | Output in JSON format | |
+| `-v, --verbose` | Be verbose; show detailed progress | |
+
+## Global Options
+
+| Option | Description |
+|--------|-------------|
+| `-h`, `--help` | Print help information |
+| `-V`, `--version` | Print version information |
+
+## Examples
+
+```bash
+# List all worktrees with status
+daft list
+
+# Machine-readable JSON output
+daft list --json
+
+# Pipe JSON to jq for filtering
+daft list --json | jq '.[] | select(.unstaged > 0)'
+```
 
 ## See Also
 
-- [git worktree-list](./git-worktree-list.md) for full options reference
+- [git worktree-list](./git-worktree-list.md) for the underlying git-native command

--- a/docs/cli/daft-rename.md
+++ b/docs/cli/daft-rename.md
@@ -13,18 +13,61 @@ Rename a branch and move its worktree
 daft rename [OPTIONS] <SOURCE> <NEW_BRANCH>
 ```
 
-This is equivalent to `git worktree-branch -m`. All options and arguments
-are the same.
-
 ## Description
 
 Renames a local branch and moves its associated worktree directory to match
-the new name. Optionally renames the remote branch as well (push new name,
-delete old name).
+the new name. If the branch has a remote tracking branch, the remote branch
+is also renamed (push new name, delete old name) unless `--no-remote` is
+specified.
 
-Arguments can be branch names or worktree paths. If run from inside the
-worktree being renamed, the shell wrapper will cd to the new location.
+The source can be specified as a branch name or a path to an existing
+worktree (absolute or relative). If you are currently inside the worktree
+being renamed, the shell wrapper will cd to the new location after the
+rename completes.
+
+Empty parent directories left behind by the move are automatically cleaned up.
+
+## Arguments
+
+| Argument | Description | Required |
+|----------|-------------|----------|
+| `<SOURCE>` | Branch name or worktree path to rename | Yes |
+| `<NEW_BRANCH>` | New branch name | Yes |
+
+## Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--no-remote` | Skip remote branch rename | |
+| `--dry-run` | Preview changes without executing | |
+| `-q, --quiet` | Suppress non-error output | |
+| `-v, --verbose` | Be verbose; show detailed progress | |
+
+## Global Options
+
+| Option | Description |
+|--------|-------------|
+| `-h`, `--help` | Print help information |
+| `-V`, `--version` | Print version information |
+
+## Examples
+
+```bash
+# Rename a branch (local + remote + worktree directory)
+daft rename feature/old-name feature/new-name
+
+# Rename without updating the remote branch
+daft rename feature/old-name feature/new-name --no-remote
+
+# Preview what would happen
+daft rename feature/old-name feature/new-name --dry-run
+
+# Rename from inside the worktree being renamed
+cd feature/old-name
+daft rename . feature/new-name
+```
 
 ## See Also
 
-- [git worktree-branch](./git-worktree-branch.md) for full options reference
+- [git worktree-branch](./git-worktree-branch.md) for the underlying git-native command (rename mode with `-m`)
+- [daft remove](./daft-remove.md) to delete branches instead of renaming

--- a/docs/cli/daft-sync.md
+++ b/docs/cli/daft-sync.md
@@ -13,28 +13,59 @@ Synchronize worktrees with remote (prune + update all)
 daft sync [OPTIONS]
 ```
 
-This is equivalent to `git sync`. All options and arguments are
-the same.
-
 ## Description
 
 Synchronizes all worktrees with the remote in a single command.
 
 This is equivalent to running `daft prune` followed by `daft update --all`:
 
-  1. Prune: fetches with --prune, removes worktrees and branches for deleted
-     remote branches, executes lifecycle hooks for each removal.
-  2. Update: pulls all remaining worktrees from their remote tracking branches.
-  3. Rebase (--rebase BRANCH): rebases all remaining worktrees onto BRANCH.
-     Best-effort: conflicts are immediately aborted and reported.
+  1. **Prune**: fetches with `--prune`, removes worktrees and branches for
+     deleted remote branches, executes lifecycle hooks for each removal.
+  2. **Update**: pulls all remaining worktrees from their remote tracking
+     branches.
+  3. **Rebase** (`--rebase BRANCH`): rebases all remaining worktrees onto
+     BRANCH. Best-effort: conflicts are immediately aborted and reported.
 
 If you are currently inside a worktree that gets pruned, the shell is redirected
 to a safe location (project root by default, or as configured via
-daft.prune.cdTarget).
+`daft.prune.cdTarget`).
 
 For fine-grained control over either phase, use `daft prune` and `daft update`
 separately.
 
+## Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-v, --verbose` | Be verbose; show detailed progress | |
+| `-f, --force` | Force removal of worktrees with uncommitted changes | |
+| `--rebase <BRANCH>` | Rebase all branches onto BRANCH after updating | |
+
+## Global Options
+
+| Option | Description |
+|--------|-------------|
+| `-h`, `--help` | Print help information |
+| `-V`, `--version` | Print version information |
+
+## Examples
+
+```bash
+# Prune stale worktrees and update all remaining ones
+daft sync
+
+# Sync with verbose output to see what happens in each phase
+daft sync --verbose
+
+# Sync and rebase all worktrees onto main
+daft sync --rebase main
+
+# Force sync even if worktrees have uncommitted changes
+daft sync --force
+```
+
 ## See Also
 
-- [git sync](./git-sync.md) for full options reference
+- [git sync](./git-sync.md) for the underlying git-native command
+- [daft prune](./daft-prune.md) to prune stale worktrees only
+- [daft update](./daft-update.md) to update branches only

--- a/docs/cli/daft-update.md
+++ b/docs/cli/daft-update.md
@@ -13,26 +13,78 @@ Update worktree branches from remote
 daft update [OPTIONS] [TARGETS] [PULL_ARGS]
 ```
 
-This is equivalent to `git worktree-fetch`. All options and arguments are
-the same.
-
 ## Description
 
 Updates worktree branches from their remote tracking branches. Targets can
 use refspec syntax (`source:destination`) to update a worktree from a
-different remote branch:
+different remote branch.
 
-- `daft update master` -- pulls master via `git pull --ff-only`
-- `daft update master:test` -- fetches `origin/master` and resets the test worktree to it
-- `daft update` -- pulls the current worktree's tracking branch
-- `daft update --all` -- pulls all worktrees
+**Same-branch mode** (source equals destination, or no refspec) uses `git pull`
+with configurable options (`--rebase`, `--ff-only`, `--autostash`, and any
+extra `PULL_ARGS`). The default pull strategy is `--ff-only`, configurable via
+`git config daft.update.args`.
 
-Same-branch mode (source equals destination) uses `git pull` with configurable
-options. Cross-branch mode uses `git fetch` + `git reset --hard` and ignores
-pull flags.
+**Cross-branch mode** (source differs from destination, e.g. `master:test`)
+uses `git fetch` + `git reset --hard` and ignores all pull flags. This is
+useful for resetting a worktree to match a different remote branch.
 
 Worktrees with uncommitted changes are skipped unless `--force` is specified.
+Use `--dry-run` to preview what would be done without making changes.
+
+## Arguments
+
+| Argument | Description | Required |
+|----------|-------------|----------|
+| `<TARGETS>` | Target worktree(s) by name or refspec (`source:destination`) | No |
+| `<PULL_ARGS>` | Additional arguments to pass to `git pull` (same-branch mode only) | No |
+
+## Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--all` | Update all worktrees | |
+| `-f, --force` | Update even with uncommitted changes | |
+| `--dry-run` | Show what would be done | |
+| `--rebase` | Use `git pull --rebase` | |
+| `--autostash` | Use `git pull --autostash` | |
+| `--ff-only` | Only fast-forward (default) | |
+| `--no-ff-only` | Allow merge commits | |
+| `-v, --verbose` | Be verbose; show detailed progress | |
+| `-q, --quiet` | Suppress non-error output | |
+
+## Global Options
+
+| Option | Description |
+|--------|-------------|
+| `-h`, `--help` | Print help information |
+| `-V`, `--version` | Print version information |
+
+## Examples
+
+```bash
+# Update the current worktree from its tracking branch
+daft update
+
+# Update a specific worktree
+daft update feature/auth
+
+# Update all worktrees
+daft update --all
+
+# Update with rebase instead of merge
+daft update --rebase
+
+# Reset the test worktree to match origin/master (cross-branch)
+daft update master:test
+
+# Preview what would happen
+daft update --all --dry-run
+
+# Force update even if worktrees have uncommitted changes
+daft update --all --force
+```
 
 ## See Also
 
-- [git worktree-fetch](./git-worktree-fetch.md) for full options reference
+- [git worktree-fetch](./git-worktree-fetch.md) for the underlying git-native command
+- [daft sync](./daft-sync.md) to prune + update all in one step

--- a/docs/guide/shortcuts.md
+++ b/docs/guide/shortcuts.md
@@ -28,6 +28,7 @@ Prefix: `gwt` (Git Worktree)
 | `gwtcarry` | `git-worktree-carry`       |
 | `gwtfetch` | `git-worktree-fetch`       |
 | `gwtls`    | `git-worktree-list`        |
+| `gwtsync`  | `git-sync`                 |
 
 ### Shell Style
 
@@ -107,3 +108,7 @@ This creates shell functions (not symlinks) for the shell-style shortcuts
 `git-worktree-checkout -b`. Default-branch shortcuts (`gwtcm`, `gwtcbm`,
 `gwcobd`, `gcbdw`) are always included in `daft shell-init` output regardless of
 the `--aliases` flag.
+
+`daft shell-init` also generates shell functions for `gwtrn` (maps to
+`daft rename`) and `gwtsync` (maps to `git-sync`). These are always included in
+the shell-init output and provide the same cd behavior as other shell wrappers.

--- a/docs/guide/worktree-workflow.md
+++ b/docs/guide/worktree-workflow.md
@@ -113,6 +113,18 @@ daft go feature/teammate-work
 git worktree-checkout feature/teammate-work
 ```
 
+### Toggling Between Worktrees
+
+Quickly switch back and forth between two worktrees:
+
+```bash
+daft go -           # switch to the previous worktree
+daft go -           # switch back
+```
+
+Each `daft go` or `daft start` records the source worktree, so `daft go -`
+always takes you to the last one you came from.
+
 ### Branching from Default
 
 When your current branch has diverged and you need a fresh start:
@@ -133,12 +145,57 @@ Started work in the wrong branch? Move it:
 daft carry feature/correct-branch
 ```
 
+### Renaming a Branch
+
+Rename a branch and its worktree directory in one step. The remote branch is
+updated too:
+
+```bash
+daft rename feature/old-name feature/new-name
+```
+
+### Listing Worktrees
+
+See all worktrees with status indicators, ahead/behind counts, and branch age:
+
+```bash
+daft list
+```
+
+Use `daft list --json` for machine-readable output.
+
 ### Cleaning Up
 
 After branches are merged and deleted on the remote:
 
 ```bash
 daft prune
+```
+
+### Syncing Everything
+
+Prune stale worktrees and update all remaining ones in a single command:
+
+```bash
+daft sync
+```
+
+This is equivalent to `daft prune` followed by `daft update --all`. Use
+`--rebase main` to also rebase all branches onto main after updating.
+
+### Updating Branches
+
+Pull the latest changes for specific worktrees or all at once:
+
+```bash
+# Update a specific worktree
+daft update feature/auth
+
+# Update all worktrees
+daft update --all
+
+# Reset a worktree to match a different remote branch
+daft update master:test
 ```
 
 ## How Commands Find the Project Root


### PR DESCRIPTION
## Summary

- Expand CLI reference pages (`daft-update`, `daft-rename`, `daft-sync`, `daft-list`, `daft-go`) to be self-contained with arguments/options tables and examples, instead of deferring to `git-*` equivalents
- Add new workflow sections to the worktree workflow guide: toggling between worktrees, renaming, listing, syncing, and updating
- Update shortcuts page with `gwtsync` symlink and `gwtrn`/`gwtsync` shell functions
- Add `daft sync`, `daft rename`, `gwtls`, `gwtsync`, `gwtrn` to SKILL.md

## Test plan

- [x] `mise run docs:site:build` passes
- [x] `mise run docs:site:check` passes (Biome lint)
- [ ] Visual review of each modified page in the dev server
- [ ] Verify all internal cross-reference links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)