### PR TITLE
fix: add missing completions for top-level flags

### DIFF
--- a/src/commands/completions/bash.rs
+++ b/src/commands/completions/bash.rs
@@ -258,9 +258,13 @@ _daft() {
         esac
     fi
 
-    # top-level: complete daft subcommands
+    # top-level: complete daft subcommands and flags
     if [[ $cword -eq 1 ]]; then
-        COMPREPLY=( $(compgen -W "hooks shell-init setup multi-remote release-notes doctor clone init go start carry update list prune rename sync remove adopt eject" -- "$cur") )
+        if [[ "$cur" == -* ]]; then
+            COMPREPLY=( $(compgen -W "--version -V --help -h" -- "$cur") )
+        else
+            COMPREPLY=( $(compgen -W "hooks shell-init setup multi-remote release-notes doctor clone init go start carry update list prune rename sync remove adopt eject" -- "$cur") )
+        fi
         return 0
     fi
 }

--- a/src/commands/completions/fish.rs
+++ b/src/commands/completions/fish.rs
@@ -178,6 +178,8 @@ fn generate_verb_alias_flag_completions() -> String {
 
 const DAFT_FISH_COMPLETIONS: &str = r#"# daft subcommand completions
 complete -c daft -f
+complete -c daft -n '__fish_use_subcommand' -s V -l version -d 'Print version information'
+complete -c daft -n '__fish_use_subcommand' -s h -l help -d 'Print help'
 complete -c daft -n '__fish_use_subcommand' -a 'hooks' -d 'Manage lifecycle hooks'
 complete -c daft -n '__fish_use_subcommand' -a 'shell-init' -d 'Generate shell wrappers'
 complete -c daft -n '__fish_use_subcommand' -a 'setup' -d 'Setup and configuration'

--- a/src/commands/completions/zsh.rs
+++ b/src/commands/completions/zsh.rs
@@ -296,10 +296,14 @@ _daft() {
         esac
     fi
 
-    # top-level: complete daft subcommands
+    # top-level: complete daft subcommands and flags
     if (( CURRENT == 2 )); then
-        compadd hooks shell-init setup multi-remote release-notes doctor \
-                clone init go start carry update list prune rename sync remove adopt eject
+        if [[ "$curword" == -* ]]; then
+            compadd -- --version -V --help -h
+        else
+            compadd hooks shell-init setup multi-remote release-notes doctor \
+                    clone init go start carry update list prune rename sync remove adopt eject
+        fi
         return
     fi
 }


### PR DESCRIPTION
## Summary

- Add `--version`/`-V` and `--help`/`-h` flag completions to the top-level `daft` command in bash, zsh, and fish shell completion scripts
- Previously only subcommands were completed; the fig spec already had these flags

## Test plan

- [x] `mise run fmt` — passes
- [x] `mise run clippy` — passes, zero warnings
- [x] `mise run test:unit` — all 656 tests pass
- [x] Verified completion output for all three shells includes the new flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)