### PR TITLE
fix: add daft-go/daft-start to all packaging symlink lists

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -249,7 +249,8 @@ jobs:
                      git-worktree-branch git-worktree-branch-delete \
                      git-worktree-prune git-worktree-carry \
                      git-worktree-fetch git-worktree-flow-adopt git-worktree-flow-eject \
-                     git-worktree-list git-worktree-sync git-daft daft-remove daft-rename; do
+                     git-worktree-list git-worktree-sync git-daft \
+                     daft-go daft-start daft-remove daft-rename; do
             ln -sf daft "$cmd"
           done
           cd ../..
@@ -297,6 +298,8 @@ jobs:
           ./target/release/git-worktree-flow-adopt --help
           ./target/release/git-worktree-flow-eject --help
           ./target/release/git-worktree-sync --help
+          ./target/release/daft-go --help
+          ./target/release/daft-start --help
           ./target/release/daft-remove --help
           ./target/release/daft-rename --help
           ./target/release/daft | head -20
@@ -342,7 +345,7 @@ jobs:
                      git-worktree-init git-worktree-branch git-worktree-branch-delete \
                      git-worktree-prune git-worktree-carry git-worktree-fetch \
                      git-worktree-flow-adopt git-worktree-flow-eject git-worktree-sync git-daft \
-                     daft-remove daft-rename; do
+                     daft-go daft-start daft-remove daft-rename; do
             ln -sf daft "$PREFIX/bin/$cmd"
           done
 
@@ -366,7 +369,7 @@ jobs:
                      git-worktree-init git-worktree-branch git-worktree-branch-delete \
                      git-worktree-prune git-worktree-carry git-worktree-fetch \
                      git-worktree-flow-adopt git-worktree-flow-eject git-worktree-sync git-daft \
-                     daft-remove daft-rename; do
+                     daft-go daft-start daft-remove daft-rename; do
             echo "  Testing $cmd..."
             "$PREFIX/bin/$cmd" --help > /dev/null || { echo "FAILED: $cmd --help"; exit 1; }
           done

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,8 @@ for cmd in git-worktree-clone git-worktree-init git-worktree-checkout \
            git-worktree-branch git-worktree-branch-delete \
            git-worktree-prune git-worktree-carry git-worktree-fetch \
            git-worktree-flow-adopt git-worktree-flow-eject \
-           git-worktree-list git-worktree-sync git-daft daft-remove daft-rename; do
+           git-worktree-list git-worktree-sync git-daft \
+           daft-go daft-start daft-remove daft-rename; do
     ln -sf daft "/usr/bin/$cmd"
 done
 """
@@ -62,7 +63,8 @@ for cmd in git-worktree-clone git-worktree-init git-worktree-checkout \
            git-worktree-branch git-worktree-branch-delete \
            git-worktree-prune git-worktree-carry git-worktree-fetch \
            git-worktree-flow-adopt git-worktree-flow-eject \
-           git-worktree-list git-worktree-sync git-daft daft-remove daft-rename; do
+           git-worktree-list git-worktree-sync git-daft \
+           daft-go daft-start daft-remove daft-rename; do
     rm -f "/usr/bin/$cmd"
 done
 """

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -43,6 +43,8 @@ daft = [
     "git-worktree-list",
     "git-worktree-sync",
     "git-daft",
+    "daft-go",
+    "daft-start",
     "daft-remove",
     "daft-rename",
 ]

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -131,9 +131,11 @@ sudo mv daft /usr/local/bin/
 # Create command symlinks
 cd /usr/local/bin
 for cmd in git-worktree-clone git-worktree-init git-worktree-checkout \
