### PR TITLE
fix: shared status/sync/manage from contained layout root

### DIFF
--- a/src/commands/shared.rs
+++ b/src/commands/shared.rs
@@ -460,8 +460,10 @@ fn run_status(output: &mut dyn Output) -> Result<()> {
     use crate::styles;
 
     let git_common_dir = repo::get_git_common_dir()?;
-    let worktree_path = repo::get_current_worktree_path()?;
-    let shared_paths = shared::read_shared_paths(&worktree_path)?;
+    let worktree_path = repo::get_current_worktree_path()
+        .or_else(|_| std::env::current_dir().context("Failed to determine current directory"))?;
+    let config_root = shared::resolve_config_root(&worktree_path);
+    let shared_paths = shared::read_shared_paths(&config_root)?;
     let worktree_paths = shared::list_worktree_paths()?;
     let materialized = shared::MaterializedState::load(&git_common_dir)?;
 
@@ -558,9 +560,10 @@ fn run_status(output: &mut dyn Output) -> Result<()> {
 
 fn run_sync(output: &mut dyn Output) -> Result<()> {
     let git_common_dir = repo::get_git_common_dir()?;
-    let worktree_path = repo::get_current_worktree_path()?;
+    let worktree_path = repo::get_current_worktree_path()
+        .or_else(|_| std::env::current_dir().context("Failed to determine current directory"))?;
     let config_root = shared::resolve_config_root(&worktree_path);
-    let shared_paths = shared::read_shared_paths(&worktree_path)?;
+    let shared_paths = shared::read_shared_paths(&config_root)?;
     let worktree_paths = shared::list_worktree_paths()?;
     let mut materialized = shared::MaterializedState::load(&git_common_dir)?;
 
@@ -658,9 +661,10 @@ fn run_sync(output: &mut dyn Output) -> Result<()> {
 
 fn run_manage(_output: &mut dyn Output) -> Result<()> {
     let git_common_dir = repo::get_git_common_dir()?;
-    let worktree_path = repo::get_current_worktree_path()?;
+    let worktree_path = repo::get_current_worktree_path()
+        .or_else(|_| std::env::current_dir().context("Failed to determine current directory"))?;
     let config_root = shared::resolve_config_root(&worktree_path);
-    let shared_paths = shared::read_shared_paths(&worktree_path)?;
+    let shared_paths = shared::read_shared_paths(&config_root)?;
     let worktree_paths = shared::list_worktree_paths()?;
     let materialized = shared::MaterializedState::load(&git_common_dir)?;
 

--- a/tests/manual/scenarios/shared/status-from-container-root.yml
+++ b/tests/manual/scenarios/shared/status-from-container-root.yml
@@ -1,0 +1,30 @@
+name: Shared status from container root
+description:
+  daft shared status works when run from the container root of a contained
+  layout
+
+repos:
+  - name: test-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone with contained layout
+    run: git-worktree-clone --layout contained $REMOTE_TEST_REPO
+    expect:
+      exit_code: 0
+
+  - name: Create a shared file from main worktree
+    run: |
+      echo "SECRET=yes" > .env
+      daft shared add .env
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+
+  - name: Run shared status from container root
+    run: daft shared status
+    cwd: "$WORK_DIR/test-repo"
+    expect:
+      exit_code: 0
+      output_contains:
+        - ".env"


### PR DESCRIPTION
## Summary
- Fix `daft shared status` (and `sync`/`manage`) failing when run from the container root of a contained layout
- Fall back to `current_dir()` when `get_current_worktree_path()` fails (bare repo has no working tree)
- Use `resolve_config_root()` to reliably locate `daft.yml` before reading shared paths — fixes the case where `load_yaml_config_with_fallback` skips its project-root fallback when worktree path equals project root
- Also fixes a latent bug in `run_sync`/`run_manage` where `resolve_config_root` was called but its result wasn't passed to `read_shared_paths`

Fixes #353

## Test plan
- [x] New regression test: `shared/status-from-container-root`
- [x] All existing shared scenario tests pass
- [x] Clippy clean, fmt clean
- [ ] Manual sandbox test: run `daft shared status` from contained layout root

🤖 Generated with [Claude Code](https://claude.com/claude-code)