### PR TITLE
feat(sync): add --autostash flag for rebase phase

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -112,21 +112,21 @@ these as `git` subcommands (e.g., `daft worktree-checkout` is
 
 ### Worktree Lifecycle
 
-| Command                                                                  | Description                                                                                                                    |
-| ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
-| `daft worktree-clone <url>`                                              | Clone a remote repository into daft's worktree layout                                                                          |
-| `daft worktree-init <name>`                                              | Initialize a new local repository in worktree layout                                                                           |
-| `daft worktree-checkout <branch>`                                        | Create a worktree for an existing local or remote branch                                                                       |
-| `daft worktree-checkout -- -`                                            | Switch to the previous worktree (`cd -` style toggle)                                                                          |
-| `daft worktree-checkout -s <branch>`                                     | Same as above, but auto-creates branch if not found (also `daft.go.autoStart`)                                                 |
-| `daft worktree-checkout -b <new-branch> [base]`                          | Create a new branch and worktree from current or specified base                                                                |
-| `daft worktree-branch -d <branch>`                                       | Safely delete a branch: its worktree, local branch, and remote tracking branch                                                 |
-| `daft worktree-branch -D <branch>`                                       | Force-delete a branch bypassing safety checks; for the default branch, removes worktree only (preserves branch ref and remote) |
-| `daft worktree-prune [-f] [-v\|-vv] [--stat summary\|lines]`             | Remove worktrees whose remote branches have been deleted (`-v` hook details, `-vv` full sequential)                            |
-| `daft worktree-carry <targets>`                                          | Transfer uncommitted changes to one or more other worktrees                                                                    |
-| `daft worktree-fetch [targets]`                                          | Update worktree branches from remote (supports refspec syntax source:destination)                                              |
-| `daft worktree-branch -m <source> <new-branch>`                          | Rename a branch, move its worktree, and rename the remote branch                                                               |
-| `daft git-sync [-f] [-v\|-vv] [--rebase BRANCH] [--stat summary\|lines]` | Synchronize all worktrees: prune stale + update all + optional rebase (`-v` hook details, `-vv` full sequential)               |
+| Command                                                                                | Description                                                                                                                    |
+| -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `daft worktree-clone <url>`                                                            | Clone a remote repository into daft's worktree layout                                                                          |
+| `daft worktree-init <name>`                                                            | Initialize a new local repository in worktree layout                                                                           |
+| `daft worktree-checkout <branch>`                                                      | Create a worktree for an existing local or remote branch                                                                       |
+| `daft worktree-checkout -- -`                                                          | Switch to the previous worktree (`cd -` style toggle)                                                                          |
+| `daft worktree-checkout -s <branch>`                                                   | Same as above, but auto-creates branch if not found (also `daft.go.autoStart`)                                                 |
+| `daft worktree-checkout -b <new-branch> [base]`                                        | Create a new branch and worktree from current or specified base                                                                |
+| `daft worktree-branch -d <branch>`                                                     | Safely delete a branch: its worktree, local branch, and remote tracking branch                                                 |
+| `daft worktree-branch -D <branch>`                                                     | Force-delete a branch bypassing safety checks; for the default branch, removes worktree only (preserves branch ref and remote) |
+| `daft worktree-prune [-f] [-v\|-vv] [--stat summary\|lines]`                           | Remove worktrees whose remote branches have been deleted (`-v` hook details, `-vv` full sequential)                            |
+| `daft worktree-carry <targets>`                                                        | Transfer uncommitted changes to one or more other worktrees                                                                    |
+| `daft worktree-fetch [targets]`                                                        | Update worktree branches from remote (supports refspec syntax source:destination)                                              |
+| `daft worktree-branch -m <source> <new-branch>`                                        | Rename a branch, move its worktree, and rename the remote branch                                                               |
+| `daft git-sync [-f] [-v\|-vv] [--rebase BRANCH [--autostash]] [--stat summary\|lines]` | Synchronize all worktrees: prune stale + update all + optional rebase (`-v` hook details, `-vv` full sequential)               |
 
 ### Adoption and Ejection
 

--- a/docs/cli/daft-sync.md
+++ b/docs/cli/daft-sync.md
@@ -40,6 +40,7 @@ separately.
 | `-v, --verbose` | Increase verbosity (`-v` for hook details, `-vv` for full sequential output) | |
 | `-f, --force` | Force removal of worktrees with uncommitted changes | |
 | `--rebase <BRANCH>` | Rebase all branches onto BRANCH after updating | |
+| `--autostash` | Automatically stash/unstash uncommitted changes during rebase (requires `--rebase`) | |
 | `--stat <STAT>` | Statistics mode: `summary` or `lines` (default: from git config `daft.sync.stat`, or `summary`) | |
 
 ## Global Options
@@ -63,6 +64,9 @@ daft sync -vv
 
 # Sync and rebase all worktrees onto main
 daft sync --rebase main
+
+# Sync, rebase onto main, and autostash uncommitted changes
+daft sync --rebase main --autostash
 
 # Force sync even if worktrees have uncommitted changes
 daft sync --force

--- a/docs/cli/git-sync.md
+++ b/docs/cli/git-sync.md
@@ -43,6 +43,7 @@ git sync [OPTIONS]
 | `-v, --verbose` | Increase verbosity (-v for hook details, -vv for full sequential output) |  |
 | `-f, --force` | Force removal of worktrees with uncommitted changes |  |
 | `--rebase <BRANCH>` | Rebase all branches onto BRANCH after updating |  |
+| `--autostash` | Automatically stash and unstash uncommitted changes before/after rebase |  |
 | `--stat <STAT>` | Statistics mode: summary or lines (default: from git config daft.sync.stat, or summary) |  |
 
 ## Global Options

--- a/man/daft-sync.1
+++ b/man/daft-sync.1
@@ -4,7 +4,7 @@
 .SH NAME
 daft\-sync \- Synchronize worktrees with remote (prune + update all)
 .SH SYNOPSIS
-\fBdaft\-sync\fR [\fB\-v\fR|\fB\-\-verbose\fR]... [\fB\-f\fR|\fB\-\-force\fR] [\fB\-\-rebase\fR] [\fB\-\-stat\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] 
+\fBdaft\-sync\fR [\fB\-v\fR|\fB\-\-verbose\fR]... [\fB\-f\fR|\fB\-\-force\fR] [\fB\-\-rebase\fR] [\fB\-\-autostash\fR] [\fB\-\-stat\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] 
 .SH DESCRIPTION
 .PP
 Synchronizes all worktrees with the remote in a single command.
@@ -33,6 +33,9 @@ Force removal of worktrees with uncommitted changes
 .TP
 \fB\-\-rebase\fR \fI<BRANCH>\fR
 Rebase all branches onto BRANCH after updating
+.TP
+\fB\-\-autostash\fR
+Automatically stash and unstash uncommitted changes before/after rebase
 .TP
 \fB\-\-stat\fR \fI<STAT>\fR
 Statistics mode: summary or lines (default: from git config daft.sync.stat, or summary)

--- a/man/git-sync.1
+++ b/man/git-sync.1
@@ -4,7 +4,7 @@
 .SH NAME
 git\-sync \- Synchronize worktrees with remote (prune + update all)
 .SH SYNOPSIS
-\fBgit\-sync\fR [\fB\-v\fR|\fB\-\-verbose\fR]... [\fB\-f\fR|\fB\-\-force\fR] [\fB\-\-rebase\fR] [\fB\-\-stat\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] 
+\fBgit\-sync\fR [\fB\-v\fR|\fB\-\-verbose\fR]... [\fB\-f\fR|\fB\-\-force\fR] [\fB\-\-rebase\fR] [\fB\-\-autostash\fR] [\fB\-\-stat\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] 
 .SH DESCRIPTION
 .PP
 Synchronizes all worktrees with the remote in a single command.
@@ -33,6 +33,9 @@ Force removal of worktrees with uncommitted changes
 .TP
 \fB\-\-rebase\fR \fI<BRANCH>\fR
 Rebase all branches onto BRANCH after updating
+.TP
+\fB\-\-autostash\fR
+Automatically stash and unstash uncommitted changes before/after rebase
 .TP
 \fB\-\-stat\fR \fI<STAT>\fR
 Statistics mode: summary or lines (default: from git config daft.sync.stat, or summary)

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -80,6 +80,13 @@ pub struct Args {
 
     #[arg(
         long,
+        requires = "rebase",
+        help = "Automatically stash and unstash uncommitted changes before/after rebase"
+    )]
+    autostash: bool,
+
+    #[arg(
+        long,
         value_enum,
         help = "Statistics mode: summary or lines (default: from git config daft.sync.stat, or summary)"
     )]
