### PR TITLE
fix(sync): treat non-fast-forwardable branches as warnings

### DIFF
--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -495,6 +495,8 @@ fn execute_update_task(
 
     if result.skipped {
         (TaskStatus::Skipped, TaskMessage::Ok(result.message))
+    } else if result.diverged {
+        (TaskStatus::Succeeded, TaskMessage::Diverged)
     } else if result.success && result.up_to_date {
         (TaskStatus::Succeeded, TaskMessage::UpToDate)
     } else if result.success {
@@ -651,6 +653,8 @@ fn render_fetch_result(result: &fetch::FetchResult, output: &mut dyn Output) {
 fn render_worktree_status(r: &fetch::WorktreeFetchResult, output: &mut dyn Output) {
     if r.skipped {
         output.info(&format!(" * {} {}", tag_skipped(), r.worktree_name));
+    } else if r.diverged {
+        output.warning(&format!(" * {} {}", tag_diverged(), r.worktree_name));
     } else if r.success {
         if r.up_to_date {
             output.info(&format!(" * {} {}", tag_up_to_date(), r.worktree_name));
@@ -676,6 +680,7 @@ fn print_summary(result: &fetch::FetchResult, output: &mut dyn Output) {
     let updated = result.updated_count();
     let up_to_date = result.up_to_date_count();
     let skipped = result.skipped_count();
+    let diverged = result.diverged_count();
     let failed = result.failed_count();
 
     if failed == 0 {
@@ -695,6 +700,18 @@ fn print_summary(result: &fetch::FetchResult, output: &mut dyn Output) {
                 &format!("{up_to_date} already up to date")
             };
             parts.push(phrase.to_string());
+        }
+        if diverged > 0 {
+            let word = if diverged == 1 {
+                "worktree"
+            } else {
+                "worktrees"
+            };
+            if parts.is_empty() {
+                parts.push(format!("{diverged} {word} diverged"));
+            } else {
+                parts.push(format!("{diverged} diverged"));
+            }
         }
         if skipped > 0 {
             let word = if skipped == 1 {
@@ -725,6 +742,9 @@ fn print_summary(result: &fetch::FetchResult, output: &mut dyn Output) {
         }
         if up_to_date > 0 {
             parts.push(format!("{up_to_date} already up to date"));
+        }
+        if diverged > 0 {
+            parts.push(format!("{diverged} diverged"));
         }
         if skipped > 0 {
             let word = if skipped == 1 {
@@ -894,6 +914,14 @@ fn tag_up_to_date() -> String {
         format!("{}\u{2713} up to date{}", styles::DIM, styles::RESET)
     } else {
         "\u{2713} up to date".to_string()
+    }
+}
+
+fn tag_diverged() -> String {
+    if styles::colors_enabled() {
+        format!("{}\u{2298} diverged{}", styles::YELLOW, styles::RESET)
+    } else {
+        "\u{2298} diverged".to_string()
     }
 }
 

--- a/src/core/worktree/fetch.rs
+++ b/src/core/worktree/fetch.rs
@@ -78,6 +78,8 @@ pub struct WorktreeFetchResult {
     pub skipped: bool,
     /// True when the pull succeeded but there were no new changes.
     pub up_to_date: bool,
+    /// True when `--ff-only` pull failed because the branch has diverged from upstream.
+    pub diverged: bool,
     /// Captured git pull stdout (diff stats, fast-forward info). None when up-to-date or on error.
     pub pull_output: Option<String>,
 }
@@ -98,7 +100,7 @@ impl FetchResult {
     pub fn updated_count(&self) -> usize {
         self.results
             .iter()
-            .filter(|r| r.success && !r.skipped && !r.up_to_date)
+            .filter(|r| r.success && !r.skipped && !r.up_to_date && !r.diverged)
             .count()
     }
 
@@ -118,6 +120,10 @@ impl FetchResult {
             .iter()
             .filter(|r| !r.success && !r.skipped)
             .count()
+    }
+
+    pub fn diverged_count(&self) -> usize {
+        self.results.iter().filter(|r| r.diverged).count()
     }
 }
 
@@ -391,15 +397,29 @@ pub fn update_single_worktree(
                     "Updated successfully".to_string()
                 },
                 skipped: false,
+                diverged: false,
                 up_to_date,
                 pull_output,
             }
         }
-        Err(e) => WorktreeFetchResult {
-            worktree_name: worktree_name.to_string(),
-            message: format!("Failed: {e}"),
-            ..Default::default()
-        },
+        Err(e) => {
+            let err_msg = format!("{e}");
+            if is_ff_only_failure(&err_msg) {
+                WorktreeFetchResult {
+                    worktree_name: worktree_name.to_string(),
+                    success: true,
+                    diverged: true,
+                    message: "Diverged from upstream (not fast-forwardable)".to_string(),
+                    ..Default::default()
+                }
+            } else {
+                WorktreeFetchResult {
+                    worktree_name: worktree_name.to_string(),
+                    message: format!("Failed: {e}"),
+                    ..Default::default()
+                }
+            }
+        }
     }
 }
 
@@ -518,15 +538,29 @@ fn process_same_branch(
                     "Updated successfully".to_string()
                 },
                 skipped: false,
+                diverged: false,
                 up_to_date,
                 pull_output,
             }
         }
-        Err(e) => WorktreeFetchResult {
-            worktree_name: worktree_name.to_string(),
-            message: format!("Failed: {e}"),
-            ..Default::default()
-        },
+        Err(e) => {
+            let err_msg = format!("{e}");
+            if is_ff_only_failure(&err_msg) {
+                WorktreeFetchResult {
+                    worktree_name: worktree_name.to_string(),
+                    success: true,
+                    diverged: true,
+                    message: "Diverged from upstream (not fast-forwardable)".to_string(),
+                    ..Default::default()
+                }
+            } else {
+                WorktreeFetchResult {
+                    worktree_name: worktree_name.to_string(),
+                    message: format!("Failed: {e}"),
+                    ..Default::default()
+                }
+            }
+        }
     }
 }
 
@@ -594,6 +628,11 @@ fn check_has_upstream(git: &GitCommand) -> Result<()> {
         anyhow::bail!("No upstream configured for branch '{}'", branch);
     }
     Ok(())
+}
+
+/// Check if a git pull error is a fast-forward-only failure (diverged branches).
+fn is_ff_only_failure(error_msg: &str) -> bool {
+    error_msg.contains("Not possible to fast-forward")
 }
 
 #[cfg(test)]

--- a/src/core/worktree/sync_dag.rs
+++ b/src/core/worktree/sync_dag.rs
@@ -60,6 +60,8 @@ pub enum TaskMessage {
     Deferred,
     /// Prune found nothing to remove.
     NoActionNeeded,
+    /// Update couldn't fast-forward (branch diverged from upstream).
+    Diverged,
     /// Task failed with error message.
     Failed(String),
 }

--- a/src/output/tui/columns.rs
+++ b/src/output/tui/columns.rs
@@ -91,6 +91,7 @@ pub(super) fn status_display_width(status: &WorktreeStatus) -> u16 {
             FinalStatus::UpToDate => 12, // "✓ up to date"
             FinalStatus::Rebased => 9,   // "✓ rebased"
             FinalStatus::Conflict => 10, // "✗ conflict"
+            FinalStatus::Diverged => 10, // "⊘ diverged"
             FinalStatus::Skipped => 9,   // "⊘ skipped"
             FinalStatus::Pruned => 8,    // "— pruned"
             FinalStatus::Failed => 8,    // "✗ failed"

--- a/src/output/tui/render.rs
+++ b/src/output/tui/render.rs
@@ -406,6 +406,10 @@ fn render_status_cell(wt: &super::state::WorktreeRow, tick: usize) -> Cell<'stat
                 format!("{CROSS} conflict"),
                 Style::default().fg(Color::Red),
             ))),
