### PR TITLE
feat: allow force-removal of default branch worktree

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -112,21 +112,21 @@ these as `git` subcommands (e.g., `daft worktree-checkout` is
 
 ### Worktree Lifecycle
 
-| Command                                         | Description                                                                       |
-| ----------------------------------------------- | --------------------------------------------------------------------------------- |
-| `daft worktree-clone <url>`                     | Clone a remote repository into daft's worktree layout                             |
-| `daft worktree-init <name>`                     | Initialize a new local repository in worktree layout                              |
-| `daft worktree-checkout <branch>`               | Create a worktree for an existing local or remote branch                          |
-| `daft worktree-checkout -- -`                   | Switch to the previous worktree (`cd -` style toggle)                             |
-| `daft worktree-checkout -s <branch>`            | Same as above, but auto-creates branch if not found (also `daft.go.autoStart`)    |
-| `daft worktree-checkout -b <new-branch> [base]` | Create a new branch and worktree from current or specified base                   |
-| `daft worktree-branch -d <branch>`              | Safely delete a branch: its worktree, local branch, and remote tracking branch    |
-| `daft worktree-branch -D <branch>`              | Force-delete a branch bypassing safety checks (except default branch protection)  |
-| `daft worktree-prune`                           | Remove worktrees whose remote branches have been deleted                          |
-| `daft worktree-carry <targets>`                 | Transfer uncommitted changes to one or more other worktrees                       |
-| `daft worktree-fetch [targets]`                 | Update worktree branches from remote (supports refspec syntax source:destination) |
-| `daft worktree-branch -m <source> <new-branch>` | Rename a branch, move its worktree, and rename the remote branch                  |
-| `daft git-sync`                                 | Synchronize all worktrees: prune stale + update all + optional rebase             |
+| Command                                         | Description                                                                                                                    |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `daft worktree-clone <url>`                     | Clone a remote repository into daft's worktree layout                                                                          |
+| `daft worktree-init <name>`                     | Initialize a new local repository in worktree layout                                                                           |
+| `daft worktree-checkout <branch>`               | Create a worktree for an existing local or remote branch                                                                       |
+| `daft worktree-checkout -- -`                   | Switch to the previous worktree (`cd -` style toggle)                                                                          |
+| `daft worktree-checkout -s <branch>`            | Same as above, but auto-creates branch if not found (also `daft.go.autoStart`)                                                 |
+| `daft worktree-checkout -b <new-branch> [base]` | Create a new branch and worktree from current or specified base                                                                |
+| `daft worktree-branch -d <branch>`              | Safely delete a branch: its worktree, local branch, and remote tracking branch                                                 |
+| `daft worktree-branch -D <branch>`              | Force-delete a branch bypassing safety checks; for the default branch, removes worktree only (preserves branch ref and remote) |
+| `daft worktree-prune`                           | Remove worktrees whose remote branches have been deleted                                                                       |
+| `daft worktree-carry <targets>`                 | Transfer uncommitted changes to one or more other worktrees                                                                    |
+| `daft worktree-fetch [targets]`                 | Update worktree branches from remote (supports refspec syntax source:destination)                                              |
+| `daft worktree-branch -m <source> <new-branch>` | Rename a branch, move its worktree, and rename the remote branch                                                               |
+| `daft git-sync`                                 | Synchronize all worktrees: prune stale + update all + optional rebase                                                          |
 
 ### Adoption and Ejection
 

--- a/docs/cli/daft-remove.md
+++ b/docs/cli/daft-remove.md
@@ -24,6 +24,8 @@ remote tracking branches in a single operation. Arguments can be branch names
 or worktree paths.
 
 Safety checks prevent accidental data loss. Use `-f` (`--force`) to override.
+For the default branch (e.g. main), `-f` removes its worktree only -- the
+local branch ref and remote branch are always preserved.
 
 ## See Also
 

--- a/docs/cli/git-worktree-branch-delete.md
+++ b/docs/cli/git-worktree-branch-delete.md
@@ -30,8 +30,9 @@ branch that:
   - has not been merged (or squash-merged) into the default branch
   - is out of sync with its remote tracking branch
 
-Use -D (--force) to override these safety checks. The command always refuses
-to delete the repository's default branch (e.g. main), even with --force.
+Use -D (--force) to override these safety checks. For the default branch
+(e.g. main), --force removes its worktree only — the local branch ref and
+remote branch are always preserved.
 
 All targeted branches are validated before any deletions begin. If any branch
 fails validation without --force, the entire command aborts and no branches

--- a/docs/cli/git-worktree-branch.md
+++ b/docs/cli/git-worktree-branch.md
@@ -39,8 +39,9 @@ delete a branch that:
   - has not been merged (or squash-merged) into the default branch
   - is out of sync with its remote tracking branch
 
-Use -D to override these safety checks. The command always refuses to delete
-the repository's default branch (e.g. main), even with -D.
+Use -D to override these safety checks. For the default branch (e.g. main),
+-D removes its worktree only — the local branch ref and remote branch are
+always preserved.
 
 All targeted branches are validated before any deletions begin. If any branch
 fails validation without -D, the entire command aborts and no branches are

--- a/man/daft-remove.1
+++ b/man/daft-remove.1
@@ -26,8 +26,9 @@ branch that:
   \- has not been merged (or squash\-merged) into the default branch
   \- is out of sync with its remote tracking branch
 .PP
-Use \-f to override these safety checks. The command always refuses to delete
-the repository\*(Aqs default branch (e.g. main), even with \-f.
+Use \-f to override these safety checks. For the default branch (e.g. main),
+\-f removes its worktree only — the local branch ref and remote branch are
+always preserved.
 .PP
 All targeted branches are validated before any deletions begin. If any branch
 fails validation without \-f, the entire command aborts and no branches are

--- a/man/git-worktree-branch-delete.1
+++ b/man/git-worktree-branch-delete.1
@@ -23,8 +23,9 @@ branch that:
   \- has not been merged (or squash\-merged) into the default branch
   \- is out of sync with its remote tracking branch
 .PP
-Use \-D (\-\-force) to override these safety checks. The command always refuses
-to delete the repository\*(Aqs default branch (e.g. main), even with \-\-force.
+Use \-D (\-\-force) to override these safety checks. For the default branch
+(e.g. main), \-\-force removes its worktree only — the local branch ref and
+remote branch are always preserved.
 .PP
 All targeted branches are validated before any deletions begin. If any branch
 fails validation without \-\-force, the entire command aborts and no branches

--- a/man/git-worktree-branch.1
+++ b/man/git-worktree-branch.1
@@ -31,8 +31,9 @@ delete a branch that:
   \- has not been merged (or squash\-merged) into the default branch
   \- is out of sync with its remote tracking branch
 .PP
-Use \-D to override these safety checks. The command always refuses to delete
-the repository\*(Aqs default branch (e.g. main), even with \-D.
+Use \-D to override these safety checks. For the default branch (e.g. main),
+\-D removes its worktree only — the local branch ref and remote branch are
+always preserved.
 .PP
 All targeted branches are validated before any deletions begin. If any branch
 fails validation without \-D, the entire command aborts and no branches are

--- a/src/commands/branch_delete.rs
+++ b/src/commands/branch_delete.rs
@@ -32,8 +32,9 @@ branch that:
   - has not been merged (or squash-merged) into the default branch
   - is out of sync with its remote tracking branch
 
-Use -D (--force) to override these safety checks. The command always refuses
-to delete the repository's default branch (e.g. main), even with --force.
+Use -D (--force) to override these safety checks. For the default branch
+(e.g. main), --force removes its worktree only — the local branch ref and
+remote branch are always preserved.
 
 All targeted branches are validated before any deletions begin. If any branch
 fails validation without --force, the entire command aborts and no branches

--- a/src/commands/worktree_branch.rs
+++ b/src/commands/worktree_branch.rs
@@ -43,8 +43,9 @@ delete a branch that:
   - has not been merged (or squash-merged) into the default branch
   - is out of sync with its remote tracking branch
 
-Use -D to override these safety checks. The command always refuses to delete
-the repository's default branch (e.g. main), even with -D.
+Use -D to override these safety checks. For the default branch (e.g. main),
+-D removes its worktree only — the local branch ref and remote branch are
+always preserved.
 
 All targeted branches are validated before any deletions begin. If any branch
 fails validation without -D, the entire command aborts and no branches are
@@ -142,8 +143,9 @@ branch that:
   - has not been merged (or squash-merged) into the default branch
   - is out of sync with its remote tracking branch
 
-Use -f to override these safety checks. The command always refuses to delete
-the repository's default branch (e.g. main), even with -f.
+Use -f to override these safety checks. For the default branch (e.g. main),
+-f removes its worktree only — the local branch ref and remote branch are
+always preserved.
 
 All targeted branches are validated before any deletions begin. If any branch
 fails validation without -f, the entire command aborts and no branches are

--- a/src/core/worktree/branch_delete.rs
+++ b/src/core/worktree/branch_delete.rs
@@ -107,6 +107,9 @@ struct ValidatedBranch {
     remote_name: Option<String>,
     remote_branch_name: Option<String>,
     is_current_worktree: bool,
+    /// When true, only the worktree is removed — local branch ref and remote
+    /// branch are preserved. Used for the default branch.
+    worktree_only: bool,
 }
 
 enum ResolveResult {
@@ -316,7 +319,8 @@ fn try_resolve_relative_to_root(
 ///
 /// Each branch goes through up to 5 checks:
 ///   1. Branch exists locally
-///   2. Not the default branch (even with --force)
+///   2. Default branch protection: without --force, always refused; with
+///      --force, allowed as worktree-only removal (skips checks 3-5)
 ///   3. No uncommitted changes in worktree (skip with --force)
 ///   4. Merged into default branch (skip with --force)
 ///   5. Local/remote in sync (skip with --force)
@@ -355,19 +359,57 @@ fn validate_branches(
             }
         }
 
-        // Check 2: Not the default branch (never allowed, even with --force)
-        if branch == &ctx.default_branch {
-            errors.push(ValidationError {
-                branch: branch.clone(),
-                message: format!(
-                    "refusing to delete the default branch '{}'",
-                    ctx.default_branch
-                ),
-            });
-            continue;
-        }
-
         let wt_path = worktree_map.get(branch.as_str()).cloned();
+
+        // Check 2: Default branch protection
+        if branch == &ctx.default_branch {
+            if !force {
+                errors.push(ValidationError {
+                    branch: branch.clone(),
+                    message: format!(
+                        "refusing to delete the default branch '{}' (use --force to remove the worktree only)",
+                        ctx.default_branch
+                    ),
+                });
+                continue;
+            } else if wt_path.is_none() {
+                errors.push(ValidationError {
+                    branch: branch.clone(),
+                    message: format!(
+                        "the default branch '{}' has no worktree to remove",
+                        ctx.default_branch
+                    ),
+                });
+                continue;
+            } else {
+                // Force + worktree exists: allow worktree-only removal.
+                // Skip checks 3-5 since we are not deleting the branch ref.
+                let is_current = match (&wt_path, current_wt_path) {
+                    (Some(wt), Some(current)) => {
+                        wt == current
+                            || std::fs::canonicalize(wt).ok() == std::fs::canonicalize(current).ok()
+                    }
+                    _ => false,
+                } || (wt_path.is_some()
+                    && current_branch.is_some()
+                    && current_branch == Some(branch.as_str()));
+
+                sink.on_step(&format!(
+                    "Default branch '{}' — will remove worktree only",
+                    branch
+                ));
+
+                validated.push(ValidatedBranch {
+                    name: branch.clone(),
+                    worktree_path: wt_path,
+                    remote_name: None,
+                    remote_branch_name: None,
+                    is_current_worktree: is_current,
+                    worktree_only: true,
+                });
+                continue;
+            }
+        }
 
         // Check 3: No uncommitted changes (skip with --force)
         if !force {
@@ -477,6 +519,7 @@ fn validate_branches(
             remote_name,
             remote_branch_name,
             is_current_worktree: is_current,
+            worktree_only: false,
         });
     }
 
@@ -681,25 +724,28 @@ fn delete_single_branch(
     }
 
     // Step 2: Delete remote branch (hardest to recreate, do first)
-    if let (Some(ref remote), Some(ref remote_branch)) =
-        (&branch.remote_name, &branch.remote_branch_name)
-    {
-        sink.on_step(&format!(
-            "Deleting remote branch {}/{}...",
-            remote, remote_branch
-        ));
-        match ctx.git.push_delete(remote, remote_branch) {
-            Ok(()) => {
-                result.remote_deleted = true;
-                sink.on_step(&format!(
-                    "Remote branch {}/{} deleted",
-                    remote, remote_branch
-                ));
-            }
-            Err(e) => {
-                result.errors.push(format!(
-                    "Failed to delete remote branch {remote}/{remote_branch}: {e}"
-                ));
+    // Skipped for worktree-only removal (default branch).
+    if !branch.worktree_only {
+        if let (Some(ref remote), Some(ref remote_branch)) =
+            (&branch.remote_name, &branch.remote_branch_name)
+        {
+            sink.on_step(&format!(
+                "Deleting remote branch {}/{}...",
+                remote, remote_branch
+            ));
+            match ctx.git.push_delete(remote, remote_branch) {
+                Ok(()) => {
+                    result.remote_deleted = true;
+                    sink.on_step(&format!(
+                        "Remote branch {}/{} deleted",
+                        remote, remote_branch
+                    ));
+                }
+                Err(e) => {
+                    result.errors.push(format!(
+                        "Failed to delete remote branch {remote}/{remote_branch}: {e}"
+                    ));
+                }
             }
         }
     }
@@ -747,18 +793,21 @@ fn delete_single_branch(
     }
 
     // Step 4: Delete local branch
-    // Always use force-delete (-D) here because our validation has already passed.
-    sink.on_step(&format!("Deleting local branch {}...", branch.name));
-    match ctx.git.branch_delete(&branch.name, true) {
-        Ok(()) => {
-            result.branch_deleted = true;
-            sink.on_step(&format!("Branch {} deleted", branch.name));
-        }
-        Err(e) => {
-            result.errors.push(format!(
-                "Failed to delete local branch {}: {e}",
-                branch.name
-            ));
+    // Skipped for worktree-only removal (default branch).
+    if !branch.worktree_only {
+        // Always use force-delete (-D) here because our validation has already passed.
+        sink.on_step(&format!("Deleting local branch {}...", branch.name));
+        match ctx.git.branch_delete(&branch.name, true) {
+            Ok(()) => {
+                result.branch_deleted = true;
+                sink.on_step(&format!("Branch {} deleted", branch.name));
+            }
+            Err(e) => {
+                result.errors.push(format!(
+                    "Failed to delete local branch {}: {e}",
+                    branch.name
+                ));
+            }
         }
     }
 
@@ -941,10 +990,12 @@ mod tests {
             remote_name: Some("origin".to_string()),
             remote_branch_name: Some("feature/test".to_string()),
             is_current_worktree: false,
+            worktree_only: false,
         };
         assert_eq!(vb.name, "feature/test");
         assert!(vb.worktree_path.is_some());
         assert!(!vb.is_current_worktree);
+        assert!(!vb.worktree_only);
     }
 
     #[test]
@@ -955,10 +1006,40 @@ mod tests {
             remote_name: None,
             remote_branch_name: None,
             is_current_worktree: false,
+            worktree_only: false,
         };
         assert!(vb.worktree_path.is_none());
         assert!(vb.remote_name.is_none());
         assert!(vb.remote_branch_name.is_none());
+    }
+
+    #[test]
+    fn test_validated_branch_worktree_only() {
+        let vb = ValidatedBranch {
+            name: "main".to_string(),
+            worktree_path: Some(PathBuf::from("/tmp/project/main")),
+            remote_name: None,
+            remote_branch_name: None,
+            is_current_worktree: false,
+            worktree_only: true,
+        };
+        assert!(vb.worktree_only);
+        assert!(vb.worktree_path.is_some());
+        assert!(vb.remote_name.is_none());
+        assert!(vb.remote_branch_name.is_none());
+    }
+
+    #[test]
+    fn test_deletion_result_worktree_only() {
+        let result = DeletionResult {
+            branch: "main".to_string(),
+            remote_deleted: false,
+            worktree_removed: true,
+            branch_deleted: false,
+            errors: Vec::new(),
+        };
+        assert!(!result.has_errors());
+        assert_eq!(result.deleted_parts(), "worktree");
     }
 
     #[test]

--- a/tests/integration/test_branch_delete.sh
+++ b/tests/integration/test_branch_delete.sh
@@ -116,11 +116,14 @@ test_branch_delete_refuses_default() {
     git-worktree-clone "$remote_repo" || return 1
     cd "test-repo-bd-default"
 
-    # Should fail even with --force
-    if git-worktree-branch-delete -D main 2>/dev/null; then
-        log_error "Should have refused to delete default branch"
+    # Should fail WITHOUT --force
+    if git-worktree-branch-delete main 2>/dev/null; then
+        log_error "Should have refused to delete default branch without force"
         return 1
     fi
+
+    # Verify main worktree still exists
+    assert_directory_exists "main" || return 1
 
     return 0
 }
@@ -662,6 +665,159 @@ test_branch_delete_deprecated_warning() {
     return 0
 }
 
+# Test force-delete default branch removes worktree only
+test_branch_delete_default_force_worktree_only() {
+    local remote_repo=$(create_test_remote "test-repo-bd-default-force" "main")
+
+    git-worktree-clone "$remote_repo" || return 1
+    cd "test-repo-bd-default-force"
+    local project_root=$(pwd)
+
+    # Verify main worktree exists
+    assert_directory_exists "main" || return 1
+
+    # Create another branch so we can check from it
+    git-worktree-checkout -b feature/other || return 1
+    cd "feature/other"
+
+    # Force-delete the default branch — should remove worktree only
+    git-worktree-branch-delete -D main || return 1
+
+    # Verify worktree was removed
+    if [[ -d "$project_root/main" ]]; then
+        log_error "Default branch worktree should have been removed"
+        return 1
+    fi
+
+    # Verify local branch ref still exists
+    if ! git branch | grep -q " main$"; then
+        log_error "Default branch local ref should have been preserved"
+        return 1
+    fi
+
+    # Verify remote branch still exists
+    if ! git ls-remote --heads origin main 2>/dev/null | grep -q main; then
+        log_error "Default branch remote should have been preserved"
+        return 1
+    fi
+
+    return 0
+}
+
+# Test force-delete default branch fails when no worktree exists
+test_branch_delete_default_no_worktree_force_fails() {
+    local remote_repo=$(create_test_remote "test-repo-bd-default-nowt" "main")
+
+    git-worktree-clone "$remote_repo" || return 1
+    cd "test-repo-bd-default-nowt"
+    local project_root=$(pwd)
+
+    # Create another branch so we can work from it
+    git-worktree-checkout -b feature/other || return 1
+    cd "feature/other"
+
+    # Remove worktree manually first
+    git worktree remove "$project_root/main" >/dev/null 2>&1
+
+    # Force-delete should fail — no worktree to remove
+    if git-worktree-branch-delete -D main 2>/dev/null; then
+        log_error "Should have failed when default branch has no worktree"
+        return 1
+    fi
+
+    # Verify local branch ref still exists
+    if ! git branch | grep -q " main$"; then
+        log_error "Default branch local ref should still exist"
+        return 1
+    fi
+
+    return 0
+}
+
+# Test force-delete default branch from inside its worktree
+test_branch_delete_default_from_current_worktree() {
+    local remote_repo=$(create_test_remote "test-repo-bd-default-current" "main")
+
+    git-worktree-clone "$remote_repo" || return 1
+    cd "test-repo-bd-default-current"
+    local project_root=$(pwd)
+
+    # Create another branch so cd target has somewhere to go
+    git-worktree-checkout -b feature/other || return 1
+
+    # cd into default branch worktree
+    cd "main"
+
+    # Force-delete with DAFT_CD_FILE set
+    local cd_file
+    cd_file=$(mktemp)
+    DAFT_CD_FILE="$cd_file" git-worktree-branch-delete -D main || return 1
+
+    # Verify worktree was removed
+    if [[ -d "$project_root/main" ]]; then
+        log_error "Default branch worktree should have been removed"
+        return 1
+    fi
+
+    # Verify cd file was written
+    if [[ ! -s "$cd_file" ]]; then
+        log_error "DAFT_CD_FILE should have been written"
+        rm -f "$cd_file"
+        return 1
+    fi
+
+    # cd to the target written by the command
+    cd "$(cat "$cd_file")" 2>/dev/null || cd "$project_root"
+
+    # Verify local branch ref still exists
+    if ! git branch | grep -q " main$"; then
+        log_error "Default branch local ref should have been preserved"
+        rm -f "$cd_file"
+        return 1
+    fi
+
+    rm -f "$cd_file"
+    return 0
+}
+
+# Test daft remove -f on default branch (tests the daft-remove entry point)
+test_daft_remove_default_force_worktree_only() {
+    local remote_repo=$(create_test_remote "test-repo-bd-daft-remove" "main")
+
+    git-worktree-clone "$remote_repo" || return 1
+    cd "test-repo-bd-daft-remove"
+    local project_root=$(pwd)
+
+    assert_directory_exists "main" || return 1
+
+    # Create another branch so we can check from it
+    git-worktree-checkout -b feature/other || return 1
+    cd "feature/other"
+
+    # Force-delete via daft remove -f
+    daft-remove -f main || return 1
+
+    # Verify worktree was removed
+    if [[ -d "$project_root/main" ]]; then
+        log_error "Default branch worktree should have been removed"
+        return 1
+    fi
+
+    # Verify local branch ref still exists
+    if ! git branch | grep -q " main$"; then
+        log_error "Default branch local ref should have been preserved"
+        return 1
+    fi
+
+    # Verify remote branch still exists
+    if ! git ls-remote --heads origin main 2>/dev/null | grep -q main; then
+        log_error "Default branch remote should have been preserved"
+        return 1
+    fi
+
+    return 0
+}
+
 run_branch_delete_tests() {
     log "Running git-worktree-branch-delete integration tests..."
 
@@ -669,6 +825,10 @@ run_branch_delete_tests() {
     run_test "branch_delete_refuses_unmerged" "test_branch_delete_refuses_unmerged"
     run_test "branch_delete_force_unmerged" "test_branch_delete_force_unmerged"
     run_test "branch_delete_refuses_default" "test_branch_delete_refuses_default"
+    run_test "branch_delete_default_force_worktree_only" "test_branch_delete_default_force_worktree_only"
+    run_test "branch_delete_default_no_worktree_force_fails" "test_branch_delete_default_no_worktree_force_fails"
+    run_test "branch_delete_default_from_current_worktree" "test_branch_delete_default_from_current_worktree"
+    run_test "daft_remove_default_force_worktree_only" "test_daft_remove_default_force_worktree_only"
     run_test "branch_delete_refuses_dirty" "test_branch_delete_refuses_dirty"
     run_test "branch_delete_multiple" "test_branch_delete_multiple"
     run_test "branch_delete_no_worktree" "test_branch_delete_no_worktree"


### PR DESCRIPTION
## Summary

- With `--force` / `-D` / `-f`, the default branch's worktree can now be removed while preserving the local branch ref and remote branch
- Without force, the error message hints at the worktree-only option: `(use --force to remove the worktree only)`
- Added `worktree_only` field to `ValidatedBranch` with belt-and-suspenders safety (also nulls remote info)

## Test plan

- [x] `mise run fmt` -- clean
- [x] `mise run clippy` -- zero warnings
- [x] `mise run test:unit` -- all pass (including 2 new unit tests)
- [x] `mise run test:integration` -- 265 tests pass (both default and gitoxide backends)
- [x] `mise run man:verify` -- man pages up-to-date
- [x] Pre-commit hooks pass (prettier, fmt, clippy, man:verify, docs:cli:verify)
- [ ] New integration tests cover: force worktree-only removal, no-worktree-force failure, removal from inside current worktree, `daft remove -f` entry point

🤖 Generated with [Claude Code](https://claude.com/claude-code)