-           git-worktree-checkout-branch git-worktree-prune git-worktree-carry \
-           git-worktree-fetch git-worktree-flow-adopt git-worktree-flow-eject \
-           git-daft daft-remove daft-rename; do
+           git-worktree-branch git-worktree-branch-delete \
+           git-worktree-prune git-worktree-carry git-worktree-fetch \
+           git-worktree-flow-adopt git-worktree-flow-eject \
+           git-worktree-list git-worktree-sync git-daft \
+           daft-go daft-start daft-remove daft-rename; do
   sudo ln -sf daft "$cmd"
 done
 ```

--- a/flake.nix
+++ b/flake.nix
@@ -70,6 +70,8 @@
                   git-worktree-flow-adopt \
                   git-worktree-flow-eject \
                   git-daft \
+                  daft-go \
+                  daft-start \
                   daft-remove \
                   daft-rename; do
                   ln -s daft "$cmd"

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -36,7 +36,8 @@ package() {
                git-worktree-branch git-worktree-branch-delete \
                git-worktree-prune git-worktree-carry git-worktree-fetch \
                git-worktree-flow-adopt git-worktree-flow-eject \
-               git-worktree-list git-worktree-sync git-daft daft-remove daft-rename; do
+               git-worktree-list git-worktree-sync git-daft \
+               daft-go daft-start daft-remove daft-rename; do
         ln -s daft "$cmd"
     done
 

--- a/packaging/deb/postinst
+++ b/packaging/deb/postinst
@@ -7,7 +7,8 @@ case "$1" in
                    git-worktree-branch git-worktree-branch-delete \
                    git-worktree-prune git-worktree-carry git-worktree-fetch \
                    git-worktree-flow-adopt git-worktree-flow-eject \
-                   git-worktree-list git-worktree-sync git-daft daft-remove daft-rename; do
+                   git-worktree-list git-worktree-sync git-daft \
+                   daft-go daft-start daft-remove daft-rename; do
             ln -sf daft "/usr/bin/$cmd"
         done
         ;;

--- a/packaging/deb/prerm
+++ b/packaging/deb/prerm
@@ -7,7 +7,8 @@ case "$1" in
                    git-worktree-branch git-worktree-branch-delete \
                    git-worktree-prune git-worktree-carry git-worktree-fetch \
                    git-worktree-flow-adopt git-worktree-flow-eject \
-                   git-worktree-list git-worktree-sync git-daft daft-remove daft-rename; do
+                   git-worktree-list git-worktree-sync git-daft \
+                   daft-go daft-start daft-remove daft-rename; do
             rm -f "/usr/bin/$cmd"
         done
         ;;

--- a/src/doctor/installation.rs
+++ b/src/doctor/installation.rs
@@ -23,6 +23,8 @@ const EXPECTED_SYMLINKS: &[&str] = &[
     "git-worktree-list",
     "git-worktree-sync",
     "git-daft",
+    "daft-go",
+    "daft-start",
     "daft-remove",
     "daft-rename",
 ];
@@ -571,7 +573,7 @@ mod tests {
 
     #[test]
     fn test_expected_symlinks_count() {
-        assert_eq!(EXPECTED_SYMLINKS.len(), 15);
+        assert_eq!(EXPECTED_SYMLINKS.len(), 17);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- PR #265 split `daft go`/`daft start` into standalone verbs with dispatch in `src/main.rs`, but the symlink manifests used by every packaging backend (Homebrew via cargo-dist, deb, rpm, AUR, Nix, manual install docs) were not updated, so the installed binaries have been missing `daft-go` and `daft-start` since v1.3.0.
- A later commit (23d1116) added `daft-go`/`daft-start` to the `test-homebrew` verification loop, which is why every release since has failed with `daft-go: command not found` — visible on the [v1.6.2 run](https://github.com/avihut/daft/actions/runs/24277971305/job/70895053254).
- Adds the two names to every symlink list, bumps the `doctor` `EXPECTED_SYMLINKS` count assertion from 15 → 17, and refreshes the manual-install snippet in `docs/getting-started/installation.md` which had drifted on several other symlinks as well.

## Test plan

- [x] `mise run fmt:check`
- [x] `mise run clippy` (zero warnings)
- [x] `cargo test --lib doctor::installation::tests::test_expected_symlinks_count` — passes with new count
- [ ] `test-homebrew` workflow passes on the next release (or a manual `workflow_dispatch` once the tap formula is regenerated)

Note: 7 pre-existing test failures under `tests::test_daft_{data,config}_dir_*` and `core::layout::template::tests::test_render_centralized_template` reproduce on `master` unchanged and are unrelated to this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)