### PR TITLE
fix: gate unix-only MetadataExt behind cfg(unix) for Windows build

### DIFF
--- a/src/core/worktree/list.rs
+++ b/src/core/worktree/list.rs
@@ -676,34 +676,61 @@ fn get_remote_line_counts(branch: &str, worktree_path: &Path) -> Option<(usize, 
 /// all readable files. Tracks seen inodes to count hard-linked files only once
 /// (matching `du` behavior). Does not follow symlinks.
 fn compute_directory_size(path: &Path) -> Option<u64> {
-    use std::collections::HashSet;
-    use std::os::unix::fs::MetadataExt;
+    #[cfg(unix)]
+    {
+        use std::collections::HashSet;
+        use std::os::unix::fs::MetadataExt;
 
-    fn walk(dir: &Path, seen: &mut HashSet<(u64, u64)>) -> u64 {
-        let Ok(entries) = std::fs::read_dir(dir) else {
-            return 0;
-        };
-        let mut total = 0u64;
-        for entry in entries {
-            let Ok(entry) = entry else { continue };
-            let Ok(meta) = std::fs::symlink_metadata(entry.path()) else {
-                continue;
+        fn walk(dir: &Path, seen: &mut HashSet<(u64, u64)>) -> u64 {
+            let Ok(entries) = std::fs::read_dir(dir) else {
+                return 0;
             };
-            if meta.is_dir() {
-                total += walk(&entry.path(), seen);
-            } else {
-                // Skip hard links we've already counted (dev + ino pair).
-                if meta.nlink() > 1 && !seen.insert((meta.dev(), meta.ino())) {
+            let mut total = 0u64;
+            for entry in entries {
+                let Ok(entry) = entry else { continue };
+                let Ok(meta) = std::fs::symlink_metadata(entry.path()) else {
                     continue;
+                };
+                if meta.is_dir() {
+                    total += walk(&entry.path(), seen);
+                } else {
+                    // Skip hard links we've already counted (dev + ino pair).
+                    if meta.nlink() > 1 && !seen.insert((meta.dev(), meta.ino())) {
+                        continue;
+                    }
+                    total += meta.len();
                 }
-                total += meta.len();
             }
+            total
         }
-        total
+
+        let mut seen = HashSet::new();
+        Some(walk(path, &mut seen))
     }
 
-    let mut seen = HashSet::new();
-    Some(walk(path, &mut seen))
+    #[cfg(not(unix))]
+    {
+        fn walk(dir: &Path) -> u64 {
+            let Ok(entries) = std::fs::read_dir(dir) else {
+                return 0;
+            };
+            let mut total = 0u64;
+            for entry in entries {
+                let Ok(entry) = entry else { continue };
+                let Ok(meta) = std::fs::symlink_metadata(entry.path()) else {
+                    continue;
+                };
+                if meta.is_dir() {
+                    total += walk(&entry.path());
+                } else {
+                    total += meta.len();
+                }
+            }
+            total
+        }
+
+        Some(walk(path))
+    }
 }
 
 /// Return the most recent mtime among a set of changed/untracked files.


### PR DESCRIPTION
## Summary

- The `compute_directory_size` function used `std::os::unix::fs::MetadataExt` (`nlink`, `dev`, `ino`) unconditionally, which fails to compile on Windows
- Gate the hard-link deduplication behind `#[cfg(unix)]` and provide a simpler fallback for non-unix platforms that just sums file sizes
- Fixes the v1.3.0 release build failure on `x86_64-pc-windows-msvc`

## Test plan

- [x] `cargo check` passes locally
- [x] `mise run clippy` passes with zero warnings
- [x] `mise run fmt` shows no changes
- [x] Unit tests pass (7 pre-existing failures unrelated to this change)
- [ ] CI passes on all platforms including Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)