### PR TITLE
deps: update lefthook 2.1.3 -> 2.1.4

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -97,52 +97,53 @@ checksum = "sha256:074f68f05d270da5c0d69d3e234ec362bec4c6e3189c21d1c948d03860365
 url = "https://github.com/cocogitto/cocogitto/releases/download/7.0.0/cocogitto-7.0.0-x86_64-pc-windows-msvc.tar.gz"
 
 [[tools.lefthook]]
-version = "2.1.3"
+version = "2.1.4"
 backend = "aqua:evilmartians/lefthook"
 
 [tools.lefthook."platforms.linux-arm64"]
-checksum = "sha256:13fe7bacf9794e625e02a2329c907168d34bdd368e69b8d569791fc0cf375155"
-url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.3/lefthook_2.1.3_Linux_aarch64.gz"
+checksum = "sha256:68f563d14ff2d24539c2c09cfab32895081282a52d08da14f14268de851e7144"
+url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.4/lefthook_2.1.4_Linux_aarch64.gz"
 
 [tools.lefthook."platforms.linux-arm64-musl"]
-checksum = "sha256:13fe7bacf9794e625e02a2329c907168d34bdd368e69b8d569791fc0cf375155"
-url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.3/lefthook_2.1.3_Linux_aarch64.gz"
+checksum = "sha256:68f563d14ff2d24539c2c09cfab32895081282a52d08da14f14268de851e7144"
+url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.4/lefthook_2.1.4_Linux_aarch64.gz"
 
 [tools.lefthook."platforms.linux-x64"]
-checksum = "sha256:5c3b9f78cbee27efbd4c6c64eba8966cc808cbe3636dce5acb14b410cc6f4ccb"
-url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.3/lefthook_2.1.3_Linux_x86_64.gz"
+checksum = "sha256:991a11fb98c853dbecf7de3fe7f4b5648872f4279ac2b50ef3302f0a058c99bd"
+url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.4/lefthook_2.1.4_Linux_x86_64.gz"
 
 [tools.lefthook."platforms.linux-x64-baseline"]
-checksum = "sha256:5c3b9f78cbee27efbd4c6c64eba8966cc808cbe3636dce5acb14b410cc6f4ccb"
-url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.3/lefthook_2.1.3_Linux_x86_64.gz"
+checksum = "sha256:991a11fb98c853dbecf7de3fe7f4b5648872f4279ac2b50ef3302f0a058c99bd"
+url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.4/lefthook_2.1.4_Linux_x86_64.gz"
 
 [tools.lefthook."platforms.linux-x64-musl"]
-checksum = "sha256:5c3b9f78cbee27efbd4c6c64eba8966cc808cbe3636dce5acb14b410cc6f4ccb"
-url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.3/lefthook_2.1.3_Linux_x86_64.gz"
+checksum = "sha256:991a11fb98c853dbecf7de3fe7f4b5648872f4279ac2b50ef3302f0a058c99bd"
+url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.4/lefthook_2.1.4_Linux_x86_64.gz"
 
 [tools.lefthook."platforms.linux-x64-musl-baseline"]
-checksum = "sha256:5c3b9f78cbee27efbd4c6c64eba8966cc808cbe3636dce5acb14b410cc6f4ccb"
-url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.3/lefthook_2.1.3_Linux_x86_64.gz"
+checksum = "sha256:991a11fb98c853dbecf7de3fe7f4b5648872f4279ac2b50ef3302f0a058c99bd"
+url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.4/lefthook_2.1.4_Linux_x86_64.gz"
 
 [tools.lefthook."platforms.macos-arm64"]
-checksum = "sha256:14c4ba9c162d761e5a9e9778354d5bcef607dffbb3e82190265223c167a9219e"
-url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.3/lefthook_2.1.3_MacOS_arm64.gz"
+checksum = "sha256:41fa330710344f66683edb2ee19dfd531e9469bebf7c89ef8e201263565c12ad"
+url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.4/lefthook_2.1.4_MacOS_arm64.gz"
+provenance = "github-attestations"
 
 [tools.lefthook."platforms.macos-x64"]
-checksum = "sha256:9e88138119b06ffb8983a7d2e917e938b3d421f4451be72ea910188821a46d55"
-url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.3/lefthook_2.1.3_MacOS_x86_64.gz"
+checksum = "sha256:1b59f28e460577150b0b5c1fb1a3cc3868fb4cee9c76900daa85ba99ca37b4a1"
+url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.4/lefthook_2.1.4_MacOS_x86_64.gz"
 
 [tools.lefthook."platforms.macos-x64-baseline"]
-checksum = "sha256:9e88138119b06ffb8983a7d2e917e938b3d421f4451be72ea910188821a46d55"
-url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.3/lefthook_2.1.3_MacOS_x86_64.gz"
+checksum = "sha256:1b59f28e460577150b0b5c1fb1a3cc3868fb4cee9c76900daa85ba99ca37b4a1"
+url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.4/lefthook_2.1.4_MacOS_x86_64.gz"
 
 [tools.lefthook."platforms.windows-x64"]
-checksum = "sha256:a7373ea9f2319f7ebf53aad024189e40765cc70a32b4ec31911b36a0faa1c558"
-url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.3/lefthook_2.1.3_Windows_x86_64.gz"
+checksum = "sha256:f76f1a38e7e918c772bfb03071ca7cf9b87b51b6b56d8332dcf391f99841f561"
+url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.4/lefthook_2.1.4_Windows_x86_64.gz"
 
 [tools.lefthook."platforms.windows-x64-baseline"]
-checksum = "sha256:a7373ea9f2319f7ebf53aad024189e40765cc70a32b4ec31911b36a0faa1c558"
-url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.3/lefthook_2.1.3_Windows_x86_64.gz"
+checksum = "sha256:f76f1a38e7e918c772bfb03071ca7cf9b87b51b6b56d8332dcf391f99841f561"
+url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.4/lefthook_2.1.4_Windows_x86_64.gz"
 
 [[tools.rust]]
 version = "stable"


### PR DESCRIPTION
## Summary

- Update lefthook from v2.1.3 to v2.1.4 in `mise.lock`

## Test plan

- [ ] CI passes with updated lockfile
- [ ] `mise run dev` works with new tool versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)