### PR TITLE
fix(sync): show dirty status instead of pruned for unremovable worktrees

### DIFF
--- a/src/commands/sync_shared.rs
+++ b/src/commands/sync_shared.rs
@@ -83,6 +83,8 @@ pub fn execute_prune_task(
                 // Deferred branches (current worktree) are still considered successful
                 // but the actual removal happens after the TUI finishes.
                 (TaskStatus::Succeeded, TaskMessage::Deferred)
+            } else if result.skipped_dirty {
+                (TaskStatus::Succeeded, TaskMessage::SkippedDirty)
             } else {
                 (TaskStatus::Succeeded, TaskMessage::NoActionNeeded)
             }

--- a/src/core/worktree/prune.rs
+++ b/src/core/worktree/prune.rs
@@ -70,12 +70,25 @@ pub struct SingleBranchPruneResult {
     pub branches_deleted: u32,
     pub worktrees_removed: u32,
     pub deferred: bool,
+    /// True when pruning was skipped because the worktree has uncommitted changes.
+    pub skipped_dirty: bool,
 }
 
 /// Result of removing a single worktree + deleting its branch.
 struct SinglePruneResult {
     worktree_removed: bool,
     branch_deleted: bool,
+    skipped_dirty: bool,
+}
+
+/// Outcome of attempting to remove a worktree.
+enum RemoveOutcome {
+    /// Worktree was successfully removed.
+    Removed,
+    /// Skipped because worktree has uncommitted changes.
+    SkippedDirty,
+    /// Skipped due to an error (not dirty-related).
+    Failed,
 }
 
 /// Execute the prune operation.
