### PR TITLE
fix(list): use orange for default branch indicator and tighten first column

### DIFF
--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -16,7 +16,7 @@ use clap::Parser;
 use pathdiff::diff_paths;
 use tabled::{
     builder::Builder,
-    settings::{peaker::Priority, Style, Width},
+    settings::{object::Columns, peaker::Priority, Padding, Style, Width},
 };
 use terminal_size::{terminal_size, Width as TermWidth};
 
@@ -170,7 +170,7 @@ fn print_table(
             // Branch name with default branch indicator (◉)
             let name = if info.is_default_branch {
                 if use_color {
-                    format!("{} {}", info.name, styles::dim("\u{25C9}"))
+                    format!("{} {}", info.name, styles::orange("\u{25C9}"))
                 } else {
                     format!("{} \u{25C9}", info.name)
                 }
@@ -249,6 +249,7 @@ fn print_table(
 
     let mut table = builder.build();
     table.with(Style::blank());
+    table.modify(Columns::first(), Padding::new(1, 0, 0, 0));
 
     if let Some((TermWidth(width), _)) = terminal_size() {
         table.with(

--- a/src/styles.rs
+++ b/src/styles.rs
@@ -69,6 +69,9 @@ pub const RED: &str = "\x1b[31m";
 /// ANSI escape code for cyan text.
 pub const CYAN: &str = "\x1b[36m";
 
+/// ANSI escape code for orange text (256-color).
+pub const ORANGE: &str = "\x1b[38;5;208m";
+
 /// Wraps text in bold styling.
 pub fn bold(text: &str) -> String {
     format!("{BOLD}{text}{RESET}")
@@ -97,6 +100,11 @@ pub fn red(text: &str) -> String {
 /// Wraps text in cyan styling (good for commands/code).
 pub fn cyan(text: &str) -> String {
     format!("{CYAN}{text}{RESET}")
+}
+
+/// Wraps text in orange styling (brand color).
+pub fn orange(text: &str) -> String {
+    format!("{ORANGE}{text}{RESET}")
 }
 
 /// Formats a definition list item with a bold term.


### PR DESCRIPTION
## Summary
- Change the default branch indicator (◉) color from dim to daft orange (256-color 208)
- Reduce first column width from 3 to 2 characters by removing trailing padding
- Add `orange` color constant and helper to the styles module

## Test plan
- [x] `mise run fmt` — no changes
- [x] `mise run clippy` — zero warnings
- [x] `mise run test:unit` — all tests pass
- [ ] Visual check: run `daft list` in a repo with a default branch worktree and verify the ◉ indicator is orange
- [ ] Visual check: verify the current worktree `>` column is tighter (2 chars instead of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)