### PR TITLE
refactor: hide completions command from help and shell completions

### DIFF
--- a/src/commands/completions/bash.rs
+++ b/src/commands/completions/bash.rs
@@ -187,7 +187,7 @@ _daft() {
 
     # top-level: complete daft subcommands
     if [[ $cword -eq 1 ]]; then
-        COMPREPLY=( $(compgen -W "hooks shell-init completions setup multi-remote release-notes doctor clone init go start carry update list prune rename sync remove adopt eject" -- "$cur") )
+        COMPREPLY=( $(compgen -W "hooks shell-init setup multi-remote release-notes doctor clone init go start carry update list prune rename sync remove adopt eject" -- "$cur") )
         return 0
     fi
 }

--- a/src/commands/completions/fig.rs
+++ b/src/commands/completions/fig.rs
@@ -310,7 +310,6 @@ fn build_fig_multi_remote_subcommand() -> FigSubcommand {
 pub(super) fn generate_fig_daft_spec() -> Result<String> {
     let simple_subcommands = [
         ("shell-init", "Generate shell initialization scripts"),
-        ("completions", "Generate shell completion scripts"),
         ("setup", "Setup and configuration"),
         ("release-notes", "Generate release notes"),
     ];

--- a/src/commands/completions/fish.rs
+++ b/src/commands/completions/fish.rs
@@ -155,7 +155,6 @@ const DAFT_FISH_COMPLETIONS: &str = r#"# daft subcommand completions
 complete -c daft -f
 complete -c daft -n '__fish_use_subcommand' -a 'hooks' -d 'Manage lifecycle hooks'
 complete -c daft -n '__fish_use_subcommand' -a 'shell-init' -d 'Generate shell wrappers'
-complete -c daft -n '__fish_use_subcommand' -a 'completions' -d 'Generate completions'
 complete -c daft -n '__fish_use_subcommand' -a 'setup' -d 'Setup and configuration'
 complete -c daft -n '__fish_use_subcommand' -a 'multi-remote' -d 'Multi-remote management'
 complete -c daft -n '__fish_use_subcommand' -a 'release-notes' -d 'Generate release notes'

--- a/src/commands/completions/zsh.rs
+++ b/src/commands/completions/zsh.rs
@@ -200,7 +200,7 @@ _daft() {
 
     # top-level: complete daft subcommands
     if (( CURRENT == 2 )); then
-        compadd hooks shell-init completions setup multi-remote release-notes doctor \
+        compadd hooks shell-init setup multi-remote release-notes doctor \
                 clone init go start carry update list prune rename sync remove adopt eject
         return
     fi

--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -7,8 +7,8 @@ use clap::{Command, CommandFactory};
 use std::path::Path;
 
 use crate::commands::{
-    carry, checkout, clone, completions, doctor, fetch, flow_adopt, flow_eject, hooks, init, list,
-    multi_remote, prune, release_notes, shell_init, shortcuts, sync, worktree_branch,
+    carry, checkout, clone, doctor, fetch, flow_adopt, flow_eject, hooks, init, list, multi_remote,
+    prune, release_notes, shell_init, shortcuts, sync, worktree_branch,
 };
 
 /// A category of commands with a title and list of commands.
@@ -108,10 +108,6 @@ fn get_command_categories() -> Vec<CommandCategory> {
                 CommandEntry {
                     display_name: "daft doctor",
                     command: doctor::Args::command(),
-                },
-                CommandEntry {
-                    display_name: "daft completions",
-                    command: completions::Args::command(),
                 },
                 CommandEntry {
                     display_name: "daft release-notes",


### PR DESCRIPTION
## Summary

- Hide the `daft completions` subcommand from help output and shell completions (bash, zsh, fish, fig)
- The command remains fully functional when invoked directly (`daft completions <shell>`)
- Keep it in `suggest.rs` so "did you mean?" still resolves typos to `completions`

## Test plan

- [x] `mise run fmt` -- clean
- [x] `mise run clippy` -- zero warnings
- [x] `mise run test:unit` -- all tests pass
- [x] `cargo run -- help` does not list `completions`
- [x] `cargo run -- completions bash` still generates completions

🤖 Generated with [Claude Code](https://claude.com/claude-code)