@@ -121,7 +128,13 @@ fn run_sequential(args: Args, settings: DaftSettings) -> Result<()> {
 
     // Phase 3: Rebase all worktrees onto base branch (if requested)
     if let Some(ref base_branch) = args.rebase {
-        run_rebase_phase(&mut output, &settings, base_branch, args.force)?;
+        run_rebase_phase(
+            &mut output,
+            &settings,
+            base_branch,
+            args.force,
+            args.autostash,
+        )?;
     }
 
     // Write the cd target for the shell wrapper (from prune phase)
@@ -231,6 +244,7 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
         remote_name: settings.remote.clone(),
     }));
     let shared_force = args.force;
+    let shared_autostash = args.autostash;
     let shared_is_bare_layout = is_bare_layout;
 
     let git_dir = get_git_common_dir()?;
@@ -359,6 +373,7 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
                             &shared_project_root,
                             &shared_settings,
                             shared_force,
+                            shared_autostash,
                         );
                         let updated = if status == TaskStatus::Succeeded
                             && !matches!(message, TaskMessage::Conflict)
@@ -514,6 +529,7 @@ fn execute_rebase_task(
     project_root: &std::path::Path,
     settings: &DaftSettings,
     force: bool,
+    autostash: bool,
 ) -> (TaskStatus, TaskMessage) {
     let Some(target_path) = worktree_path else {
         return (
@@ -538,6 +554,7 @@ fn execute_rebase_task(
         &worktree_name,
         base_branch,
         force,
+        autostash,
         &mut sink,
     );
 
@@ -765,6 +782,7 @@ fn run_rebase_phase(
     settings: &DaftSettings,
     base_branch: &str,
     force: bool,
+    autostash: bool,
 ) -> Result<()> {
     let wt_config = WorktreeConfig {
         remote_name: settings.remote.clone(),
@@ -777,6 +795,7 @@ fn run_rebase_phase(
         base_branch: base_branch.to_string(),
         force,
         quiet: output.is_quiet(),
+        autostash,
     };
 
     output.start_spinner("Rebasing worktrees...");

--- a/src/core/worktree/rebase.rs
+++ b/src/core/worktree/rebase.rs
@@ -18,6 +18,8 @@ pub struct RebaseParams {
     pub force: bool,
     /// Suppress verbose output.
     pub quiet: bool,
+    /// Automatically stash and unstash uncommitted changes before/after rebase.
+    pub autostash: bool,
 }
 
 /// Result of rebasing a single worktree.
@@ -94,6 +96,7 @@ pub fn execute(
             &worktree_name,
             &params.base_branch,
             params.force,
+            params.autostash,
             progress,
         );
         results.push(result);
@@ -124,6 +127,7 @@ pub fn rebase_single_worktree(
     worktree_name: &str,
     base_branch: &str,
     force: bool,
+    autostash: bool,
     progress: &mut dyn ProgressSink,
 ) -> WorktreeRebaseResult {
     // Verify directory exists
@@ -137,7 +141,7 @@ pub fn rebase_single_worktree(
 
     // Check for uncommitted changes
     match git.has_uncommitted_changes_in(worktree_path) {
-        Ok(true) if !force => {
+        Ok(true) if !force && !autostash => {
             progress.on_warning(&format!(
                 "Skipping '{worktree_name}': has uncommitted changes (use --force to rebase anyway)"
             ));
@@ -160,7 +164,7 @@ pub fn rebase_single_worktree(
     }
 
     // Run git rebase with explicit working directory (thread-safe)
-    match git.rebase_in(base_branch, Some(worktree_path)) {
+    match git.rebase_in(base_branch, Some(worktree_path), autostash) {
         Ok(output) => {
             let already_up_to_date =
                 output.contains("is up to date") || output.contains("up to date");

--- a/src/git/remote.rs
+++ b/src/git/remote.rs
@@ -336,19 +336,22 @@ impl GitCommand {
     /// Returns the combined stdout+stderr on success. On failure (e.g., conflicts),
     /// returns an error with the combined output.
     pub fn rebase(&self, base: &str) -> Result<String> {
-        self.rebase_in(base, None)
+        self.rebase_in(base, None, false)
     }
 
     /// Rebase with an explicit working directory.
     ///
     /// When `dir` is `Some`, the git command runs in that directory instead
     /// of inheriting the process CWD. Required for parallel workers.
-    pub fn rebase_in(&self, base: &str, dir: Option<&Path>) -> Result<String> {
+    pub fn rebase_in(&self, base: &str, dir: Option<&Path>, autostash: bool) -> Result<String> {
         let mut cmd = Command::new("git");
         if let Some(d) = dir {
             cmd.current_dir(d);
         }
         cmd.args(["rebase", base]);
+        if autostash {
+            cmd.arg("--autostash");
+        }
 
         let output = cmd
             .output()

--- a/tests/integration/test_sync.sh
+++ b/tests/integration/test_sync.sh
@@ -305,6 +305,87 @@ test_sync_diverged_branch_no_rebase() {
     return 0
 }
 
+# Test sync --rebase --autostash stashes dirty worktree, rebases, and restores
+test_sync_rebase_autostash() {
+    local remote_repo=$(create_test_remote "test-repo-sync-autostash" "main")
+
+    # Clone the repository
+    git-worktree-clone "$remote_repo" || return 1
+    cd "test-repo-sync-autostash"
+
+    # Create a feature worktree
+    git-worktree-checkout develop || return 1
+
+    # Make a local commit on develop so rebase has work to do
+    (
+        cd develop
+        echo "develop-only content" > develop-feature.txt
+        git add develop-feature.txt >/dev/null 2>&1
+        git commit -m "Add develop feature" >/dev/null 2>&1
+    ) >/dev/null 2>&1
+
+    # Push a new commit to main via remote (develop will rebase onto this)
+    # Use main.py (not README.md) to avoid conflicting with develop's README.md changes
+    local temp_clone="$TEMP_BASE_DIR/temp_sync_autostash_clone"
+    git clone "$remote_repo" "$temp_clone" >/dev/null 2>&1
+    (
+        cd "$temp_clone"
+        echo "Remote main change" >> main.py
+        git add main.py >/dev/null 2>&1
+        git commit -m "Update main for autostash test" >/dev/null 2>&1
+        git push origin main >/dev/null 2>&1
+    ) >/dev/null 2>&1
+    rm -rf "$temp_clone"
+
+    # Make uncommitted changes in develop in a non-conflicting file
+    echo "Uncommitted local work" > develop/local-wip.txt
+
+    # Run sync with --rebase --autostash (use -vv for sequential mode)
+    git-sync --rebase main --autostash --verbose --verbose || {
+        log_error "Sync --rebase --autostash should succeed with dirty worktree"
+        return 1
+    }
+
+    # Verify develop was rebased onto main (main's latest commit is in develop's history)
+    local main_commit=$(cd main && git rev-parse HEAD)
+    if ! (cd develop && git log --format=%H | grep -q "$main_commit"); then
+        log_error "Develop branch should have been rebased onto main"
+        return 1
+    fi
+
+    # Verify uncommitted changes are still present
+    if ! grep -q "Uncommitted local work" develop/local-wip.txt; then
+        log_error "Uncommitted changes should have been restored after autostash rebase"
+        return 1
+    fi
+
+    return 0
+}
+
+# Test sync --autostash without --rebase fails with validation error
+test_sync_autostash_without_rebase() {
+    local remote_repo=$(create_test_remote "test-repo-sync-autostash-norebase" "main")
+
+    # Clone the repository
+    git-worktree-clone "$remote_repo" || return 1
+    cd "test-repo-sync-autostash-norebase"
+
+    # Run sync with --autostash but without --rebase — should fail
+    local output
+    output=$(git-sync --autostash 2>&1) && {
+        log_error "Sync --autostash without --rebase should fail"
+        return 1
+    }
+
+    # Verify the error mentions the requirement
+    if ! echo "$output" | grep -qi "rebase"; then
+        log_error "Error message should mention --rebase requirement, got: $output"
+        return 1
+    fi
+
+    return 0
+}
+
 # Run all sync tests
 run_sync_tests() {
     log "Running git-sync integration tests..."
@@ -318,6 +399,8 @@ run_sync_tests() {
     run_test "sync_outside_repo" "test_sync_outside_repo"
     run_test "sync_diverged_branch_with_rebase" "test_sync_diverged_branch_with_rebase"
     run_test "sync_diverged_branch_no_rebase" "test_sync_diverged_branch_no_rebase"
+    run_test "sync_rebase_autostash" "test_sync_rebase_autostash"
+    run_test "sync_autostash_without_rebase" "test_sync_autostash_without_rebase"
 }
 
 # Main execution


### PR DESCRIPTION
## Summary

- Add `--autostash` flag to `daft sync --rebase` that passes `--autostash` to the underlying `git rebase` command, automatically stashing and restoring uncommitted changes during rebase
- Using `--autostash` without `--rebase` produces a clap validation error via `requires = "rebase"`
- Threads the flag through both sequential and parallel DAG execution paths

## Test plan

- [x] `mise run clippy` passes with zero warnings
- [x] `mise run fmt:check` passes
- [x] `mise run test:unit` — 618 tests pass
- [x] `mise run man:verify` — man pages up to date
- [x] Integration test: `test_sync_rebase_autostash` — dirty worktree is rebased with autostash, uncommitted changes preserved
- [x] Integration test: `test_sync_autostash_without_rebase` — error when `--autostash` used without `--rebase`

🤖 Generated with [Claude Code](https://claude.com/claude-code)