### PR TITLE
fix: use resolved remote URL for trust fingerprint during clone

### DIFF
--- a/src/commands/clone.rs
+++ b/src/commands/clone.rs
@@ -3,7 +3,10 @@ use crate::{
     core::{worktree::clone, OutputSink},
     git::should_show_gitoxide_notice,
     hints::maybe_show_shell_hint,
-    hooks::{HookContext, HookExecutor, HookType, HooksConfig, TrustDatabase, TrustLevel},
+    hooks::{
+        get_remote_url_for_git_dir, HookContext, HookExecutor, HookType, HooksConfig,
+        TrustDatabase, TrustLevel,
+    },
     logging::init_logging,
     output::{CliOutput, Output, OutputConfig},
     settings::DaftSettings,
@@ -235,11 +238,11 @@ fn run_post_clone_hook(
 
     if args.trust_hooks {
         output.step("Trusting repository for hooks (--trust-hooks flag)");
-        executor.trust_repository_with_fingerprint(
-            &result.git_dir,
-            TrustLevel::Allow,
-            result.repository_url.clone(),
-        )?;
+        if let Some(fp) = get_remote_url_for_git_dir(&result.git_dir) {
+            executor.trust_repository_with_fingerprint(&result.git_dir, TrustLevel::Allow, fp)?;
+        } else {
+            executor.trust_repository(&result.git_dir, TrustLevel::Allow)?;
+        }
     }
 
     let worktree_path = result.worktree_dir.as_ref().unwrap();
@@ -284,11 +287,11 @@ fn run_post_create_hook(
     let mut executor = HookExecutor::new(hooks_config)?;
 
     if args.trust_hooks {
-        executor.trust_repository_with_fingerprint(
-            &result.git_dir,
-            TrustLevel::Allow,
-            result.repository_url.clone(),
-        )?;
+        if let Some(fp) = get_remote_url_for_git_dir(&result.git_dir) {
+            executor.trust_repository_with_fingerprint(&result.git_dir, TrustLevel::Allow, fp)?;
+        } else {
+            executor.trust_repository(&result.git_dir, TrustLevel::Allow)?;
+        }
     }
 
     let worktree_path = result.worktree_dir.as_ref().unwrap();


### PR DESCRIPTION
## Summary

- `--trust-hooks` stored the raw user-typed URL (e.g. SSH shorthand `avihut:repo`) as the trust fingerprint, but verification calls `git remote get-url origin` which returns the resolved form (`git@github.com:avihut/repo`). This mismatch silently skipped hooks.
- Use `get_remote_url_for_git_dir()` to store the resolved URL, matching the pattern already used in `flow_adopt.rs`.

Fixes the scenario where cloning with `--trust-hooks` using SSH shorthands (configured in `~/.ssh/config`) would always produce a fingerprint mismatch warning and skip hooks.

## Test plan

- [ ] Clone a repo using an SSH shorthand with `--trust-hooks` — hooks should run without warnings
- [ ] Clone a repo using a full URL with `--trust-hooks` — hooks should run without warnings
- [ ] Re-clone to a path with a stale trust entry — new fingerprint should overwrite the stale one
- [ ] Clone without `--trust-hooks` — stale trust entry should still be removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)