+            FinalStatus::Diverged => Cell::from(Line::from(Span::styled(
+                format!("{SKIP} diverged"),
+                Style::default().fg(Color::Yellow),
+            ))),
             FinalStatus::Skipped => Cell::from(Line::from(Span::styled(
                 format!("{SKIP} skipped"),
                 Style::default().fg(Color::Yellow),

--- a/src/output/tui/state.rs
+++ b/src/output/tui/state.rs
@@ -36,6 +36,7 @@ pub enum FinalStatus {
     UpToDate,
     Rebased,
     Conflict,
+    Diverged,
     Skipped,
     Pruned,
     Failed,
@@ -390,6 +391,7 @@ impl TuiState {
                 },
                 OperationPhase::Update => match message {
                     TaskMessage::UpToDate => FinalStatus::UpToDate,
+                    TaskMessage::Diverged => FinalStatus::Diverged,
                     _ => FinalStatus::Updated,
                 },
                 OperationPhase::Rebase(_) => match message {

--- a/tests/integration/test_sync.sh
+++ b/tests/integration/test_sync.sh
@@ -230,6 +230,81 @@ test_sync_outside_repo() {
     return 0
 }
 
+# Test sync with diverged branch and --rebase continues successfully
+test_sync_diverged_branch_with_rebase() {
+    local remote_repo=$(create_test_remote "test-repo-sync-diverged-rebase" "main")
+
+    # Clone the repository
+    git-worktree-clone "$remote_repo" || return 1
+    cd "test-repo-sync-diverged-rebase"
+
+    # Create a feature worktree
+    git-worktree-checkout develop || return 1
+
+    # Make the local develop branch diverge from upstream by amending
+    (
+        cd develop
+        echo "Local diverged change" >> README.md
+        git add README.md >/dev/null 2>&1
+        git commit --amend -m "Amended: diverged from upstream" >/dev/null 2>&1
+    ) >/dev/null 2>&1
+
+    # Run sync with --rebase (use --verbose --verbose for sequential mode)
+    git-sync --rebase main --verbose --verbose || {
+        log_error "Sync --rebase should not fail when a branch has diverged"
+        return 1
+    }
+
+    # Verify develop was rebased onto main (check that main's commit is in develop's history)
+    local main_commit=$(cd main && git rev-parse HEAD)
+    if ! (cd develop && git log --format=%H | grep -q "$main_commit"); then
+        log_error "Develop branch should have been rebased onto main"
+        return 1
+    fi
+
+    return 0
+}
+
+# Test sync with diverged branch without --rebase succeeds (warning, not failure)
+test_sync_diverged_branch_no_rebase() {
+    local remote_repo=$(create_test_remote "test-repo-sync-diverged-norebase" "main")
+
+    # Clone the repository
+    git-worktree-clone "$remote_repo" || return 1
+    cd "test-repo-sync-diverged-norebase"
+
+    # Create a feature worktree
+    git-worktree-checkout develop || return 1
+
+    # Record the develop commit before diverging
+    local original_commit=$(cd develop && git rev-parse HEAD)
+
+    # Make the local develop branch diverge from upstream by amending
+    (
+        cd develop
+        echo "Local diverged change" >> README.md
+        git add README.md >/dev/null 2>&1
+        git commit --amend -m "Amended: diverged from upstream" >/dev/null 2>&1
+    ) >/dev/null 2>&1
+
+    local diverged_commit=$(cd develop && git rev-parse HEAD)
+
+    # Run sync without --rebase (use --verbose --verbose for sequential mode)
+    git-sync --verbose --verbose || {
+        log_error "Sync should not fail when a branch has diverged (should warn instead)"
+        return 1
+    }
+
+    # Verify develop is still at its diverged commit (not changed)
+    local current_commit=$(cd develop && git rev-parse HEAD)
+    if [[ "$current_commit" != "$diverged_commit" ]]; then
+        log_error "Develop branch should remain at its diverged commit when no --rebase is used"
+        return 1
+    fi
+
+    return 0
+}
+
 # Run all sync tests
 run_sync_tests() {
     log "Running git-sync integration tests..."
@@ -241,6 +316,8 @@ run_sync_tests() {
     run_test "sync_cd_target" "test_sync_cd_target"
     run_test "sync_help" "test_sync_help"
     run_test "sync_outside_repo" "test_sync_outside_repo"
+    run_test "sync_diverged_branch_with_rebase" "test_sync_diverged_branch_with_rebase"
+    run_test "sync_diverged_branch_no_rebase" "test_sync_diverged_branch_no_rebase"
 }
 
 # Main execution


### PR DESCRIPTION
## Summary

- When `git pull --ff-only` fails during sync (branch diverged from upstream), treat it as a soft "diverged" warning instead of a hard failure that aborts the entire sync
- This allows the `--rebase` phase to proceed and bring diverged branches up to date, which is the whole point of passing `--rebase`
- Diverged branches show as yellow `⊘ diverged` in both sequential and TUI modes

Fixes #291

## Test plan

- [x] `mise run fmt` — no changes
- [x] `mise run clippy` — zero warnings
- [x] `mise run test:unit` — all pass
- [x] New integration test `test_sync_diverged_branch_with_rebase` — diverged branch + `--rebase` succeeds and rebases
- [x] New integration test `test_sync_diverged_branch_no_rebase` — diverged branch without `--rebase` succeeds (warning only)
- [x] All existing sync integration tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)