### PR TITLE
fix(sync): refresh remote tracking info after push in TUI output

### DIFF
--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -437,7 +437,16 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
                             &shared_settings,
                             shared_force_with_lease,
                         );
-                        (status, message, None)
+                        let updated = if status == TaskStatus::Succeeded {
+                            orch_info_map.get(branch_name.as_str()).map(|info| {
+                                let mut refreshed = info.clone();
+                                refreshed.refresh_dynamic_fields(&orch_base_branch, orch_stat);
+                                Box::new(refreshed)
+                            })
+                        } else {
+                            None
+                        };
+                        (status, message, updated)
                     }
                 }
             },


### PR DESCRIPTION
## Summary
- After a successful push, the sync TUI displayed stale pre-push remote ahead/behind values (e.g., `⇡14 ⇣13`) because the Push task handler returned `None` for `updated_info`
- Added `refresh_dynamic_fields()` call after successful push, matching the existing pattern used by Update and Rebase task handlers

## Test plan
- [ ] Run `daft sync --push --force-with-lease` on a branch with pending pushes and verify the end-of-sync status shows correct (empty) remote values
- [ ] Run `daft list` immediately after and confirm values match the sync output
- [ ] Verify failed pushes still show correct status (no refresh on failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)