@@ -238,6 +251,7 @@ pub fn prune_single_branch(
     let mut branches_deleted: u32 = 0;
     let mut worktrees_removed: u32 = 0;
     let mut deferred = false;
+    let mut skipped_dirty = false;
 
     let wt_info = worktree_map.get(branch_name).cloned();
 
@@ -253,6 +267,7 @@ pub fn prune_single_branch(
                 sink,
                 &mut branches_deleted,
                 &mut worktrees_removed,
+                &mut skipped_dirty,
             )?;
         }
         Some((ref wt_path, _)) if !is_bare_layout => {
@@ -268,6 +283,7 @@ pub fn prune_single_branch(
                 &mut branches_deleted,
                 &mut worktrees_removed,
                 &mut deferred_branch,
+                &mut skipped_dirty,
             );
             if deferred_branch.is_some() {
                 deferred = true;
@@ -287,6 +303,7 @@ pub fn prune_single_branch(
                 &mut branches_deleted,
                 &mut worktrees_removed,
                 &mut deferred_branch,
+                &mut skipped_dirty,
             );
             if deferred_branch.is_some() {
                 deferred = true;
@@ -313,6 +330,7 @@ pub fn prune_single_branch(
         branches_deleted,
         worktrees_removed,
         deferred,
+        skipped_dirty,
     })
 }
 
@@ -412,6 +430,7 @@ fn process_main_worktree_branch(
     sink: &mut (impl ProgressSink + HookRunner),
     branches_deleted: &mut u32,
     worktrees_removed: &mut u32,
+    skipped_dirty: &mut bool,
 ) -> Result<()> {
     sink.on_step(&format!(
         "Branch {branch_name} is checked out in the main worktree"
@@ -447,7 +466,11 @@ fn process_main_worktree_branch(
             "Branch {branch_name} has worktree at {} but is not checked out there; removing worktree",
             wt_path.display()
         ));
-        if !remove_worktree(ctx, wt_path, branch_name, params.force, sink) {
+        let outcome = remove_worktree(ctx, wt_path, branch_name, params.force, sink);
+        if !matches!(outcome, RemoveOutcome::Removed) {
+            if matches!(outcome, RemoveOutcome::SkippedDirty) {
+                *skipped_dirty = true;
+            }
             return Ok(());
         }
         wt_removed = true;
@@ -482,6 +505,7 @@ fn process_linked_worktree_branch(
     branches_deleted: &mut u32,
     worktrees_removed: &mut u32,
     deferred_branch: &mut Option<String>,
+    skipped_dirty: &mut bool,
 ) {
     let is_current = current_wt_path
         .as_ref()
@@ -497,6 +521,9 @@ fn process_linked_worktree_branch(
     }
 
     let result = remove_worktree_and_delete_branch(ctx, wt_path, branch_name, force, sink);
+    if result.skipped_dirty {
+        *skipped_dirty = true;
+    }
     if result.worktree_removed {
         *worktrees_removed += 1;
     }
@@ -527,6 +554,7 @@ fn process_bare_layout_branch(
     branches_deleted: &mut u32,
     worktrees_removed: &mut u32,
     deferred_branch: &mut Option<String>,
+    skipped_dirty: &mut bool,
 ) {
     if is_main {
         // The first entry in a bare repo is the bare dir, not a real worktree
@@ -552,6 +580,9 @@ fn process_bare_layout_branch(
     }
 
     let result = remove_worktree_and_delete_branch(ctx, wt_path, branch_name, force, sink);
+    if result.skipped_dirty {
+        *skipped_dirty = true;
+    }
     if result.worktree_removed {
         *worktrees_removed += 1;
     }
@@ -633,14 +664,14 @@ fn process_deferred_branch(
 
 // ── Worktree operations ────────────────────────────────────────────────────
 
-/// Remove a worktree (with hooks and dirty checks). Returns true on success.
+/// Remove a worktree (with hooks and dirty checks).
 fn remove_worktree(
     ctx: &PruneContext,
     wt_path: &Path,
     branch_name: &str,
     force: bool,
     sink: &mut (impl ProgressSink + HookRunner),
-) -> bool {
+) -> RemoveOutcome {
     // Check for uncommitted changes
     if wt_path.exists() && !force {
         match ctx.git.has_uncommitted_changes_in(wt_path) {
@@ -648,14 +679,14 @@ fn remove_worktree(
                 sink.on_warning(&format!(
                     "Skipping {branch_name}: worktree has uncommitted changes or untracked files (use --force to override)"
                 ));
-                return false;
+                return RemoveOutcome::SkippedDirty;
             }
             Ok(false) => {}
             Err(e) => {
                 sink.on_warning(&format!(
                     "Skipping {branch_name}: failed to check for uncommitted changes: {e} (use --force to override)"
                 ));
-                return false;
+                return RemoveOutcome::Failed;
             }
         }
     }
@@ -670,7 +701,7 @@ fn remove_worktree(
                 "Failed to remove worktree {}: {e}. Skipping deletion of branch {branch_name}.",
                 wt_path.display()
             ));
-            return false;
+            return RemoveOutcome::Failed;
         }
         sink.on_step(&format!("Removed worktree '{branch_name}'"));
     } else {
@@ -683,7 +714,7 @@ fn remove_worktree(
                 "Failed to remove orphaned worktree record {}: {e}. Skipping deletion of branch {branch_name}.",
                 wt_path.display()
             ));
-            return false;
+            return RemoveOutcome::Failed;
         }
         sink.on_step(&format!("Removed worktree '{branch_name}'"));
     }
@@ -694,7 +725,7 @@ fn remove_worktree(
     // Clean up empty parent directories
     cleanup_empty_parent_dirs(&ctx.project_root, wt_path, sink);
 
-    true
+    RemoveOutcome::Removed
 }
 
 /// Remove a worktree and delete its branch.
@@ -710,10 +741,12 @@ fn remove_worktree_and_delete_branch(
         wt_path.display()
     ));
 
-    if !remove_worktree(ctx, wt_path, branch_name, force, sink) {
+    let outcome = remove_worktree(ctx, wt_path, branch_name, force, sink);
+    if !matches!(outcome, RemoveOutcome::Removed) {
         return SinglePruneResult {
             worktree_removed: false,
             branch_deleted: false,
+            skipped_dirty: matches!(outcome, RemoveOutcome::SkippedDirty),
         };
     }
 
@@ -722,6 +755,7 @@ fn remove_worktree_and_delete_branch(
     SinglePruneResult {
         worktree_removed: true,
         branch_deleted,
+        skipped_dirty: false,
     }
 }
 

--- a/src/core/worktree/sync_dag.rs
+++ b/src/core/worktree/sync_dag.rs
@@ -62,6 +62,8 @@ pub enum TaskMessage {
     Deferred,
     /// Prune found nothing to remove.
     NoActionNeeded,
+    /// Prune skipped because worktree has uncommitted changes.
+    SkippedDirty,
     /// Update couldn't fast-forward (branch diverged from upstream).
     Diverged,
     /// Push completed successfully.

--- a/src/output/tui/columns.rs
+++ b/src/output/tui/columns.rs
@@ -96,6 +96,7 @@ pub(super) fn status_display_width(status: &WorktreeStatus) -> u16 {
             FinalStatus::Pushed => 8,          // "✓ pushed"
             FinalStatus::NoPushUpstream => 11, // "⊘ no remote"
             FinalStatus::Pruned => 8,          // "— pruned"
+            FinalStatus::Dirty => 7,           // "⊘ dirty"
             FinalStatus::Failed => 8,          // "✗ failed"
         },
     }

--- a/src/output/tui/render.rs
+++ b/src/output/tui/render.rs
@@ -414,6 +414,10 @@ fn render_status_cell(wt: &super::state::WorktreeRow, tick: usize) -> Cell<'stat
                 format!("{SKIP} skipped"),
                 Style::default().fg(Color::Yellow),
             ))),
+            FinalStatus::Dirty => Cell::from(Line::from(Span::styled(
+                format!("{SKIP} dirty"),
+                Style::default().fg(Color::Yellow),
+            ))),
             FinalStatus::Pruned => {
                 if wt.hook_failed {
                     Cell::from(Line::from(Span::styled(

--- a/src/output/tui/state.rs
+++ b/src/output/tui/state.rs
@@ -39,6 +39,8 @@ pub enum FinalStatus {
     Diverged,
     Skipped,
     Pruned,
+    /// Prune skipped because the worktree has uncommitted changes.
+    Dirty,
     Failed,
     Pushed,
     NoPushUpstream,
@@ -390,8 +392,9 @@ impl TuiState {
             TaskStatus::Succeeded => match phase {
                 OperationPhase::Prune => match message {
                     TaskMessage::Removed | TaskMessage::Deferred => FinalStatus::Pruned,
+                    TaskMessage::SkippedDirty => FinalStatus::Dirty,
                     TaskMessage::NoActionNeeded => FinalStatus::UpToDate,
-                    _ => FinalStatus::Pruned,
+                    _ => FinalStatus::UpToDate,
                 },
                 OperationPhase::Update => match message {
                     TaskMessage::UpToDate => FinalStatus::UpToDate,
@@ -550,6 +553,30 @@ mod tests {
             .find(|w| w.info.name == "feat/old")
             .unwrap();
         assert_eq!(row.status, WorktreeStatus::Done(FinalStatus::Pruned));
+    }
+
+    #[test]
+    fn prune_skipped_dirty_sets_dirty_status() {
+        let mut state = make_test_state();
+
+        state.apply_event(&DagEvent::TaskStarted {
+            phase: OperationPhase::Prune,
+            branch_name: "feat/old".into(),
+        });
+        state.apply_event(&DagEvent::TaskCompleted {
+            phase: OperationPhase::Prune,
+            branch_name: "feat/old".into(),
+            status: TaskStatus::Succeeded,
+            message: TaskMessage::SkippedDirty,
+            updated_info: None,
+        });
+
+        let row = state
+            .worktrees
+            .iter()
+            .find(|w| w.info.name == "feat/old")
+            .unwrap();
+        assert_eq!(row.status, WorktreeStatus::Done(FinalStatus::Dirty));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- When a worktree has uncommitted changes and its remote branch is deleted, the TUI prune phase now shows "⊘ dirty" (yellow) instead of misleadingly showing "✓ up to date" or potentially "— pruned" with strikethrough
- Adds `RemoveOutcome` enum to distinguish dirty-skipped from other removal failures, propagated through the prune call chain via new `skipped_dirty` field
- Fixes dangerous catch-all `_ => FinalStatus::Pruned` in the prune status mapping (changed to `UpToDate`)

## Test plan

- [x] `mise run fmt:check` passes
- [x] `mise run clippy` passes with zero warnings
- [x] `mise run test:unit` passes (638 tests, including new `prune_skipped_dirty_sets_dirty_status` test)
- [ ] Manual test: create a worktree, make it dirty, delete its remote branch, run `daft sync` — verify "⊘ dirty" appears instead of "— pruned" or "✓ up to date"

🤖 Generated with [Claude Code](https://claude.com/claude-code)