### PR TITLE
fix(ci): run test-homebrew clone from a clean workspace subdir

### DIFF
--- a/.github/workflows/test-homebrew.yml
+++ b/.github/workflows/test-homebrew.yml
@@ -120,7 +120,12 @@ jobs:
           cd ..
           rm -rf temp-init
 
-          # Test git-worktree-clone
+          # Test git-worktree-clone from a clean workspace directory so the
+          # bare remote at /tmp/test-daft/remote.git is not a sibling of the
+          # worktree daft creates -- otherwise the `remote.*/` glob below also
+          # matches the bare remote and picks it alphabetically before
+          # `remote.master/`.
+          mkdir workspace && cd workspace
           echo ""
           echo "Testing git worktree-clone..."
           git worktree-clone /tmp/test-daft/remote.git


### PR DESCRIPTION
## Summary

- The `Test basic functionality` step in `.github/workflows/test-homebrew.yml` creates a bare remote at `/tmp/test-daft/remote.git`, then runs `git worktree-clone` from the same directory. The resulting sibling layout produces `remote/` (bare) and `remote.master/` (worktree), but the `remote.*/` glob the test uses to locate the worktree also matches the leftover `remote.git/` bare repo — and `remote.git` sorts before `remote.master`, so the test picks the bare repo and fails with `README.md not found in worktree`.
- This bug was masked for months by the earlier `daft-go`/`daft-start` symlink failure (#358) which killed the workflow one step earlier. With that fix landed, the dormant glob collision surfaced on [v1.6.3's run](https://github.com/avihut/daft/actions/runs/24278719750).
- Fix: run the clone from a fresh `workspace/` subdirectory so the bare remote is no longer a sibling of the daft-created worktree. No regex, no glob filtering — just a clean working directory.

## Test plan

- [x] `mise run fmt:check`
- [ ] `test-homebrew` workflow passes on the next release (or a `workflow_dispatch` rerun once this is merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)