### PR TITLE
feat(completions): rich grouped completions with configurable columns

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ similar = "3.0"
 nucleo-matcher = "0.3"
 ignore = "0.4"
 edtui = { version = "0.11", features = ["syntax-highlighting"] }
+filetime = "0.2"
 
 # pager is Unix-only (uses fork/pipes)
 [target.'cfg(unix)'.dependencies]

--- a/benches/run_all.sh
+++ b/benches/run_all.sh
@@ -30,6 +30,7 @@ SCENARIOS=(
     fetch
     branch_delete
     workflow_full
+    complete
 )
 
 # Parse arguments

--- a/benches/scenarios/complete.sh
+++ b/benches/scenarios/complete.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Benchmark: daft __complete daft-go (tab-completion speed)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../bench_framework.sh"
+source "$SCRIPT_DIR/../fixtures/create_repo.sh"
+
+setup_bench_env
+
+# Number of linked worktrees per size
+declare -A WT_COUNTS=([small]=1 [medium]=3 [large]=5)
+
+for size in small medium large; do
+    log "=== Completion benchmark: $size ==="
+
+    FIXTURE="$TEMP_BASE/fixture-complete-${size}.git"
+    create_bare_repo "$FIXTURE" "$size"
+
+    ROOT="$TEMP_BASE/complete-${size}"
+    mkdir -p "$ROOT"
+
+    # Set up a contained layout: bare repo + linked worktrees
+    git clone --bare "file://$FIXTURE" "$ROOT/.git" 2>/dev/null
+
+    # Create the main worktree
+    git -C "$ROOT/.git" worktree add "$ROOT/main" main 2>/dev/null
+
+    # Create additional linked worktrees for branches
+    wt_count="${WT_COUNTS[$size]}"
+    for i in $(seq 1 "$wt_count"); do
+        branch="feature/branch-$i"
+        git -C "$ROOT/.git" worktree add "$ROOT/feature-branch-$i" "$branch" 2>/dev/null || true
+    done
+
+    log "  Branches: $(git -C "$ROOT/.git" for-each-ref --format='%(refname:short)' refs/heads/ | wc -l | tr -d ' ') local, $(git -C "$ROOT/.git" for-each-ref --format='%(refname:short)' refs/remotes/ | wc -l | tr -d ' ') remote"
+    log "  Worktrees: $((wt_count + 1))"
+
+    json_out="$RESULTS_DIR/complete-${size}.json"
+    md_out="$RESULTS_DIR/complete-${size}.md"
+
+    # Show command output on failure (CI debugging) but not in normal runs
+    show_output=()
+    if [[ "${CI:-}" == "true" ]]; then
+        show_output=(--show-output)
+    fi
+
+    hyperfine \
+        --warmup 3 \
+        --min-runs 10 \
+        "${show_output[@]}" \
+        --export-json "$json_out" \
+        --export-markdown "$md_out" \
+        --command-name "complete-${size}" \
+        "cd $ROOT/main && daft __complete daft-go '' --position 1"
+
+    log_success "Completion ($size) done"
+done

--- a/docs/cli/daft-go.md
+++ b/docs/cli/daft-go.md
@@ -88,6 +88,43 @@ daft go feature/auth -x 'npm install'
 daft go feature/auth --no-cd
 ```
 
+## Completion behavior
+
+`daft go <TAB>` offers candidates grouped by type:
+
+1. **Worktrees** — branches that already have a linked worktree. These
+   are the primary navigation targets and are listed first. The branch
+   you are currently sitting in is excluded.
+2. **Local branches** — branches in `refs/heads/` that don't have a
+   worktree yet. Selecting one of these will check it out into a new
+   worktree.
+3. **Remote branches** — branches in `refs/remotes/` that don't already
+   exist locally. In single-remote mode the `<remote>/` prefix is
+   stripped for readability; in multi-remote mode the full
+   `<remote>/<branch>` form is preserved.
+
+In zsh and fish, each candidate is annotated with the relative time of
+its last commit (e.g. "3 days ago"). In zsh the three groups are
+colored distinctly — worktrees in bright green, local branches in
+bright blue, remote branches in dim gray. Bash shows a flat list in
+the same group order but without colors or descriptions.
+
+### Fetch-on-miss
+
+If you type a prefix that doesn't match any local or already-fetched
+remote ref, daft will run `git fetch` once (from the configured
+default remote) and re-resolve, showing a spinner while the fetch
+runs. This lets you tab-complete to a remote branch that exists
+upstream but hasn't been pulled yet.
+
+The fetch path is gated by a 30-second cooldown per repository, so
+rapid keystrokes won't trigger repeated fetches. To disable the
+feature entirely:
+
+```sh
+git config daft.go.fetchOnMiss false
+```
+
 ## See Also
 
 - [daft start](./daft-start.md) to create a new branch

--- a/docs/superpowers/plans/2026-04-11-go-command-completions.md
+++ b/docs/superpowers/plans/2026-04-11-go-command-completions.md
@@ -2,22 +2,22 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use
 > superpowers:subagent-driven-development (recommended) or
-> superpowers:executing-plans to implement this plan task-by-task. Steps
-> use checkbox (`- [ ]`) syntax for tracking.
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Group `daft go` completions as worktrees → local → remote, fix the
-zsh flag-leak bug, color each group distinctly, and add a fetch-on-miss
-spinner path for remote-only branches.
+**Goal:** Group `daft go` completions as worktrees → local → remote, fix the zsh
+flag-leak bug, color each group distinctly, and add a fetch-on-miss spinner path
+for remote-only branches.
 
 **Architecture:** A new pure function `build_go_completions()` in
-`src/commands/complete.rs` takes already-collected git ref data and
-produces a `Vec<CompletionEntry>`. A thin wrapper `complete_daft_go()`
-collects real data from git, calls the pure function, and optionally runs
-a `git fetch` with a `/dev/tty` spinner when the prefix yields no local
-matches. Shell generators in `completions/{zsh,bash,fish}.rs` emit bespoke
-code paths for `daft-go` that parse tab-separated output (name, group,
-description) and render per-group via `_describe -t <tag>` in zsh,
-ordered flat lists in bash, and awk-reshuffled descriptions in fish.
+`src/commands/complete.rs` takes already-collected git ref data and produces a
+`Vec<CompletionEntry>`. A thin wrapper `complete_daft_go()` collects real data
+from git, calls the pure function, and optionally runs a `git fetch` with a
+`/dev/tty` spinner when the prefix yields no local matches. Shell generators in
+`completions/{zsh,bash,fish}.rs` emit bespoke code paths for `daft-go` that
+parse tab-separated output (name, group, description) and render per-group via
+`_describe -t <tag>` in zsh, ordered flat lists in bash, and awk-reshuffled
+descriptions in fish.
 
 **Tech Stack:** Rust, clap, lefthook, mise, YAML integration scenarios
 (`tests/manual/scenarios/`).
@@ -32,32 +32,31 @@ ordered flat lists in bash, and awk-reshuffled descriptions in fish.
   `CompletionGroup`, `build_go_completions()`, `complete_daft_go()`,
   `--fetch-on-miss` flag, fetch cooldown, spinner integration. Route
   `("daft-go", 1)` to `complete_daft_go()`.
-- **Create** `src/completion_spinner.rs` — `/dev/tty` braille-dot spinner
-  with a background thread and cancellation signal.
+- **Create** `src/completion_spinner.rs` — `/dev/tty` braille-dot spinner with a
+  background thread and cancellation signal.
 - **Modify** `src/lib.rs` — declare `pub mod completion_spinner;`.
 - **Modify** `src/core/settings.rs` — add `go_fetch_on_miss: bool` to
-  `DaftSettings`, `GO_FETCH_ON_MISS` const in `defaults` and `keys`,
-  wire into `load()` / `load_global()`.
-- **Modify** `src/commands/completions/zsh.rs` — bespoke
-  `daft-go` generator path with `_describe -t <tag>` per group, flag
-  gating on `-`, and tab-separated stdout parsing. Add zstyle coloring
-  block to `DAFT_ZSH_COMPLETIONS`.
-- **Modify** `src/commands/completions/bash.rs` — bespoke
-  `daft-go` generator path that concatenates `wt + local + remote` in
-  order and best-effort `compopt -o nosort`.
-- **Modify** `src/commands/completions/fish.rs` — update the
-  `daft-go` completion line to pass `--fetch-on-miss` and awk-reshuffle
-  tab-separated output into fish's `name\tdescription` format.
-- **Modify** `src/commands/completions/mod.rs` — add test module wiring
-  if needed (most tests go inside existing generator files).
-- **Create** `tests/manual/scenarios/completions/go-grouped.yml` —
-  end-to-end scenario that sets up a repo with worktrees, local
-  branches, and remote-only branches, and asserts exact tab-separated
-  output from `daft __complete daft-go`.
+  `DaftSettings`, `GO_FETCH_ON_MISS` const in `defaults` and `keys`, wire into
+  `load()` / `load_global()`.
+- **Modify** `src/commands/completions/zsh.rs` — bespoke `daft-go` generator
+  path with `_describe -t <tag>` per group, flag gating on `-`, and
+  tab-separated stdout parsing. Add zstyle coloring block to
+  `DAFT_ZSH_COMPLETIONS`.
+- **Modify** `src/commands/completions/bash.rs` — bespoke `daft-go` generator
+  path that concatenates `wt + local + remote` in order and best-effort
+  `compopt -o nosort`.
+- **Modify** `src/commands/completions/fish.rs` — update the `daft-go`
+  completion line to pass `--fetch-on-miss` and awk-reshuffle tab-separated
+  output into fish's `name\tdescription` format.
+- **Modify** `src/commands/completions/mod.rs` — add test module wiring if
+  needed (most tests go inside existing generator files).
+- **Create** `tests/manual/scenarios/completions/go-grouped.yml` — end-to-end
+  scenario that sets up a repo with worktrees, local branches, and remote-only
+  branches, and asserts exact tab-separated output from
+  `daft __complete daft-go`.
 - **Modify** `docs/cli/daft-go.md` — add "Completion behavior" section.
-- **Create** `test-plans/go-completions.md` — manual checklist for the
-  spinner / color / group-ordering path that's hard to assert in
-  automated tests.
+- **Create** `test-plans/go-completions.md` — manual checklist for the spinner /
+  color / group-ordering path that's hard to assert in automated tests.
 - **Regenerate** `man/daft-go.1` via `mise run man:gen`.
 
 ---
@@ -65,25 +64,25 @@ ordered flat lists in bash, and awk-reshuffled descriptions in fish.
 ## Ordering notes
 
 Task 1 is a standalone regression fix for the zsh flag-leak bug. It ships
-independently — if the rest of the plan is delayed, Task 1 has already
-fixed the most user-visible annoyance. Tasks 2–9 build the new data
-layer; Tasks 10–13 swap the shell rendering. Task 14 wires colors. Tasks
-15–16 are docs and manual test plan.
+independently — if the rest of the plan is delayed, Task 1 has already fixed the
+most user-visible annoyance. Tasks 2–9 build the new data layer; Tasks 10–13
+swap the shell rendering. Task 14 wires colors. Tasks 15–16 are docs and manual
+test plan.
 
 ---
 
 ### Task 1: Regression test + fix for zsh flag-gating in `daft-go`
 
-**Why first:** CLAUDE.md requires every bugfix to ship with a regression
-test. This is a self-contained fix that's valuable even if the rest of
-the plan is never merged.
+**Why first:** CLAUDE.md requires every bugfix to ship with a regression test.
+This is a self-contained fix that's valuable even if the rest of the plan is
+never merged.
 
 **Files:**
 
-- Modify: `src/commands/completions/zsh.rs` (the branch-completion block
-  for commands in the `has_branches` set)
-- Modify: `src/commands/completions/mod.rs` — add `#[cfg(test)] mod tests`
-  block if one doesn't exist yet
+- Modify: `src/commands/completions/zsh.rs` (the branch-completion block for
+  commands in the `has_branches` set)
+- Modify: `src/commands/completions/mod.rs` — add `#[cfg(test)] mod tests` block
+  if one doesn't exist yet
 
 - [ ] **Step 1: Write the failing unit test**
 
@@ -123,14 +122,15 @@ mod tests {
 cargo test -p daft --lib commands::completions::tests::zsh_daft_go_gates_flags_on_leading_dash
 ```
 
-Expected: FAIL with `generated script must gate flag completion on a
-leading dash before adding flags`. Current generator does not emit that
-guard — it adds flags unconditionally via `compadd -a flags`.
+Expected: FAIL with
+`generated script must gate flag completion on a leading dash before adding flags`.
+Current generator does not emit that guard — it adds flags unconditionally via
+`compadd -a flags`.
 
 - [ ] **Step 3: Fix the zsh generator**
 
-In `src/commands/completions/zsh.rs`, locate the block that reads
-(approximately lines 171–186):
+In `src/commands/completions/zsh.rs`, locate the block that reads (approximately
+lines 171–186):
 
 ```rust
 output.push_str("    # Flag completions (extracted from clap)\n");
@@ -150,8 +150,8 @@ output.push_str("    compadd -a flags\n");
 output.push_str("}\n");
 ```
 
-Wrap the `compadd -a flags` call in a guard so it only runs when the user
-has typed a leading dash:
+Wrap the `compadd -a flags` call in a guard so it only runs when the user has
+typed a leading dash:
 
 ```rust
 output.push_str("    # Flag completions (extracted from clap)\n");
@@ -173,11 +173,10 @@ output.push_str("    fi\n");
 output.push_str("}\n");
 ```
 
-Note: the branch-completion block earlier in the function already has
-its own `if [[ $curword != -* ]]; then ... fi` guard and continues to
-work as-is. Moving the flag block into an `if` guard means the function
-only emits flags when the user typed a `-`, and only emits branches when
-they didn't — never both.
+Note: the branch-completion block earlier in the function already has its own
+`if [[ $curword != -* ]]; then ... fi` guard and continues to work as-is. Moving
+the flag block into an `if` guard means the function only emits flags when the
+user typed a `-`, and only emits branches when they didn't — never both.
 
 - [ ] **Step 4: Run the test and verify it passes**
 
@@ -195,9 +194,9 @@ mise run test:manual -- --ci completions
 ```
 
 Expected: all tests pass. The manual scenarios in
-`tests/manual/scenarios/completions/` verify that generated scripts for
-every command are parseable by the target shell — they must still pass
-after the guard change.
+`tests/manual/scenarios/completions/` verify that generated scripts for every
+command are parseable by the target shell — they must still pass after the guard
+change.
 
 - [ ] **Step 6: Commit**
 
@@ -222,8 +221,8 @@ EOF
 
 ### Task 2: Add `go_fetch_on_miss` setting to `DaftSettings`
 
-**Why:** `complete_daft_go()` in Task 5 will need to read this setting.
-Adding it first means the data-layer tasks can reference it directly.
+**Why:** `complete_daft_go()` in Task 5 will need to read this setting. Adding
+it first means the data-layer tasks can reference it directly.
 
 **Files:**
 
@@ -231,9 +230,9 @@ Adding it first means the data-layer tasks can reference it directly.
 
 - [ ] **Step 1: Write the failing unit test**
 
-Add to the existing `#[cfg(test)] mod tests` block in
-`src/core/settings.rs` (the file already has a tests module — grep for
-`#[test]` near the end of the file to find it):
+Add to the existing `#[cfg(test)] mod tests` block in `src/core/settings.rs`
+(the file already has a tests module — grep for `#[test]` near the end of the
+file to find it):
 
 ```rust
 #[test]
@@ -317,9 +316,8 @@ Expected: PASS.
 cargo test -p daft --lib core::settings
 ```
 
-Expected: all existing tests still pass (the new field has a default
-value, so existing tests that construct `DaftSettings::default()` are
-unaffected).
+Expected: all existing tests still pass (the new field has a default value, so
+existing tests that construct `DaftSettings::default()` are unaffected).
 
 - [ ] **Step 6: Commit**
 
@@ -543,8 +541,8 @@ Expected: all FAIL with `cannot find function build_go_completions` /
 
 - [ ] **Step 3: Define types and implement the pure function**
 
-Add to `src/commands/complete.rs` (below the existing `complete` function
-and its helpers, above the existing `#[cfg(test)] mod tests` block):
+Add to `src/commands/complete.rs` (below the existing `complete` function and
+its helpers, above the existing `#[cfg(test)] mod tests` block):
 
 ```rust
 /// Which group a completion entry belongs to, used for visual separation
@@ -870,11 +868,11 @@ pub(crate) fn complete_daft_go(
 }
 ```
 
-- [ ] **Step 2: Route `("daft-go", 1)` to `complete_daft_go()` and emit
-      the tab-separated format**
+- [ ] **Step 2: Route `("daft-go", 1)` to `complete_daft_go()` and emit the
+      tab-separated format**
 
-In the existing `complete()` dispatcher in `src/commands/complete.rs`,
-replace the `daft-go` arm:
+In the existing `complete()` dispatcher in `src/commands/complete.rs`, replace
+the `daft-go` arm:
 
 ```rust
 // daft-go: complete existing branch names
@@ -898,15 +896,15 @@ with:
 }
 ```
 
-Note: we deliberately don't call `format_go_completions()` here because
-the dispatcher returns `Vec<String>` (one entry per line) while
+Note: we deliberately don't call `format_go_completions()` here because the
+dispatcher returns `Vec<String>` (one entry per line) while
 `format_go_completions()` returns a single pre-joined `String`.
-`format_go_completions()` stays in the module for direct use by unit
-tests and for any future caller that wants the full stdout blob.
+`format_go_completions()` stays in the module for direct use by unit tests and
+for any future caller that wants the full stdout blob.
 
-The outer `run()` function already prints each suggestion on its own
-line, so the existing `for suggestion in suggestions { println!(...); }`
-loop handles the tab-separated strings correctly.
+The outer `run()` function already prints each suggestion on its own line, so
+the existing `for suggestion in suggestions { println!(...); }` loop handles the
+tab-separated strings correctly.
 
 - [ ] **Step 3: Build and run the existing unit tests**
 
@@ -915,9 +913,9 @@ cargo build -p daft
 cargo test -p daft --lib commands::complete
 ```
 
-Expected: compiles cleanly, all existing tests pass. The new git
-collection helpers aren't unit-tested here — they're covered by the YAML
-scenario in Task 6.
+Expected: compiles cleanly, all existing tests pass. The new git collection
+helpers aren't unit-tested here — they're covered by the YAML scenario in
+Task 6.
 
 - [ ] **Step 4: Manual smoke test in the daft repo itself**
 
@@ -929,9 +927,9 @@ cargo build
 ./target/debug/daft __complete daft-go "" --position 1
 ```
 
-Expected output: tab-separated lines with your current worktrees, local
-branches (minus any with worktrees), and remote-only branches. The
-current worktree's branch should be absent from the worktree group.
+Expected output: tab-separated lines with your current worktrees, local branches
+(minus any with worktrees), and remote-only branches. The current worktree's
+branch should be absent from the worktree group.
 
 - [ ] **Step 5: Commit**
 
@@ -966,8 +964,8 @@ EOF
 cat tests/manual/scenarios/completions/dynamic-branch.yml
 ```
 
-Note the `steps`, `run`, `cwd`, `expect.exit_code`, and
-`expect.output_contains` / `expect.output_matches` fields.
+Note the `steps`, `run`, `cwd`, `expect.exit_code`, and `expect.output_contains`
+/ `expect.output_matches` fields.
 
 - [ ] **Step 2: Write the failing scenario**
 
@@ -1048,11 +1046,10 @@ steps:
 grep -rn "output_not_contains" tests/manual/ | head -5
 ```
 
-Expected: at least a few hits showing the field is supported by the
-runner. If not supported, the test must use `output_matches` with a
-negated regex instead — adjust the step to use only
-`output_contains` and leave `output_not_contains` out of this task; the
-positive assertions cover the grouping behavior.
+Expected: at least a few hits showing the field is supported by the runner. If
+not supported, the test must use `output_matches` with a negated regex instead —
+adjust the step to use only `output_contains` and leave `output_not_contains`
+out of this task; the positive assertions cover the grouping behavior.
 
 - [ ] **Step 4: Run the scenario**
 
@@ -1060,8 +1057,8 @@ positive assertions cover the grouping behavior.
 mise run test:manual -- --ci completions go-grouped
 ```
 
-Expected: the scenario sets up the repo and asserts the grouped
-output. Should PASS.
+Expected: the scenario sets up the repo and asserts the grouped output. Should
+PASS.
 
 - [ ] **Step 5: Commit**
 
@@ -1436,9 +1433,8 @@ In the `Args` struct in `src/commands/complete.rs`, add:
 fetch_on_miss: bool,
 ```
 
-In the `run()` function, update the call to `complete()` to pass the
-new flag through. Extend the `complete()` function signature to accept
-it:
+In the `run()` function, update the call to `complete()` to pass the new flag
+through. Extend the `complete()` function signature to accept it:
 
 ```rust
 fn complete(
@@ -1462,11 +1458,11 @@ And update the `("daft-go", 1)` arm from Task 4:
 }
 ```
 
-The parameter is named `fetch_on_miss` (no underscore prefix) in the
-signature because it IS used by the `("daft-go", 1)` arm. Other arms
-simply don't reference it — that's fine, Rust only warns on unused
-parameters if no branch reads them, and the daft-go arm counts as a
-read. No warning, no underscore needed.
+The parameter is named `fetch_on_miss` (no underscore prefix) in the signature
+because it IS used by the `("daft-go", 1)` arm. Other arms simply don't
+reference it — that's fine, Rust only warns on unused parameters if no branch
+reads them, and the daft-go arm counts as a read. No warning, no underscore
+needed.
 
 - [ ] **Step 2: Implement the fetch-on-miss path in `complete_daft_go()`**
 
@@ -1563,11 +1559,10 @@ cargo test -p daft --lib commands::complete
 cargo test -p daft --lib completion_spinner
 ```
 
-Expected: all existing tests still PASS. No new unit tests in this
-task — the fetch-on-miss behavior is a composition of already-tested
-primitives (`should_run_fetch`, `touch_fetch_marker`, the spinner, and
-`complete_daft_go`). The manual test plan (Task 16) verifies the
-end-to-end user-visible behavior.
+Expected: all existing tests still PASS. No new unit tests in this task — the
+fetch-on-miss behavior is a composition of already-tested primitives
+(`should_run_fetch`, `touch_fetch_marker`, the spinner, and `complete_daft_go`).
+The manual test plan (Task 16) verifies the end-to-end user-visible behavior.
 
 - [ ] **Step 5: Manual smoke test**
 
@@ -1578,9 +1573,8 @@ cargo build
 ```
 
 Expected: the spinner line appears on the terminal for the duration of
-`git fetch`, then disappears. Output is empty if the fetch did not
-produce any matching refs. Running again within 30s should NOT show the
-spinner (cooldown).
+`git fetch`, then disappears. Output is empty if the fetch did not produce any
+matching refs. Running again within 30s should NOT show the spinner (cooldown).
 
 - [ ] **Step 6: Commit**
 
@@ -1648,15 +1642,14 @@ cargo test -p daft --lib commands::completions::tests::zsh_daft_go
 ```
 
 Expected: the two new tests FAIL; the existing
-`zsh_daft_go_gates_flags_on_leading_dash` test still PASSES (it just
-checks for the guard).
+`zsh_daft_go_gates_flags_on_leading_dash` test still PASSES (it just checks for
+the guard).
 
 - [ ] **Step 3: Add a bespoke `daft-go` code path in the zsh generator**
 
-In `src/commands/completions/zsh.rs`, inside
-`generate_zsh_completion_string()`, special-case `daft-go` before the
-generic branch-completion code. The cleanest shape is to early-return a
-hand-written function body for `daft-go`:
+In `src/commands/completions/zsh.rs`, inside `generate_zsh_completion_string()`,
+special-case `daft-go` before the generic branch-completion code. The cleanest
+shape is to early-return a hand-written function body for `daft-go`:
 
 ```rust
 pub(super) fn generate_zsh_completion_string(command_name: &str) -> Result<String> {
@@ -1728,9 +1721,9 @@ compdef _daft_go daft-go
 }
 ```
 
-Note: the `compdef` at the bottom is for direct invocation of
-`daft-go`. Shortcut aliases are handled by the existing umbrella
-wiring in `DAFT_ZSH_COMPLETIONS`, which is updated in Task 13.
+Note: the `compdef` at the bottom is for direct invocation of `daft-go`.
+Shortcut aliases are handled by the existing umbrella wiring in
+`DAFT_ZSH_COMPLETIONS`, which is updated in Task 13.
 
 - [ ] **Step 4: Run the new tests**
 
@@ -1739,8 +1732,8 @@ cargo test -p daft --lib commands::completions::tests::zsh_daft_go
 ```
 
 Expected: all three zsh_daft_go tests PASS, including the existing
-`zsh_daft_go_gates_flags_on_leading_dash` regression test (the guard
-remains present in the new hand-written body).
+`zsh_daft_go_gates_flags_on_leading_dash` regression test (the guard remains
+present in the new hand-written body).
 
 - [ ] **Step 5: Run the full completion scenario suite**
 
@@ -1748,8 +1741,8 @@ remains present in the new hand-written body).
 mise run test:manual -- --ci completions
 ```
 
-Expected: all scenarios pass. The `all-commands` scenario that
-generates zsh completions for every command must still succeed — verify
+Expected: all scenarios pass. The `all-commands` scenario that generates zsh
+completions for every command must still succeed — verify
 `daft completions zsh --command=daft-go` returns exit 0.
 
 - [ ] **Step 6: Commit**
@@ -1927,8 +1920,8 @@ fn fish_daft_go_passes_fetch_on_miss_and_awk_reshuffles() {
 }
 ```
 
-Also check `DAFT_FISH_COMPLETIONS` since the existing daft-go completion
-line lives in the umbrella string constant, not the per-command output:
+Also check `DAFT_FISH_COMPLETIONS` since the existing daft-go completion line
+lives in the umbrella string constant, not the per-command output:
 
 ```rust
 #[test]
@@ -1954,22 +1947,22 @@ Expected: both FAIL.
 
 - [ ] **Step 3: Update the fish generator**
 
-In `src/commands/completions/fish.rs`, find the per-command generator
-and special-case `daft-go` similarly to zsh/bash — return a bespoke
-function body that passes `--fetch-on-miss` and awk-reshuffles:
+In `src/commands/completions/fish.rs`, find the per-command generator and
+special-case `daft-go` similarly to zsh/bash — return a bespoke function body
+that passes `--fetch-on-miss` and awk-reshuffles:
 
-The per-command fish generator is relatively small. Replace the
-dynamic branch-completion line it would otherwise emit with (this is
-the final fish text — show this exact output when running
+The per-command fish generator is relatively small. Replace the dynamic
+branch-completion line it would otherwise emit with (this is the final fish text
+— show this exact output when running
 `daft completions fish --command=daft-go`):
 
 ```fish
 complete -c daft-go -f -a "(daft __complete daft-go (commandline -ct) --position 1 --fetch-on-miss 2>/dev/null | awk -F'\t' '{printf \"%s\t%s · %s\n\", $1, $3, $2}')"
 ```
 
-In Rust source, write this via `r#"..."#` raw strings (no special
-escaping) or via `"..."` with `\\t` and `\\n` for the literal
-backslash escape sequences that fish / awk see:
+In Rust source, write this via `r#"..."#` raw strings (no special escaping) or
+via `"..."` with `\\t` and `\\n` for the literal backslash escape sequences that
+fish / awk see:
 
 ```rust
 fn generate_fish_daft_go_line() -> &'static str {
@@ -1980,12 +1973,12 @@ fn generate_fish_daft_go_line() -> &'static str {
 }
 ```
 
-After implementing, verify with `./target/debug/daft completions fish
---command=daft-go` and confirm the output matches the expected fish
-text above character-for-character.
+After implementing, verify with
+`./target/debug/daft completions fish --command=daft-go` and confirm the output
+matches the expected fish text above character-for-character.
 
-Also update `DAFT_FISH_COMPLETIONS` in the same file — replace the
-existing line:
+Also update `DAFT_FISH_COMPLETIONS` in the same file — replace the existing
+line:
 
 ```fish
 complete -c daft -n '__fish_seen_subcommand_from go' -f -a "(daft __complete daft-go '' 2>/dev/null)"
@@ -2014,8 +2007,8 @@ cargo build
 ./target/debug/daft shell-init fish | grep -A1 "daft __complete daft-go"
 ```
 
-Inspect the emitted lines — the `awk` invocation should be correctly
-escaped for fish (single tab field separator, three-column reshuffle).
+Inspect the emitted lines — the `awk` invocation should be correctly escaped for
+fish (single tab field separator, three-column reshuffle).
 
 - [ ] **Step 6: Commit**
 
@@ -2073,11 +2066,12 @@ cargo test -p daft --lib commands::completions::tests::zsh_daft_go_emits_zstyle_
 
 Expected: FAIL.
 
-- [ ] **Step 3: Prepend the zstyle block to `generate_zsh_daft_go_completion()`**
+- [ ] **Step 3: Prepend the zstyle block to
+      `generate_zsh_daft_go_completion()`**
 
-Edit `generate_zsh_daft_go_completion()` in `src/commands/completions/zsh.rs`
-so the returned string begins with a zstyle block before the
-`#compdef` line. Replace the `format!` header:
+Edit `generate_zsh_daft_go_completion()` in `src/commands/completions/zsh.rs` so
+the returned string begins with a zstyle block before the `#compdef` line.
+Replace the `format!` header:
 
 ```rust
 format!(
@@ -2127,16 +2121,15 @@ EOF
 
 ### Task 13: Wire `go` verb alias to the grouped completion in `DAFT_ZSH_COMPLETIONS`
 
-**Why:** The zsh umbrella function in `DAFT_ZSH_COMPLETIONS` currently
-delegates `daft go` to `__daft_go_impl`. That's already the right path
-name — Task 9 kept the `__daft_go_impl` name intentionally. Verify
-there's no stale delegation to adjust, and add a test that pins the
-contract.
+**Why:** The zsh umbrella function in `DAFT_ZSH_COMPLETIONS` currently delegates
+`daft go` to `__daft_go_impl`. That's already the right path name — Task 9 kept
+the `__daft_go_impl` name intentionally. Verify there's no stale delegation to
+adjust, and add a test that pins the contract.
 
 **Files:**
 
-- Modify: `src/commands/completions/mod.rs` (test only, unless a real
-  bug is found)
+- Modify: `src/commands/completions/mod.rs` (test only, unless a real bug is
+  found)
 
 - [ ] **Step 1: Write a test that locks in the alias wiring**
 
@@ -2162,13 +2155,13 @@ fn zsh_umbrella_delegates_go_to_daft_go_impl() {
 cargo test -p daft --lib commands::completions::tests::zsh_umbrella_delegates_go_to_daft_go_impl
 ```
 
-If the test passes unchanged: the umbrella wiring already matches.
-Commit and move on.
+If the test passes unchanged: the umbrella wiring already matches. Commit and
+move on.
 
-If the test fails: inspect `DAFT_ZSH_COMPLETIONS` in `zsh.rs` and
-update the `go)` case inside the verb-alias `case` block to call
-`__daft_go_impl` (this is the pre-existing shape — the call site
-already exists, so expect the test to pass).
+If the test fails: inspect `DAFT_ZSH_COMPLETIONS` in `zsh.rs` and update the
+`go)` case inside the verb-alias `case` block to call `__daft_go_impl` (this is
+the pre-existing shape — the call site already exists, so expect the test to
+pass).
 
 - [ ] **Step 3: Commit**
 
@@ -2190,8 +2183,8 @@ EOF
 **Files:**
 
 - Modify: `docs/cli/daft-go.md`
-- Modify: `docs/guide/configuration.md` (if the config reference page
-  lists daft settings — verify first)
+- Modify: `docs/guide/configuration.md` (if the config reference page lists daft
+  settings — verify first)
 
 - [ ] **Step 1: Check the current state of `docs/cli/daft-go.md`**
 
@@ -2205,50 +2198,49 @@ Note the existing structure — frontmatter, synopsis, options table, etc.
 
 Append to `docs/cli/daft-go.md` (before any trailing "See also" block):
 
-```markdown
+````markdown
 ## Completion behavior
 
 `daft go <TAB>` offers candidates grouped by type:
 
-1. **Worktrees** — branches that already have a linked worktree. These
-   are the primary navigation targets and are listed first. The branch
-   you are currently sitting in is excluded.
-2. **Local branches** — branches in `refs/heads/` that don't have a
-   worktree yet. Selecting one of these will check it out into a new
-   worktree.
-3. **Remote branches** — branches in `refs/remotes/` that don't already
-   exist locally. In single-remote mode the `<remote>/` prefix is
-   stripped for readability; in multi-remote mode the full
-   `<remote>/<branch>` form is preserved.
+1. **Worktrees** — branches that already have a linked worktree. These are the
+   primary navigation targets and are listed first. The branch you are currently
+   sitting in is excluded.
+2. **Local branches** — branches in `refs/heads/` that don't have a worktree
+   yet. Selecting one of these will check it out into a new worktree.
+3. **Remote branches** — branches in `refs/remotes/` that don't already exist
+   locally. In single-remote mode the `<remote>/` prefix is stripped for
+   readability; in multi-remote mode the full `<remote>/<branch>` form is
+   preserved.
 
-In zsh and fish, each candidate is annotated with the relative time of
-its last commit (e.g. "3 days ago"). In zsh the three groups are
-colored distinctly — worktrees in bright green, local branches in
-bright blue, remote branches in dim gray. Bash shows a flat list in
-the same group order but without colors or descriptions.
+In zsh and fish, each candidate is annotated with the relative time of its last
+commit (e.g. "3 days ago"). In zsh the three groups are colored distinctly —
+worktrees in bright green, local branches in bright blue, remote branches in dim
+gray. Bash shows a flat list in the same group order but without colors or
+descriptions.
 
 ### Fetch-on-miss
 
-If you type a prefix that doesn't match any local or already-fetched
-remote ref, daft will run `git fetch` once (from the configured
-default remote) and re-resolve, showing a spinner while the fetch
-runs. This lets you tab-complete to a remote branch that exists
-upstream but hasn't been pulled yet.
+If you type a prefix that doesn't match any local or already-fetched remote ref,
+daft will run `git fetch` once (from the configured default remote) and
+re-resolve, showing a spinner while the fetch runs. This lets you tab-complete
+to a remote branch that exists upstream but hasn't been pulled yet.
 
-The fetch path is gated by a 30-second cooldown per repository, so
-rapid keystrokes won't trigger repeated fetches. To disable the
-feature entirely:
+The fetch path is gated by a 30-second cooldown per repository, so rapid
+keystrokes won't trigger repeated fetches. To disable the feature entirely:
 
 ```sh
 git config daft.go.fetchOnMiss false
 ```
-```
+````
+
+````
 
 - [ ] **Step 3: Regenerate the man page**
 
 ```bash
 mise run man:gen
-```
+````
 
 Expected: `man/daft-go.1` is updated. Verify with:
 
@@ -2309,25 +2301,23 @@ branch: fix/go-completions
 ## Setup
 
 - [ ] Install the current build via `mise run dev`.
-- [ ] In a test repo with ≥ 3 worktrees, ≥ 2 local-only branches, and
-      ≥ 5 remote-only branches, open a new zsh shell and a new bash
-      shell.
+- [ ] In a test repo with ≥ 3 worktrees, ≥ 2 local-only branches, and ≥ 5
+      remote-only branches, open a new zsh shell and a new bash shell.
 
 ## Group ordering
 
-- [ ] `daft go <TAB>` in zsh lists worktrees first, then local
-      branches, then remote branches, in that order.
+- [ ] `daft go <TAB>` in zsh lists worktrees first, then local branches, then
+      remote branches, in that order.
 - [ ] Same in bash (flat list but preserving the order).
 - [ ] Same in fish.
-- [ ] The current worktree's branch does NOT appear in the worktree
-      group.
+- [ ] The current worktree's branch does NOT appear in the worktree group.
 
 ## Descriptions and colors
 
 - [ ] zsh: each entry shows a relative age ("3 days ago", etc.) in the
       description column.
-- [ ] zsh: worktree entries are bright green, local are bright blue,
-      remote are dim gray.
+- [ ] zsh: worktree entries are bright green, local are bright blue, remote are
+      dim gray.
 - [ ] fish: each entry shows `<age> · <group>` in the description.
 - [ ] bash: no descriptions, but no flags leaked into the branch list.
 
@@ -2339,19 +2329,19 @@ branch: fix/go-completions
 
 ## Fetch-on-miss + spinner
 
-- [ ] Find a remote-only branch that's NOT in your local `refs/remotes/`
-      (ask someone to push a branch, or delete your local remote ref
-      with `git update-ref -d refs/remotes/origin/<branch>`).
-- [ ] Type `daft go <prefix-of-that-branch><TAB>`. Expected: a
-      braille-dot spinner with "Fetching refs from origin…" appears
-      on the terminal for the duration of the fetch, then clears.
-- [ ] After the fetch completes, the completion list now includes
-      the remote branch.
-- [ ] Immediately type the same completion again. Expected: no
-      spinner this time (cooldown).
+- [ ] Find a remote-only branch that's NOT in your local `refs/remotes/` (ask
+      someone to push a branch, or delete your local remote ref with
+      `git update-ref -d refs/remotes/origin/<branch>`).
+- [ ] Type `daft go <prefix-of-that-branch><TAB>`. Expected: a braille-dot
+      spinner with "Fetching refs from origin…" appears on the terminal for the
+      duration of the fetch, then clears.
+- [ ] After the fetch completes, the completion list now includes the remote
+      branch.
+- [ ] Immediately type the same completion again. Expected: no spinner this time
+      (cooldown).
 - [ ] Wait 30+ seconds and retry. Expected: spinner reappears.
-- [ ] `git config daft.go.fetchOnMiss false` — expected: spinner never
-      appears, regardless of cooldown.
+- [ ] `git config daft.go.fetchOnMiss false` — expected: spinner never appears,
+      regardless of cooldown.
 - [ ] Reset with `git config --unset daft.go.fetchOnMiss`.
 
 ## Multi-remote mode
@@ -2363,11 +2353,11 @@ branch: fix/go-completions
 
 ## Non-interactive invocation
 
-- [ ] `daft __complete daft-go "" --position 1 | head` inside a
-      repository emits tab-separated lines with three columns each.
-- [ ] The same command with `--fetch-on-miss` and a non-matching
-      prefix does NOT draw a spinner (no /dev/tty when stdout is
-      piped) and still emits any matching output.
+- [ ] `daft __complete daft-go "" --position 1 | head` inside a repository emits
+      tab-separated lines with three columns each.
+- [ ] The same command with `--fetch-on-miss` and a non-matching prefix does NOT
+      draw a spinner (no /dev/tty when stdout is piped) and still emits any
+      matching output.
 ```
 
 - [ ] **Step 3: Commit**
@@ -2397,12 +2387,12 @@ EOF
 mise run ci
 ```
 
-Expected: clippy, fmt check, unit tests, integration tests, man-page
-verify all pass. The CLAUDE.md pre-commit requirements (`mise run fmt`,
-`mise run clippy`, `mise run test:unit`) are a subset of `mise run ci`.
+Expected: clippy, fmt check, unit tests, integration tests, man-page verify all
+pass. The CLAUDE.md pre-commit requirements (`mise run fmt`, `mise run clippy`,
+`mise run test:unit`) are a subset of `mise run ci`.
 
-If anything fails, fix the root cause in a new commit — do not skip
-lefthook or amend earlier commits in the chain.
+If anything fails, fix the root cause in a new commit — do not skip lefthook or
+amend earlier commits in the chain.
 
 - [ ] **Step 2: Run the full manual test plan**
 
@@ -2413,9 +2403,8 @@ Open the manual test plan from Task 15:
 cat test-plans/go-completions.md
 ```
 
-Walk through each checkbox. If any manual check fails, fix the root
-cause and add a new commit. Update the plan if the expected behavior
-changed.
+Walk through each checkbox. If any manual check fails, fix the root cause and
+add a new commit. Update the plan if the expected behavior changed.
 
 - [ ] **Step 3: Push the branch (no auto-PR)**
 
@@ -2423,7 +2412,7 @@ changed.
 git push -u origin fix/go-completions
 ```
 
-Per CLAUDE.md: PRs target master and are always squash-merged. The
-user will open the PR manually via `gh pr create` or the GitHub UI,
-with title `feat(completions): overhaul daft go completion grouping`
-and the spec + plan referenced in the body.
+Per CLAUDE.md: PRs target master and are always squash-merged. The user will
+open the PR manually via `gh pr create` or the GitHub UI, with title
+`feat(completions): overhaul daft go completion grouping` and the spec + plan
+referenced in the body.

--- a/docs/superpowers/plans/2026-04-11-go-command-completions.md
+++ b/docs/superpowers/plans/2026-04-11-go-command-completions.md
@@ -1,0 +1,2429 @@
+# `daft go` Completion Overhaul — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps
+> use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Group `daft go` completions as worktrees → local → remote, fix the
+zsh flag-leak bug, color each group distinctly, and add a fetch-on-miss
+spinner path for remote-only branches.
+
+**Architecture:** A new pure function `build_go_completions()` in
+`src/commands/complete.rs` takes already-collected git ref data and
+produces a `Vec<CompletionEntry>`. A thin wrapper `complete_daft_go()`
+collects real data from git, calls the pure function, and optionally runs
+a `git fetch` with a `/dev/tty` spinner when the prefix yields no local
+matches. Shell generators in `completions/{zsh,bash,fish}.rs` emit bespoke
+code paths for `daft-go` that parse tab-separated output (name, group,
+description) and render per-group via `_describe -t <tag>` in zsh,
+ordered flat lists in bash, and awk-reshuffled descriptions in fish.
+
+**Tech Stack:** Rust, clap, lefthook, mise, YAML integration scenarios
+(`tests/manual/scenarios/`).
+
+**Spec:** `docs/superpowers/specs/2026-04-11-go-command-completions-design.md`
+
+---
+
+## File map
+
+- **Modify** `src/commands/complete.rs` — add `CompletionEntry`,
+  `CompletionGroup`, `build_go_completions()`, `complete_daft_go()`,
+  `--fetch-on-miss` flag, fetch cooldown, spinner integration. Route
+  `("daft-go", 1)` to `complete_daft_go()`.
+- **Create** `src/completion_spinner.rs` — `/dev/tty` braille-dot spinner
+  with a background thread and cancellation signal.
+- **Modify** `src/lib.rs` — declare `pub mod completion_spinner;`.
+- **Modify** `src/core/settings.rs` — add `go_fetch_on_miss: bool` to
+  `DaftSettings`, `GO_FETCH_ON_MISS` const in `defaults` and `keys`,
+  wire into `load()` / `load_global()`.
+- **Modify** `src/commands/completions/zsh.rs` — bespoke
+  `daft-go` generator path with `_describe -t <tag>` per group, flag
+  gating on `-`, and tab-separated stdout parsing. Add zstyle coloring
+  block to `DAFT_ZSH_COMPLETIONS`.
+- **Modify** `src/commands/completions/bash.rs` — bespoke
+  `daft-go` generator path that concatenates `wt + local + remote` in
+  order and best-effort `compopt -o nosort`.
+- **Modify** `src/commands/completions/fish.rs` — update the
+  `daft-go` completion line to pass `--fetch-on-miss` and awk-reshuffle
+  tab-separated output into fish's `name\tdescription` format.
+- **Modify** `src/commands/completions/mod.rs` — add test module wiring
+  if needed (most tests go inside existing generator files).
+- **Create** `tests/manual/scenarios/completions/go-grouped.yml` —
+  end-to-end scenario that sets up a repo with worktrees, local
+  branches, and remote-only branches, and asserts exact tab-separated
+  output from `daft __complete daft-go`.
+- **Modify** `docs/cli/daft-go.md` — add "Completion behavior" section.
+- **Create** `test-plans/go-completions.md` — manual checklist for the
+  spinner / color / group-ordering path that's hard to assert in
+  automated tests.
+- **Regenerate** `man/daft-go.1` via `mise run man:gen`.
+
+---
+
+## Ordering notes
+
+Task 1 is a standalone regression fix for the zsh flag-leak bug. It ships
+independently — if the rest of the plan is delayed, Task 1 has already
+fixed the most user-visible annoyance. Tasks 2–9 build the new data
+layer; Tasks 10–13 swap the shell rendering. Task 14 wires colors. Tasks
+15–16 are docs and manual test plan.
+
+---
+
+### Task 1: Regression test + fix for zsh flag-gating in `daft-go`
+
+**Why first:** CLAUDE.md requires every bugfix to ship with a regression
+test. This is a self-contained fix that's valuable even if the rest of
+the plan is never merged.
+
+**Files:**
+
+- Modify: `src/commands/completions/zsh.rs` (the branch-completion block
+  for commands in the `has_branches` set)
+- Modify: `src/commands/completions/mod.rs` — add `#[cfg(test)] mod tests`
+  block if one doesn't exist yet
+
+- [ ] **Step 1: Write the failing unit test**
+
+Add at the bottom of `src/commands/completions/mod.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zsh_daft_go_gates_flags_on_leading_dash() {
+        let script = zsh::generate_zsh_completion_string("daft-go")
+            .expect("generator must succeed");
+        let flags_pos = script
+            .find("compadd -a flags")
+            .expect("generated script must contain `compadd -a flags`");
+        let guard_pos = script
+            .find("[[ \"$curword\" == -* ]]")
+            .expect(
+                "generated script must gate flag completion on a leading \
+                 dash before adding flags (zsh flag-leak regression)",
+            );
+        assert!(
+            guard_pos < flags_pos,
+            "flag-gating guard must appear before `compadd -a flags`, \
+             otherwise flags leak into branch completions. \
+             guard_pos={guard_pos} flags_pos={flags_pos}",
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+```bash
+cargo test -p daft --lib commands::completions::tests::zsh_daft_go_gates_flags_on_leading_dash
+```
+
+Expected: FAIL with `generated script must gate flag completion on a
+leading dash before adding flags`. Current generator does not emit that
+guard — it adds flags unconditionally via `compadd -a flags`.
+
+- [ ] **Step 3: Fix the zsh generator**
+
+In `src/commands/completions/zsh.rs`, locate the block that reads
+(approximately lines 171–186):
+
+```rust
+output.push_str("    # Flag completions (extracted from clap)\n");
+output.push_str("    local -a flags\n");
+output.push_str("    flags=(\n");
+
+let cmd = get_command_for_name(command_name)
+    .context(format!("Unknown command: {}", command_name))?;
+let (all_flags, _, _) = extract_flags(&cmd);
+
+for flag in all_flags {
+    output.push_str(&format!("        '{}'\n", flag));
+}
+
+output.push_str("    )\n");
+output.push_str("    compadd -a flags\n");
+output.push_str("}\n");
+```
+
+Wrap the `compadd -a flags` call in a guard so it only runs when the user
+has typed a leading dash:
+
+```rust
+output.push_str("    # Flag completions (extracted from clap)\n");
+output.push_str("    if [[ \"$curword\" == -* ]]; then\n");
+output.push_str("        local -a flags\n");
+output.push_str("        flags=(\n");
+
+let cmd = get_command_for_name(command_name)
+    .context(format!("Unknown command: {}", command_name))?;
+let (all_flags, _, _) = extract_flags(&cmd);
+
+for flag in all_flags {
+    output.push_str(&format!("            '{}'\n", flag));
+}
+
+output.push_str("        )\n");
+output.push_str("        compadd -a flags\n");
+output.push_str("    fi\n");
+output.push_str("}\n");
+```
+
+Note: the branch-completion block earlier in the function already has
+its own `if [[ $curword != -* ]]; then ... fi` guard and continues to
+work as-is. Moving the flag block into an `if` guard means the function
+only emits flags when the user typed a `-`, and only emits branches when
+they didn't — never both.
+
+- [ ] **Step 4: Run the test and verify it passes**
+
+```bash
+cargo test -p daft --lib commands::completions::tests::zsh_daft_go_gates_flags_on_leading_dash
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the full completion test suite to catch regressions**
+
+```bash
+cargo test -p daft --lib commands::completions
+mise run test:manual -- --ci completions
+```
+
+Expected: all tests pass. The manual scenarios in
+`tests/manual/scenarios/completions/` verify that generated scripts for
+every command are parseable by the target shell — they must still pass
+after the guard change.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/commands/completions/zsh.rs src/commands/completions/mod.rs
+git commit -m "$(cat <<'EOF'
+fix(completions): gate zsh flag completions on leading dash
+
+Flags were being added unconditionally via `compadd -a flags`, so they
+leaked into branch completions for `daft go`, `daft start`, and other
+commands with dynamic branch completion. Wrap the flag block in an
+`if [[ $curword == -* ]]` guard so flags only appear when the user has
+typed a dash.
+
+Includes a regression test that asserts the guard is present and
+appears before the `compadd -a flags` call in the generated script.
+EOF
+)"
+```
+
+---
+
+### Task 2: Add `go_fetch_on_miss` setting to `DaftSettings`
+
+**Why:** `complete_daft_go()` in Task 5 will need to read this setting.
+Adding it first means the data-layer tasks can reference it directly.
+
+**Files:**
+
+- Modify: `src/core/settings.rs`
+
+- [ ] **Step 1: Write the failing unit test**
+
+Add to the existing `#[cfg(test)] mod tests` block in
+`src/core/settings.rs` (the file already has a tests module — grep for
+`#[test]` near the end of the file to find it):
+
+```rust
+#[test]
+fn default_settings_have_go_fetch_on_miss_true() {
+    let settings = DaftSettings::default();
+    assert!(
+        settings.go_fetch_on_miss,
+        "go.fetchOnMiss must default to true — the fetch-on-miss spinner \
+         path is opt-out, not opt-in"
+    );
+}
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+```bash
+cargo test -p daft --lib core::settings::tests::default_settings_have_go_fetch_on_miss_true
+```
+
+Expected: FAIL with `no field 'go_fetch_on_miss' on type 'DaftSettings'`.
+
+- [ ] **Step 3: Add the constant, key, struct field, default, and loaders**
+
+In `src/core/settings.rs`, near the existing `GO_AUTO_START` entries:
+
+- In `mod defaults`, add:
+
+```rust
+/// Default value for go.fetchOnMiss setting.
+pub const GO_FETCH_ON_MISS: bool = true;
+```
+
+- In `mod keys`, add (placed near `GO_AUTO_START`):
+
+```rust
+/// Config key for go.fetchOnMiss setting.
+pub const GO_FETCH_ON_MISS: &str = "daft.go.fetchOnMiss";
+```
+
+- In `pub struct DaftSettings`, add (placed near `go_auto_start`):
+
+```rust
+/// Whether `daft go` completion should run `git fetch` when the typed
+/// prefix has no local matches. Controlled by `daft.go.fetchOnMiss`.
+pub go_fetch_on_miss: bool,
+```
+
+- In `impl Default for DaftSettings`, add (near `go_auto_start`):
+
+```rust
+go_fetch_on_miss: defaults::GO_FETCH_ON_MISS,
+```
+
+- In `load()` (near the `GO_AUTO_START` block), add:
+
+```rust
+if let Some(value) = git.config_get(keys::GO_FETCH_ON_MISS)? {
+    settings.go_fetch_on_miss = parse_bool(&value, defaults::GO_FETCH_ON_MISS);
+}
+```
+
+- In `load_global()` (near the `GO_AUTO_START` block), add:
+
+```rust
+if let Some(value) = git.config_get_global(keys::GO_FETCH_ON_MISS)? {
+    settings.go_fetch_on_miss = parse_bool(&value, defaults::GO_FETCH_ON_MISS);
+}
+```
+
+- [ ] **Step 4: Run the test and verify it passes**
+
+```bash
+cargo test -p daft --lib core::settings::tests::default_settings_have_go_fetch_on_miss_true
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the full settings test module**
+
+```bash
+cargo test -p daft --lib core::settings
+```
+
+Expected: all existing tests still pass (the new field has a default
+value, so existing tests that construct `DaftSettings::default()` are
+unaffected).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/core/settings.rs
+git commit -m "$(cat <<'EOF'
+feat(settings): add go.fetchOnMiss to DaftSettings
+
+Add `go_fetch_on_miss: bool` field (default true) and wire it through
+the local and global config loaders. This setting controls whether
+`daft go` completion runs `git fetch` with a spinner when the user
+types a prefix that matches nothing locally.
+EOF
+)"
+```
+
+---
+
+### Task 3: Define types and the pure grouping function
+
+**Files:**
+
+- Modify: `src/commands/complete.rs`
+
+- [ ] **Step 1: Write failing unit tests for grouping behavior**
+
+Add to the existing `#[cfg(test)] mod tests` block at the bottom of
+`src/commands/complete.rs`:
+
+```rust
+// Tests for the new go-completion grouping function.
+
+fn wt(name: &str, path: &str) -> (String, std::path::PathBuf) {
+    (name.to_string(), std::path::PathBuf::from(path))
+}
+
+fn br(name: &str, age: &str) -> (String, String) {
+    (name.to_string(), age.to_string())
+}
+
+#[test]
+fn go_completions_group_order_is_worktrees_then_local_then_remote() {
+    let entries = build_go_completions(
+        &[wt("master", "/tmp/repo/master")],
+        &[br("feat/local", "4 days ago")],
+        &[br("origin/bug/xyz", "3 weeks ago")],
+        None,   // no current worktree
+        "origin",
+        false,  // single-remote mode
+        "",
+    );
+    let groups: Vec<CompletionGroup> = entries.iter().map(|e| e.group).collect();
+    assert_eq!(
+        groups,
+        vec![
+            CompletionGroup::Worktree,
+            CompletionGroup::Local,
+            CompletionGroup::Remote,
+        ],
+        "worktrees must come first, then local, then remote"
+    );
+}
+
+#[test]
+fn go_completions_sort_within_group_alphabetically() {
+    let entries = build_go_completions(
+        &[wt("b", "/tmp/b"), wt("a", "/tmp/a")],
+        &[br("z", "1 day ago"), br("m", "2 days ago")],
+        &[],
+        None,
+        "origin",
+        false,
+        "",
+    );
+    let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+    assert_eq!(names, vec!["a", "b", "m", "z"]);
+}
+
+#[test]
+fn go_completions_local_shadows_remote() {
+    let entries = build_go_completions(
+        &[],
+        &[br("feat/shared", "1 day ago")],
+        &[br("origin/feat/shared", "2 days ago")],
+        None,
+        "origin",
+        false,
+        "",
+    );
+    assert_eq!(entries.len(), 1, "remote should be shadowed by local");
+    assert_eq!(entries[0].name, "feat/shared");
+    assert_eq!(entries[0].group, CompletionGroup::Local);
+}
+
+#[test]
+fn go_completions_worktree_shadows_local_and_remote() {
+    let entries = build_go_completions(
+        &[wt("master", "/tmp/master")],
+        &[br("master", "1 day ago")],
+        &[br("origin/master", "2 days ago")],
+        None,
+        "origin",
+        false,
+        "",
+    );
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].name, "master");
+    assert_eq!(entries[0].group, CompletionGroup::Worktree);
+}
+
+#[test]
+fn go_completions_exclude_current_worktree() {
+    let entries = build_go_completions(
+        &[wt("master", "/tmp/master"), wt("feat/x", "/tmp/feat-x")],
+        &[],
+        &[],
+        Some("feat/x"),
+        "origin",
+        false,
+        "",
+    );
+    let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+    assert_eq!(names, vec!["master"]);
+}
+
+#[test]
+fn go_completions_strip_remote_prefix_in_single_remote_mode() {
+    let entries = build_go_completions(
+        &[],
+        &[],
+        &[br("origin/bug/xyz", "3 weeks ago")],
+        None,
+        "origin",
+        false,
+        "",
+    );
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].name, "bug/xyz");
+    assert_eq!(entries[0].group, CompletionGroup::Remote);
+}
+
+#[test]
+fn go_completions_keep_remote_prefix_in_multi_remote_mode() {
+    let entries = build_go_completions(
+        &[],
+        &[],
+        &[
+            br("origin/bug/xyz", "3 weeks ago"),
+            br("fork/feat/y", "2 days ago"),
+        ],
+        None,
+        "origin",
+        true, // multi-remote mode
+        "",
+    );
+    let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+    assert_eq!(names, vec!["fork/feat/y", "origin/bug/xyz"]);
+}
+
+#[test]
+fn go_completions_filter_by_prefix() {
+    let entries = build_go_completions(
+        &[wt("master", "/tmp/master")],
+        &[br("feat/x", "1d"), br("fix/y", "2d")],
+        &[br("origin/bug/z", "3w")],
+        None,
+        "origin",
+        false,
+        "fe",
+    );
+    let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+    assert_eq!(names, vec!["feat/x"]);
+}
+
+#[test]
+fn go_completions_drop_remote_head_symrefs() {
+    let entries = build_go_completions(
+        &[],
+        &[],
+        &[br("origin/HEAD", "just now"), br("origin/master", "1 day ago")],
+        None,
+        "origin",
+        false,
+        "",
+    );
+    let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+    assert_eq!(names, vec!["master"]);
+}
+
+#[test]
+fn format_go_completions_emits_tab_separated_name_group_description() {
+    let entries = vec![
+        CompletionEntry {
+            name: "master".into(),
+            group: CompletionGroup::Worktree,
+            description: "2 hours ago".into(),
+        },
+        CompletionEntry {
+            name: "feat/bar".into(),
+            group: CompletionGroup::Local,
+            description: "4 days ago".into(),
+        },
+    ];
+    let out = format_go_completions(&entries);
+    assert_eq!(
+        out,
+        "master\tworktree\t2 hours ago\nfeat/bar\tlocal\t4 days ago\n"
+    );
+}
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+```bash
+cargo test -p daft --lib commands::complete::tests::go_completions
+cargo test -p daft --lib commands::complete::tests::format_go_completions
+```
+
+Expected: all FAIL with `cannot find function build_go_completions` /
+`cannot find type CompletionGroup`.
+
+- [ ] **Step 3: Define types and implement the pure function**
+
+Add to `src/commands/complete.rs` (below the existing `complete` function
+and its helpers, above the existing `#[cfg(test)] mod tests` block):
+
+```rust
+/// Which group a completion entry belongs to, used for visual separation
+/// in shells that support per-item tags.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CompletionGroup {
+    /// Branch has a worktree — immediate navigation target.
+    Worktree,
+    /// Local branch without a worktree.
+    Local,
+    /// Remote-tracking branch not mirrored locally.
+    Remote,
+}
+
+impl CompletionGroup {
+    fn as_str(self) -> &'static str {
+        match self {
+            CompletionGroup::Worktree => "worktree",
+            CompletionGroup::Local => "local",
+            CompletionGroup::Remote => "remote",
+        }
+    }
+}
+
+/// A single completion candidate emitted by `daft __complete daft-go`.
+#[derive(Debug, Clone)]
+pub(crate) struct CompletionEntry {
+    pub name: String,
+    pub group: CompletionGroup,
+    pub description: String,
+}
+
+/// Pure grouping/dedupe/filter/sort function for `daft go` completions.
+///
+/// Takes already-collected git data and produces a flat, ordered list of
+/// completion entries: worktrees first, then local branches, then remote
+/// branches. Within each group, entries are sorted alphabetically.
+///
+/// Dedupe rules: worktree shadows local and remote; local shadows remote.
+/// Shadowing is by stripped-name comparison — a remote-only branch whose
+/// stripped name collides with a local or worktree branch is dropped.
+///
+/// The current worktree (if any) is excluded from the worktree group —
+/// `daft go` to the branch you're already on is a no-op.
+///
+/// In single-remote mode, the leading `<default_remote>/` prefix is
+/// stripped from remote-branch names. In multi-remote mode the full
+/// `<remote>/<branch>` form is preserved. HEAD symrefs (`origin/HEAD`,
+/// etc.) are always dropped.
+///
+/// Entries whose name doesn't start with `prefix` are filtered out.
+pub(crate) fn build_go_completions(
+    worktrees: &[(String, std::path::PathBuf)],
+    local_branches: &[(String, String)],
+    remote_branches: &[(String, String)],
+    current_worktree_branch: Option<&str>,
+    default_remote: &str,
+    multi_remote: bool,
+    prefix: &str,
+) -> Vec<CompletionEntry> {
+    use std::collections::BTreeSet;
+
+    // Worktree group: exclude the current worktree's branch.
+    let mut wt_entries: Vec<CompletionEntry> = worktrees
+        .iter()
+        .filter(|(name, _)| Some(name.as_str()) != current_worktree_branch)
+        .filter(|(name, _)| name.starts_with(prefix))
+        .map(|(name, path)| CompletionEntry {
+            name: name.clone(),
+            group: CompletionGroup::Worktree,
+            description: path.display().to_string(),
+        })
+        .collect();
+    wt_entries.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let wt_names: BTreeSet<&str> =
+        wt_entries.iter().map(|e| e.name.as_str()).collect();
+
+    // Local group: drop anything already in the worktree group.
+    let mut local_entries: Vec<CompletionEntry> = local_branches
+        .iter()
+        .filter(|(name, _)| !wt_names.contains(name.as_str()))
+        .filter(|(name, _)| name.starts_with(prefix))
+        .map(|(name, age)| CompletionEntry {
+            name: name.clone(),
+            group: CompletionGroup::Local,
+            description: age.clone(),
+        })
+        .collect();
+    local_entries.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let local_names: BTreeSet<String> = local_entries
+        .iter()
+        .map(|e| e.name.clone())
+        .collect::<BTreeSet<_>>();
+
+    // Remote group: drop HEAD symrefs, prefix-strip in single-remote mode,
+    // dedupe against worktree + local by stripped name.
+    let prefix_to_strip = format!("{default_remote}/");
+    let mut remote_entries: Vec<CompletionEntry> = remote_branches
+        .iter()
+        .filter(|(name, _)| !name.ends_with("/HEAD") && name != "HEAD")
+        .filter_map(|(name, age)| {
+            let display = if multi_remote {
+                name.clone()
+            } else if let Some(stripped) = name.strip_prefix(&prefix_to_strip) {
+                stripped.to_string()
+            } else {
+                // In single-remote mode, a remote from a non-default remote
+                // is unusual — keep its full name rather than inventing a
+                // shadowing rule.
+                name.clone()
+            };
+            if wt_names.contains(display.as_str())
+                || local_names.contains(&display)
+            {
+                return None;
+            }
+            if !display.starts_with(prefix) {
+                return None;
+            }
+            Some(CompletionEntry {
+                name: display,
+                group: CompletionGroup::Remote,
+                description: age.clone(),
+            })
+        })
+        .collect();
+    remote_entries.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let mut out = Vec::with_capacity(
+        wt_entries.len() + local_entries.len() + remote_entries.len(),
+    );
+    out.extend(wt_entries);
+    out.extend(local_entries);
+    out.extend(remote_entries);
+    out
+}
+
+/// Format grouped completion entries as tab-separated lines for the
+/// shell completion protocol: `<name>\t<group>\t<description>`.
+pub(crate) fn format_go_completions(entries: &[CompletionEntry]) -> String {
+    let mut out = String::new();
+    for entry in entries {
+        out.push_str(&entry.name);
+        out.push('\t');
+        out.push_str(entry.group.as_str());
+        out.push('\t');
+        out.push_str(&entry.description);
+        out.push('\n');
+    }
+    out
+}
+```
+
+- [ ] **Step 4: Run tests and verify they pass**
+
+```bash
+cargo test -p daft --lib commands::complete::tests
+```
+
+Expected: all ten new tests PASS. Existing tests
+(`test_suggest_new_branch_names`, `test_suggest_new_branch_names_no_match`)
+still PASS.
+
+- [ ] **Step 5: Run clippy**
+
+```bash
+mise run clippy
+```
+
+Expected: zero warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/commands/complete.rs
+git commit -m "$(cat <<'EOF'
+feat(completions): add pure grouping function for daft-go completions
+
+Introduce CompletionGroup, CompletionEntry, build_go_completions(), and
+format_go_completions() in src/commands/complete.rs. These are the
+data-layer primitives for the grouped daft go completion overhaul.
+
+The grouping function takes already-collected ref data and applies
+dedupe, prefix filtering, current-worktree exclusion, and multi-remote
+naming rules. Unit-tested with fixture inputs — no git invocations
+yet.
+
+Spec: docs/superpowers/specs/2026-04-11-go-command-completions-design.md
+EOF
+)"
+```
+
+---
+
+### Task 4: Collect git data and wire `complete_daft_go()` into the dispatcher
+
+**Files:**
+
+- Modify: `src/commands/complete.rs`
+
+- [ ] **Step 1: Add the git collection helpers and wrapper**
+
+Add to `src/commands/complete.rs`, near the existing
+`complete_existing_branches` helper:
+
+```rust
+/// Collect `(branch, path)` pairs for every linked worktree that has a
+/// branch checked out. Detached HEADs and bare repos are skipped —
+/// they're not navigation targets.
+fn collect_go_worktrees() -> Vec<(String, std::path::PathBuf)> {
+    use crate::git::GitCommand;
+
+    let git = GitCommand::new(true);
+    let entries =
+        match crate::core::worktree::prune::parse_worktree_list(&git) {
+            Ok(e) => e,
+            Err(_) => return Vec::new(),
+        };
+
+    entries
+        .into_iter()
+        .filter(|wt| !wt.is_bare && !wt.is_detached)
+        .filter_map(|wt| wt.branch.map(|b| (b, wt.path)))
+        .collect()
+}
+
+/// Collect `(branch, relative_age)` pairs for every local branch.
+fn collect_go_local_branches() -> Vec<(String, String)> {
+    let output = Command::new("git")
+        .args([
+            "for-each-ref",
+            "--format=%(refname:short)%09%(committerdate:relative)",
+            "refs/heads/",
+        ])
+        .output();
+
+    let output = match output {
+        Ok(o) if o.status.success() => o,
+        _ => return Vec::new(),
+    };
+
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| {
+            let (name, age) = line.split_once('\t')?;
+            Some((name.to_string(), age.to_string()))
+        })
+        .collect()
+}
+
+/// Collect `(branch, relative_age)` pairs for every remote-tracking
+/// branch across all remotes.
+fn collect_go_remote_branches() -> Vec<(String, String)> {
+    let output = Command::new("git")
+        .args([
+            "for-each-ref",
+            "--format=%(refname:short)%09%(committerdate:relative)",
+            "refs/remotes/",
+        ])
+        .output();
+
+    let output = match output {
+        Ok(o) if o.status.success() => o,
+        _ => return Vec::new(),
+    };
+
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| {
+            let (name, age) = line.split_once('\t')?;
+            Some((name.to_string(), age.to_string()))
+        })
+        .collect()
+}
+
+/// Collect the current worktree's branch, if any — used to exclude it
+/// from the completion list. Returns `None` if the caller is outside a
+/// worktree or the current worktree is detached.
+fn current_worktree_branch() -> Option<String> {
+    use crate::git::GitCommand;
+
+    let git = GitCommand::new(true);
+    let current_path = crate::core::repo::get_current_worktree_path().ok()?;
+    let entries =
+        crate::core::worktree::prune::parse_worktree_list(&git).ok()?;
+    entries
+        .into_iter()
+        .find(|wt| wt.path == current_path)
+        .and_then(|wt| wt.branch)
+}
+
+/// Top-level completion helper for `daft go`. Collects real git data,
+/// applies grouping rules, and returns the ordered candidate list.
+/// `fetch_on_miss` is wired in Task 9 — for now it is always false.
+pub(crate) fn complete_daft_go(
+    prefix: &str,
+    _fetch_on_miss: bool,
+) -> Result<Vec<CompletionEntry>> {
+    let settings =
+        crate::core::settings::DaftSettings::load().unwrap_or_default();
+    let default_remote = if settings.multi_remote_enabled {
+        settings.multi_remote_default.clone()
+    } else {
+        settings.remote.clone()
+    };
+
+    let worktrees = collect_go_worktrees();
+    let local = collect_go_local_branches();
+    let remote = collect_go_remote_branches();
+    let current_branch = current_worktree_branch();
+
+    Ok(build_go_completions(
+        &worktrees,
+        &local,
+        &remote,
+        current_branch.as_deref(),
+        &default_remote,
+        settings.multi_remote_enabled,
+        prefix,
+    ))
+}
+```
+
+- [ ] **Step 2: Route `("daft-go", 1)` to `complete_daft_go()` and emit
+      the tab-separated format**
+
+In the existing `complete()` dispatcher in `src/commands/complete.rs`,
+replace the `daft-go` arm:
+
+```rust
+// daft-go: complete existing branch names
+("daft-go", 1) => complete_existing_branches(word, verbose),
+```
+
+with:
+
+```rust
+// daft-go: grouped worktree/local/remote completions
+("daft-go", 1) => {
+    let entries = complete_daft_go(word, false)?;
+    // Re-emit as individual tab-separated lines so the outer
+    // `for suggestion in suggestions { println!(...) }` loop in
+    // run() writes one line per entry, matching the shell-facing
+    // format produced by `format_go_completions()`.
+    Ok(entries
+        .iter()
+        .map(|e| format!("{}\t{}\t{}", e.name, e.group.as_str(), e.description))
+        .collect())
+}
+```
+
+Note: we deliberately don't call `format_go_completions()` here because
+the dispatcher returns `Vec<String>` (one entry per line) while
+`format_go_completions()` returns a single pre-joined `String`.
+`format_go_completions()` stays in the module for direct use by unit
+tests and for any future caller that wants the full stdout blob.
+
+The outer `run()` function already prints each suggestion on its own
+line, so the existing `for suggestion in suggestions { println!(...); }`
+loop handles the tab-separated strings correctly.
+
+- [ ] **Step 3: Build and run the existing unit tests**
+
+```bash
+cargo build -p daft
+cargo test -p daft --lib commands::complete
+```
+
+Expected: compiles cleanly, all existing tests pass. The new git
+collection helpers aren't unit-tested here — they're covered by the YAML
+scenario in Task 6.
+
+- [ ] **Step 4: Manual smoke test in the daft repo itself**
+
+Per `CLAUDE.md`: never use the daft repo as a test target for worktree
+operations. But `daft __complete` is read-only and safe. Run:
+
+```bash
+cargo build
+./target/debug/daft __complete daft-go "" --position 1
+```
+
+Expected output: tab-separated lines with your current worktrees, local
+branches (minus any with worktrees), and remote-only branches. The
+current worktree's branch should be absent from the worktree group.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/commands/complete.rs
+git commit -m "$(cat <<'EOF'
+feat(completions): collect grouped go completions from live git data
+
+Add `collect_go_worktrees`, `collect_go_local_branches`,
+`collect_go_remote_branches`, `current_worktree_branch`, and the
+`complete_daft_go` wrapper. Route the `daft-go` completion arm to the
+new function and emit tab-separated `name<TAB>group<TAB>description`
+lines.
+
+Shell scripts that only read column 1 continue to work; zsh/fish
+rendering using columns 2-3 lands in later tasks.
+EOF
+)"
+```
+
+---
+
+### Task 5: YAML scenario exercising the grouped completion
+
+**Files:**
+
+- Create: `tests/manual/scenarios/completions/go-grouped.yml`
+
+- [ ] **Step 1: Look at an existing similar scenario for schema cues**
+
+```bash
+cat tests/manual/scenarios/completions/dynamic-branch.yml
+```
+
+Note the `steps`, `run`, `cwd`, `expect.exit_code`, and
+`expect.output_contains` / `expect.output_matches` fields.
+
+- [ ] **Step 2: Write the failing scenario**
+
+Create `tests/manual/scenarios/completions/go-grouped.yml`:
+
+```yaml
+name: daft go completion groups worktrees, locals, and remotes
+description:
+  `daft __complete daft-go` emits tab-separated lines grouped as
+  worktrees first, then local branches, then remote branches, with
+  correct dedupe and current-worktree exclusion.
+
+steps:
+  - name: Create a bare repo with linked worktrees, local branches, and a fake remote
+    run: |
+      set -e
+      mkdir -p $WORK_DIR/go-complete && cd $WORK_DIR/go-complete &&
+      git init --bare origin.git &&
+      git clone origin.git work &&
+      cd work &&
+      git config user.name "Test" &&
+      git config user.email "test@test.com" &&
+      echo "hello" > README.md &&
+      git add README.md &&
+      git commit -m "initial" &&
+      git branch master-dup &&
+      git checkout -b feat/local-only &&
+      git commit --allow-empty -m "local work" &&
+      git checkout -b feat/with-worktree &&
+      git commit --allow-empty -m "worktree work" &&
+      git checkout master &&
+      git push origin master feat/local-only feat/with-worktree master-dup &&
+      git checkout -b feat/remote-shadow &&
+      git push origin feat/remote-shadow &&
+      git checkout master &&
+      git branch -D feat/remote-shadow &&
+      git fetch origin &&
+      git worktree add ../feat-with-worktree feat/with-worktree
+    expect:
+      exit_code: 0
+
+  - name: Run completion from the master worktree (excludes master from worktree group)
+    run: $DAFT_BIN __complete daft-go "" --position 1
+    cwd: "$WORK_DIR/go-complete/work"
+    expect:
+      exit_code: 0
+      # Expected tab-separated lines, in grouped order.
+      # Worktree group contains feat/with-worktree (master excluded as current).
+      # Local group contains feat/local-only, master-dup.
+      # Remote group contains feat/remote-shadow (only that remote is not shadowed).
+      output_contains:
+        - "feat/with-worktree\tworktree\t"
+        - "feat/local-only\tlocal\t"
+        - "master-dup\tlocal\t"
+        - "feat/remote-shadow\tremote\t"
+      output_not_contains:
+        - "master\tworktree"
+        - "master\tlocal"
+        - "origin/master"
+        - "origin/HEAD"
+
+  - name: Prefix filter returns only matching entries
+    run: $DAFT_BIN __complete daft-go "feat/l" --position 1
+    cwd: "$WORK_DIR/go-complete/work"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "feat/local-only\tlocal\t"
+      output_not_contains:
+        - "feat/with-worktree"
+        - "feat/remote-shadow"
+        - "master-dup"
+```
+
+- [ ] **Step 3: Verify the YAML runner supports `output_not_contains`**
+
+```bash
+grep -rn "output_not_contains" tests/manual/ | head -5
+```
+
+Expected: at least a few hits showing the field is supported by the
+runner. If not supported, the test must use `output_matches` with a
+negated regex instead — adjust the step to use only
+`output_contains` and leave `output_not_contains` out of this task; the
+positive assertions cover the grouping behavior.
+
+- [ ] **Step 4: Run the scenario**
+
+```bash
+mise run test:manual -- --ci completions go-grouped
+```
+
+Expected: the scenario sets up the repo and asserts the grouped
+output. Should PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/manual/scenarios/completions/go-grouped.yml
+git commit -m "$(cat <<'EOF'
+test(completions): add go-grouped integration scenario
+
+Sets up a bare repo with worktrees, local branches, and remote-only
+branches, then asserts that `daft __complete daft-go` emits the
+expected tab-separated grouped output with correct dedupe and
+current-worktree exclusion.
+EOF
+)"
+```
+
+---
+
+### Task 6: Fetch cooldown marker
+
+**Files:**
+
+- Modify: `src/commands/complete.rs`
+
+- [ ] **Step 1: Write failing unit tests**
+
+Add to the tests module in `src/commands/complete.rs`:
+
+```rust
+use std::time::{Duration, SystemTime};
+
+#[test]
+fn fetch_cooldown_allows_fetch_when_marker_missing() {
+    let tmp = tempfile::tempdir().unwrap();
+    let marker = tmp.path().join("daft_complete_last_fetch");
+    assert!(
+        should_run_fetch(&marker, Duration::from_secs(30)),
+        "missing marker must allow fetch"
+    );
+}
+
+#[test]
+fn fetch_cooldown_blocks_fetch_within_window() {
+    let tmp = tempfile::tempdir().unwrap();
+    let marker = tmp.path().join("daft_complete_last_fetch");
+    touch_fetch_marker(&marker).unwrap();
+    assert!(
+        !should_run_fetch(&marker, Duration::from_secs(30)),
+        "freshly touched marker must block fetch"
+    );
+}
+
+#[test]
+fn fetch_cooldown_allows_fetch_after_window() {
+    let tmp = tempfile::tempdir().unwrap();
+    let marker = tmp.path().join("daft_complete_last_fetch");
+    touch_fetch_marker(&marker).unwrap();
+    // Backdate the marker by 31 seconds.
+    let old = SystemTime::now() - Duration::from_secs(31);
+    filetime::set_file_mtime(&marker, filetime::FileTime::from_system_time(old))
+        .unwrap();
+    assert!(
+        should_run_fetch(&marker, Duration::from_secs(30)),
+        "marker older than cooldown must allow fetch"
+    );
+}
+```
+
+Also add the `filetime` dev-dependency if it isn't already present:
+
+```bash
+grep -n 'filetime' Cargo.toml
+```
+
+If absent, add under `[dev-dependencies]`:
+
+```toml
+filetime = "0.2"
+tempfile = "3"
+```
+
+(`tempfile` is already used elsewhere in this crate — verify with
+`grep -n 'tempfile' Cargo.toml`. If already present, leave alone.)
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+```bash
+cargo test -p daft --lib commands::complete::tests::fetch_cooldown
+```
+
+Expected: FAIL with `cannot find function should_run_fetch` /
+`touch_fetch_marker`.
+
+- [ ] **Step 3: Implement the cooldown helpers**
+
+Add to `src/commands/complete.rs`:
+
+```rust
+/// Return `true` if the cooldown marker is missing or older than
+/// `cooldown`. Used to decide whether the fetch-on-miss path should run.
+fn should_run_fetch(marker: &std::path::Path, cooldown: std::time::Duration) -> bool {
+    let metadata = match std::fs::metadata(marker) {
+        Ok(m) => m,
+        Err(_) => return true, // Missing marker -> fetch allowed
+    };
+    let mtime = match metadata.modified() {
+        Ok(t) => t,
+        Err(_) => return true,
+    };
+    match std::time::SystemTime::now().duration_since(mtime) {
+        Ok(age) => age >= cooldown,
+        Err(_) => true, // Clock skew -> be permissive
+    }
+}
+
+/// Create or update the cooldown marker to reflect a just-completed fetch.
+fn touch_fetch_marker(marker: &std::path::Path) -> std::io::Result<()> {
+    if let Some(parent) = marker.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(marker)?;
+    filetime::set_file_mtime(
+        marker,
+        filetime::FileTime::from_system_time(std::time::SystemTime::now()),
+    )?;
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Run tests and verify they pass**
+
+```bash
+cargo test -p daft --lib commands::complete::tests::fetch_cooldown
+```
+
+Expected: all three tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/commands/complete.rs Cargo.toml Cargo.lock
+git commit -m "$(cat <<'EOF'
+feat(completions): add fetch cooldown marker helpers
+
+`should_run_fetch` and `touch_fetch_marker` implement the 30-second
+cooldown that prevents the fetch-on-miss spinner path from thrashing
+`git fetch` on every keystroke. The marker lives at
+`<git-common-dir>/daft_complete_last_fetch`.
+
+Unit-tested against tempfile-backed markers with backdated mtimes.
+EOF
+)"
+```
+
+---
+
+### Task 7: `/dev/tty` spinner module
+
+**Files:**
+
+- Create: `src/completion_spinner.rs`
+- Modify: `src/lib.rs`
+
+- [ ] **Step 1: Write the failing unit test for the frame sequence**
+
+Create `src/completion_spinner.rs`:
+
+```rust
+//! Single-line braille-dot spinner drawn directly to `/dev/tty`.
+//!
+//! Used by shell-completion paths that need to run a slow operation
+//! (e.g. `git fetch`) while giving the user a visible signal that
+//! something is happening. The shell completion function itself is
+//! synchronous from readline's perspective — the spinner is drawn by
+//! this module (not the shell wrapper) by opening `/dev/tty` directly
+//! and writing frames prefixed with `\r` so each frame overwrites the
+//! previous one in place.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn spinner_frames_cycle_through_braille_dots() {
+        let frames: Vec<&str> = (0..20).map(frame_for_tick).collect();
+        assert_eq!(frames[0], "⠋");
+        assert_eq!(frames[1], "⠙");
+        assert_eq!(frames[9], "⠏");
+        assert_eq!(frames[10], "⠋", "frame sequence must wrap at 10");
+        assert_eq!(frames[19], "⠏");
+    }
+}
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+```bash
+cargo test -p daft --lib completion_spinner
+```
+
+Expected: FAIL — module doesn't exist yet.
+
+- [ ] **Step 3: Wire the module into lib.rs**
+
+In `src/lib.rs`, add near the other `pub mod` declarations:
+
+```rust
+pub mod completion_spinner;
+```
+
+- [ ] **Step 4: Implement the spinner**
+
+Replace the contents of `src/completion_spinner.rs` with:
+
+```rust
+//! Single-line braille-dot spinner drawn directly to `/dev/tty`.
+//!
+//! Used by shell-completion paths that need to run a slow operation
+//! (e.g. `git fetch`) while giving the user a visible signal that
+//! something is happening. The shell completion function itself is
+//! synchronous from readline's perspective — the spinner is drawn by
+//! this module (not the shell wrapper) by opening `/dev/tty` directly
+//! and writing frames prefixed with `\r` so each frame overwrites the
+//! previous one in place.
+
+use std::io::Write;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+const FRAMES: [&str; 10] =
+    ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+/// Return the spinner frame for a given tick number.
+///
+/// The frame cycle wraps modulo 10 — ticks 0..10 map to FRAMES[0..10],
+/// tick 10 wraps back to FRAMES[0], and so on.
+pub(crate) fn frame_for_tick(tick: usize) -> &'static str {
+    FRAMES[tick % FRAMES.len()]
+}
+
+/// A running spinner. Drop or call `stop()` to clear it.
+pub struct Spinner {
+    stop_flag: Arc<AtomicBool>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl Spinner {
+    /// Start a spinner with the given label. Returns `None` if
+    /// `/dev/tty` cannot be opened for writing — the caller should fall
+    /// back to silent execution in that case.
+    pub fn start(label: &str) -> Option<Self> {
+        let mut tty = std::fs::OpenOptions::new()
+            .write(true)
+            .open("/dev/tty")
+            .ok()?;
+        let stop_flag = Arc::new(AtomicBool::new(false));
+        let flag = stop_flag.clone();
+        let label = label.to_string();
+        let thread = thread::spawn(move || {
+            let mut tick = 0usize;
+            while !flag.load(Ordering::Relaxed) {
+                let frame = frame_for_tick(tick);
+                let _ = write!(tty, "\r{frame} {label}");
+                let _ = tty.flush();
+                tick += 1;
+                thread::sleep(Duration::from_millis(100));
+            }
+            // Clear the line on exit.
+            let _ = write!(tty, "\r\x1b[K");
+            let _ = tty.flush();
+        });
+        Some(Self {
+            stop_flag,
+            thread: Some(thread),
+        })
+    }
+
+    /// Stop the spinner and wait for the draw thread to exit.
+    pub fn stop(mut self) {
+        self.stop_flag.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.thread.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+impl Drop for Spinner {
+    fn drop(&mut self) {
+        self.stop_flag.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.thread.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn spinner_frames_cycle_through_braille_dots() {
+        let frames: Vec<&str> = (0..20).map(frame_for_tick).collect();
+        assert_eq!(frames[0], "⠋");
+        assert_eq!(frames[1], "⠙");
+        assert_eq!(frames[9], "⠏");
+        assert_eq!(frames[10], "⠋", "frame sequence must wrap at 10");
+        assert_eq!(frames[19], "⠏");
+    }
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+cargo test -p daft --lib completion_spinner
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run clippy**
+
+```bash
+mise run clippy
+```
+
+Expected: zero warnings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/completion_spinner.rs src/lib.rs
+git commit -m "$(cat <<'EOF'
+feat(completions): add /dev/tty braille-dot spinner
+
+Single-line spinner module used by the daft-go fetch-on-miss path to
+give the user a visible signal during git fetch. Opens /dev/tty
+directly so it works from inside shell completion functions, which
+are synchronous from readline's perspective. Returns None when the
+tty cannot be opened (non-interactive, CI) so the caller falls back
+to silent execution.
+
+Unit-tested frame cycle; the actual tty drawing is verified by manual
+test plan.
+EOF
+)"
+```
+
+---
+
+### Task 8: Wire fetch-on-miss into `complete_daft_go()`
+
+**Files:**
+
+- Modify: `src/commands/complete.rs`
+
+- [ ] **Step 1: Add the `--fetch-on-miss` CLI flag**
+
+In the `Args` struct in `src/commands/complete.rs`, add:
+
+```rust
+#[arg(
+    long,
+    help = "When no local matches are found for the prefix, run `git fetch` \
+            with a spinner and re-resolve"
+)]
+fetch_on_miss: bool,
+```
+
+In the `run()` function, update the call to `complete()` to pass the
+new flag through. Extend the `complete()` function signature to accept
+it:
+
+```rust
+fn complete(
+    command: &str,
+    position: usize,
+    word: &str,
+    verbose: bool,
+    fetch_on_miss: bool,
+) -> Result<Vec<String>> {
+```
+
+And update the `("daft-go", 1)` arm from Task 4:
+
+```rust
+("daft-go", 1) => {
+    let entries = complete_daft_go(word, fetch_on_miss)?;
+    Ok(entries
+        .iter()
+        .map(|e| format!("{}\t{}\t{}", e.name, e.group.as_str(), e.description))
+        .collect())
+}
+```
+
+The parameter is named `fetch_on_miss` (no underscore prefix) in the
+signature because it IS used by the `("daft-go", 1)` arm. Other arms
+simply don't reference it — that's fine, Rust only warns on unused
+parameters if no branch reads them, and the daft-go arm counts as a
+read. No warning, no underscore needed.
+
+- [ ] **Step 2: Implement the fetch-on-miss path in `complete_daft_go()`**
+
+Replace the body of `complete_daft_go()` with:
+
+```rust
+pub(crate) fn complete_daft_go(
+    prefix: &str,
+    fetch_on_miss: bool,
+) -> Result<Vec<CompletionEntry>> {
+    let settings =
+        crate::core::settings::DaftSettings::load().unwrap_or_default();
+    let default_remote = if settings.multi_remote_enabled {
+        settings.multi_remote_default.clone()
+    } else {
+        settings.remote.clone()
+    };
+
+    let collect = || -> Vec<CompletionEntry> {
+        let worktrees = collect_go_worktrees();
+        let local = collect_go_local_branches();
+        let remote = collect_go_remote_branches();
+        let current_branch = current_worktree_branch();
+        build_go_completions(
+            &worktrees,
+            &local,
+            &remote,
+            current_branch.as_deref(),
+            &default_remote,
+            settings.multi_remote_enabled,
+            prefix,
+        )
+    };
+
+    let entries = collect();
+    if !entries.is_empty()
+        || !fetch_on_miss
+        || !settings.go_fetch_on_miss
+        || prefix.is_empty()
+    {
+        return Ok(entries);
+    }
+
+    // Fetch-on-miss gate: prefix non-empty, zero local matches, caller
+    // opted in, setting not explicitly disabled.
+    let git_common_dir = match crate::core::repo::get_git_common_dir() {
+        Ok(d) => d,
+        Err(_) => return Ok(entries),
+    };
+    let marker = git_common_dir.join("daft_complete_last_fetch");
+    if !should_run_fetch(&marker, std::time::Duration::from_secs(30)) {
+        return Ok(entries);
+    }
+
+    let spinner = crate::completion_spinner::Spinner::start(&format!(
+        "Fetching refs from {default_remote}…"
+    ));
+
+    let fetch_result = std::process::Command::new("git")
+        .args([
+            "fetch",
+            "--quiet",
+            "--no-tags",
+            "--no-recurse-submodules",
+            &default_remote,
+        ])
+        .output();
+    // Best-effort: drop the result, just note completion.
+    let _ = fetch_result;
+
+    if let Some(s) = spinner {
+        s.stop();
+    }
+
+    let _ = touch_fetch_marker(&marker);
+
+    Ok(collect())
+}
+```
+
+- [ ] **Step 3: Verify `get_git_common_dir` is re-exported where we need it**
+
+```bash
+grep -n "pub fn get_git_common_dir" src/core/repo.rs src/lib.rs
+```
+
+If missing from `src/core/repo.rs`, use the existing crate-level
+`crate::get_git_common_dir()` wrapper instead.
+
+- [ ] **Step 4: Run unit tests**
+
+```bash
+cargo test -p daft --lib commands::complete
+cargo test -p daft --lib completion_spinner
+```
+
+Expected: all existing tests still PASS. No new unit tests in this
+task — the fetch-on-miss behavior is a composition of already-tested
+primitives (`should_run_fetch`, `touch_fetch_marker`, the spinner, and
+`complete_daft_go`). The manual test plan (Task 16) verifies the
+end-to-end user-visible behavior.
+
+- [ ] **Step 5: Manual smoke test**
+
+```bash
+cargo build
+# Inside a repo where you know there are no local branches matching "zzzz":
+./target/debug/daft __complete daft-go "zzzz" --position 1 --fetch-on-miss
+```
+
+Expected: the spinner line appears on the terminal for the duration of
+`git fetch`, then disappears. Output is empty if the fetch did not
+produce any matching refs. Running again within 30s should NOT show the
+spinner (cooldown).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/commands/complete.rs
+git commit -m "$(cat <<'EOF'
+feat(completions): fetch-on-miss with spinner for daft-go
+
+When `daft __complete daft-go` is called with `--fetch-on-miss` and
+the user's prefix has no local matches, run `git fetch` with a
+braille-dot spinner drawn to /dev/tty, then re-resolve. Gated by the
+`daft.go.fetchOnMiss` setting (default on) and a 30-second cooldown
+marker at `<git-common-dir>/daft_complete_last_fetch` to keep the
+path from thrashing when the user types past a known-good prefix.
+EOF
+)"
+```
+
+---
+
+### Task 9: Rewrite zsh generator for `daft-go` with grouped `_describe`
+
+**Files:**
+
+- Modify: `src/commands/completions/zsh.rs`
+
+- [ ] **Step 1: Write failing unit tests for the new zsh shape**
+
+Add to the tests module in `src/commands/completions/mod.rs`:
+
+```rust
+#[test]
+fn zsh_daft_go_emits_describe_per_group() {
+    let script = zsh::generate_zsh_completion_string("daft-go")
+        .expect("generator must succeed");
+    assert!(
+        script.contains("_describe -t worktree"),
+        "daft-go zsh completion must call _describe with the worktree tag"
+    );
+    assert!(
+        script.contains("_describe -t local"),
+        "daft-go zsh completion must call _describe with the local tag"
+    );
+    assert!(
+        script.contains("_describe -t remote"),
+        "daft-go zsh completion must call _describe with the remote tag"
+    );
+}
+
+#[test]
+fn zsh_daft_go_passes_fetch_on_miss_flag() {
+    let script = zsh::generate_zsh_completion_string("daft-go")
+        .expect("generator must succeed");
+    assert!(
+        script.contains("--fetch-on-miss"),
+        "daft-go zsh completion must pass --fetch-on-miss to daft __complete"
+    );
+}
+```
+
+- [ ] **Step 2: Run and verify the new tests fail**
+
+```bash
+cargo test -p daft --lib commands::completions::tests::zsh_daft_go
+```
+
+Expected: the two new tests FAIL; the existing
+`zsh_daft_go_gates_flags_on_leading_dash` test still PASSES (it just
+checks for the guard).
+
+- [ ] **Step 3: Add a bespoke `daft-go` code path in the zsh generator**
+
+In `src/commands/completions/zsh.rs`, inside
+`generate_zsh_completion_string()`, special-case `daft-go` before the
+generic branch-completion code. The cleanest shape is to early-return a
+hand-written function body for `daft-go`:
+
+```rust
+pub(super) fn generate_zsh_completion_string(command_name: &str) -> Result<String> {
+    if command_name == "daft-go" {
+        return Ok(generate_zsh_daft_go_completion());
+    }
+    // ...existing generic body unchanged...
+}
+```
+
+Add the new function at the bottom of the file:
+
+```rust
+fn generate_zsh_daft_go_completion() -> String {
+    let cmd = crate::commands::checkout::GoArgs::command();
+    let (all_flags, _, _) = extract_flags(&cmd);
+    let flags_block: String = all_flags
+        .iter()
+        .map(|f| format!("            '{f}'\n"))
+        .collect();
+
+    format!(
+        r#"#compdef daft-go
+
+__daft_go_impl() {{
+    local curword="${{words[$CURRENT]}}"
+    local cword=$((CURRENT - 1))
+
+    # Flag completions — only when the user has typed a leading dash.
+    if [[ "$curword" == -* ]]; then
+        local -a flags
+        flags=(
+{flags_block}        )
+        compadd -a flags
+        return
+    fi
+
+    # Collect grouped candidates from daft __complete (tab-separated).
+    local -a raw wt_items local_items remote_items
+    raw=(${{(f)"$(daft __complete daft-go "$curword" --position "$cword" --fetch-on-miss 2>/dev/null)"}})
+
+    local line name rest group desc
+    for line in "${{raw[@]}}"; do
+        name="${{line%%$'\t'*}}"
+        rest="${{line#*$'\t'}}"
+        group="${{rest%%$'\t'*}}"
+        desc="${{rest#*$'\t'}}"
+        case "$group" in
+            worktree) wt_items+=("$name:$desc") ;;
+            local)    local_items+=("$name:$desc") ;;
+            remote)   remote_items+=("$name:$desc") ;;
+        esac
+    done
+
+    # Three _describe calls with empty string suppress group headers
+    # but keep ordering: worktrees, then locals, then remotes.
+    _describe -t worktree '' wt_items
+    _describe -t local    '' local_items
+    _describe -t remote   '' remote_items
+}}
+
+_daft_go() {{
+    __daft_go_impl
+}}
+
+compdef _daft_go daft-go
+"#
+    )
+}
+```
+
+Note: the `compdef` at the bottom is for direct invocation of
+`daft-go`. Shortcut aliases are handled by the existing umbrella
+wiring in `DAFT_ZSH_COMPLETIONS`, which is updated in Task 13.
+
+- [ ] **Step 4: Run the new tests**
+
+```bash
+cargo test -p daft --lib commands::completions::tests::zsh_daft_go
+```
+
+Expected: all three zsh_daft_go tests PASS, including the existing
+`zsh_daft_go_gates_flags_on_leading_dash` regression test (the guard
+remains present in the new hand-written body).
+
+- [ ] **Step 5: Run the full completion scenario suite**
+
+```bash
+mise run test:manual -- --ci completions
+```
+
+Expected: all scenarios pass. The `all-commands` scenario that
+generates zsh completions for every command must still succeed — verify
+`daft completions zsh --command=daft-go` returns exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/commands/completions/zsh.rs src/commands/completions/mod.rs
+git commit -m "$(cat <<'EOF'
+feat(completions): grouped zsh completion for daft-go
+
+Special-case daft-go in the zsh generator with a bespoke function
+that parses tab-separated output from `daft __complete` and renders
+three _describe calls (worktree, local, remote) with empty group
+descriptions. This preserves visible ordering without showing
+headers.
+
+The flag-gating regression test from Task 1 continues to pass — the
+new hand-written body still enforces the `$curword == -*` guard.
+`--fetch-on-miss` is passed through to `daft __complete` so the
+spinner path triggers when the user types a prefix with no local
+match.
+EOF
+)"
+```
+
+---
+
+### Task 10: Update bash generator for `daft-go` with ordered output
+
+**Files:**
+
+- Modify: `src/commands/completions/bash.rs`
+
+- [ ] **Step 1: Write the failing unit test**
+
+Add to the tests module in `src/commands/completions/mod.rs`:
+
+```rust
+#[test]
+fn bash_daft_go_uses_nosort_and_fetch_on_miss() {
+    let script = bash::generate_bash_completion_string("daft-go")
+        .expect("generator must succeed");
+    assert!(
+        script.contains("--fetch-on-miss"),
+        "daft-go bash completion must pass --fetch-on-miss to daft __complete"
+    );
+    assert!(
+        script.contains("compopt -o nosort"),
+        "daft-go bash completion must attempt compopt -o nosort to \
+         preserve group ordering"
+    );
+    assert!(
+        script.contains("cut -f1"),
+        "daft-go bash completion must strip tab-separated group/desc \
+         columns with cut -f1"
+    );
+}
+```
+
+- [ ] **Step 2: Run and verify it fails**
+
+```bash
+cargo test -p daft --lib commands::completions::tests::bash_daft_go_uses_nosort_and_fetch_on_miss
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Special-case `daft-go` in the bash generator**
+
+In `src/commands/completions/bash.rs`, near the top of
+`generate_bash_completion_string()`:
+
+```rust
+pub(super) fn generate_bash_completion_string(command_name: &str) -> Result<String> {
+    if command_name == "daft-go" {
+        return Ok(generate_bash_daft_go_completion());
+    }
+    // ...existing generic body unchanged...
+}
+```
+
+Add at the bottom of the file:
+
+```rust
+fn generate_bash_daft_go_completion() -> String {
+    let cmd = crate::commands::checkout::GoArgs::command();
+    let (all_flags, _, _) = extract_flags(&cmd);
+    let flags_joined = all_flags.join(" ");
+
+    format!(
+        r#"_daft_go() {{
+    local cur prev words cword
+    _init_completion || return
+
+    if [[ "$cur" == -* ]]; then
+        local flags="{flags_joined}"
+        COMPREPLY=( $(compgen -W "$flags" -- "$cur") )
+        return 0
+    fi
+
+    local raw
+    raw=$(daft __complete daft-go "$cur" --position "$cword" --fetch-on-miss 2>/dev/null | cut -f1)
+    if [[ -n "$raw" ]]; then
+        COMPREPLY=( $(compgen -W "$raw" -- "$cur") )
+        compopt -o nosort 2>/dev/null || true
+        return 0
+    fi
+}}
+complete -F _daft_go daft-go
+"#
+    )
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cargo test -p daft --lib commands::completions::tests::bash_daft_go
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the manual completion scenarios**
+
+```bash
+mise run test:manual -- --ci completions
+```
+
+Expected: all scenarios pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/commands/completions/bash.rs src/commands/completions/mod.rs
+git commit -m "$(cat <<'EOF'
+feat(completions): grouped bash completion for daft-go
+
+Special-case daft-go in the bash generator with a hand-written
+function that strips tab-separated group/description columns with
+`cut -f1` and preserves the ordering emitted by `daft __complete`
+with best-effort `compopt -o nosort`. Flags are gated on leading
+dash, and `--fetch-on-miss` is passed through for the spinner path.
+
+Bash has no per-item description or color support — the visible
+benefit over the old behavior is group ordering (worktrees first)
+and no flag leaks.
+EOF
+)"
+```
+
+---
+
+### Task 11: Update fish generator for `daft-go`
+
+**Files:**
+
+- Modify: `src/commands/completions/fish.rs`
+
+- [ ] **Step 1: Write the failing unit test**
+
+Add to the tests module in `src/commands/completions/mod.rs`:
+
+```rust
+#[test]
+fn fish_daft_go_passes_fetch_on_miss_and_awk_reshuffles() {
+    let script = fish::generate_fish_completion_string("daft-go")
+        .expect("generator must succeed");
+    assert!(
+        script.contains("--fetch-on-miss"),
+        "daft-go fish completion must pass --fetch-on-miss"
+    );
+    assert!(
+        script.contains("awk"),
+        "daft-go fish completion must reshuffle tab-separated columns via awk"
+    );
+}
+```
+
+Also check `DAFT_FISH_COMPLETIONS` since the existing daft-go completion
+line lives in the umbrella string constant, not the per-command output:
+
+```rust
+#[test]
+fn fish_daft_umbrella_passes_fetch_on_miss_for_go() {
+    let fish_completions = fish::generate_daft_fish_completions();
+    assert!(
+        fish_completions.contains("daft __complete daft-go")
+            && fish_completions.contains("--fetch-on-miss"),
+        "daft go subcommand in umbrella fish completions must pass \
+         --fetch-on-miss"
+    );
+}
+```
+
+- [ ] **Step 2: Run and verify the tests fail**
+
+```bash
+cargo test -p daft --lib commands::completions::tests::fish_daft_go
+cargo test -p daft --lib commands::completions::tests::fish_daft_umbrella
+```
+
+Expected: both FAIL.
+
+- [ ] **Step 3: Update the fish generator**
+
+In `src/commands/completions/fish.rs`, find the per-command generator
+and special-case `daft-go` similarly to zsh/bash — return a bespoke
+function body that passes `--fetch-on-miss` and awk-reshuffles:
+
+The per-command fish generator is relatively small. Replace the
+dynamic branch-completion line it would otherwise emit with (this is
+the final fish text — show this exact output when running
+`daft completions fish --command=daft-go`):
+
+```fish
+complete -c daft-go -f -a "(daft __complete daft-go (commandline -ct) --position 1 --fetch-on-miss 2>/dev/null | awk -F'\t' '{printf \"%s\t%s · %s\n\", $1, $3, $2}')"
+```
+
+In Rust source, write this via `r#"..."#` raw strings (no special
+escaping) or via `"..."` with `\\t` and `\\n` for the literal
+backslash escape sequences that fish / awk see:
+
+```rust
+fn generate_fish_daft_go_line() -> &'static str {
+    // Raw string avoids double-escaping. Fish sees literal
+    // backslash-t and backslash-n inside the awk invocation, which
+    // awk then interprets as tab and newline.
+    r#"complete -c daft-go -f -a "(daft __complete daft-go (commandline -ct) --position 1 --fetch-on-miss 2>/dev/null | awk -F'\t' '{printf \"%s\t%s · %s\n\", $1, $3, $2}')""#
+}
+```
+
+After implementing, verify with `./target/debug/daft completions fish
+--command=daft-go` and confirm the output matches the expected fish
+text above character-for-character.
+
+Also update `DAFT_FISH_COMPLETIONS` in the same file — replace the
+existing line:
+
+```fish
+complete -c daft -n '__fish_seen_subcommand_from go' -f -a "(daft __complete daft-go '' 2>/dev/null)"
+```
+
+with:
+
+```fish
+complete -c daft -n '__fish_seen_subcommand_from go' -f -a "(daft __complete daft-go (commandline -ct) --position 1 --fetch-on-miss 2>/dev/null | awk -F'\t' '{printf \"%s\t%s · %s\n\", $1, $3, $2}')"
+```
+
+- [ ] **Step 4: Run tests and verify they pass**
+
+```bash
+cargo test -p daft --lib commands::completions::tests::fish_daft_go
+cargo test -p daft --lib commands::completions::tests::fish_daft_umbrella
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Manual verification of the generated fish script**
+
+```bash
+cargo build
+./target/debug/daft completions fish --command=daft-go
+./target/debug/daft shell-init fish | grep -A1 "daft __complete daft-go"
+```
+
+Inspect the emitted lines — the `awk` invocation should be correctly
+escaped for fish (single tab field separator, three-column reshuffle).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/commands/completions/fish.rs src/commands/completions/mod.rs
+git commit -m "$(cat <<'EOF'
+feat(completions): grouped fish completion for daft-go
+
+Pass `--fetch-on-miss` to `daft __complete daft-go` and reshuffle the
+tab-separated output into fish's `name\tdescription` format where
+the description is `<age> · <group>`. Fish colors descriptions
+distinctly from the main completion, which gives implicit visual
+grouping without needing an explicit color config.
+EOF
+)"
+```
+
+---
+
+### Task 12: Emit zstyle coloring block for `daft-go`
+
+**Files:**
+
+- Modify: `src/commands/completions/zsh.rs`
+
+- [ ] **Step 1: Write the failing unit test**
+
+Add to `src/commands/completions/mod.rs`:
+
+```rust
+#[test]
+fn zsh_daft_go_emits_zstyle_colors_per_group() {
+    let script = zsh::generate_zsh_completion_string("daft-go")
+        .expect("generator must succeed");
+    assert!(
+        script.contains(":*:daft-go:*:worktree"),
+        "zsh daft-go must emit a zstyle line for the worktree group"
+    );
+    assert!(
+        script.contains(":*:daft-go:*:local"),
+        "zsh daft-go must emit a zstyle line for the local group"
+    );
+    assert!(
+        script.contains(":*:daft-go:*:remote"),
+        "zsh daft-go must emit a zstyle line for the remote group"
+    );
+}
+```
+
+- [ ] **Step 2: Run and verify it fails**
+
+```bash
+cargo test -p daft --lib commands::completions::tests::zsh_daft_go_emits_zstyle_colors_per_group
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Prepend the zstyle block to `generate_zsh_daft_go_completion()`**
+
+Edit `generate_zsh_daft_go_completion()` in `src/commands/completions/zsh.rs`
+so the returned string begins with a zstyle block before the
+`#compdef` line. Replace the `format!` header:
+
+```rust
+format!(
+    r#"#compdef daft-go
+"#
+```
+
+with:
+
+```rust
+format!(
+    r#"#compdef daft-go
+
+# Per-group colors for `daft go` completions. Scoped to daft-go so the
+# user's global completion colors are untouched. `zstyle -d` to disable.
+zstyle ':completion:*:*:daft-go:*:worktree' list-colors '=(#b)(*)=0=1;32'
+zstyle ':completion:*:*:daft-go:*:local'    list-colors '=(#b)(*)=0=1;34'
+zstyle ':completion:*:*:daft-go:*:remote'   list-colors '=(#b)(*)=0=2;37'
+"#
+```
+
+- [ ] **Step 4: Run the test**
+
+```bash
+cargo test -p daft --lib commands::completions::tests::zsh_daft_go_emits_zstyle_colors_per_group
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/commands/completions/zsh.rs src/commands/completions/mod.rs
+git commit -m "$(cat <<'EOF'
+feat(completions): color daft-go groups in zsh via zstyle
+
+Emit a scoped zstyle block alongside the daft-go zsh completion so
+worktree entries show in bright green, local in bright blue, and
+remote in dim gray. Scoped to `:*:daft-go:*:<group>` so user-level
+completion colors are unaffected. Users who dislike the defaults
+can `zstyle -d` the entries.
+EOF
+)"
+```
+
+---
+
+### Task 13: Wire `go` verb alias to the grouped completion in `DAFT_ZSH_COMPLETIONS`
+
+**Why:** The zsh umbrella function in `DAFT_ZSH_COMPLETIONS` currently
+delegates `daft go` to `__daft_go_impl`. That's already the right path
+name — Task 9 kept the `__daft_go_impl` name intentionally. Verify
+there's no stale delegation to adjust, and add a test that pins the
+contract.
+
+**Files:**
+
+- Modify: `src/commands/completions/mod.rs` (test only, unless a real
+  bug is found)
+
+- [ ] **Step 1: Write a test that locks in the alias wiring**
+
+```rust
+#[test]
+fn zsh_umbrella_delegates_go_to_daft_go_impl() {
+    let combined = format!(
+        "{}\n{}",
+        zsh::generate_zsh_completion_string("daft-go").unwrap(),
+        zsh::DAFT_ZSH_COMPLETIONS,
+    );
+    // The umbrella must delegate `daft go` to the grouped implementation.
+    assert!(
+        combined.contains("__daft_go_impl"),
+        "zsh umbrella must call __daft_go_impl for the `go` verb alias"
+    );
+}
+```
+
+- [ ] **Step 2: Run and verify the test result**
+
+```bash
+cargo test -p daft --lib commands::completions::tests::zsh_umbrella_delegates_go_to_daft_go_impl
+```
+
+If the test passes unchanged: the umbrella wiring already matches.
+Commit and move on.
+
+If the test fails: inspect `DAFT_ZSH_COMPLETIONS` in `zsh.rs` and
+update the `go)` case inside the verb-alias `case` block to call
+`__daft_go_impl` (this is the pre-existing shape — the call site
+already exists, so expect the test to pass).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/commands/completions/mod.rs
+git commit -m "$(cat <<'EOF'
+test(completions): pin zsh umbrella delegation for daft go
+
+Lock in that `daft go` delegates to __daft_go_impl, which is the
+new grouped completion function introduced in the daft-go overhaul.
+EOF
+)"
+```
+
+---
+
+### Task 14: Docs — `daft go` CLI reference and config reference
+
+**Files:**
+
+- Modify: `docs/cli/daft-go.md`
+- Modify: `docs/guide/configuration.md` (if the config reference page
+  lists daft settings — verify first)
+
+- [ ] **Step 1: Check the current state of `docs/cli/daft-go.md`**
+
+```bash
+cat docs/cli/daft-go.md
+```
+
+Note the existing structure — frontmatter, synopsis, options table, etc.
+
+- [ ] **Step 2: Add a "Completion behavior" section**
+
+Append to `docs/cli/daft-go.md` (before any trailing "See also" block):
+
+```markdown
+## Completion behavior
+
+`daft go <TAB>` offers candidates grouped by type:
+
+1. **Worktrees** — branches that already have a linked worktree. These
+   are the primary navigation targets and are listed first. The branch
+   you are currently sitting in is excluded.
+2. **Local branches** — branches in `refs/heads/` that don't have a
+   worktree yet. Selecting one of these will check it out into a new
+   worktree.
+3. **Remote branches** — branches in `refs/remotes/` that don't already
+   exist locally. In single-remote mode the `<remote>/` prefix is
+   stripped for readability; in multi-remote mode the full
+   `<remote>/<branch>` form is preserved.
+
+In zsh and fish, each candidate is annotated with the relative time of
+its last commit (e.g. "3 days ago"). In zsh the three groups are
+colored distinctly — worktrees in bright green, local branches in
+bright blue, remote branches in dim gray. Bash shows a flat list in
+the same group order but without colors or descriptions.
+
+### Fetch-on-miss
+
+If you type a prefix that doesn't match any local or already-fetched
+remote ref, daft will run `git fetch` once (from the configured
+default remote) and re-resolve, showing a spinner while the fetch
+runs. This lets you tab-complete to a remote branch that exists
+upstream but hasn't been pulled yet.
+
+The fetch path is gated by a 30-second cooldown per repository, so
+rapid keystrokes won't trigger repeated fetches. To disable the
+feature entirely:
+
+```sh
+git config daft.go.fetchOnMiss false
+```
+```
+
+- [ ] **Step 3: Regenerate the man page**
+
+```bash
+mise run man:gen
+```
+
+Expected: `man/daft-go.1` is updated. Verify with:
+
+```bash
+git diff man/daft-go.1
+```
+
+- [ ] **Step 4: Run docs lint**
+
+```bash
+mise run fmt
+```
+
+Expected: prettier formats the markdown files without errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/cli/daft-go.md man/daft-go.1
+git commit -m "$(cat <<'EOF'
+docs(cli): document daft go completion grouping and fetch-on-miss
+
+Add a "Completion behavior" section to the daft-go reference page
+covering the three-group layout, per-shell rendering, and the
+fetch-on-miss spinner gated by daft.go.fetchOnMiss.
+EOF
+)"
+```
+
+---
+
+### Task 15: Manual test plan for the spinner and visual rendering
+
+**Files:**
+
+- Create: `test-plans/go-completions.md`
+
+- [ ] **Step 1: Inspect an existing test plan for format**
+
+```bash
+ls test-plans/
+head -30 test-plans/*.md | head -40
+```
+
+Note the frontmatter and markdown-checklist shape.
+
+- [ ] **Step 2: Write the plan**
+
+Create `test-plans/go-completions.md`:
+
+```markdown
+---
+branch: fix/go-completions
+---
+
+# daft go Completion Overhaul
+
+## Setup
+
+- [ ] Install the current build via `mise run dev`.
+- [ ] In a test repo with ≥ 3 worktrees, ≥ 2 local-only branches, and
+      ≥ 5 remote-only branches, open a new zsh shell and a new bash
+      shell.
+
+## Group ordering
+
+- [ ] `daft go <TAB>` in zsh lists worktrees first, then local
+      branches, then remote branches, in that order.
+- [ ] Same in bash (flat list but preserving the order).
+- [ ] Same in fish.
+- [ ] The current worktree's branch does NOT appear in the worktree
+      group.
+
+## Descriptions and colors
+
+- [ ] zsh: each entry shows a relative age ("3 days ago", etc.) in the
+      description column.
+- [ ] zsh: worktree entries are bright green, local are bright blue,
+      remote are dim gray.
+- [ ] fish: each entry shows `<age> · <group>` in the description.
+- [ ] bash: no descriptions, but no flags leaked into the branch list.
+
+## Flag gating
+
+- [ ] `daft go -<TAB>` in zsh shows ONLY flags, no branches.
+- [ ] `daft go -<TAB>` in bash shows ONLY flags, no branches.
+- [ ] `daft go <TAB>` (no dash) shows ONLY branches, no flags.
+
+## Fetch-on-miss + spinner
+
+- [ ] Find a remote-only branch that's NOT in your local `refs/remotes/`
+      (ask someone to push a branch, or delete your local remote ref
+      with `git update-ref -d refs/remotes/origin/<branch>`).
+- [ ] Type `daft go <prefix-of-that-branch><TAB>`. Expected: a
+      braille-dot spinner with "Fetching refs from origin…" appears
+      on the terminal for the duration of the fetch, then clears.
+- [ ] After the fetch completes, the completion list now includes
+      the remote branch.
+- [ ] Immediately type the same completion again. Expected: no
+      spinner this time (cooldown).
+- [ ] Wait 30+ seconds and retry. Expected: spinner reappears.
+- [ ] `git config daft.go.fetchOnMiss false` — expected: spinner never
+      appears, regardless of cooldown.
+- [ ] Reset with `git config --unset daft.go.fetchOnMiss`.
+
+## Multi-remote mode
+
+- [ ] Enable multi-remote via `daft multi-remote enable`.
+- [ ] `daft go <TAB>` — remote-only entries now show `<remote>/<branch>`
+      verbatim instead of stripped form.
+- [ ] Disable multi-remote again via `daft multi-remote disable`.
+
+## Non-interactive invocation
+
+- [ ] `daft __complete daft-go "" --position 1 | head` inside a
+      repository emits tab-separated lines with three columns each.
+- [ ] The same command with `--fetch-on-miss` and a non-matching
+      prefix does NOT draw a spinner (no /dev/tty when stdout is
+      piped) and still emits any matching output.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test-plans/go-completions.md
+git commit -m "$(cat <<'EOF'
+test(plan): add manual test plan for daft go completion overhaul
+
+Covers group ordering, descriptions, colors, flag gating, the
+fetch-on-miss spinner + cooldown, multi-remote naming, and
+non-interactive invocation. Tied to branch fix/go-completions via
+frontmatter for the sandbox `test-plan` command to pick up.
+EOF
+)"
+```
+
+---
+
+### Task 16: Full CI simulation and ready-for-review
+
+**Files:** none
+
+- [ ] **Step 1: Run the full CI locally**
+
+```bash
+mise run ci
+```
+
+Expected: clippy, fmt check, unit tests, integration tests, man-page
+verify all pass. The CLAUDE.md pre-commit requirements (`mise run fmt`,
+`mise run clippy`, `mise run test:unit`) are a subset of `mise run ci`.
+
+If anything fails, fix the root cause in a new commit — do not skip
+lefthook or amend earlier commits in the chain.
+
+- [ ] **Step 2: Run the full manual test plan**
+
+Open the manual test plan from Task 15:
+
+```bash
+# Inside the daft sandbox if available, or manually:
+cat test-plans/go-completions.md
+```
+
+Walk through each checkbox. If any manual check fails, fix the root
+cause and add a new commit. Update the plan if the expected behavior
+changed.
+
+- [ ] **Step 3: Push the branch (no auto-PR)**
+
+```bash
+git push -u origin fix/go-completions
+```
+
+Per CLAUDE.md: PRs target master and are always squash-merged. The
+user will open the PR manually via `gh pr create` or the GitHub UI,
+with title `feat(completions): overhaul daft go completion grouping`
+and the spec + plan referenced in the body.

--- a/docs/superpowers/specs/2026-04-11-go-command-completions-design.md
+++ b/docs/superpowers/specs/2026-04-11-go-command-completions-design.md
@@ -1,0 +1,373 @@
+# `daft go` Completion Overhaul
+
+## Problem
+
+`daft go <TAB>` currently produces a confusing, flat list that mixes every local
+branch, every `origin/*` branch (with the prefix stripped), and every
+command-line flag together. Two concrete problems:
+
+1. **Flags leak into branch completion in zsh.** The zsh generator appends
+   `compadd -a flags` unconditionally, so flags appear alongside branches even
+   when the user has typed no leading `-`. Bash already early-returns when
+   `$cur` doesn't start with `-`, so this bug is zsh-specific.
+2. **Names are ambiguous and occasionally nonsensical.** `origin/*` branches are
+   shown with the `origin/` prefix stripped, which means a remote-only branch
+   looks identical to a local one. In at least one observed case a bare `origin`
+   token surfaces in the list — a token that is not a valid navigation target.
+
+There is also no hint of which branches actually have a worktree to navigate to,
+no metadata (e.g. how recently the branch was touched), and no visual grouping —
+everything is one flat alphabetical list.
+
+## Goals
+
+- Group completions as **worktrees → local branches → remote branches**, in that
+  order, without group headers. Sorted within each group.
+- Disambiguate names: don't collide local and remote branches; surface the
+  remote prefix only in multi-remote mode.
+- Show the last-commit relative age next to each name on shells that support
+  per-item descriptions (zsh, fish).
+- Color each group distinctly in zsh. Fish gets implicit differentiation from
+  its native description rendering. Bash gets no color.
+- Only show flags when the user has typed a leading `-`.
+- When the user types a prefix that matches nothing locally, run `git fetch`
+  with a spinner drawn to the terminal, then re-resolve — so that completing to
+  a remote-only branch "just works" even if the local ref cache is stale.
+
+## Non-goals
+
+- Dirty-state indicator (`●`), ahead/behind counts, or any metadata beyond
+  last-commit age. Speed is the preference; these require per-worktree
+  `git status` / `rev-list` calls that blow the perf budget.
+- Bash coloring. Bash completion has no per-item color mechanism worth building
+  around.
+- Fetching from non-default remotes in multi-remote mode. The fetch-on-miss path
+  only fetches from the configured default remote. Other remotes are listed from
+  whatever is already cached locally.
+- A fuzzy/fzf-style picker on TAB. That is a separate, larger feature.
+- Changing Fig / Amazon Q completions. Fig specs are declarative and do not
+  participate in the dynamic completion path; `fig.rs` stays as-is.
+
+## Architecture
+
+There are three layers:
+
+1. **The data layer** — `daft __complete daft-go` in `src/commands/complete.rs`
+   collects refs and worktrees, groups and dedupes them, emits one line per
+   suggestion in a tab-separated format.
+2. **The shell layer** — generated completion scripts in
+   `src/commands/completions/{bash,zsh,fish}.rs` call `daft __complete`, parse
+   its output, and push it into the shell's completion system (grouped and
+   colored where supported).
+3. **The fetch-on-miss layer** — when invoked with `--fetch-on-miss` and the
+   prefix has no matches in the local+cached data, `daft __complete` runs
+   `git fetch` in-process while drawing a single-line braille-dot spinner to
+   `/dev/tty`, then re-resolves and emits results.
+
+### Data protocol
+
+`daft __complete daft-go <prefix>` emits one line per candidate in tab-separated
+form:
+
+```
+<name>\t<group>\t<description>
+```
+
+Where:
+
+- `<name>` is the token the shell should complete to.
+- `<group>` is one of `worktree`, `local`, `remote`.
+- `<description>` is the last-commit relative age (e.g. `3 days ago`,
+  `just now`). May be empty.
+
+Example:
+
+```
+master<TAB>worktree<TAB>2 hours ago
+fix/go-completions<TAB>worktree<TAB>just now
+feat/bar<TAB>local<TAB>4 days ago
+bug/xyz<TAB>remote<TAB>3 weeks ago
+```
+
+Older shell scripts that only read column 1 still get correct (if un-grouped,
+un-described) completion, which matters while users have a mix of old and
+newly-regenerated completion scripts in flight.
+
+A new flag `--fetch-on-miss` triggers the fetch path described below. It is
+ignored by any caller that does not pass it — shell scripts that predate this
+change continue to work.
+
+### Population rules
+
+**Worktree group.** `git worktree list --porcelain` → `(branch, path)` pairs. If
+completion is invoked from inside a worktree, that worktree's branch is excluded
+from the list — `daft go` to the branch you are already on is a no-op. If
+completion is invoked from outside any worktree (e.g. from a bare repository
+root), nothing is excluded. Sorted by branch name.
+
+**Local group.**
+`git for-each-ref refs/heads/ --format='%(refname:short) \t%(committerdate:relative)%(if)%(worktreepath)%(then)\tHAS_WT%(end)'`.
+Entries tagged `HAS_WT` are dropped — they already appear in the worktree group.
+Sorted by branch name.
+
+**Remote group.**
+`git for-each-ref refs/remotes/ --format='%(refname:short)\t%(committerdate:relative)'`.
+Filter:
+
+- Drop HEAD symrefs (`origin/HEAD`, etc.).
+- Drop any entry whose name (after potential prefix stripping) matches a
+  worktree or local branch — local shadows remote.
+- In **single-remote mode** (the default, i.e. when
+  `multi_remote_enabled == false`), strip the leading `<default_remote>/` prefix
+  from the name. The description column is the relative age.
+- In **multi-remote mode** keep the full `<remote>/<branch>` form verbatim. No
+  stripping — the prefix is part of the navigation target.
+- Sorted by name after prefix handling.
+
+All three groups come from at most three `git for-each-ref` /
+`git worktree list` calls — no per-branch git invocations. The perf target is
+unchanged: < 50 ms for the local path (no fetch).
+
+### Fetch-on-miss with spinner
+
+Triggered only when:
+
+- `--fetch-on-miss` is passed by the shell script (always passed for `daft-go`),
+  AND
+- The prefix is non-empty (empty prefix = browsing, not searching), AND
+- The local+cached resolution produces zero candidates, AND
+- The cooldown marker (`<git-common-dir>/daft_complete_last_fetch`) is either
+  missing or older than 30 seconds, AND
+- `daft.go.fetchOnMiss` is not explicitly set to `false`.
+
+When triggered:
+
+1. Open `/dev/tty` for writing. If that fails (non-interactive shell, CI, piped
+   completion) skip straight to silent fetch.
+2. Spawn a background thread that writes braille-dot frames
+   (`⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏`) at ~10 Hz to `/dev/tty`, each frame prefixed with
+   `\r` so they overwrite in place. Frame text:
+   `<frame> Fetching refs from <remote>…`.
+3. On the main thread, run `git fetch --quiet --no-tags <default_remote>` with a
+   5-second timeout.
+4. When the fetch returns (or times out), signal the spinner thread to stop,
+   wait for it to join, clear the line with `\r\033[K`, and close `/dev/tty`.
+5. Touch the cooldown marker.
+6. Re-run the population rules against the now-updated refs, emit results to
+   stdout as normal.
+
+On fetch error or timeout, clear the spinner and return whatever the local
+resolution found (possibly empty). No error output — shell completion is not the
+right channel for errors.
+
+### Settings
+
+Add `go_fetch_on_miss: bool` to `DaftSettings` in `src/core/settings.rs`,
+alongside the existing `go_auto_start`. Sourced from the git config key
+`daft.go.fetchOnMiss`, default `true`. Documented on the config reference page.
+
+### Fixing the flag-gating bug
+
+In the generated zsh script, the existing sequence:
+
+```zsh
+# Branch completions
+if [[ $curword != -* ]]; then
+    compadd -a branches
+fi
+# ...
+compadd -a flags
+```
+
+becomes:
+
+```zsh
+if [[ $curword == -* ]]; then
+    compadd -a flags
+    return
+fi
+# grouped worktree/local/remote via _describe
+```
+
+This is the regression fix that CLAUDE.md's "every bugfix needs a repro test"
+rule covers.
+
+## Shell rendering
+
+### zsh
+
+The `daft-go` branch of the zsh generator is the biggest rewrite:
+
+```zsh
+__daft_go_impl() {
+    local curword="${words[$CURRENT]}"
+
+    # Flags only when user has typed '-'
+    if [[ "$curword" == -* ]]; then
+        local -a flags
+        flags=( ... )     # from clap introspection, same as before
+        compadd -a flags
+        return
+    fi
+
+    # Fetch candidates from daft __complete (tab-separated)
+    local -a raw wt_items local_items remote_items
+    raw=(${(f)"$(daft __complete daft-go "$curword" --position "$cword" \
+                    --fetch-on-miss 2>/dev/null)"})
+
+    local line name group desc
+    for line in "${raw[@]}"; do
+        name="${line%%$'\t'*}"
+        local rest="${line#*$'\t'}"
+        group="${rest%%$'\t'*}"
+        desc="${rest#*$'\t'}"
+        case "$group" in
+            worktree) wt_items+=("$name:$desc") ;;
+            local)    local_items+=("$name:$desc") ;;
+            remote)   remote_items+=("$name:$desc") ;;
+        esac
+    done
+
+    _describe -t worktree '' wt_items
+    _describe -t local    '' local_items
+    _describe -t remote   '' remote_items
+}
+```
+
+Empty-string tag descriptions (`''`) suppress the group headers. The three
+`_describe` calls execute in order, so worktrees appear first in the menu. The
+`-t <tag>` parameter is what lets zstyle color each group.
+
+Shell-init emits a scoped zstyle block alongside the generated functions:
+
+```zsh
+zstyle ':completion:*:*:daft-go:*:worktree' list-colors '=(#b)(*)=0=1;32'
+zstyle ':completion:*:*:daft-go:*:local'    list-colors '=(#b)(*)=0=1;34'
+zstyle ':completion:*:*:daft-go:*:remote'   list-colors '=(#b)(*)=0=2;37'
+```
+
+worktree = bright green, local = bright blue, remote = dim gray. Scoped to the
+`daft-go` completion context so the user's global completion colors are
+untouched. Users who dislike these colors can `zstyle -d` them.
+
+### bash
+
+Bash has no per-item description or color support. The generator parses column 1
+only and concatenates `worktree + local + remote` in that order:
+
+```bash
+if [[ "$cur" != -* ]]; then
+    local raw
+    raw=$(daft __complete daft-go "$cur" --position "$cword" \
+              --fetch-on-miss 2>/dev/null | cut -f1)
+    if [[ -n "$raw" ]]; then
+        COMPREPLY=( $(compgen -W "$raw" -- "$cur") )
+        compopt -o nosort 2>/dev/null || true
+        return 0
+    fi
+fi
+```
+
+`compopt -o nosort` (bash ≥ 4.4) preserves the group ordering emitted by
+`daft __complete`. On older bash it silently falls through and the user gets
+alphabetical ordering — correctness is preserved, only group ordering is lost.
+
+The flag-gating `if [[ "$cur" == -* ]]` branch is already correct in bash and is
+unchanged.
+
+### fish
+
+Fish's existing pattern for `daft-go` is a single
+`complete -f -a "(daft __complete daft-go '' 2>/dev/null)"` line. Extend it to
+pass the description column — fish natively reads `name\tdescription` from
+completion helpers:
+
+```fish
+complete -c daft -n '__fish_seen_subcommand_from go' -f -a \
+    "(daft __complete daft-go (commandline -ct) --fetch-on-miss 2>/dev/null \
+      | awk -F'\\t' '{printf \"%s\\t%s · %s\\n\", \$1, \$3, \$2}')"
+```
+
+The `awk` reshuffles tab-separated columns into fish's `name\tdescription`
+format with the description as `<age> · <group>`. Fish colors descriptions
+distinctly from the main completion, which provides the visual grouping
+automatically. The exact shell-quoting of the inline awk expression will be
+finalized during implementation — the snippet above is illustrative.
+
+## Testing
+
+- **Unit tests on the data layer.** `complete_daft_go()` driven by fixture git
+  output (ref lists, worktree porcelain). Assertions on exact tab-separated
+  output for: grouping order, dedupe (local shadows remote, worktree shadows
+  local), current-worktree exclusion, single- vs multi-remote naming, empty
+  prefix, matching prefix, non-matching prefix.
+- **Cooldown marker.** Unit test that touches the marker and asserts fetch is
+  skipped within 30s, and runs again after.
+- **Generator snapshot tests.** For each of `bash.rs` / `zsh.rs` / `fish.rs`,
+  assert that the generated script for `daft-go` contains:
+  - The flag-gating on `-`.
+  - `_describe -t worktree`, `-t local`, `-t remote` (zsh).
+  - `compopt -o nosort` (bash).
+  - The zstyle block (zsh, in the daft subcommand completions).
+- **Regression test** for the zsh flag-leak bug: snapshot assertion that the
+  generated zsh script contains the `curword == -*` gate and does **not**
+  contain an unconditional `compadd -a flags` after the branches.
+- **YAML scenario** in `tests/manual/scenarios/go/` that sets up a repo with (a)
+  a current worktree, (b) another worktree on a different branch, (c) a local
+  branch with no worktree, (d) a remote-only branch, and asserts
+  `daft __complete daft-go '' --position 1` emits the expected three-group
+  output.
+- **Spinner.** The tty-drawing side is awkward to test end-to-end. Unit tests
+  cover the frame generator (returns the right characters at the right cadence)
+  and the cooldown-file logic. The actual drawing is verified via a manual test
+  plan entry in `test-plans/`.
+
+## Migration and backward compatibility
+
+- Old callers of `daft __complete daft-go <word>` that parse only the first
+  column still work — they lose grouping and descriptions but the completion
+  targets are correct.
+- `--fetch-on-miss` is a new optional flag; completion scripts that don't pass
+  it simply don't get the fetch behavior. Shell-init regenerates the wrapper
+  scripts on every shell start, so users pick up the new behavior automatically
+  on next shell.
+- The zstyle block and `compopt -o nosort` are additive. Users with customized
+  completion styles keep theirs.
+- `daft.go.fetchOnMiss` defaults to `true`. Existing users who never set it get
+  the new fetch behavior.
+- `man daft-go` and `docs/cli/daft-go.md` gain a short "Completion behavior"
+  section. Man page regenerated via `mise run man:gen`.
+- **Not touched**: `fig.rs`. Fig specs are declarative and don't participate in
+  the dynamic completion path.
+
+## Files touched
+
+- `src/commands/complete.rs` — new `complete_daft_go()` function;
+  `--fetch-on-miss` flag; cooldown-marker I/O; spinner module (inline or
+  `src/completion_spinner.rs` — decide during implementation).
+- `src/commands/completions/zsh.rs` — rewrite the branch branch of the
+  generator; `_describe -t <tag>` per group; flag gating; zstyle block.
+- `src/commands/completions/bash.rs` — `compopt -o nosort`; consume new
+  tab-separated output from column 1.
+- `src/commands/completions/fish.rs` — awk reshuffle into fish's
+  `name\tdescription` format for `daft-go`.
+- `src/core/settings.rs` — `go_fetch_on_miss: bool` field on `DaftSettings`
+  (alongside the existing `go_auto_start`), sourced from the git config key
+  `daft.go.fetchOnMiss`, default `true`.
+- `tests/manual/scenarios/go/` — new completion scenario YAML.
+- `docs/cli/daft-go.md`, `man/daft-go.1` — completion behavior paragraph.
+- `test-plans/go-completions.md` — manual checklist for the spinner path.
+
+## Open questions
+
+None. All scope decisions are locked in:
+
+- Grouping without headers, sorted within groups, ordered worktree → local →
+  remote.
+- Strip the remote prefix only in single-remote mode; keep it verbatim in
+  multi-remote mode.
+- Last-commit relative age as the description column.
+- zsh colors: worktree=bright green, local=bright blue, remote=dim gray.
+- Fetch-on-miss is in scope. 5-second fetch timeout. Default on; opt-out via
+  `daft.go.fetchOnMiss = false`. 30-second cooldown marker.
+- Spinner drawn by `daft __complete` to `/dev/tty`, not by shell scripts.

--- a/mise-tasks/bench/complete
+++ b/mise-tasks/bench/complete
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+#MISE description="Run completion benchmark"
+#MISE depends=["dev:setup"]
+set -euo pipefail
+export PATH="$(git rev-parse --show-toplevel)/target/release:$PATH"
+
+bash "$(git rev-parse --show-toplevel)/benches/scenarios/complete.sh"

--- a/src/commands/complete.rs
+++ b/src/commands/complete.rs
@@ -437,6 +437,158 @@ fn find_worktree_root() -> Result<std::path::PathBuf> {
     ))
 }
 
+/// Which group a completion entry belongs to, used for visual separation
+/// in shells that support per-item tags.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
+pub(crate) enum CompletionGroup {
+    /// Branch has a worktree — immediate navigation target.
+    Worktree,
+    /// Local branch without a worktree.
+    Local,
+    /// Remote-tracking branch not mirrored locally.
+    Remote,
+}
+
+impl CompletionGroup {
+    #[allow(dead_code)]
+    fn as_str(self) -> &'static str {
+        match self {
+            CompletionGroup::Worktree => "worktree",
+            CompletionGroup::Local => "local",
+            CompletionGroup::Remote => "remote",
+        }
+    }
+}
+
+/// A single completion candidate emitted by `daft __complete daft-go`.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub(crate) struct CompletionEntry {
+    pub name: String,
+    pub group: CompletionGroup,
+    pub description: String,
+}
+
+/// Pure grouping/dedupe/filter/sort function for `daft go` completions.
+///
+/// Takes already-collected git data and produces a flat, ordered list of
+/// completion entries: worktrees first, then local branches, then remote
+/// branches. Within each group, entries are sorted alphabetically.
+///
+/// Dedupe rules: worktree shadows local and remote; local shadows remote.
+/// Shadowing is by stripped-name comparison — a remote-only branch whose
+/// stripped name collides with a local or worktree branch is dropped.
+///
+/// The current worktree (if any) is excluded from the worktree group —
+/// `daft go` to the branch you're already on is a no-op.
+///
+/// In single-remote mode, the leading `<default_remote>/` prefix is
+/// stripped from remote-branch names. In multi-remote mode the full
+/// `<remote>/<branch>` form is preserved. HEAD symrefs (`origin/HEAD`,
+/// etc.) are always dropped.
+///
+/// Entries whose name doesn't start with `prefix` are filtered out.
+#[allow(dead_code)]
+pub(crate) fn build_go_completions(
+    worktrees: &[(String, std::path::PathBuf)],
+    local_branches: &[(String, String)],
+    remote_branches: &[(String, String)],
+    current_worktree_branch: Option<&str>,
+    default_remote: &str,
+    multi_remote: bool,
+    prefix: &str,
+) -> Vec<CompletionEntry> {
+    use std::collections::BTreeSet;
+
+    // Worktree group: exclude the current worktree's branch.
+    let mut wt_entries: Vec<CompletionEntry> = worktrees
+        .iter()
+        .filter(|(name, _)| Some(name.as_str()) != current_worktree_branch)
+        .filter(|(name, _)| name.starts_with(prefix))
+        .map(|(name, path)| CompletionEntry {
+            name: name.clone(),
+            group: CompletionGroup::Worktree,
+            description: path.display().to_string(),
+        })
+        .collect();
+    wt_entries.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let wt_names: BTreeSet<&str> = wt_entries.iter().map(|e| e.name.as_str()).collect();
+
+    // Local group: drop anything already in the worktree group.
+    let mut local_entries: Vec<CompletionEntry> = local_branches
+        .iter()
+        .filter(|(name, _)| !wt_names.contains(name.as_str()))
+        .filter(|(name, _)| name.starts_with(prefix))
+        .map(|(name, age)| CompletionEntry {
+            name: name.clone(),
+            group: CompletionGroup::Local,
+            description: age.clone(),
+        })
+        .collect();
+    local_entries.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let local_names: BTreeSet<String> = local_entries
+        .iter()
+        .map(|e| e.name.clone())
+        .collect::<BTreeSet<_>>();
+
+    // Remote group: drop HEAD symrefs, prefix-strip in single-remote mode,
+    // dedupe against worktree + local by stripped name.
+    let prefix_to_strip = format!("{default_remote}/");
+    let mut remote_entries: Vec<CompletionEntry> = remote_branches
+        .iter()
+        .filter(|(name, _)| !name.ends_with("/HEAD") && name != "HEAD")
+        .filter_map(|(name, age)| {
+            let display = if multi_remote {
+                name.clone()
+            } else if let Some(stripped) = name.strip_prefix(&prefix_to_strip) {
+                stripped.to_string()
+            } else {
+                // In single-remote mode, a remote from a non-default remote
+                // is unusual — keep its full name rather than inventing a
+                // shadowing rule.
+                name.clone()
+            };
+            if wt_names.contains(display.as_str()) || local_names.contains(&display) {
+                return None;
+            }
+            if !display.starts_with(prefix) {
+                return None;
+            }
+            Some(CompletionEntry {
+                name: display,
+                group: CompletionGroup::Remote,
+                description: age.clone(),
+            })
+        })
+        .collect();
+    remote_entries.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let mut out = Vec::with_capacity(wt_entries.len() + local_entries.len() + remote_entries.len());
+    out.extend(wt_entries);
+    out.extend(local_entries);
+    out.extend(remote_entries);
+    out
+}
+
+/// Format grouped completion entries as tab-separated lines for the
+/// shell completion protocol: `<name>\t<group>\t<description>`.
+#[allow(dead_code)]
+pub(crate) fn format_go_completions(entries: &[CompletionEntry]) -> String {
+    let mut out = String::new();
+    for entry in entries {
+        out.push_str(&entry.name);
+        out.push('\t');
+        out.push_str(entry.group.as_str());
+        out.push('\t');
+        out.push_str(&entry.description);
+        out.push('\n');
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -457,5 +609,188 @@ mod tests {
     fn test_suggest_new_branch_names_no_match() {
         let suggestions = suggest_new_branch_names("xyz");
         assert!(suggestions.is_empty());
+    }
+
+    // Tests for the new go-completion grouping function.
+
+    fn wt(name: &str, path: &str) -> (String, std::path::PathBuf) {
+        (name.to_string(), std::path::PathBuf::from(path))
+    }
+
+    fn br(name: &str, age: &str) -> (String, String) {
+        (name.to_string(), age.to_string())
+    }
+
+    #[test]
+    fn go_completions_group_order_is_worktrees_then_local_then_remote() {
+        let entries = build_go_completions(
+            &[wt("master", "/tmp/repo/master")],
+            &[br("feat/local", "4 days ago")],
+            &[br("origin/bug/xyz", "3 weeks ago")],
+            None, // no current worktree
+            "origin",
+            false, // single-remote mode
+            "",
+        );
+        let groups: Vec<CompletionGroup> = entries.iter().map(|e| e.group).collect();
+        assert_eq!(
+            groups,
+            vec![
+                CompletionGroup::Worktree,
+                CompletionGroup::Local,
+                CompletionGroup::Remote,
+            ],
+            "worktrees must come first, then local, then remote"
+        );
+    }
+
+    #[test]
+    fn go_completions_sort_within_group_alphabetically() {
+        let entries = build_go_completions(
+            &[wt("b", "/tmp/b"), wt("a", "/tmp/a")],
+            &[br("z", "1 day ago"), br("m", "2 days ago")],
+            &[],
+            None,
+            "origin",
+            false,
+            "",
+        );
+        let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+        assert_eq!(names, vec!["a", "b", "m", "z"]);
+    }
+
+    #[test]
+    fn go_completions_local_shadows_remote() {
+        let entries = build_go_completions(
+            &[],
+            &[br("feat/shared", "1 day ago")],
+            &[br("origin/feat/shared", "2 days ago")],
+            None,
+            "origin",
+            false,
+            "",
+        );
+        assert_eq!(entries.len(), 1, "remote should be shadowed by local");
+        assert_eq!(entries[0].name, "feat/shared");
+        assert_eq!(entries[0].group, CompletionGroup::Local);
+    }
+
+    #[test]
+    fn go_completions_worktree_shadows_local_and_remote() {
+        let entries = build_go_completions(
+            &[wt("master", "/tmp/master")],
+            &[br("master", "1 day ago")],
+            &[br("origin/master", "2 days ago")],
+            None,
+            "origin",
+            false,
+            "",
+        );
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "master");
+        assert_eq!(entries[0].group, CompletionGroup::Worktree);
+    }
+
+    #[test]
+    fn go_completions_exclude_current_worktree() {
+        let entries = build_go_completions(
+            &[wt("master", "/tmp/master"), wt("feat/x", "/tmp/feat-x")],
+            &[],
+            &[],
+            Some("feat/x"),
+            "origin",
+            false,
+            "",
+        );
+        let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+        assert_eq!(names, vec!["master"]);
+    }
+
+    #[test]
+    fn go_completions_strip_remote_prefix_in_single_remote_mode() {
+        let entries = build_go_completions(
+            &[],
+            &[],
+            &[br("origin/bug/xyz", "3 weeks ago")],
+            None,
+            "origin",
+            false,
+            "",
+        );
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "bug/xyz");
+        assert_eq!(entries[0].group, CompletionGroup::Remote);
+    }
+
+    #[test]
+    fn go_completions_keep_remote_prefix_in_multi_remote_mode() {
+        let entries = build_go_completions(
+            &[],
+            &[],
+            &[
+                br("origin/bug/xyz", "3 weeks ago"),
+                br("fork/feat/y", "2 days ago"),
+            ],
+            None,
+            "origin",
+            true, // multi-remote mode
+            "",
+        );
+        let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+        assert_eq!(names, vec!["fork/feat/y", "origin/bug/xyz"]);
+    }
+
+    #[test]
+    fn go_completions_filter_by_prefix() {
+        let entries = build_go_completions(
+            &[wt("master", "/tmp/master")],
+            &[br("feat/x", "1d"), br("fix/y", "2d")],
+            &[br("origin/bug/z", "3w")],
+            None,
+            "origin",
+            false,
+            "fe",
+        );
+        let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+        assert_eq!(names, vec!["feat/x"]);
+    }
+
+    #[test]
+    fn go_completions_drop_remote_head_symrefs() {
+        let entries = build_go_completions(
+            &[],
+            &[],
+            &[
+                br("origin/HEAD", "just now"),
+                br("origin/master", "1 day ago"),
+            ],
+            None,
+            "origin",
+            false,
+            "",
+        );
+        let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+        assert_eq!(names, vec!["master"]);
+    }
+
+    #[test]
+    fn format_go_completions_emits_tab_separated_name_group_description() {
+        let entries = vec![
+            CompletionEntry {
+                name: "master".into(),
+                group: CompletionGroup::Worktree,
+                description: "2 hours ago".into(),
+            },
+            CompletionEntry {
+                name: "feat/bar".into(),
+                group: CompletionGroup::Local,
+                description: "4 days ago".into(),
+            },
+        ];
+        let out = format_go_completions(&entries);
+        assert_eq!(
+            out,
+            "master\tworktree\t2 hours ago\nfeat/bar\tlocal\t4 days ago\n"
+        );
     }
 }

--- a/src/commands/complete.rs
+++ b/src/commands/complete.rs
@@ -692,14 +692,23 @@ pub(crate) fn build_go_completions(
     use std::collections::HashSet;
 
     // Worktree group: exclude the current worktree's branch.
+    // Look up the commit age from local_branches for each worktree, and
+    // pack both age and path into the description as "age\tpath".
     let mut wt_entries: Vec<CompletionEntry> = worktrees
         .iter()
         .filter(|(name, _)| Some(name.as_str()) != current_worktree_branch)
         .filter(|(name, _)| name.starts_with(prefix))
-        .map(|(name, path)| CompletionEntry {
-            name: name.clone(),
-            group: CompletionGroup::Worktree,
-            description: path.display().to_string(),
+        .map(|(name, path)| {
+            let age = local_branches
+                .iter()
+                .find(|(n, _)| n == name)
+                .map(|(_, a)| a.as_str())
+                .unwrap_or("");
+            CompletionEntry {
+                name: name.clone(),
+                group: CompletionGroup::Worktree,
+                description: format!("{}\t{}", age, path.display()),
+            }
         })
         .collect();
     wt_entries.sort_by(|a, b| a.name.cmp(&b.name));
@@ -973,7 +982,7 @@ mod tests {
             CompletionEntry {
                 name: "master".into(),
                 group: CompletionGroup::Worktree,
-                description: "2 hours ago".into(),
+                description: "2 hours ago\t/tmp/wt/master".into(),
             },
             CompletionEntry {
                 name: "feat/bar".into(),
@@ -984,7 +993,7 @@ mod tests {
         let out = format_go_completions(&entries);
         assert_eq!(
             out,
-            "master\tworktree\t2 hours ago\nfeat/bar\tlocal\t4 days ago\n"
+            "master\tworktree\t2 hours ago\t/tmp/wt/master\nfeat/bar\tlocal\t4 days ago\n"
         );
     }
 

--- a/src/commands/complete.rs
+++ b/src/commands/complete.rs
@@ -244,18 +244,10 @@ fn collect_go_remote_branches() -> Vec<(String, String)> {
 }
 
 /// Collect the current worktree's branch, if any — used to exclude it
-/// from the completion list. Returns `None` if the caller is outside a
-/// worktree or the current worktree is detached.
+/// from the completion list. Returns `None` if HEAD is detached or if
+/// the current directory is outside a git repository.
 fn current_worktree_branch() -> Option<String> {
-    use crate::git::GitCommand;
-
-    let git = GitCommand::new(true);
-    let current_path = crate::core::repo::get_current_worktree_path().ok()?;
-    let entries = crate::core::worktree::prune::parse_worktree_list(&git).ok()?;
-    entries
-        .into_iter()
-        .find(|wt| wt.path == current_path)
-        .and_then(|wt| wt.branch)
+    crate::core::repo::get_current_branch().ok()
 }
 
 /// Top-level completion helper for `daft go`. Collects real git data,
@@ -649,7 +641,14 @@ pub(crate) fn build_go_completions(
     let prefix_to_strip = format!("{default_remote}/");
     let mut remote_entries: Vec<CompletionEntry> = remote_branches
         .iter()
-        .filter(|(name, _)| !name.ends_with("/HEAD") && name != "HEAD")
+        .filter(|(name, _)| {
+            // Drop HEAD symrefs (`origin/HEAD`) and the collapsed HEAD
+            // short-form (git emits the bare remote name `origin` for the
+            // remote HEAD symref via `for-each-ref --format=%(refname:short)`).
+            // Any legitimate remote-tracking branch has a `/` separating
+            // the remote name from the branch path.
+            !name.ends_with("/HEAD") && name != "HEAD" && name.contains('/')
+        })
         .filter_map(|(name, age)| {
             let display = if multi_remote {
                 name.clone()
@@ -957,5 +956,52 @@ mod tests {
         );
         let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
         assert_eq!(names, vec!["fork/feat/x", "origin/feat/x"]);
+    }
+
+    #[test]
+    fn go_completions_drop_bare_remote_name_symref_collapse() {
+        // `git for-each-ref refs/remotes/ --format=%(refname:short)` emits
+        // the bare remote name (`origin`) as the short name for
+        // `refs/remotes/origin/HEAD`. This is the collapsed form that our
+        // `/HEAD` suffix filter misses, so it needs its own filter rule.
+        let entries = build_go_completions(
+            &[],
+            &[],
+            &[
+                br("origin", "2 hours ago"),
+                br("origin/master", "1 day ago"),
+            ],
+            None,
+            "origin",
+            false,
+            "",
+        );
+        let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["master"],
+            "bare remote name `origin` must be filtered out"
+        );
+    }
+
+    #[test]
+    fn go_completions_drop_bare_remote_name_in_multi_remote_mode() {
+        // In multi-remote mode, bare remote names are equally bogus — git
+        // still collapses `refs/remotes/<remote>/HEAD` to just `<remote>`.
+        let entries = build_go_completions(
+            &[],
+            &[],
+            &[
+                br("origin", "1 day ago"),
+                br("fork", "2 days ago"),
+                br("origin/feat/x", "1 hour ago"),
+            ],
+            None,
+            "origin",
+            true,
+            "",
+        );
+        let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+        assert_eq!(names, vec!["origin/feat/x"]);
     }
 }

--- a/src/commands/complete.rs
+++ b/src/commands/complete.rs
@@ -30,6 +30,13 @@ struct Args {
         help = "Enable verbose error output for debugging completion issues"
     )]
     verbose: bool,
+
+    #[arg(
+        long,
+        help = "When no local matches are found for the prefix, run `git fetch` \
+                with a spinner and re-resolve"
+    )]
+    fetch_on_miss: bool,
 }
 
 pub fn run() -> Result<()> {
@@ -49,6 +56,7 @@ pub fn run() -> Result<()> {
         args.position.unwrap_or(1),
         &args.word,
         args.verbose,
+        args.fetch_on_miss,
     )?;
 
     for suggestion in suggestions {
@@ -59,7 +67,13 @@ pub fn run() -> Result<()> {
 }
 
 /// Provide context-aware completions based on command and position
-fn complete(command: &str, position: usize, word: &str, verbose: bool) -> Result<Vec<String>> {
+fn complete(
+    command: &str,
+    position: usize,
+    word: &str,
+    verbose: bool,
+    fetch_on_miss: bool,
+) -> Result<Vec<String>> {
     match (command, position) {
         // git-worktree-checkout: complete existing branch names
         ("git-worktree-checkout", 1) => complete_existing_branches(word, verbose),
@@ -81,7 +95,7 @@ fn complete(command: &str, position: usize, word: &str, verbose: bool) -> Result
 
         // daft-go: grouped worktree/local/remote completions
         ("daft-go", 1) => {
-            let entries = complete_daft_go(word, false)?;
+            let entries = complete_daft_go(word, fetch_on_miss)?;
             Ok(entries
                 .iter()
                 .map(|e| format!("{}\t{}\t{}", e.name, e.group.as_str(), e.description))
@@ -252,8 +266,9 @@ fn current_worktree_branch() -> Option<String> {
 
 /// Top-level completion helper for `daft go`. Collects real git data,
 /// applies grouping rules, and returns the ordered candidate list.
-/// `fetch_on_miss` is wired in a later task — for now it is always false.
-pub(crate) fn complete_daft_go(prefix: &str, _fetch_on_miss: bool) -> Result<Vec<CompletionEntry>> {
+/// When `fetch_on_miss` is true and the prefix has no local matches,
+/// runs `git fetch` with a spinner and re-resolves.
+pub(crate) fn complete_daft_go(prefix: &str, fetch_on_miss: bool) -> Result<Vec<CompletionEntry>> {
     let settings = crate::core::settings::DaftSettings::load().unwrap_or_default();
     let default_remote = if settings.multi_remote_enabled {
         settings.multi_remote_default.clone()
@@ -261,20 +276,57 @@ pub(crate) fn complete_daft_go(prefix: &str, _fetch_on_miss: bool) -> Result<Vec
         settings.remote.clone()
     };
 
-    let worktrees = collect_go_worktrees();
-    let local = collect_go_local_branches();
-    let remote = collect_go_remote_branches();
-    let current_branch = current_worktree_branch();
+    let collect = || -> Vec<CompletionEntry> {
+        let worktrees = collect_go_worktrees();
+        let local = collect_go_local_branches();
+        let remote = collect_go_remote_branches();
+        let current_branch = current_worktree_branch();
+        build_go_completions(
+            &worktrees,
+            &local,
+            &remote,
+            current_branch.as_deref(),
+            &default_remote,
+            settings.multi_remote_enabled,
+            prefix,
+        )
+    };
 
-    Ok(build_go_completions(
-        &worktrees,
-        &local,
-        &remote,
-        current_branch.as_deref(),
-        &default_remote,
-        settings.multi_remote_enabled,
-        prefix,
-    ))
+    let entries = collect();
+    if !entries.is_empty() || !fetch_on_miss || !settings.go_fetch_on_miss || prefix.is_empty() {
+        return Ok(entries);
+    }
+
+    let git_common_dir = match crate::core::repo::get_git_common_dir() {
+        Ok(d) => d,
+        Err(_) => return Ok(entries),
+    };
+    let marker = git_common_dir.join("daft_complete_last_fetch");
+    if !should_run_fetch(&marker, std::time::Duration::from_secs(30)) {
+        return Ok(entries);
+    }
+
+    let spinner =
+        crate::completion_spinner::Spinner::start(&format!("Fetching refs from {default_remote}…"));
+
+    let fetch_result = std::process::Command::new("git")
+        .args([
+            "fetch",
+            "--quiet",
+            "--no-tags",
+            "--no-recurse-submodules",
+            &default_remote,
+        ])
+        .output();
+    let _ = fetch_result;
+
+    if let Some(s) = spinner {
+        s.stop();
+    }
+
+    let _ = touch_fetch_marker(&marker);
+
+    Ok(collect())
 }
 
 /// Suggest common branch name patterns for new branches
@@ -547,7 +599,6 @@ fn find_worktree_root() -> Result<std::path::PathBuf> {
 
 /// Return `true` if the cooldown marker is missing or older than
 /// `cooldown`. Used to decide whether the fetch-on-miss path should run.
-#[allow(dead_code)]
 fn should_run_fetch(marker: &std::path::Path, cooldown: std::time::Duration) -> bool {
     let metadata = match std::fs::metadata(marker) {
         Ok(m) => m,
@@ -564,7 +615,6 @@ fn should_run_fetch(marker: &std::path::Path, cooldown: std::time::Duration) -> 
 }
 
 /// Create or update the cooldown marker to reflect a just-completed fetch.
-#[allow(dead_code)]
 fn touch_fetch_marker(marker: &std::path::Path) -> std::io::Result<()> {
     if let Some(parent) = marker.parent() {
         std::fs::create_dir_all(parent)?;
@@ -630,7 +680,6 @@ pub(crate) struct CompletionEntry {
 /// etc.) are always dropped.
 ///
 /// Entries whose name doesn't start with `prefix` are filtered out.
-#[allow(dead_code)]
 pub(crate) fn build_go_completions(
     worktrees: &[(String, std::path::PathBuf)],
     local_branches: &[(String, String)],

--- a/src/commands/complete.rs
+++ b/src/commands/complete.rs
@@ -545,6 +545,42 @@ fn find_worktree_root() -> Result<std::path::PathBuf> {
     ))
 }
 
+/// Return `true` if the cooldown marker is missing or older than
+/// `cooldown`. Used to decide whether the fetch-on-miss path should run.
+#[allow(dead_code)]
+fn should_run_fetch(marker: &std::path::Path, cooldown: std::time::Duration) -> bool {
+    let metadata = match std::fs::metadata(marker) {
+        Ok(m) => m,
+        Err(_) => return true,
+    };
+    let mtime = match metadata.modified() {
+        Ok(t) => t,
+        Err(_) => return true,
+    };
+    match std::time::SystemTime::now().duration_since(mtime) {
+        Ok(age) => age >= cooldown,
+        Err(_) => true,
+    }
+}
+
+/// Create or update the cooldown marker to reflect a just-completed fetch.
+#[allow(dead_code)]
+fn touch_fetch_marker(marker: &std::path::Path) -> std::io::Result<()> {
+    if let Some(parent) = marker.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(marker)?;
+    filetime::set_file_mtime(
+        marker,
+        filetime::FileTime::from_system_time(std::time::SystemTime::now()),
+    )?;
+    Ok(())
+}
+
 /// Which group a completion entry belongs to, used for visual separation
 /// in shells that support per-item tags.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1003,5 +1039,39 @@ mod tests {
         );
         let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
         assert_eq!(names, vec!["origin/feat/x"]);
+    }
+
+    #[test]
+    fn fetch_cooldown_allows_fetch_when_marker_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let marker = tmp.path().join("daft_complete_last_fetch");
+        assert!(
+            should_run_fetch(&marker, std::time::Duration::from_secs(30)),
+            "missing marker must allow fetch"
+        );
+    }
+
+    #[test]
+    fn fetch_cooldown_blocks_fetch_within_window() {
+        let tmp = tempfile::tempdir().unwrap();
+        let marker = tmp.path().join("daft_complete_last_fetch");
+        touch_fetch_marker(&marker).unwrap();
+        assert!(
+            !should_run_fetch(&marker, std::time::Duration::from_secs(30)),
+            "freshly touched marker must block fetch"
+        );
+    }
+
+    #[test]
+    fn fetch_cooldown_allows_fetch_after_window() {
+        let tmp = tempfile::tempdir().unwrap();
+        let marker = tmp.path().join("daft_complete_last_fetch");
+        touch_fetch_marker(&marker).unwrap();
+        let old = std::time::SystemTime::now() - std::time::Duration::from_secs(31);
+        filetime::set_file_mtime(&marker, filetime::FileTime::from_system_time(old)).unwrap();
+        assert!(
+            should_run_fetch(&marker, std::time::Duration::from_secs(30)),
+            "marker older than cooldown must allow fetch"
+        );
     }
 }

--- a/src/commands/complete.rs
+++ b/src/commands/complete.rs
@@ -79,8 +79,14 @@ fn complete(command: &str, position: usize, word: &str, verbose: bool) -> Result
         // git-worktree-branch: complete existing branch names for deletion
         ("git-worktree-branch", _) => complete_existing_branches(word, verbose),
 
-        // daft-go: complete existing branch names
-        ("daft-go", 1) => complete_existing_branches(word, verbose),
+        // daft-go: grouped worktree/local/remote completions
+        ("daft-go", 1) => {
+            let entries = complete_daft_go(word, false)?;
+            Ok(entries
+                .iter()
+                .map(|e| format!("{}\t{}\t{}", e.name, e.group.as_str(), e.description))
+                .collect())
+        }
 
         // daft-start: no dynamic completion for new branch names
         ("daft-start", _) => Ok(vec![]),
@@ -167,6 +173,116 @@ fn complete_existing_branches(prefix: &str, verbose: bool) -> Result<Vec<String>
     }
 
     Ok(unique_branches)
+}
+
+/// Collect `(branch, path)` pairs for every linked worktree that has a
+/// branch checked out. Detached HEADs and bare repos are skipped —
+/// they're not navigation targets.
+fn collect_go_worktrees() -> Vec<(String, std::path::PathBuf)> {
+    use crate::git::GitCommand;
+
+    let git = GitCommand::new(true);
+    let entries = match crate::core::worktree::prune::parse_worktree_list(&git) {
+        Ok(e) => e,
+        Err(_) => return Vec::new(),
+    };
+
+    entries
+        .into_iter()
+        .filter(|wt| !wt.is_bare && !wt.is_detached)
+        .filter_map(|wt| wt.branch.map(|b| (b, wt.path)))
+        .collect()
+}
+
+/// Collect `(branch, relative_age)` pairs for every local branch.
+fn collect_go_local_branches() -> Vec<(String, String)> {
+    let output = Command::new("git")
+        .args([
+            "for-each-ref",
+            "--format=%(refname:short)%09%(committerdate:relative)",
+            "refs/heads/",
+        ])
+        .output();
+
+    let output = match output {
+        Ok(o) if o.status.success() => o,
+        _ => return Vec::new(),
+    };
+
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| {
+            let (name, age) = line.split_once('\t')?;
+            Some((name.to_string(), age.to_string()))
+        })
+        .collect()
+}
+
+/// Collect `(branch, relative_age)` pairs for every remote-tracking
+/// branch across all remotes.
+fn collect_go_remote_branches() -> Vec<(String, String)> {
+    let output = Command::new("git")
+        .args([
+            "for-each-ref",
+            "--format=%(refname:short)%09%(committerdate:relative)",
+            "refs/remotes/",
+        ])
+        .output();
+
+    let output = match output {
+        Ok(o) if o.status.success() => o,
+        _ => return Vec::new(),
+    };
+
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| {
+            let (name, age) = line.split_once('\t')?;
+            Some((name.to_string(), age.to_string()))
+        })
+        .collect()
+}
+
+/// Collect the current worktree's branch, if any — used to exclude it
+/// from the completion list. Returns `None` if the caller is outside a
+/// worktree or the current worktree is detached.
+fn current_worktree_branch() -> Option<String> {
+    use crate::git::GitCommand;
+
+    let git = GitCommand::new(true);
+    let current_path = crate::core::repo::get_current_worktree_path().ok()?;
+    let entries = crate::core::worktree::prune::parse_worktree_list(&git).ok()?;
+    entries
+        .into_iter()
+        .find(|wt| wt.path == current_path)
+        .and_then(|wt| wt.branch)
+}
+
+/// Top-level completion helper for `daft go`. Collects real git data,
+/// applies grouping rules, and returns the ordered candidate list.
+/// `fetch_on_miss` is wired in a later task — for now it is always false.
+pub(crate) fn complete_daft_go(prefix: &str, _fetch_on_miss: bool) -> Result<Vec<CompletionEntry>> {
+    let settings = crate::core::settings::DaftSettings::load().unwrap_or_default();
+    let default_remote = if settings.multi_remote_enabled {
+        settings.multi_remote_default.clone()
+    } else {
+        settings.remote.clone()
+    };
+
+    let worktrees = collect_go_worktrees();
+    let local = collect_go_local_branches();
+    let remote = collect_go_remote_branches();
+    let current_branch = current_worktree_branch();
+
+    Ok(build_go_completions(
+        &worktrees,
+        &local,
+        &remote,
+        current_branch.as_deref(),
+        &default_remote,
+        settings.multi_remote_enabled,
+        prefix,
+    ))
 }
 
 /// Suggest common branch name patterns for new branches
@@ -440,7 +556,6 @@ fn find_worktree_root() -> Result<std::path::PathBuf> {
 /// Which group a completion entry belongs to, used for visual separation
 /// in shells that support per-item tags.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(dead_code)]
 pub(crate) enum CompletionGroup {
     /// Branch has a worktree — immediate navigation target.
     Worktree,
@@ -451,7 +566,6 @@ pub(crate) enum CompletionGroup {
 }
 
 impl CompletionGroup {
-    #[allow(dead_code)]
     fn as_str(self) -> &'static str {
         match self {
             CompletionGroup::Worktree => "worktree",
@@ -463,7 +577,6 @@ impl CompletionGroup {
 
 /// A single completion candidate emitted by `daft __complete daft-go`.
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub(crate) struct CompletionEntry {
     pub name: String,
     pub group: CompletionGroup,

--- a/src/commands/complete.rs
+++ b/src/commands/complete.rs
@@ -499,7 +499,7 @@ pub(crate) fn build_go_completions(
     multi_remote: bool,
     prefix: &str,
 ) -> Vec<CompletionEntry> {
-    use std::collections::BTreeSet;
+    use std::collections::HashSet;
 
     // Worktree group: exclude the current worktree's branch.
     let mut wt_entries: Vec<CompletionEntry> = worktrees
@@ -514,7 +514,7 @@ pub(crate) fn build_go_completions(
         .collect();
     wt_entries.sort_by(|a, b| a.name.cmp(&b.name));
 
-    let wt_names: BTreeSet<&str> = wt_entries.iter().map(|e| e.name.as_str()).collect();
+    let wt_names: HashSet<&str> = wt_entries.iter().map(|e| e.name.as_str()).collect();
 
     // Local group: drop anything already in the worktree group.
     let mut local_entries: Vec<CompletionEntry> = local_branches
@@ -529,10 +529,7 @@ pub(crate) fn build_go_completions(
         .collect();
     local_entries.sort_by(|a, b| a.name.cmp(&b.name));
 
-    let local_names: BTreeSet<String> = local_entries
-        .iter()
-        .map(|e| e.name.clone())
-        .collect::<BTreeSet<_>>();
+    let local_names: HashSet<&str> = local_entries.iter().map(|e| e.name.as_str()).collect();
 
     // Remote group: drop HEAD symrefs, prefix-strip in single-remote mode,
     // dedupe against worktree + local by stripped name.
@@ -551,7 +548,7 @@ pub(crate) fn build_go_completions(
                 // shadowing rule.
                 name.clone()
             };
-            if wt_names.contains(display.as_str()) || local_names.contains(&display) {
+            if wt_names.contains(display.as_str()) || local_names.contains(display.as_str()) {
                 return None;
             }
             if !display.starts_with(prefix) {
@@ -792,5 +789,60 @@ mod tests {
             out,
             "master\tworktree\t2 hours ago\nfeat/bar\tlocal\t4 days ago\n"
         );
+    }
+
+    #[test]
+    fn go_completions_empty_input_returns_empty() {
+        let entries = build_go_completions(&[], &[], &[], None, "origin", false, "");
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn go_completions_non_matching_prefix_returns_empty() {
+        let entries = build_go_completions(
+            &[wt("master", "/tmp/master")],
+            &[br("feat/x", "1d")],
+            &[br("origin/bug/y", "2d")],
+            None,
+            "origin",
+            false,
+            "zzz",
+        );
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn go_completions_prefix_filter_applies_after_remote_strip() {
+        // In single-remote mode, the user sees `bug/xyz` (not `origin/bug/xyz`).
+        // The prefix filter must match against the stripped display name.
+        let entries = build_go_completions(
+            &[],
+            &[],
+            &[br("origin/bug/xyz", "3w")],
+            None,
+            "origin",
+            false,
+            "bu",
+        );
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "bug/xyz");
+        assert_eq!(entries[0].group, CompletionGroup::Remote);
+    }
+
+    #[test]
+    fn go_completions_multi_remote_dedupe_keeps_distinct_display_names() {
+        // In multi-remote mode, `origin/feat/x` and `fork/feat/x` are distinct
+        // display names and both must survive — they don't shadow each other.
+        let entries = build_go_completions(
+            &[],
+            &[],
+            &[br("origin/feat/x", "1d"), br("fork/feat/x", "2d")],
+            None,
+            "origin",
+            true, // multi-remote
+            "",
+        );
+        let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+        assert_eq!(names, vec!["fork/feat/x", "origin/feat/x"]);
     }
 }

--- a/src/commands/complete.rs
+++ b/src/commands/complete.rs
@@ -413,21 +413,37 @@ fn current_worktree_branch(repo: &gix::Repository) -> Option<String> {
 pub(crate) fn complete_daft_go(prefix: &str, fetch_on_miss: bool) -> Result<Vec<CompletionEntry>> {
     use std::time::Instant;
 
+    use crate::core::settings::{defaults, keys};
+
     let timings = std::env::var("DAFT_COMPLETE_TIMINGS").is_ok();
     let t_total = Instant::now();
 
     let t = Instant::now();
-    let settings = crate::core::settings::DaftSettings::load().unwrap_or_default();
-    let default_remote = if settings.multi_remote_enabled {
-        settings.multi_remote_default.clone()
-    } else {
-        settings.remote.clone()
-    };
-    let d_settings = t.elapsed();
-
-    let t = Instant::now();
     let repo = discover_repo()?;
     let d_discover = t.elapsed();
+
+    // Read only the config keys completions actually need — directly from
+    // the repo's in-memory config snapshot (no subprocess overhead).
+    let t = Instant::now();
+    let config = repo.config_snapshot();
+    let multi_remote_enabled = config
+        .boolean(keys::multi_remote::ENABLED)
+        .unwrap_or(defaults::MULTI_REMOTE_ENABLED);
+    let default_remote = if multi_remote_enabled {
+        config
+            .string(keys::multi_remote::DEFAULT_REMOTE)
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| defaults::MULTI_REMOTE_DEFAULT_REMOTE.to_string())
+    } else {
+        config
+            .string(keys::REMOTE)
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| defaults::REMOTE.to_string())
+    };
+    let go_fetch_on_miss = config
+        .boolean(keys::GO_FETCH_ON_MISS)
+        .unwrap_or(defaults::GO_FETCH_ON_MISS);
+    let d_settings = t.elapsed();
 
     let collect = |repo: &gix::Repository, timings: bool| -> Vec<CompletionEntry> {
         let t = Instant::now();
@@ -453,7 +469,7 @@ pub(crate) fn complete_daft_go(prefix: &str, fetch_on_miss: bool) -> Result<Vec<
             &remote,
             current_branch.as_deref(),
             &default_remote,
-            settings.multi_remote_enabled,
+            multi_remote_enabled,
             prefix,
         );
         let d_build = t.elapsed();
@@ -486,18 +502,18 @@ pub(crate) fn complete_daft_go(prefix: &str, fetch_on_miss: bool) -> Result<Vec<
 
     if timings {
         eprintln!(
-            "[timings] settings_load    : {:>7.1}ms",
-            d_settings.as_secs_f64() * 1000.0
-        );
-        eprintln!(
             "[timings] repo_discover    : {:>7.1}ms",
             d_discover.as_secs_f64() * 1000.0
+        );
+        eprintln!(
+            "[timings] settings_load    : {:>7.1}ms",
+            d_settings.as_secs_f64() * 1000.0
         );
     }
 
     let entries = collect(&repo, timings);
 
-    if !entries.is_empty() || !fetch_on_miss || !settings.go_fetch_on_miss || prefix.is_empty() {
+    if !entries.is_empty() || !fetch_on_miss || !go_fetch_on_miss || prefix.is_empty() {
         if timings {
             eprintln!(
                 "[timings] total            : {:>7.1}ms",

--- a/src/commands/complete.rs
+++ b/src/commands/complete.rs
@@ -7,6 +7,7 @@
 use anyhow::{Context, Result};
 use clap::Parser;
 
+use crate::core::columns::{CompletionColumn, CompletionColumnSelection};
 use crate::hooks::yaml_config_loader;
 
 #[derive(Parser)]
@@ -408,20 +409,28 @@ pub(crate) fn complete_daft_go(prefix: &str, fetch_on_miss: bool) -> Result<Vec<
     let repo = discover_repo()?;
     let d_discover = t.elapsed();
 
-    // Read remote config + go-specific fetch-on-miss setting.
+    // Read remote config + go-specific fetch-on-miss setting + columns.
     let t = Instant::now();
     let (default_remote, multi_remote_enabled) = read_remote_config(&repo);
     let go_fetch_on_miss = repo
         .config_snapshot()
         .boolean(keys::GO_FETCH_ON_MISS)
         .unwrap_or(defaults::GO_FETCH_ON_MISS);
+    let columns = read_completion_columns(&repo);
     let d_settings = t.elapsed();
+
+    let check_tracked = columns.contains(&CompletionColumn::TrackedChanges);
+    let check_untracked = columns.contains(&CompletionColumn::Untracked);
 
     let cwd = std::env::current_dir().ok();
     let collect = |repo: &gix::Repository, timings: bool| -> Vec<CompletionEntry> {
         let t = Instant::now();
         let worktrees = collect_worktrees(repo);
         let d_wt = t.elapsed();
+
+        let t = Instant::now();
+        let statuses = collect_worktree_statuses(&worktrees, check_tracked, check_untracked);
+        let d_statuses = t.elapsed();
 
         let t = Instant::now();
         let local = collect_local_branches(repo);
@@ -445,6 +454,8 @@ pub(crate) fn complete_daft_go(prefix: &str, fetch_on_miss: bool) -> Result<Vec<
             multi_remote_enabled,
             prefix,
             cwd.as_deref(),
+            &columns,
+            &statuses,
         );
         let d_build = t.elapsed();
 
@@ -452,6 +463,10 @@ pub(crate) fn complete_daft_go(prefix: &str, fetch_on_miss: bool) -> Result<Vec<
             eprintln!(
                 "[timings] worktrees        : {:>7.1}ms",
                 d_wt.as_secs_f64() * 1000.0
+            );
+            eprintln!(
+                "[timings] wt_statuses      : {:>7.1}ms",
+                d_statuses.as_secs_f64() * 1000.0
             );
             eprintln!(
                 "[timings] local_branches   : {:>7.1}ms",
@@ -781,6 +796,67 @@ fn read_remote_config(repo: &gix::Repository) -> (String, bool) {
     (default_remote, multi_remote_enabled)
 }
 
+/// Read the completion columns config from the repo's in-memory config
+/// snapshot (zero subprocess overhead). Falls back to defaults on missing
+/// or invalid config.
+fn read_completion_columns(repo: &gix::Repository) -> Vec<CompletionColumn> {
+    use crate::core::settings::keys;
+
+    let config = repo.config_snapshot();
+    match config.string(keys::completions::BRANCHES_COLUMNS) {
+        Some(value) => CompletionColumnSelection::parse(&value.to_string())
+            .unwrap_or_else(|_| CompletionColumn::completion_defaults().to_vec()),
+        None => CompletionColumn::completion_defaults().to_vec(),
+    }
+}
+
+/// Status flags for a worktree branch (tracked changes / untracked files).
+pub(crate) struct WorktreeStatus {
+    has_tracked_changes: bool,
+    has_untracked: bool,
+}
+
+/// Check dirty status for all worktrees in parallel using gitoxide.
+/// Returns a map from branch name to status flags.
+/// Returns an empty map when both flags are false (zero cost path).
+fn collect_worktree_statuses(
+    worktrees: &[(String, std::path::PathBuf)],
+    check_tracked: bool,
+    check_untracked: bool,
+) -> std::collections::HashMap<String, WorktreeStatus> {
+    use std::collections::HashMap;
+
+    if !check_tracked && !check_untracked {
+        return HashMap::new();
+    }
+
+    std::thread::scope(|scope| {
+        let handles: Vec<_> = worktrees
+            .iter()
+            .map(|(name, path)| {
+                let name = name.clone();
+                let path = path.clone();
+                scope.spawn(move || {
+                    let (tracked, untracked) =
+                        crate::git::oxide::worktree_dirty_status(&path).unwrap_or((false, false));
+                    (
+                        name,
+                        WorktreeStatus {
+                            has_tracked_changes: check_tracked && tracked,
+                            has_untracked: check_untracked && untracked,
+                        },
+                    )
+                })
+            })
+            .collect();
+
+        handles
+            .into_iter()
+            .filter_map(|h| h.join().ok())
+            .collect::<HashMap<_, _>>()
+    })
+}
+
 /// Shared rich branch completion entry point. Discovers the repo, reads
 /// config, collects branch/worktree data according to `config`, and
 /// returns grouped completion entries.
@@ -790,6 +866,7 @@ fn complete_rich_branches(
 ) -> Result<Vec<CompletionEntry>> {
     let repo = discover_repo()?;
     let (default_remote, multi_remote_enabled) = read_remote_config(&repo);
+    let columns = read_completion_columns(&repo);
 
     let worktrees = if config.include_worktrees {
         collect_worktrees(&repo)
@@ -814,6 +891,10 @@ fn complete_rich_branches(
         None
     };
 
+    let check_tracked = columns.contains(&CompletionColumn::TrackedChanges);
+    let check_untracked = columns.contains(&CompletionColumn::Untracked);
+    let statuses = collect_worktree_statuses(&worktrees, check_tracked, check_untracked);
+
     let cwd = std::env::current_dir().ok();
     let mut entries = build_rich_completions(
         &worktrees,
@@ -824,6 +905,8 @@ fn complete_rich_branches(
         multi_remote_enabled,
         prefix,
         cwd.as_deref(),
+        &columns,
+        &statuses,
     );
 
     // If the config excludes local branches but we collected them for
@@ -993,12 +1076,19 @@ pub(crate) fn build_rich_completions(
     multi_remote: bool,
     prefix: &str,
     cwd: Option<&std::path::Path>,
+    columns: &[CompletionColumn],
+    statuses: &std::collections::HashMap<String, WorktreeStatus>,
 ) -> Vec<CompletionEntry> {
     use std::collections::HashSet;
+
+    let show_age = columns.contains(&CompletionColumn::Age);
+    let show_author = columns.contains(&CompletionColumn::Author);
+    let show_path = columns.contains(&CompletionColumn::Path);
 
     // Worktree group: exclude the current worktree's branch.
     // Look up the commit info from local_branches for each worktree, and
     // pack age, author, and path into the description as "age\tauthor\tpath".
+    // Disabled columns emit empty strings to keep the field count fixed.
     let mut wt_entries: Vec<CompletionEntry> = worktrees
         .iter()
         .filter(|(name, _)| Some(name.as_str()) != current_worktree_branch)
@@ -1008,13 +1098,36 @@ pub(crate) fn build_rich_completions(
                 .iter()
                 .find(|(n, _)| n == name)
                 .map(|(_, i)| i);
-            let age = info.map(|i| i.age.as_str()).unwrap_or("");
-            let author = info.map(|i| i.author.as_str()).unwrap_or("");
-            let display_path = cwd
-                .and_then(|base| pathdiff::diff_paths(path, base))
-                .unwrap_or_else(|| path.to_path_buf());
+            let age = if show_age {
+                info.map(|i| i.age.as_str()).unwrap_or("")
+            } else {
+                ""
+            };
+            let author = if show_author {
+                info.map(|i| i.author.as_str()).unwrap_or("")
+            } else {
+                ""
+            };
+            let display_path = if show_path {
+                cwd.and_then(|base| pathdiff::diff_paths(path, base))
+                    .unwrap_or_else(|| path.to_path_buf())
+            } else {
+                std::path::PathBuf::new()
+            };
+
+            // Append dirty indicators to the display name.
+            let mut display_name = name.clone();
+            if let Some(status) = statuses.get(name.as_str()) {
+                if status.has_tracked_changes {
+                    display_name.push('*');
+                }
+                if status.has_untracked {
+                    display_name.push('?');
+                }
+            }
+
             CompletionEntry {
-                name: name.clone(),
+                name: display_name,
                 group: CompletionGroup::Worktree,
                 description: format!("{}\t{}\t{}", age, author, display_path.display()),
             }
@@ -1022,17 +1135,31 @@ pub(crate) fn build_rich_completions(
         .collect();
     wt_entries.sort_by(|a, b| a.name.cmp(&b.name));
 
-    let wt_names: HashSet<&str> = wt_entries.iter().map(|e| e.name.as_str()).collect();
+    // wt_names uses the clean branch name (without indicators) for dedup.
+    let wt_names: HashSet<&str> = worktrees
+        .iter()
+        .filter(|(name, _)| Some(name.as_str()) != current_worktree_branch)
+        .filter(|(name, _)| name.starts_with(prefix))
+        .map(|(name, _)| name.as_str())
+        .collect();
 
     // Local group: drop anything already in the worktree group.
     let mut local_entries: Vec<CompletionEntry> = local_branches
         .iter()
         .filter(|(name, _)| !wt_names.contains(name.as_str()))
         .filter(|(name, _)| name.starts_with(prefix))
-        .map(|(name, info)| CompletionEntry {
-            name: name.clone(),
-            group: CompletionGroup::Local,
-            description: format!("{}\t{}", info.age, info.author),
+        .map(|(name, info)| {
+            let age = if show_age { info.age.as_str() } else { "" };
+            let author = if show_author {
+                info.author.as_str()
+            } else {
+                ""
+            };
+            CompletionEntry {
+                name: name.clone(),
+                group: CompletionGroup::Local,
+                description: format!("{}\t{}", age, author),
+            }
         })
         .collect();
     local_entries.sort_by(|a, b| a.name.cmp(&b.name));
@@ -1069,10 +1196,16 @@ pub(crate) fn build_rich_completions(
             if !display.starts_with(prefix) {
                 return None;
             }
+            let age = if show_age { info.age.as_str() } else { "" };
+            let author = if show_author {
+                info.author.as_str()
+            } else {
+                ""
+            };
             Some(CompletionEntry {
                 name: display,
                 group: CompletionGroup::Remote,
-                description: format!("{}\t{}", info.age, info.author),
+                description: format!("{}\t{}", age, author),
             })
         })
         .collect();
@@ -1125,6 +1258,14 @@ mod tests {
 
     // Tests for the rich completion grouping function.
 
+    fn default_columns() -> &'static [CompletionColumn] {
+        CompletionColumn::completion_defaults()
+    }
+
+    fn empty_statuses() -> std::collections::HashMap<String, WorktreeStatus> {
+        std::collections::HashMap::new()
+    }
+
     fn wt(name: &str, path: &str) -> (String, std::path::PathBuf) {
         (name.to_string(), std::path::PathBuf::from(path))
     }
@@ -1160,6 +1301,8 @@ mod tests {
             false, // single-remote mode
             "",
             None,
+            default_columns(),
+            &empty_statuses(),
         );
         let groups: Vec<CompletionGroup> = entries.iter().map(|e| e.group).collect();
         assert_eq!(
@@ -1184,6 +1327,8 @@ mod tests {
             false,
             "",
             None,
+            default_columns(),
+            &empty_statuses(),
         );
         let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
         assert_eq!(names, vec!["a", "b", "m", "z"]);
@@ -1200,6 +1345,8 @@ mod tests {
             false,
             "",
             None,
+            default_columns(),
+            &empty_statuses(),
         );
         assert_eq!(entries.len(), 1, "remote should be shadowed by local");
         assert_eq!(entries[0].name, "feat/shared");
@@ -1217,6 +1364,8 @@ mod tests {
             false,
             "",
             None,
+            default_columns(),
+            &empty_statuses(),
         );
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].name, "master");
@@ -1234,6 +1383,8 @@ mod tests {
             false,
             "",
             None,
+            default_columns(),
+            &empty_statuses(),
         );
         let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
         assert_eq!(names, vec!["master"]);
@@ -1250,6 +1401,8 @@ mod tests {
             false,
             "",
             None,
+            default_columns(),
+            &empty_statuses(),
         );
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].name, "bug/xyz");
@@ -1270,6 +1423,8 @@ mod tests {
             true, // multi-remote mode
             "",
             None,
+            default_columns(),
+            &empty_statuses(),
         );
         let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
         assert_eq!(names, vec!["fork/feat/y", "origin/bug/xyz"]);
@@ -1286,6 +1441,8 @@ mod tests {
             false,
             "fe",
             None,
+            default_columns(),
+            &empty_statuses(),
         );
         let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
         assert_eq!(names, vec!["feat/x"]);
@@ -1305,6 +1462,8 @@ mod tests {
             false,
             "",
             None,
+            default_columns(),
+            &empty_statuses(),
         );
         let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
         assert_eq!(names, vec!["master"]);
@@ -1333,7 +1492,18 @@ mod tests {
 
     #[test]
     fn rich_completions_empty_input_returns_empty() {
-        let entries = build_rich_completions(&[], &[], &[], None, "origin", false, "", None);
+        let entries = build_rich_completions(
+            &[],
+            &[],
+            &[],
+            None,
+            "origin",
+            false,
+            "",
+            None,
+            default_columns(),
+            &empty_statuses(),
+        );
         assert!(entries.is_empty());
     }
 
@@ -1348,6 +1518,8 @@ mod tests {
             false,
             "zzz",
             None,
+            default_columns(),
+            &empty_statuses(),
         );
         assert!(entries.is_empty());
     }
@@ -1365,6 +1537,8 @@ mod tests {
             false,
             "bu",
             None,
+            default_columns(),
+            &empty_statuses(),
         );
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].name, "bug/xyz");
@@ -1384,6 +1558,8 @@ mod tests {
             true, // multi-remote
             "",
             None,
+            default_columns(),
+            &empty_statuses(),
         );
         let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
         assert_eq!(names, vec!["fork/feat/x", "origin/feat/x"]);
@@ -1407,6 +1583,8 @@ mod tests {
             false,
             "",
             None,
+            default_columns(),
+            &empty_statuses(),
         );
         let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
         assert_eq!(
@@ -1433,6 +1611,8 @@ mod tests {
             true,
             "",
             None,
+            default_columns(),
+            &empty_statuses(),
         );
         let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
         assert_eq!(names, vec!["origin/feat/x"]);
@@ -1542,8 +1722,18 @@ mod tests {
         ];
         let remote = vec![br("origin/ci", "4 days ago")];
 
-        let entries =
-            build_rich_completions(&worktrees, &local, &remote, None, "origin", false, "", None);
+        let entries = build_rich_completions(
+            &worktrees,
+            &local,
+            &remote,
+            None,
+            "origin",
+            false,
+            "",
+            None,
+            default_columns(),
+            &empty_statuses(),
+        );
 
         // build_rich_completions returns all groups — the caller filters.
         // Simulate what complete_rich_branches does with include_local=false:
@@ -1564,8 +1754,18 @@ mod tests {
         let local = vec![br("main", "1 day ago"), br("dev", "2 days ago")];
         let remote = vec![br("origin/ci", "3 days ago")];
 
-        let entries =
-            build_rich_completions(&worktrees, &local, &remote, None, "origin", false, "", None);
+        let entries = build_rich_completions(
+            &worktrees,
+            &local,
+            &remote,
+            None,
+            "origin",
+            false,
+            "",
+            None,
+            default_columns(),
+            &empty_statuses(),
+        );
 
         // Simulate exclude_remote by filtering.
         let filtered: Vec<_> = entries
@@ -1586,8 +1786,18 @@ mod tests {
         let local = vec![br("main", "1 day ago"), br("feat", "2 days ago")];
 
         // Pass None as current branch (exclude_current: false behavior)
-        let entries =
-            build_rich_completions(&worktrees, &local, &[], None, "origin", false, "", None);
+        let entries = build_rich_completions(
+            &worktrees,
+            &local,
+            &[],
+            None,
+            "origin",
+            false,
+            "",
+            None,
+            default_columns(),
+            &empty_statuses(),
+        );
         let wt_names: Vec<&str> = entries
             .iter()
             .filter(|e| e.group == CompletionGroup::Worktree)
@@ -1612,6 +1822,8 @@ mod tests {
             false,
             "",
             None,
+            default_columns(),
+            &empty_statuses(),
         );
         let wt_names: Vec<&str> = entries
             .iter()
@@ -1661,6 +1873,8 @@ mod tests {
             false,
             "",
             None,
+            default_columns(),
+            &empty_statuses(),
         );
         // Worktree entry has age + author + path
         let wt_entry = entries.iter().find(|e| e.name == "master").unwrap();
@@ -1674,5 +1888,119 @@ mod tests {
         // Remote entry has age + author
         let remote_entry = entries.iter().find(|e| e.name == "feat/remote").unwrap();
         assert_eq!(remote_entry.description, "5 days ago\tCharlie");
+    }
+
+    #[test]
+    fn rich_completions_dirty_indicators_append_to_worktree_names() {
+        let mut statuses = std::collections::HashMap::new();
+        statuses.insert(
+            "master".to_string(),
+            WorktreeStatus {
+                has_tracked_changes: true,
+                has_untracked: true,
+            },
+        );
+        statuses.insert(
+            "feat".to_string(),
+            WorktreeStatus {
+                has_tracked_changes: true,
+                has_untracked: false,
+            },
+        );
+        let entries = build_rich_completions(
+            &[wt("master", "/tmp/master"), wt("feat", "/tmp/feat")],
+            &[br("master", "1d"), br("feat", "2d")],
+            &[],
+            None,
+            "origin",
+            false,
+            "",
+            None,
+            default_columns(),
+            &statuses,
+        );
+        let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+        assert!(
+            names.contains(&"master*?"),
+            "expected master*? got {names:?}"
+        );
+        assert!(names.contains(&"feat*"), "expected feat* got {names:?}");
+    }
+
+    #[test]
+    fn rich_completions_dirty_indicators_not_on_local_or_remote() {
+        let mut statuses = std::collections::HashMap::new();
+        statuses.insert(
+            "master".to_string(),
+            WorktreeStatus {
+                has_tracked_changes: true,
+                has_untracked: true,
+            },
+        );
+        let entries = build_rich_completions(
+            &[wt("master", "/tmp/master")],
+            &[br("master", "1d"), br("feat/local", "2d")],
+            &[br("origin/feat/remote", "3d")],
+            None,
+            "origin",
+            false,
+            "",
+            None,
+            default_columns(),
+            &statuses,
+        );
+        // Local and remote entries should never have indicators
+        let local = entries.iter().find(|e| e.name == "feat/local").unwrap();
+        assert!(!local.name.contains('*'));
+        assert!(!local.name.contains('?'));
+        let remote = entries.iter().find(|e| e.name == "feat/remote").unwrap();
+        assert!(!remote.name.contains('*'));
+        assert!(!remote.name.contains('?'));
+    }
+
+    #[test]
+    fn rich_completions_columns_disable_age_emits_empty() {
+        let columns = &[CompletionColumn::Author, CompletionColumn::Path];
+        let entries = build_rich_completions(
+            &[wt("master", "/tmp/master")],
+            &[br_author("master", "1 day ago", "Alice")],
+            &[],
+            None,
+            "origin",
+            false,
+            "",
+            None,
+            columns,
+            &empty_statuses(),
+        );
+        let wt = entries.iter().find(|e| e.name == "master").unwrap();
+        // Description is "age\tauthor\tpath" — age should be empty
+        let parts: Vec<&str> = wt.description.split('\t').collect();
+        assert_eq!(parts[0], "", "age should be empty when Age column disabled");
+        assert_eq!(parts[1], "Alice", "author should still be present");
+    }
+
+    #[test]
+    fn rich_completions_columns_disable_author_emits_empty() {
+        let columns = &[CompletionColumn::Age, CompletionColumn::Path];
+        let entries = build_rich_completions(
+            &[],
+            &[br_author("feat", "2 days ago", "Bob")],
+            &[],
+            None,
+            "origin",
+            false,
+            "",
+            None,
+            columns,
+            &empty_statuses(),
+        );
+        let local = entries.iter().find(|e| e.name == "feat").unwrap();
+        let parts: Vec<&str> = local.description.split('\t').collect();
+        assert_eq!(parts[0], "2 days ago", "age should be present");
+        assert_eq!(
+            parts[1], "",
+            "author should be empty when Author column disabled"
+        );
     }
 }

--- a/src/commands/complete.rs
+++ b/src/commands/complete.rs
@@ -402,6 +402,7 @@ pub(crate) fn complete_daft_go(prefix: &str, fetch_on_miss: bool) -> Result<Vec<
         .unwrap_or(defaults::GO_FETCH_ON_MISS);
     let d_settings = t.elapsed();
 
+    let cwd = std::env::current_dir().ok();
     let collect = |repo: &gix::Repository, timings: bool| -> Vec<CompletionEntry> {
         let t = Instant::now();
         let worktrees = collect_worktrees(repo);
@@ -428,6 +429,7 @@ pub(crate) fn complete_daft_go(prefix: &str, fetch_on_miss: bool) -> Result<Vec<
             &default_remote,
             multi_remote_enabled,
             prefix,
+            cwd.as_deref(),
         );
         let d_build = t.elapsed();
 
@@ -797,6 +799,7 @@ fn complete_rich_branches(
         None
     };
 
+    let cwd = std::env::current_dir().ok();
     let mut entries = build_rich_completions(
         &worktrees,
         &local,
@@ -805,6 +808,7 @@ fn complete_rich_branches(
         &default_remote,
         multi_remote_enabled,
         prefix,
+        cwd.as_deref(),
     );
 
     // If the config excludes local branches but we collected them for
@@ -964,6 +968,7 @@ const CONFIG_BRANCH: RichCompletionConfig = RichCompletionConfig {
 /// etc.) are always dropped.
 ///
 /// Entries whose name doesn't start with `prefix` are filtered out.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn build_rich_completions(
     worktrees: &[(String, std::path::PathBuf)],
     local_branches: &[(String, String)],
@@ -972,6 +977,7 @@ pub(crate) fn build_rich_completions(
     default_remote: &str,
     multi_remote: bool,
     prefix: &str,
+    cwd: Option<&std::path::Path>,
 ) -> Vec<CompletionEntry> {
     use std::collections::HashSet;
 
@@ -988,10 +994,13 @@ pub(crate) fn build_rich_completions(
                 .find(|(n, _)| n == name)
                 .map(|(_, a)| a.as_str())
                 .unwrap_or("");
+            let display_path = cwd
+                .and_then(|base| pathdiff::diff_paths(path, base))
+                .unwrap_or_else(|| path.to_path_buf());
             CompletionEntry {
                 name: name.clone(),
                 group: CompletionGroup::Worktree,
-                description: format!("{}\t{}", age, path.display()),
+                description: format!("{}\t{}", age, display_path.display()),
             }
         })
         .collect();
@@ -1118,6 +1127,7 @@ mod tests {
             "origin",
             false, // single-remote mode
             "",
+            None,
         );
         let groups: Vec<CompletionGroup> = entries.iter().map(|e| e.group).collect();
         assert_eq!(
@@ -1141,6 +1151,7 @@ mod tests {
             "origin",
             false,
             "",
+            None,
         );
         let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
         assert_eq!(names, vec!["a", "b", "m", "z"]);
@@ -1156,6 +1167,7 @@ mod tests {
             "origin",
             false,
             "",
+            None,
         );
         assert_eq!(entries.len(), 1, "remote should be shadowed by local");
         assert_eq!(entries[0].name, "feat/shared");
@@ -1172,6 +1184,7 @@ mod tests {
             "origin",
             false,
             "",
+            None,
         );
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].name, "master");
@@ -1188,6 +1201,7 @@ mod tests {
             "origin",
             false,
             "",
+            None,
         );
         let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
         assert_eq!(names, vec!["master"]);
@@ -1203,6 +1217,7 @@ mod tests {
             "origin",
             false,
             "",
+            None,
         );
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].name, "bug/xyz");
@@ -1222,6 +1237,7 @@ mod tests {
             "origin",
             true, // multi-remote mode
             "",
+            None,
         );
         let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
         assert_eq!(names, vec!["fork/feat/y", "origin/bug/xyz"]);
@@ -1237,6 +1253,7 @@ mod tests {
             "origin",
             false,
             "fe",
+            None,
         );
         let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
         assert_eq!(names, vec!["feat/x"]);
@@ -1255,6 +1272,7 @@ mod tests {
             "origin",
             false,
             "",
+            None,
         );
         let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
         assert_eq!(names, vec!["master"]);
@@ -1283,7 +1301,7 @@ mod tests {
 
     #[test]
     fn rich_completions_empty_input_returns_empty() {
-        let entries = build_rich_completions(&[], &[], &[], None, "origin", false, "");
+        let entries = build_rich_completions(&[], &[], &[], None, "origin", false, "", None);
         assert!(entries.is_empty());
     }
 
@@ -1297,6 +1315,7 @@ mod tests {
             "origin",
             false,
             "zzz",
+            None,
         );
         assert!(entries.is_empty());
     }
@@ -1313,6 +1332,7 @@ mod tests {
             "origin",
             false,
             "bu",
+            None,
         );
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].name, "bug/xyz");
@@ -1331,6 +1351,7 @@ mod tests {
             "origin",
             true, // multi-remote
             "",
+            None,
         );
         let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
         assert_eq!(names, vec!["fork/feat/x", "origin/feat/x"]);
@@ -1353,6 +1374,7 @@ mod tests {
             "origin",
             false,
             "",
+            None,
         );
         let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
         assert_eq!(
@@ -1378,6 +1400,7 @@ mod tests {
             "origin",
             true,
             "",
+            None,
         );
         let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
         assert_eq!(names, vec!["origin/feat/x"]);
@@ -1488,7 +1511,7 @@ mod tests {
         let remote = vec![br("origin/ci", "4 days ago")];
 
         let entries =
-            build_rich_completions(&worktrees, &local, &remote, None, "origin", false, "");
+            build_rich_completions(&worktrees, &local, &remote, None, "origin", false, "", None);
 
         // build_rich_completions returns all groups — the caller filters.
         // Simulate what complete_rich_branches does with include_local=false:
@@ -1510,7 +1533,7 @@ mod tests {
         let remote = vec![br("origin/ci", "3 days ago")];
 
         let entries =
-            build_rich_completions(&worktrees, &local, &remote, None, "origin", false, "");
+            build_rich_completions(&worktrees, &local, &remote, None, "origin", false, "", None);
 
         // Simulate exclude_remote by filtering.
         let filtered: Vec<_> = entries
@@ -1531,7 +1554,8 @@ mod tests {
         let local = vec![br("main", "1 day ago"), br("feat", "2 days ago")];
 
         // Pass None as current branch (exclude_current: false behavior)
-        let entries = build_rich_completions(&worktrees, &local, &[], None, "origin", false, "");
+        let entries =
+            build_rich_completions(&worktrees, &local, &[], None, "origin", false, "", None);
         let wt_names: Vec<&str> = entries
             .iter()
             .filter(|e| e.group == CompletionGroup::Worktree)
@@ -1547,8 +1571,16 @@ mod tests {
         );
 
         // Compare with Some("main") — main removed from worktree group
-        let entries =
-            build_rich_completions(&worktrees, &local, &[], Some("main"), "origin", false, "");
+        let entries = build_rich_completions(
+            &worktrees,
+            &local,
+            &[],
+            Some("main"),
+            "origin",
+            false,
+            "",
+            None,
+        );
         let wt_names: Vec<&str> = entries
             .iter()
             .filter(|e| e.group == CompletionGroup::Worktree)

--- a/src/commands/complete.rs
+++ b/src/commands/complete.rs
@@ -4,9 +4,8 @@
 /// to get dynamic completion suggestions (e.g., branch names).
 ///
 /// Performance target: < 50ms response time
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::Parser;
-use std::process::Command;
 
 use crate::hooks::yaml_config_loader;
 
@@ -142,119 +141,255 @@ fn complete(
     }
 }
 
-/// Complete existing branch names (local and remote)
-fn complete_existing_branches(prefix: &str, verbose: bool) -> Result<Vec<String>> {
-    // Use git for-each-ref for fast, parseable output
-    let output = Command::new("git")
-        .args([
-            "for-each-ref",
-            "--format=%(refname:short)",
-            "refs/heads/",
-            "refs/remotes/origin/",
-        ])
-        .output()?;
+// ---------------------------------------------------------------------------
+// Gitoxide helpers — repo discovery and time formatting
+// ---------------------------------------------------------------------------
 
-    if !output.status.success() {
-        // Not in a git repository or git command failed
-        if verbose {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            eprintln!("Git command failed: {}", stderr.trim());
-            eprintln!("Exit code: {}", output.status.code().unwrap_or(-1));
-            if !std::path::Path::new(".git").exists() {
-                eprintln!("Note: Not in a git repository (no .git directory found)");
-            }
-        }
-        return Ok(vec![]);
-    }
-
-    let branches: Vec<String> = String::from_utf8_lossy(&output.stdout)
-        .lines()
-        .filter(|branch| !branch.contains("HEAD"))
-        .map(|branch| {
-            // Remove "origin/" prefix for cleaner suggestions
-            branch.trim_start_matches("origin/").to_string()
-        })
-        .filter(|branch| branch.starts_with(prefix))
-        .collect();
-
-    // Deduplicate branches (local and remote might have same name)
-    let mut unique_branches: Vec<String> = branches;
-    unique_branches.sort();
-    unique_branches.dedup();
-
-    if verbose && unique_branches.is_empty() {
-        eprintln!("No branches found matching prefix: '{}'", prefix);
-    }
-
-    Ok(unique_branches)
+/// Discover the git repository from the current working directory via gitoxide.
+/// This avoids spawning a subprocess and reuses the in-process gix object cache.
+fn discover_repo() -> Result<gix::Repository> {
+    let cwd = std::env::current_dir().context("Failed to get current working directory")?;
+    let repo = gix::discover(&cwd).context("Failed to discover git repository")?;
+    Ok(repo)
 }
 
-/// Collect `(branch, path)` pairs for every linked worktree that has a
-/// branch checked out. Detached HEADs and bare repos are skipped —
-/// they're not navigation targets.
-fn collect_go_worktrees() -> Vec<(String, std::path::PathBuf)> {
-    use crate::git::GitCommand;
+/// Format a Unix epoch timestamp as a human-readable relative time string
+/// matching git's `%(committerdate:relative)` output (e.g. "3 days ago").
+fn format_relative_time(epoch_secs: i64) -> String {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64;
+    let delta = now.saturating_sub(epoch_secs);
+    if delta < 0 {
+        return "in the future".to_string();
+    }
+    let delta = delta as u64;
 
-    let git = GitCommand::new(true);
-    let entries = match crate::core::worktree::prune::parse_worktree_list(&git) {
-        Ok(e) => e,
+    const MINUTE: u64 = 60;
+    const HOUR: u64 = 60 * MINUTE;
+    const DAY: u64 = 24 * HOUR;
+    const WEEK: u64 = 7 * DAY;
+    const MONTH: u64 = 30 * DAY;
+    const YEAR: u64 = 365 * DAY;
+
+    if delta < 90 {
+        let n = delta;
+        return if n == 1 {
+            "1 second ago".to_string()
+        } else {
+            format!("{n} seconds ago")
+        };
+    }
+    if delta < 90 * MINUTE {
+        let n = delta / MINUTE;
+        return if n == 1 {
+            "1 minute ago".to_string()
+        } else {
+            format!("{n} minutes ago")
+        };
+    }
+    if delta < 36 * HOUR {
+        let n = delta / HOUR;
+        return if n == 1 {
+            "1 hour ago".to_string()
+        } else {
+            format!("{n} hours ago")
+        };
+    }
+    if delta < 14 * DAY {
+        let n = delta / DAY;
+        return if n == 1 {
+            "1 day ago".to_string()
+        } else {
+            format!("{n} days ago")
+        };
+    }
+    if delta < 10 * WEEK {
+        let n = delta / WEEK;
+        return if n == 1 {
+            "1 week ago".to_string()
+        } else {
+            format!("{n} weeks ago")
+        };
+    }
+    if delta < YEAR {
+        let n = delta / MONTH;
+        return if n == 1 {
+            "1 month ago".to_string()
+        } else {
+            format!("{n} months ago")
+        };
+    }
+    let years = delta / YEAR;
+    let months = (delta % YEAR) / MONTH;
+    if months == 0 {
+        if years == 1 {
+            "1 year ago".to_string()
+        } else {
+            format!("{years} years ago")
+        }
+    } else if years == 1 {
+        format!("1 year, {months} months ago")
+    } else {
+        format!("{years} years, {months} months ago")
+    }
+}
+
+/// Read the branch checked out in a worktree from its private git dir's HEAD file.
+/// Returns `None` for detached HEAD or unreadable files.
+fn worktree_branch_from_gitdir(git_dir: &std::path::Path) -> Option<String> {
+    let head_contents = std::fs::read_to_string(git_dir.join("HEAD")).ok()?;
+    let trimmed = head_contents.trim();
+    trimmed
+        .strip_prefix("ref: refs/heads/")
+        .map(|s| s.to_string())
+}
+
+/// Peel a reference to its commit and return the committer timestamp as a
+/// relative-time string. Returns an empty string on failure (tag that doesn't
+/// point to a commit, corrupt object, etc.).
+fn ref_commit_age(reference: &mut gix::Reference<'_>) -> String {
+    let id = match reference.peel_to_id() {
+        Ok(id) => id.detach(),
+        Err(_) => return String::new(),
+    };
+    let repo = reference.repo;
+    let object = match repo.find_object(id) {
+        Ok(o) => o,
+        Err(_) => return String::new(),
+    };
+    let commit = match object.try_into_commit() {
+        Ok(c) => c,
+        Err(_) => return String::new(),
+    };
+    let sig = match commit.committer() {
+        Ok(s) => s,
+        Err(_) => return String::new(),
+    };
+    match sig.time() {
+        Ok(time) => format_relative_time(time.seconds),
+        Err(_) => String::new(),
+    }
+}
+
+/// Complete existing branch names (local and remote)
+fn complete_existing_branches(prefix: &str, verbose: bool) -> Result<Vec<String>> {
+    let repo = match discover_repo() {
+        Ok(r) => r,
+        Err(e) => {
+            if verbose {
+                eprintln!("Git repository discovery failed: {e}");
+            }
+            return Ok(vec![]);
+        }
+    };
+
+    let mut branches: Vec<String> = Vec::new();
+
+    for refs_prefix in ["refs/heads/", "refs/remotes/origin/"] {
+        let platform = match repo.references() {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+        let iter = match platform.prefixed(refs_prefix) {
+            Ok(i) => i,
+            Err(_) => continue,
+        };
+        for reference_result in iter {
+            let reference = match reference_result {
+                Ok(r) => r,
+                Err(_) => continue,
+            };
+            let short = reference.name().shorten().to_string();
+            if short.contains("HEAD") {
+                continue;
+            }
+            let display = short.trim_start_matches("origin/").to_string();
+            if display.starts_with(prefix) {
+                branches.push(display);
+            }
+        }
+    }
+
+    branches.sort();
+    branches.dedup();
+
+    if verbose && branches.is_empty() {
+        eprintln!("No branches found matching prefix: '{prefix}'");
+    }
+
+    Ok(branches)
+}
+
+/// Collect `(branch, path)` pairs for every worktree (main + linked) that
+/// has a branch checked out. Detached HEADs and bare repos are skipped —
+/// they're not navigation targets.
+fn collect_go_worktrees(repo: &gix::Repository) -> Vec<(String, std::path::PathBuf)> {
+    let mut result = Vec::new();
+
+    // Main worktree (if not bare / has a working directory).
+    if let Some(workdir) = repo.workdir() {
+        if let Ok(Some(head_ref)) = repo.head_ref() {
+            let branch = head_ref.name().shorten().to_string();
+            result.push((branch, workdir.to_path_buf()));
+        }
+        // Detached HEAD in main worktree → skip (no branch).
+    }
+
+    // Linked worktrees.
+    let proxies = match repo.worktrees() {
+        Ok(p) => p,
+        Err(_) => return result,
+    };
+    for proxy in proxies {
+        let branch = match worktree_branch_from_gitdir(proxy.git_dir()) {
+            Some(b) => b,
+            None => continue, // detached or unreadable
+        };
+        let path = match proxy.base() {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+        result.push((branch, path));
+    }
+
+    result
+}
+
+/// Collect `(branch, relative_age)` pairs for a given ref prefix via gitoxide.
+fn collect_refs_with_age(repo: &gix::Repository, prefix: &str) -> Vec<(String, String)> {
+    let platform = match repo.references() {
+        Ok(p) => p,
+        Err(_) => return Vec::new(),
+    };
+    let references = match platform.prefixed(prefix) {
+        Ok(r) => r,
         Err(_) => return Vec::new(),
     };
 
-    entries
-        .into_iter()
-        .filter(|wt| !wt.is_bare && !wt.is_detached)
-        .filter_map(|wt| wt.branch.map(|b| (b, wt.path)))
-        .collect()
+    let mut result = Vec::new();
+    for ref_result in references {
+        let mut reference = match ref_result {
+            Ok(r) => r,
+            Err(_) => continue,
+        };
+        let short_name = reference.name().shorten().to_string();
+        let age = ref_commit_age(&mut reference);
+        result.push((short_name, age));
+    }
+    result
 }
 
 /// Collect `(branch, relative_age)` pairs for every local branch.
-fn collect_go_local_branches() -> Vec<(String, String)> {
-    let output = Command::new("git")
-        .args([
-            "for-each-ref",
-            "--format=%(refname:short)%09%(committerdate:relative)",
-            "refs/heads/",
-        ])
-        .output();
-
-    let output = match output {
-        Ok(o) if o.status.success() => o,
-        _ => return Vec::new(),
-    };
-
-    String::from_utf8_lossy(&output.stdout)
-        .lines()
-        .filter_map(|line| {
-            let (name, age) = line.split_once('\t')?;
-            Some((name.to_string(), age.to_string()))
-        })
-        .collect()
+fn collect_go_local_branches(repo: &gix::Repository) -> Vec<(String, String)> {
+    collect_refs_with_age(repo, "refs/heads/")
 }
 
 /// Collect `(branch, relative_age)` pairs for every remote-tracking
 /// branch across all remotes.
-fn collect_go_remote_branches() -> Vec<(String, String)> {
-    let output = Command::new("git")
-        .args([
-            "for-each-ref",
-            "--format=%(refname:short)%09%(committerdate:relative)",
-            "refs/remotes/",
-        ])
-        .output();
-
-    let output = match output {
-        Ok(o) if o.status.success() => o,
-        _ => return Vec::new(),
-    };
-
-    String::from_utf8_lossy(&output.stdout)
-        .lines()
-        .filter_map(|line| {
-            let (name, age) = line.split_once('\t')?;
-            Some((name.to_string(), age.to_string()))
-        })
-        .collect()
+fn collect_go_remote_branches(repo: &gix::Repository) -> Vec<(String, String)> {
+    collect_refs_with_age(repo, "refs/remotes/")
 }
 
 /// Collect the current worktree's branch, if any — used to exclude it
@@ -262,15 +397,13 @@ fn collect_go_remote_branches() -> Vec<(String, String)> {
 /// the current directory is outside a git repository, or if we're in
 /// a bare repository (e.g., the root of a contained layout where HEAD
 /// points to the default branch but no worktree corresponds to CWD).
-fn current_worktree_branch() -> Option<String> {
-    let output = Command::new("git")
-        .args(["rev-parse", "--is-bare-repository"])
-        .output()
-        .ok()?;
-    if String::from_utf8_lossy(&output.stdout).trim() == "true" {
-        return None;
-    }
-    crate::core::repo::get_current_branch().ok()
+fn current_worktree_branch(repo: &gix::Repository) -> Option<String> {
+    // In a bare repository there is no "current worktree" to exclude.
+    repo.workdir()?;
+    repo.head_ref()
+        .ok()
+        .flatten()
+        .map(|r| r.name().shorten().to_string())
 }
 
 /// Top-level completion helper for `daft go`. Collects real git data,
@@ -278,19 +411,43 @@ fn current_worktree_branch() -> Option<String> {
 /// When `fetch_on_miss` is true and the prefix has no local matches,
 /// runs `git fetch` with a spinner and re-resolves.
 pub(crate) fn complete_daft_go(prefix: &str, fetch_on_miss: bool) -> Result<Vec<CompletionEntry>> {
+    use std::time::Instant;
+
+    let timings = std::env::var("DAFT_COMPLETE_TIMINGS").is_ok();
+    let t_total = Instant::now();
+
+    let t = Instant::now();
     let settings = crate::core::settings::DaftSettings::load().unwrap_or_default();
     let default_remote = if settings.multi_remote_enabled {
         settings.multi_remote_default.clone()
     } else {
         settings.remote.clone()
     };
+    let d_settings = t.elapsed();
 
-    let collect = || -> Vec<CompletionEntry> {
-        let worktrees = collect_go_worktrees();
-        let local = collect_go_local_branches();
-        let remote = collect_go_remote_branches();
-        let current_branch = current_worktree_branch();
-        build_go_completions(
+    let t = Instant::now();
+    let repo = discover_repo()?;
+    let d_discover = t.elapsed();
+
+    let collect = |repo: &gix::Repository, timings: bool| -> Vec<CompletionEntry> {
+        let t = Instant::now();
+        let worktrees = collect_go_worktrees(repo);
+        let d_wt = t.elapsed();
+
+        let t = Instant::now();
+        let local = collect_go_local_branches(repo);
+        let d_local = t.elapsed();
+
+        let t = Instant::now();
+        let remote = collect_go_remote_branches(repo);
+        let d_remote = t.elapsed();
+
+        let t = Instant::now();
+        let current_branch = current_worktree_branch(repo);
+        let d_current = t.elapsed();
+
+        let t = Instant::now();
+        let entries = build_go_completions(
             &worktrees,
             &local,
             &remote,
@@ -298,23 +455,72 @@ pub(crate) fn complete_daft_go(prefix: &str, fetch_on_miss: bool) -> Result<Vec<
             &default_remote,
             settings.multi_remote_enabled,
             prefix,
-        )
+        );
+        let d_build = t.elapsed();
+
+        if timings {
+            eprintln!(
+                "[timings] worktrees        : {:>7.1}ms",
+                d_wt.as_secs_f64() * 1000.0
+            );
+            eprintln!(
+                "[timings] local_branches   : {:>7.1}ms",
+                d_local.as_secs_f64() * 1000.0
+            );
+            eprintln!(
+                "[timings] remote_branches  : {:>7.1}ms",
+                d_remote.as_secs_f64() * 1000.0
+            );
+            eprintln!(
+                "[timings] current_branch   : {:>7.1}ms",
+                d_current.as_secs_f64() * 1000.0
+            );
+            eprintln!(
+                "[timings] build            : {:>7.1}ms",
+                d_build.as_secs_f64() * 1000.0
+            );
+        }
+
+        entries
     };
 
-    let entries = collect();
+    if timings {
+        eprintln!(
+            "[timings] settings_load    : {:>7.1}ms",
+            d_settings.as_secs_f64() * 1000.0
+        );
+        eprintln!(
+            "[timings] repo_discover    : {:>7.1}ms",
+            d_discover.as_secs_f64() * 1000.0
+        );
+    }
+
+    let entries = collect(&repo, timings);
+
     if !entries.is_empty() || !fetch_on_miss || !settings.go_fetch_on_miss || prefix.is_empty() {
+        if timings {
+            eprintln!(
+                "[timings] total            : {:>7.1}ms",
+                t_total.elapsed().as_secs_f64() * 1000.0
+            );
+        }
         return Ok(entries);
     }
 
-    let git_common_dir = match crate::core::repo::get_git_common_dir() {
-        Ok(d) => d,
-        Err(_) => return Ok(entries),
-    };
+    let common_dir = repo.common_dir().to_path_buf();
+    let git_common_dir = common_dir.canonicalize().unwrap_or(common_dir);
     let marker = git_common_dir.join("daft_complete_last_fetch");
     if !should_run_fetch(&marker, std::time::Duration::from_secs(30)) {
+        if timings {
+            eprintln!(
+                "[timings] total            : {:>7.1}ms",
+                t_total.elapsed().as_secs_f64() * 1000.0
+            );
+        }
         return Ok(entries);
     }
 
+    let t = Instant::now();
     let spinner =
         crate::completion_spinner::Spinner::start(&format!("Fetching refs from {default_remote}…"));
 
@@ -332,10 +538,27 @@ pub(crate) fn complete_daft_go(prefix: &str, fetch_on_miss: bool) -> Result<Vec<
     if let Some(s) = spinner {
         s.stop();
     }
+    let d_fetch = t.elapsed();
 
     let _ = touch_fetch_marker(&marker);
 
-    Ok(collect())
+    if timings {
+        eprintln!(
+            "[timings] fetch            : {:>7.1}ms",
+            d_fetch.as_secs_f64() * 1000.0
+        );
+    }
+
+    let entries = collect(&repo, timings);
+
+    if timings {
+        eprintln!(
+            "[timings] total            : {:>7.1}ms",
+            t_total.elapsed().as_secs_f64() * 1000.0
+        );
+    }
+
+    Ok(entries)
 }
 
 /// Suggest common branch name patterns for new branches
@@ -364,22 +587,20 @@ fn suggest_new_branch_names(prefix: &str) -> Vec<String> {
 /// Complete local branches only (for base branch selection)
 #[allow(dead_code)]
 fn complete_local_branches(prefix: &str, verbose: bool) -> Result<Vec<String>> {
-    let output = Command::new("git")
-        .args(["for-each-ref", "--format=%(refname:short)", "refs/heads/"])
-        .output()?;
-
-    if !output.status.success() {
-        if verbose {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            eprintln!("Git command failed (local branches): {}", stderr.trim());
+    let repo = match discover_repo() {
+        Ok(r) => r,
+        Err(e) => {
+            if verbose {
+                eprintln!("Git repository discovery failed: {e}");
+            }
+            return Ok(vec![]);
         }
-        return Ok(vec![]);
-    }
+    };
 
-    let branches: Vec<String> = String::from_utf8_lossy(&output.stdout)
-        .lines()
-        .filter(|branch| branch.starts_with(prefix))
-        .map(String::from)
+    let branches: Vec<String> = collect_refs_with_age(&repo, "refs/heads/")
+        .into_iter()
+        .map(|(name, _)| name)
+        .filter(|name| name.starts_with(prefix))
         .collect();
 
     Ok(branches)
@@ -388,26 +609,21 @@ fn complete_local_branches(prefix: &str, verbose: bool) -> Result<Vec<String>> {
 /// Complete remote branches only
 #[allow(dead_code)]
 fn complete_remote_branches(prefix: &str, verbose: bool) -> Result<Vec<String>> {
-    let output = Command::new("git")
-        .args([
-            "for-each-ref",
-            "--format=%(refname:short)",
-            "refs/remotes/origin/",
-        ])
-        .output()?;
-
-    if !output.status.success() {
-        if verbose {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            eprintln!("Git command failed (remote branches): {}", stderr.trim());
+    let repo = match discover_repo() {
+        Ok(r) => r,
+        Err(e) => {
+            if verbose {
+                eprintln!("Git repository discovery failed: {e}");
+            }
+            return Ok(vec![]);
         }
-        return Ok(vec![]);
-    }
+    };
 
-    let branches: Vec<String> = String::from_utf8_lossy(&output.stdout)
-        .lines()
-        .filter(|branch| !branch.contains("HEAD") && branch.starts_with(prefix))
-        .map(|branch| branch.trim_start_matches("origin/").to_string())
+    let branches: Vec<String> = collect_refs_with_age(&repo, "refs/remotes/origin/")
+        .into_iter()
+        .map(|(name, _)| name)
+        .filter(|name| !name.contains("HEAD") && name.starts_with(prefix))
+        .map(|name| name.trim_start_matches("origin/").to_string())
         .collect();
 
     Ok(branches)
@@ -575,16 +791,14 @@ fn complete_worktree_names(prefix: &str) -> Result<Vec<String>> {
 
 /// Find the project root (parent of git common dir).
 fn find_project_root() -> Result<std::path::PathBuf> {
-    let output = Command::new("git")
-        .args(["rev-parse", "--git-common-dir"])
-        .output()?;
-
-    if !output.status.success() {
-        anyhow::bail!("Not in a git repository");
-    }
-
-    let common_dir = std::path::PathBuf::from(String::from_utf8(output.stdout)?.trim());
-    let canonical = common_dir.canonicalize()?;
+    let repo = discover_repo()?;
+    let common_dir = repo.common_dir().to_path_buf();
+    let canonical = common_dir.canonicalize().with_context(|| {
+        format!(
+            "Failed to canonicalize git directory: {}",
+            common_dir.display()
+        )
+    })?;
     canonical
         .parent()
         .map(|p| p.to_path_buf())
@@ -593,17 +807,10 @@ fn find_project_root() -> Result<std::path::PathBuf> {
 
 /// Find the worktree root directory (for completions).
 fn find_worktree_root() -> Result<std::path::PathBuf> {
-    let output = Command::new("git")
-        .args(["rev-parse", "--show-toplevel"])
-        .output()?;
-
-    if !output.status.success() {
-        anyhow::bail!("Not in a git worktree");
-    }
-
-    Ok(std::path::PathBuf::from(
-        String::from_utf8(output.stdout)?.trim(),
-    ))
+    let repo = discover_repo()?;
+    repo.workdir()
+        .map(|p| p.to_path_buf())
+        .ok_or_else(|| anyhow::anyhow!("Not inside a worktree (bare repository)"))
 }
 
 /// Return `true` if the cooldown marker is missing or older than
@@ -1139,6 +1346,62 @@ mod tests {
         assert!(
             should_run_fetch(&marker, std::time::Duration::from_secs(30)),
             "marker older than cooldown must allow fetch"
+        );
+    }
+
+    // --- format_relative_time tests ---
+
+    fn now_secs() -> i64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64
+    }
+
+    #[test]
+    fn relative_time_seconds() {
+        assert_eq!(format_relative_time(now_secs() - 30), "30 seconds ago");
+        assert_eq!(format_relative_time(now_secs() - 1), "1 second ago");
+    }
+
+    #[test]
+    fn relative_time_minutes() {
+        assert_eq!(format_relative_time(now_secs() - 120), "2 minutes ago");
+        assert_eq!(format_relative_time(now_secs() - 60 * 45), "45 minutes ago");
+    }
+
+    #[test]
+    fn relative_time_hours() {
+        assert_eq!(format_relative_time(now_secs() - 3600 * 3), "3 hours ago");
+    }
+
+    #[test]
+    fn relative_time_days() {
+        assert_eq!(format_relative_time(now_secs() - 86400 * 5), "5 days ago");
+    }
+
+    #[test]
+    fn relative_time_weeks() {
+        assert_eq!(format_relative_time(now_secs() - 86400 * 21), "3 weeks ago");
+    }
+
+    #[test]
+    fn relative_time_months() {
+        assert_eq!(
+            format_relative_time(now_secs() - 86400 * 90),
+            "3 months ago"
+        );
+    }
+
+    #[test]
+    fn relative_time_years() {
+        assert_eq!(
+            format_relative_time(now_secs() - 86400 * 400),
+            "1 year, 1 months ago"
+        );
+        assert_eq!(
+            format_relative_time(now_secs() - 86400 * 800),
+            "2 years, 2 months ago"
         );
     }
 }

--- a/src/commands/complete.rs
+++ b/src/commands/complete.rs
@@ -258,9 +258,18 @@ fn collect_go_remote_branches() -> Vec<(String, String)> {
 }
 
 /// Collect the current worktree's branch, if any — used to exclude it
-/// from the completion list. Returns `None` if HEAD is detached or if
-/// the current directory is outside a git repository.
+/// from the completion list. Returns `None` if HEAD is detached, if
+/// the current directory is outside a git repository, or if we're in
+/// a bare repository (e.g., the root of a contained layout where HEAD
+/// points to the default branch but no worktree corresponds to CWD).
 fn current_worktree_branch() -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--is-bare-repository"])
+        .output()
+        .ok()?;
+    if String::from_utf8_lossy(&output.stdout).trim() == "true" {
+        return None;
+    }
     crate::core::repo::get_current_branch().ok()
 }
 

--- a/src/commands/complete.rs
+++ b/src/commands/complete.rs
@@ -51,13 +51,18 @@ pub fn run() -> Result<()> {
 
     let args = Args::parse_from(&args_vec);
 
-    let suggestions = complete(
+    // Completions must never crash — return empty results on any error
+    // (e.g. outside a git repository).
+    let suggestions = match complete(
         &args.command,
         args.position.unwrap_or(1),
         &args.word,
         args.verbose,
         args.fetch_on_miss,
-    )?;
+    ) {
+        Ok(s) => s,
+        Err(_) => return Ok(()),
+    };
 
     for suggestion in suggestions {
         println!("{}", suggestion);
@@ -309,19 +314,38 @@ fn ref_commit_info(reference: &mut gix::Reference<'_>) -> RefInfo {
 fn collect_worktrees(repo: &gix::Repository) -> Vec<(String, std::path::PathBuf)> {
     let mut result = Vec::new();
 
-    // Main worktree (if not bare / has a working directory).
+    // Current worktree (main or linked — whichever we discovered from).
     if let Some(workdir) = repo.workdir() {
         if let Ok(Some(head_ref)) = repo.head_ref() {
             let branch = head_ref.name().shorten().to_string();
             result.push((branch, workdir.to_path_buf()));
         }
-        // Detached HEAD in main worktree → skip (no branch).
+        // Detached HEAD → skip (no branch).
     }
 
-    // Linked worktrees — skip any that duplicate the current workdir
-    // (when gix::discover runs from a linked worktree, repo.workdir()
-    // already returns it, but repo.worktrees() also lists it).
-    let current_workdir = repo.workdir().map(|p| p.to_path_buf());
+    // When discovered from a linked worktree, the main worktree is not
+    // listed by repo.worktrees() and repo.workdir() returns the linked
+    // worktree's dir. Detect this (git_dir != common_dir) and collect
+    // the main worktree separately. common_dir may be a relative path
+    // (git stores `../..` in the commondir file), so canonicalize it.
+    let is_linked = repo.git_dir() != repo.common_dir();
+    if is_linked {
+        let common = std::fs::canonicalize(repo.common_dir()).ok();
+        if let Some(ref common) = common {
+            if let Some(main_workdir) = common.parent() {
+                let already = result.iter().any(|(_, p)| p == main_workdir);
+                if !already {
+                    if let Some(branch) = worktree_branch_from_gitdir(common) {
+                        result.push((branch, main_workdir.to_path_buf()));
+                    }
+                }
+            }
+        }
+    }
+
+    // Linked worktrees — skip any that duplicate an already-collected path
+    // (the current worktree or the main worktree added above).
+    let collected_paths: Vec<std::path::PathBuf> = result.iter().map(|(_, p)| p.clone()).collect();
     let proxies = match repo.worktrees() {
         Ok(p) => p,
         Err(_) => return result,
@@ -335,8 +359,8 @@ fn collect_worktrees(repo: &gix::Repository) -> Vec<(String, std::path::PathBuf)
             Ok(p) => p,
             Err(_) => continue,
         };
-        if current_workdir.as_deref() == Some(path.as_ref()) {
-            continue; // already collected via repo.workdir() above
+        if collected_paths.iter().any(|cp| cp == &*path) {
+            continue; // already collected
         }
         result.push((branch, path));
     }

--- a/src/commands/complete.rs
+++ b/src/commands/complete.rs
@@ -74,8 +74,11 @@ fn complete(
     fetch_on_miss: bool,
 ) -> Result<Vec<String>> {
     match (command, position) {
-        // git-worktree-checkout: complete existing branch names
-        ("git-worktree-checkout", 1) => complete_existing_branches(word, verbose),
+        // git-worktree-checkout: rich grouped completions (same as daft-go)
+        ("git-worktree-checkout", 1) => Ok(format_entries_as_strings(&complete_rich_branches(
+            word,
+            &CONFIG_CHECKOUT,
+        )?)),
 
         // git-worktree-clone: repository URL (no dynamic completion for now)
         ("git-worktree-clone", 1) => Ok(vec![]),
@@ -83,32 +86,44 @@ fn complete(
         // git-worktree-init: repository name (no dynamic completion)
         ("git-worktree-init", 1) => Ok(vec![]),
 
-        // git-worktree-carry: complete existing branch/worktree names
-        ("git-worktree-carry", _) => complete_existing_branches(word, verbose),
+        // git-worktree-carry: worktree-only completions
+        ("git-worktree-carry", _) => Ok(format_entries_as_strings(&complete_rich_branches(
+            word,
+            &CONFIG_CARRY,
+        )?)),
 
-        // git-worktree-fetch: complete existing branch/worktree names
-        ("git-worktree-fetch", _) => complete_existing_branches(word, verbose),
+        // git-worktree-fetch: worktree-only completions
+        ("git-worktree-fetch", _) => Ok(format_entries_as_strings(&complete_rich_branches(
+            word,
+            &CONFIG_FETCH,
+        )?)),
 
-        // git-worktree-branch: complete existing branch names for deletion
-        ("git-worktree-branch", _) => complete_existing_branches(word, verbose),
+        // git-worktree-branch: worktree + local completions for deletion
+        ("git-worktree-branch", _) => Ok(format_entries_as_strings(&complete_rich_branches(
+            word,
+            &CONFIG_BRANCH,
+        )?)),
 
-        // daft-go: grouped worktree/local/remote completions
+        // daft-go: grouped worktree/local/remote completions with fetch-on-miss
         ("daft-go", 1) => {
             let entries = complete_daft_go(word, fetch_on_miss)?;
-            Ok(entries
-                .iter()
-                .map(|e| format!("{}\t{}\t{}", e.name, e.group.as_str(), e.description))
-                .collect())
+            Ok(format_entries_as_strings(&entries))
         }
 
         // daft-start: no dynamic completion for new branch names
         ("daft-start", _) => Ok(vec![]),
 
-        // daft-remove: complete existing branch names for deletion
-        ("daft-remove", _) => complete_existing_branches(word, verbose),
+        // daft-remove: worktree + local completions for deletion
+        ("daft-remove", _) => Ok(format_entries_as_strings(&complete_rich_branches(
+            word,
+            &CONFIG_REMOVE,
+        )?)),
 
-        // daft-rename: complete existing branch names for rename
-        ("daft-rename", _) => complete_existing_branches(word, verbose),
+        // daft-rename: worktree-only completions
+        ("daft-rename", _) => Ok(format_entries_as_strings(&complete_rich_branches(
+            word,
+            &CONFIG_RENAME,
+        )?)),
 
         // git-worktree-prune: no arguments
         ("git-worktree-prune", _) => Ok(vec![]),
@@ -273,59 +288,9 @@ fn ref_commit_age(reference: &mut gix::Reference<'_>) -> String {
     }
 }
 
-/// Complete existing branch names (local and remote)
-fn complete_existing_branches(prefix: &str, verbose: bool) -> Result<Vec<String>> {
-    let repo = match discover_repo() {
-        Ok(r) => r,
-        Err(e) => {
-            if verbose {
-                eprintln!("Git repository discovery failed: {e}");
-            }
-            return Ok(vec![]);
-        }
-    };
-
-    let mut branches: Vec<String> = Vec::new();
-
-    for refs_prefix in ["refs/heads/", "refs/remotes/origin/"] {
-        let platform = match repo.references() {
-            Ok(p) => p,
-            Err(_) => continue,
-        };
-        let iter = match platform.prefixed(refs_prefix) {
-            Ok(i) => i,
-            Err(_) => continue,
-        };
-        for reference_result in iter {
-            let reference = match reference_result {
-                Ok(r) => r,
-                Err(_) => continue,
-            };
-            let short = reference.name().shorten().to_string();
-            if short.contains("HEAD") {
-                continue;
-            }
-            let display = short.trim_start_matches("origin/").to_string();
-            if display.starts_with(prefix) {
-                branches.push(display);
-            }
-        }
-    }
-
-    branches.sort();
-    branches.dedup();
-
-    if verbose && branches.is_empty() {
-        eprintln!("No branches found matching prefix: '{prefix}'");
-    }
-
-    Ok(branches)
-}
-
 /// Collect `(branch, path)` pairs for every worktree (main + linked) that
-/// has a branch checked out. Detached HEADs and bare repos are skipped —
-/// they're not navigation targets.
-fn collect_go_worktrees(repo: &gix::Repository) -> Vec<(String, std::path::PathBuf)> {
+/// has a branch checked out. Detached HEADs and bare repos are skipped.
+fn collect_worktrees(repo: &gix::Repository) -> Vec<(String, std::path::PathBuf)> {
     let mut result = Vec::new();
 
     // Main worktree (if not bare / has a working directory).
@@ -337,7 +302,10 @@ fn collect_go_worktrees(repo: &gix::Repository) -> Vec<(String, std::path::PathB
         // Detached HEAD in main worktree → skip (no branch).
     }
 
-    // Linked worktrees.
+    // Linked worktrees — skip any that duplicate the current workdir
+    // (when gix::discover runs from a linked worktree, repo.workdir()
+    // already returns it, but repo.worktrees() also lists it).
+    let current_workdir = repo.workdir().map(|p| p.to_path_buf());
     let proxies = match repo.worktrees() {
         Ok(p) => p,
         Err(_) => return result,
@@ -351,6 +319,9 @@ fn collect_go_worktrees(repo: &gix::Repository) -> Vec<(String, std::path::PathB
             Ok(p) => p,
             Err(_) => continue,
         };
+        if current_workdir.as_deref() == Some(path.as_ref()) {
+            continue; // already collected via repo.workdir() above
+        }
         result.push((branch, path));
     }
 
@@ -382,13 +353,13 @@ fn collect_refs_with_age(repo: &gix::Repository, prefix: &str) -> Vec<(String, S
 }
 
 /// Collect `(branch, relative_age)` pairs for every local branch.
-fn collect_go_local_branches(repo: &gix::Repository) -> Vec<(String, String)> {
+fn collect_local_branches(repo: &gix::Repository) -> Vec<(String, String)> {
     collect_refs_with_age(repo, "refs/heads/")
 }
 
 /// Collect `(branch, relative_age)` pairs for every remote-tracking
 /// branch across all remotes.
-fn collect_go_remote_branches(repo: &gix::Repository) -> Vec<(String, String)> {
+fn collect_remote_branches(repo: &gix::Repository) -> Vec<(String, String)> {
     collect_refs_with_age(repo, "refs/remotes/")
 }
 
@@ -422,40 +393,26 @@ pub(crate) fn complete_daft_go(prefix: &str, fetch_on_miss: bool) -> Result<Vec<
     let repo = discover_repo()?;
     let d_discover = t.elapsed();
 
-    // Read only the config keys completions actually need — directly from
-    // the repo's in-memory config snapshot (no subprocess overhead).
+    // Read remote config + go-specific fetch-on-miss setting.
     let t = Instant::now();
-    let config = repo.config_snapshot();
-    let multi_remote_enabled = config
-        .boolean(keys::multi_remote::ENABLED)
-        .unwrap_or(defaults::MULTI_REMOTE_ENABLED);
-    let default_remote = if multi_remote_enabled {
-        config
-            .string(keys::multi_remote::DEFAULT_REMOTE)
-            .map(|v| v.to_string())
-            .unwrap_or_else(|| defaults::MULTI_REMOTE_DEFAULT_REMOTE.to_string())
-    } else {
-        config
-            .string(keys::REMOTE)
-            .map(|v| v.to_string())
-            .unwrap_or_else(|| defaults::REMOTE.to_string())
-    };
-    let go_fetch_on_miss = config
+    let (default_remote, multi_remote_enabled) = read_remote_config(&repo);
+    let go_fetch_on_miss = repo
+        .config_snapshot()
         .boolean(keys::GO_FETCH_ON_MISS)
         .unwrap_or(defaults::GO_FETCH_ON_MISS);
     let d_settings = t.elapsed();
 
     let collect = |repo: &gix::Repository, timings: bool| -> Vec<CompletionEntry> {
         let t = Instant::now();
-        let worktrees = collect_go_worktrees(repo);
+        let worktrees = collect_worktrees(repo);
         let d_wt = t.elapsed();
 
         let t = Instant::now();
-        let local = collect_go_local_branches(repo);
+        let local = collect_local_branches(repo);
         let d_local = t.elapsed();
 
         let t = Instant::now();
-        let remote = collect_go_remote_branches(repo);
+        let remote = collect_remote_branches(repo);
         let d_remote = t.elapsed();
 
         let t = Instant::now();
@@ -463,7 +420,7 @@ pub(crate) fn complete_daft_go(prefix: &str, fetch_on_miss: bool) -> Result<Vec<
         let d_current = t.elapsed();
 
         let t = Instant::now();
-        let entries = build_go_completions(
+        let entries = build_rich_completions(
             &worktrees,
             &local,
             &remote,
@@ -598,51 +555,6 @@ fn suggest_new_branch_names(prefix: &str) -> Vec<String> {
         .filter(|pattern| pattern.starts_with(prefix))
         .map(|pattern| pattern.to_string())
         .collect()
-}
-
-/// Complete local branches only (for base branch selection)
-#[allow(dead_code)]
-fn complete_local_branches(prefix: &str, verbose: bool) -> Result<Vec<String>> {
-    let repo = match discover_repo() {
-        Ok(r) => r,
-        Err(e) => {
-            if verbose {
-                eprintln!("Git repository discovery failed: {e}");
-            }
-            return Ok(vec![]);
-        }
-    };
-
-    let branches: Vec<String> = collect_refs_with_age(&repo, "refs/heads/")
-        .into_iter()
-        .map(|(name, _)| name)
-        .filter(|name| name.starts_with(prefix))
-        .collect();
-
-    Ok(branches)
-}
-
-/// Complete remote branches only
-#[allow(dead_code)]
-fn complete_remote_branches(prefix: &str, verbose: bool) -> Result<Vec<String>> {
-    let repo = match discover_repo() {
-        Ok(r) => r,
-        Err(e) => {
-            if verbose {
-                eprintln!("Git repository discovery failed: {e}");
-            }
-            return Ok(vec![]);
-        }
-    };
-
-    let branches: Vec<String> = collect_refs_with_age(&repo, "refs/remotes/origin/")
-        .into_iter()
-        .map(|(name, _)| name)
-        .filter(|name| !name.contains("HEAD") && name.starts_with(prefix))
-        .map(|name| name.trim_start_matches("origin/").to_string())
-        .collect();
-
-    Ok(branches)
 }
 
 /// Complete available layout names (built-in + custom from global config).
@@ -829,6 +741,90 @@ fn find_worktree_root() -> Result<std::path::PathBuf> {
         .ok_or_else(|| anyhow::anyhow!("Not inside a worktree (bare repository)"))
 }
 
+/// Read multi-remote and default-remote settings from the repo's in-memory
+/// config snapshot (zero subprocess overhead).
+fn read_remote_config(repo: &gix::Repository) -> (String, bool) {
+    use crate::core::settings::{defaults, keys};
+
+    let config = repo.config_snapshot();
+    let multi_remote_enabled = config
+        .boolean(keys::multi_remote::ENABLED)
+        .unwrap_or(defaults::MULTI_REMOTE_ENABLED);
+    let default_remote = if multi_remote_enabled {
+        config
+            .string(keys::multi_remote::DEFAULT_REMOTE)
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| defaults::MULTI_REMOTE_DEFAULT_REMOTE.to_string())
+    } else {
+        config
+            .string(keys::REMOTE)
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| defaults::REMOTE.to_string())
+    };
+    (default_remote, multi_remote_enabled)
+}
+
+/// Shared rich branch completion entry point. Discovers the repo, reads
+/// config, collects branch/worktree data according to `config`, and
+/// returns grouped completion entries.
+fn complete_rich_branches(
+    prefix: &str,
+    config: &RichCompletionConfig,
+) -> Result<Vec<CompletionEntry>> {
+    let repo = discover_repo()?;
+    let (default_remote, multi_remote_enabled) = read_remote_config(&repo);
+
+    let worktrees = if config.include_worktrees {
+        collect_worktrees(&repo)
+    } else {
+        Vec::new()
+    };
+    let local = if config.include_local || config.include_worktrees {
+        // Always collect local branches when worktrees are included —
+        // needed to look up commit ages for worktree entries.
+        collect_local_branches(&repo)
+    } else {
+        Vec::new()
+    };
+    let remote = if config.include_remote {
+        collect_remote_branches(&repo)
+    } else {
+        Vec::new()
+    };
+    let current_branch = if config.exclude_current {
+        current_worktree_branch(&repo)
+    } else {
+        None
+    };
+
+    let mut entries = build_rich_completions(
+        &worktrees,
+        &local,
+        &remote,
+        current_branch.as_deref(),
+        &default_remote,
+        multi_remote_enabled,
+        prefix,
+    );
+
+    // If the config excludes local branches but we collected them for
+    // worktree age lookup, strip them from the output.
+    if !config.include_local {
+        entries.retain(|e| e.group != CompletionGroup::Local);
+    }
+
+    Ok(entries)
+}
+
+/// Format rich completion entries as tab-separated strings for the shell
+/// completion protocol: `<name>\t<group>\t<description>`.
+fn format_entries_as_strings(entries: &[CompletionEntry]) -> Vec<String> {
+    entries
+        .iter()
+        .map(|e| format!("{}\t{}\t{}", e.name, e.group.as_str(), e.description))
+        .collect()
+}
+
 /// Return `true` if the cooldown marker is missing or older than
 /// `cooldown`. Used to decide whether the fetch-on-miss path should run.
 fn should_run_fetch(marker: &std::path::Path, cooldown: std::time::Duration) -> bool {
@@ -885,7 +881,8 @@ impl CompletionGroup {
     }
 }
 
-/// A single completion candidate emitted by `daft __complete daft-go`.
+/// A single completion candidate emitted by `daft __complete` for rich
+/// branch completions.
 #[derive(Debug, Clone)]
 pub(crate) struct CompletionEntry {
     pub name: String,
@@ -893,7 +890,63 @@ pub(crate) struct CompletionEntry {
     pub description: String,
 }
 
-/// Pure grouping/dedupe/filter/sort function for `daft go` completions.
+/// Configuration for which groups to include in rich branch completions.
+struct RichCompletionConfig {
+    /// Include worktree branches (branches checked out in a worktree).
+    include_worktrees: bool,
+    /// Include local branches not checked out in any worktree.
+    include_local: bool,
+    /// Include remote-tracking branches.
+    include_remote: bool,
+    /// Exclude the branch checked out in the current worktree.
+    exclude_current: bool,
+}
+
+// Per-command completion configurations.
+
+const CONFIG_CHECKOUT: RichCompletionConfig = RichCompletionConfig {
+    include_worktrees: true,
+    include_local: true,
+    include_remote: true,
+    exclude_current: true,
+};
+
+const CONFIG_REMOVE: RichCompletionConfig = RichCompletionConfig {
+    include_worktrees: true,
+    include_local: true,
+    include_remote: false,
+    exclude_current: false,
+};
+
+const CONFIG_RENAME: RichCompletionConfig = RichCompletionConfig {
+    include_worktrees: true,
+    include_local: false,
+    include_remote: false,
+    exclude_current: false,
+};
+
+const CONFIG_CARRY: RichCompletionConfig = RichCompletionConfig {
+    include_worktrees: true,
+    include_local: false,
+    include_remote: false,
+    exclude_current: true,
+};
+
+const CONFIG_FETCH: RichCompletionConfig = RichCompletionConfig {
+    include_worktrees: true,
+    include_local: false,
+    include_remote: false,
+    exclude_current: false,
+};
+
+const CONFIG_BRANCH: RichCompletionConfig = RichCompletionConfig {
+    include_worktrees: true,
+    include_local: true,
+    include_remote: false,
+    exclude_current: false,
+};
+
+/// Pure grouping/dedupe/filter/sort function for rich branch completions.
 ///
 /// Takes already-collected git data and produces a flat, ordered list of
 /// completion entries: worktrees first, then local branches, then remote
@@ -903,8 +956,7 @@ pub(crate) struct CompletionEntry {
 /// Shadowing is by stripped-name comparison — a remote-only branch whose
 /// stripped name collides with a local or worktree branch is dropped.
 ///
-/// The current worktree (if any) is excluded from the worktree group —
-/// `daft go` to the branch you're already on is a no-op.
+/// The current worktree (if any) is excluded from the worktree group.
 ///
 /// In single-remote mode, the leading `<default_remote>/` prefix is
 /// stripped from remote-branch names. In multi-remote mode the full
@@ -912,7 +964,7 @@ pub(crate) struct CompletionEntry {
 /// etc.) are always dropped.
 ///
 /// Entries whose name doesn't start with `prefix` are filtered out.
-pub(crate) fn build_go_completions(
+pub(crate) fn build_rich_completions(
     worktrees: &[(String, std::path::PathBuf)],
     local_branches: &[(String, String)],
     remote_branches: &[(String, String)],
@@ -1008,10 +1060,10 @@ pub(crate) fn build_go_completions(
     out
 }
 
-/// Format grouped completion entries as tab-separated lines for the
+/// Format rich completion entries as tab-separated lines for the
 /// shell completion protocol: `<name>\t<group>\t<description>`.
 #[allow(dead_code)]
-pub(crate) fn format_go_completions(entries: &[CompletionEntry]) -> String {
+pub(crate) fn format_rich_completions(entries: &[CompletionEntry]) -> String {
     let mut out = String::new();
     for entry in entries {
         out.push_str(&entry.name);
@@ -1046,7 +1098,7 @@ mod tests {
         assert!(suggestions.is_empty());
     }
 
-    // Tests for the new go-completion grouping function.
+    // Tests for the rich completion grouping function.
 
     fn wt(name: &str, path: &str) -> (String, std::path::PathBuf) {
         (name.to_string(), std::path::PathBuf::from(path))
@@ -1057,8 +1109,8 @@ mod tests {
     }
 
     #[test]
-    fn go_completions_group_order_is_worktrees_then_local_then_remote() {
-        let entries = build_go_completions(
+    fn rich_completions_group_order_is_worktrees_then_local_then_remote() {
+        let entries = build_rich_completions(
             &[wt("master", "/tmp/repo/master")],
             &[br("feat/local", "4 days ago")],
             &[br("origin/bug/xyz", "3 weeks ago")],
@@ -1080,8 +1132,8 @@ mod tests {
     }
 
     #[test]
-    fn go_completions_sort_within_group_alphabetically() {
-        let entries = build_go_completions(
+    fn rich_completions_sort_within_group_alphabetically() {
+        let entries = build_rich_completions(
             &[wt("b", "/tmp/b"), wt("a", "/tmp/a")],
             &[br("z", "1 day ago"), br("m", "2 days ago")],
             &[],
@@ -1095,8 +1147,8 @@ mod tests {
     }
 
     #[test]
-    fn go_completions_local_shadows_remote() {
-        let entries = build_go_completions(
+    fn rich_completions_local_shadows_remote() {
+        let entries = build_rich_completions(
             &[],
             &[br("feat/shared", "1 day ago")],
             &[br("origin/feat/shared", "2 days ago")],
@@ -1111,8 +1163,8 @@ mod tests {
     }
 
     #[test]
-    fn go_completions_worktree_shadows_local_and_remote() {
-        let entries = build_go_completions(
+    fn rich_completions_worktree_shadows_local_and_remote() {
+        let entries = build_rich_completions(
             &[wt("master", "/tmp/master")],
             &[br("master", "1 day ago")],
             &[br("origin/master", "2 days ago")],
@@ -1127,8 +1179,8 @@ mod tests {
     }
 
     #[test]
-    fn go_completions_exclude_current_worktree() {
-        let entries = build_go_completions(
+    fn rich_completions_exclude_current_worktree() {
+        let entries = build_rich_completions(
             &[wt("master", "/tmp/master"), wt("feat/x", "/tmp/feat-x")],
             &[],
             &[],
@@ -1142,8 +1194,8 @@ mod tests {
     }
 
     #[test]
-    fn go_completions_strip_remote_prefix_in_single_remote_mode() {
-        let entries = build_go_completions(
+    fn rich_completions_strip_remote_prefix_in_single_remote_mode() {
+        let entries = build_rich_completions(
             &[],
             &[],
             &[br("origin/bug/xyz", "3 weeks ago")],
@@ -1158,8 +1210,8 @@ mod tests {
     }
 
     #[test]
-    fn go_completions_keep_remote_prefix_in_multi_remote_mode() {
-        let entries = build_go_completions(
+    fn rich_completions_keep_remote_prefix_in_multi_remote_mode() {
+        let entries = build_rich_completions(
             &[],
             &[],
             &[
@@ -1176,8 +1228,8 @@ mod tests {
     }
 
     #[test]
-    fn go_completions_filter_by_prefix() {
-        let entries = build_go_completions(
+    fn rich_completions_filter_by_prefix() {
+        let entries = build_rich_completions(
             &[wt("master", "/tmp/master")],
             &[br("feat/x", "1d"), br("fix/y", "2d")],
             &[br("origin/bug/z", "3w")],
@@ -1191,8 +1243,8 @@ mod tests {
     }
 
     #[test]
-    fn go_completions_drop_remote_head_symrefs() {
-        let entries = build_go_completions(
+    fn rich_completions_drop_remote_head_symrefs() {
+        let entries = build_rich_completions(
             &[],
             &[],
             &[
@@ -1209,7 +1261,7 @@ mod tests {
     }
 
     #[test]
-    fn format_go_completions_emits_tab_separated_name_group_description() {
+    fn format_rich_completions_emits_tab_separated_name_group_description() {
         let entries = vec![
             CompletionEntry {
                 name: "master".into(),
@@ -1222,7 +1274,7 @@ mod tests {
                 description: "4 days ago".into(),
             },
         ];
-        let out = format_go_completions(&entries);
+        let out = format_rich_completions(&entries);
         assert_eq!(
             out,
             "master\tworktree\t2 hours ago\t/tmp/wt/master\nfeat/bar\tlocal\t4 days ago\n"
@@ -1230,14 +1282,14 @@ mod tests {
     }
 
     #[test]
-    fn go_completions_empty_input_returns_empty() {
-        let entries = build_go_completions(&[], &[], &[], None, "origin", false, "");
+    fn rich_completions_empty_input_returns_empty() {
+        let entries = build_rich_completions(&[], &[], &[], None, "origin", false, "");
         assert!(entries.is_empty());
     }
 
     #[test]
-    fn go_completions_non_matching_prefix_returns_empty() {
-        let entries = build_go_completions(
+    fn rich_completions_non_matching_prefix_returns_empty() {
+        let entries = build_rich_completions(
             &[wt("master", "/tmp/master")],
             &[br("feat/x", "1d")],
             &[br("origin/bug/y", "2d")],
@@ -1250,10 +1302,10 @@ mod tests {
     }
 
     #[test]
-    fn go_completions_prefix_filter_applies_after_remote_strip() {
+    fn rich_completions_prefix_filter_applies_after_remote_strip() {
         // In single-remote mode, the user sees `bug/xyz` (not `origin/bug/xyz`).
         // The prefix filter must match against the stripped display name.
-        let entries = build_go_completions(
+        let entries = build_rich_completions(
             &[],
             &[],
             &[br("origin/bug/xyz", "3w")],
@@ -1268,10 +1320,10 @@ mod tests {
     }
 
     #[test]
-    fn go_completions_multi_remote_dedupe_keeps_distinct_display_names() {
+    fn rich_completions_multi_remote_dedupe_keeps_distinct_display_names() {
         // In multi-remote mode, `origin/feat/x` and `fork/feat/x` are distinct
         // display names and both must survive — they don't shadow each other.
-        let entries = build_go_completions(
+        let entries = build_rich_completions(
             &[],
             &[],
             &[br("origin/feat/x", "1d"), br("fork/feat/x", "2d")],
@@ -1285,12 +1337,12 @@ mod tests {
     }
 
     #[test]
-    fn go_completions_drop_bare_remote_name_symref_collapse() {
+    fn rich_completions_drop_bare_remote_name_symref_collapse() {
         // `git for-each-ref refs/remotes/ --format=%(refname:short)` emits
         // the bare remote name (`origin`) as the short name for
         // `refs/remotes/origin/HEAD`. This is the collapsed form that our
         // `/HEAD` suffix filter misses, so it needs its own filter rule.
-        let entries = build_go_completions(
+        let entries = build_rich_completions(
             &[],
             &[],
             &[
@@ -1311,10 +1363,10 @@ mod tests {
     }
 
     #[test]
-    fn go_completions_drop_bare_remote_name_in_multi_remote_mode() {
+    fn rich_completions_drop_bare_remote_name_in_multi_remote_mode() {
         // In multi-remote mode, bare remote names are equally bogus — git
         // still collapses `refs/remotes/<remote>/HEAD` to just `<remote>`.
-        let entries = build_go_completions(
+        let entries = build_rich_completions(
             &[],
             &[],
             &[
@@ -1419,5 +1471,115 @@ mod tests {
             format_relative_time(now_secs() - 86400 * 800),
             "2 years, 2 months ago"
         );
+    }
+
+    // --- RichCompletionConfig behavior tests ---
+
+    #[test]
+    fn rich_completions_worktree_only_returns_no_local_or_remote() {
+        // When only worktrees are requested (like daft-rename),
+        // local and remote groups must be stripped even if data is provided.
+        let worktrees = vec![wt("main", "/repo/main"), wt("feat", "/repo/feat")];
+        let local = vec![
+            br("main", "1 day ago"),
+            br("feat", "2 days ago"),
+            br("dev", "3 days ago"),
+        ];
+        let remote = vec![br("origin/ci", "4 days ago")];
+
+        let entries =
+            build_rich_completions(&worktrees, &local, &remote, None, "origin", false, "");
+
+        // build_rich_completions returns all groups — the caller filters.
+        // Simulate what complete_rich_branches does with include_local=false:
+        let filtered: Vec<_> = entries
+            .into_iter()
+            .filter(|e| e.group == CompletionGroup::Worktree)
+            .collect();
+        assert_eq!(filtered.len(), 2);
+        assert!(filtered
+            .iter()
+            .all(|e| e.group == CompletionGroup::Worktree));
+    }
+
+    #[test]
+    fn rich_completions_no_remote_returns_worktrees_and_local() {
+        // When remote is excluded (like daft-remove), only worktree + local.
+        let worktrees = vec![wt("main", "/repo/main")];
+        let local = vec![br("main", "1 day ago"), br("dev", "2 days ago")];
+        let remote = vec![br("origin/ci", "3 days ago")];
+
+        let entries =
+            build_rich_completions(&worktrees, &local, &remote, None, "origin", false, "");
+
+        // Simulate exclude_remote by filtering.
+        let filtered: Vec<_> = entries
+            .into_iter()
+            .filter(|e| e.group != CompletionGroup::Remote)
+            .collect();
+        assert_eq!(filtered.len(), 2); // main (worktree), dev (local)
+        let groups: Vec<_> = filtered.iter().map(|e| e.group).collect();
+        assert!(groups.contains(&CompletionGroup::Worktree));
+        assert!(groups.contains(&CompletionGroup::Local));
+    }
+
+    #[test]
+    fn rich_completions_exclude_current_false_keeps_current_in_worktree_group() {
+        // When exclude_current is false (like daft-remove), the current
+        // worktree branch should appear in the worktree group.
+        let worktrees = vec![wt("main", "/repo/main"), wt("feat", "/repo/feat")];
+        let local = vec![br("main", "1 day ago"), br("feat", "2 days ago")];
+
+        // Pass None as current branch (exclude_current: false behavior)
+        let entries = build_rich_completions(&worktrees, &local, &[], None, "origin", false, "");
+        let wt_names: Vec<&str> = entries
+            .iter()
+            .filter(|e| e.group == CompletionGroup::Worktree)
+            .map(|e| e.name.as_str())
+            .collect();
+        assert!(
+            wt_names.contains(&"main"),
+            "main should be in worktree group"
+        );
+        assert!(
+            wt_names.contains(&"feat"),
+            "feat should be in worktree group"
+        );
+
+        // Compare with Some("main") — main removed from worktree group
+        let entries =
+            build_rich_completions(&worktrees, &local, &[], Some("main"), "origin", false, "");
+        let wt_names: Vec<&str> = entries
+            .iter()
+            .filter(|e| e.group == CompletionGroup::Worktree)
+            .map(|e| e.name.as_str())
+            .collect();
+        assert!(
+            !wt_names.contains(&"main"),
+            "main should be excluded from worktree group"
+        );
+        assert!(
+            wt_names.contains(&"feat"),
+            "feat should remain in worktree group"
+        );
+    }
+
+    #[test]
+    fn format_entries_as_strings_produces_tab_separated_output() {
+        let entries = vec![
+            CompletionEntry {
+                name: "main".to_string(),
+                group: CompletionGroup::Worktree,
+                description: "1 day ago\t/repo/main".to_string(),
+            },
+            CompletionEntry {
+                name: "dev".to_string(),
+                group: CompletionGroup::Local,
+                description: "2 days ago".to_string(),
+            },
+        ];
+        let strings = format_entries_as_strings(&entries);
+        assert_eq!(strings[0], "main\tworktree\t1 day ago\t/repo/main");
+        assert_eq!(strings[1], "dev\tlocal\t2 days ago");
     }
 }

--- a/src/commands/complete.rs
+++ b/src/commands/complete.rs
@@ -261,31 +261,46 @@ fn worktree_branch_from_gitdir(git_dir: &std::path::Path) -> Option<String> {
         .map(|s| s.to_string())
 }
 
-/// Peel a reference to its commit and return the committer timestamp as a
-/// relative-time string. Returns an empty string on failure (tag that doesn't
-/// point to a commit, corrupt object, etc.).
-fn ref_commit_age(reference: &mut gix::Reference<'_>) -> String {
+/// Commit metadata extracted from a ref for completion display.
+pub(crate) struct RefInfo {
+    age: String,
+    author: String,
+}
+
+/// Peel a reference to its commit and return the committer timestamp
+/// (as a relative-time string) and the author name. Returns empty
+/// strings on failure (tag that doesn't point to a commit, corrupt
+/// object, etc.).
+fn ref_commit_info(reference: &mut gix::Reference<'_>) -> RefInfo {
+    let empty = || RefInfo {
+        age: String::new(),
+        author: String::new(),
+    };
     let id = match reference.peel_to_id() {
         Ok(id) => id.detach(),
-        Err(_) => return String::new(),
+        Err(_) => return empty(),
     };
     let repo = reference.repo;
     let object = match repo.find_object(id) {
         Ok(o) => o,
-        Err(_) => return String::new(),
+        Err(_) => return empty(),
     };
     let commit = match object.try_into_commit() {
         Ok(c) => c,
-        Err(_) => return String::new(),
+        Err(_) => return empty(),
     };
-    let sig = match commit.committer() {
-        Ok(s) => s,
-        Err(_) => return String::new(),
-    };
-    match sig.time() {
-        Ok(time) => format_relative_time(time.seconds),
-        Err(_) => String::new(),
-    }
+    let age = commit
+        .committer()
+        .ok()
+        .and_then(|s| s.time().ok())
+        .map(|t| format_relative_time(t.seconds))
+        .unwrap_or_default();
+    let author = commit
+        .author()
+        .ok()
+        .map(|s| s.name.to_string())
+        .unwrap_or_default();
+    RefInfo { age, author }
 }
 
 /// Collect `(branch, path)` pairs for every worktree (main + linked) that
@@ -328,8 +343,8 @@ fn collect_worktrees(repo: &gix::Repository) -> Vec<(String, std::path::PathBuf)
     result
 }
 
-/// Collect `(branch, relative_age)` pairs for a given ref prefix via gitoxide.
-fn collect_refs_with_age(repo: &gix::Repository, prefix: &str) -> Vec<(String, String)> {
+/// Collect `(branch, RefInfo)` pairs for a given ref prefix via gitoxide.
+fn collect_refs_with_info(repo: &gix::Repository, prefix: &str) -> Vec<(String, RefInfo)> {
     let platform = match repo.references() {
         Ok(p) => p,
         Err(_) => return Vec::new(),
@@ -346,21 +361,21 @@ fn collect_refs_with_age(repo: &gix::Repository, prefix: &str) -> Vec<(String, S
             Err(_) => continue,
         };
         let short_name = reference.name().shorten().to_string();
-        let age = ref_commit_age(&mut reference);
-        result.push((short_name, age));
+        let info = ref_commit_info(&mut reference);
+        result.push((short_name, info));
     }
     result
 }
 
-/// Collect `(branch, relative_age)` pairs for every local branch.
-fn collect_local_branches(repo: &gix::Repository) -> Vec<(String, String)> {
-    collect_refs_with_age(repo, "refs/heads/")
+/// Collect `(branch, RefInfo)` pairs for every local branch.
+fn collect_local_branches(repo: &gix::Repository) -> Vec<(String, RefInfo)> {
+    collect_refs_with_info(repo, "refs/heads/")
 }
 
-/// Collect `(branch, relative_age)` pairs for every remote-tracking
+/// Collect `(branch, RefInfo)` pairs for every remote-tracking
 /// branch across all remotes.
-fn collect_remote_branches(repo: &gix::Repository) -> Vec<(String, String)> {
-    collect_refs_with_age(repo, "refs/remotes/")
+fn collect_remote_branches(repo: &gix::Repository) -> Vec<(String, RefInfo)> {
+    collect_refs_with_info(repo, "refs/remotes/")
 }
 
 /// Collect the current worktree's branch, if any — used to exclude it
@@ -971,8 +986,8 @@ const CONFIG_BRANCH: RichCompletionConfig = RichCompletionConfig {
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn build_rich_completions(
     worktrees: &[(String, std::path::PathBuf)],
-    local_branches: &[(String, String)],
-    remote_branches: &[(String, String)],
+    local_branches: &[(String, RefInfo)],
+    remote_branches: &[(String, RefInfo)],
     current_worktree_branch: Option<&str>,
     default_remote: &str,
     multi_remote: bool,
@@ -982,25 +997,26 @@ pub(crate) fn build_rich_completions(
     use std::collections::HashSet;
 
     // Worktree group: exclude the current worktree's branch.
-    // Look up the commit age from local_branches for each worktree, and
-    // pack both age and path into the description as "age\tpath".
+    // Look up the commit info from local_branches for each worktree, and
+    // pack age, author, and path into the description as "age\tauthor\tpath".
     let mut wt_entries: Vec<CompletionEntry> = worktrees
         .iter()
         .filter(|(name, _)| Some(name.as_str()) != current_worktree_branch)
         .filter(|(name, _)| name.starts_with(prefix))
         .map(|(name, path)| {
-            let age = local_branches
+            let info = local_branches
                 .iter()
                 .find(|(n, _)| n == name)
-                .map(|(_, a)| a.as_str())
-                .unwrap_or("");
+                .map(|(_, i)| i);
+            let age = info.map(|i| i.age.as_str()).unwrap_or("");
+            let author = info.map(|i| i.author.as_str()).unwrap_or("");
             let display_path = cwd
                 .and_then(|base| pathdiff::diff_paths(path, base))
                 .unwrap_or_else(|| path.to_path_buf());
             CompletionEntry {
                 name: name.clone(),
                 group: CompletionGroup::Worktree,
-                description: format!("{}\t{}", age, display_path.display()),
+                description: format!("{}\t{}\t{}", age, author, display_path.display()),
             }
         })
         .collect();
@@ -1013,10 +1029,10 @@ pub(crate) fn build_rich_completions(
         .iter()
         .filter(|(name, _)| !wt_names.contains(name.as_str()))
         .filter(|(name, _)| name.starts_with(prefix))
-        .map(|(name, age)| CompletionEntry {
+        .map(|(name, info)| CompletionEntry {
             name: name.clone(),
             group: CompletionGroup::Local,
-            description: age.clone(),
+            description: format!("{}\t{}", info.age, info.author),
         })
         .collect();
     local_entries.sort_by(|a, b| a.name.cmp(&b.name));
@@ -1036,7 +1052,7 @@ pub(crate) fn build_rich_completions(
             // the remote name from the branch path.
             !name.ends_with("/HEAD") && name != "HEAD" && name.contains('/')
         })
-        .filter_map(|(name, age)| {
+        .filter_map(|(name, info)| {
             let display = if multi_remote {
                 name.clone()
             } else if let Some(stripped) = name.strip_prefix(&prefix_to_strip) {
@@ -1056,7 +1072,7 @@ pub(crate) fn build_rich_completions(
             Some(CompletionEntry {
                 name: display,
                 group: CompletionGroup::Remote,
-                description: age.clone(),
+                description: format!("{}\t{}", info.age, info.author),
             })
         })
         .collect();
@@ -1113,8 +1129,24 @@ mod tests {
         (name.to_string(), std::path::PathBuf::from(path))
     }
 
-    fn br(name: &str, age: &str) -> (String, String) {
-        (name.to_string(), age.to_string())
+    fn br(name: &str, age: &str) -> (String, RefInfo) {
+        (
+            name.to_string(),
+            RefInfo {
+                age: age.to_string(),
+                author: String::new(),
+            },
+        )
+    }
+
+    fn br_author(name: &str, age: &str, author: &str) -> (String, RefInfo) {
+        (
+            name.to_string(),
+            RefInfo {
+                age: age.to_string(),
+                author: author.to_string(),
+            },
+        )
     }
 
     #[test]
@@ -1284,18 +1316,18 @@ mod tests {
             CompletionEntry {
                 name: "master".into(),
                 group: CompletionGroup::Worktree,
-                description: "2 hours ago\t/tmp/wt/master".into(),
+                description: "2 hours ago\tAlice\t/tmp/wt/master".into(),
             },
             CompletionEntry {
                 name: "feat/bar".into(),
                 group: CompletionGroup::Local,
-                description: "4 days ago".into(),
+                description: "4 days ago\tBob".into(),
             },
         ];
         let out = format_rich_completions(&entries);
         assert_eq!(
             out,
-            "master\tworktree\t2 hours ago\t/tmp/wt/master\nfeat/bar\tlocal\t4 days ago\n"
+            "master\tworktree\t2 hours ago\tAlice\t/tmp/wt/master\nfeat/bar\tlocal\t4 days ago\tBob\n"
         );
     }
 
@@ -1602,16 +1634,45 @@ mod tests {
             CompletionEntry {
                 name: "main".to_string(),
                 group: CompletionGroup::Worktree,
-                description: "1 day ago\t/repo/main".to_string(),
+                description: "1 day ago\tAlice\t/repo/main".to_string(),
             },
             CompletionEntry {
                 name: "dev".to_string(),
                 group: CompletionGroup::Local,
-                description: "2 days ago".to_string(),
+                description: "2 days ago\tBob".to_string(),
             },
         ];
         let strings = format_entries_as_strings(&entries);
-        assert_eq!(strings[0], "main\tworktree\t1 day ago\t/repo/main");
-        assert_eq!(strings[1], "dev\tlocal\t2 days ago");
+        assert_eq!(strings[0], "main\tworktree\t1 day ago\tAlice\t/repo/main");
+        assert_eq!(strings[1], "dev\tlocal\t2 days ago\tBob");
+    }
+
+    #[test]
+    fn rich_completions_author_propagates_to_all_groups() {
+        let entries = build_rich_completions(
+            &[wt("master", "/tmp/wt/master")],
+            &[
+                br_author("master", "1 day ago", "Alice"),
+                br_author("feat/local", "3 days ago", "Bob"),
+            ],
+            &[br_author("origin/feat/remote", "5 days ago", "Charlie")],
+            None,
+            "origin",
+            false,
+            "",
+            None,
+        );
+        // Worktree entry has age + author + path
+        let wt_entry = entries.iter().find(|e| e.name == "master").unwrap();
+        assert!(wt_entry.description.contains("Alice"));
+        assert!(wt_entry.description.contains("1 day ago"));
+
+        // Local entry has age + author
+        let local_entry = entries.iter().find(|e| e.name == "feat/local").unwrap();
+        assert_eq!(local_entry.description, "3 days ago\tBob");
+
+        // Remote entry has age + author
+        let remote_entry = entries.iter().find(|e| e.name == "feat/remote").unwrap();
+        assert_eq!(remote_entry.description, "5 days ago\tCharlie");
     }
 }

--- a/src/commands/completions/bash.rs
+++ b/src/commands/completions/bash.rs
@@ -3,6 +3,10 @@ use anyhow::{Context, Result};
 
 /// Generate bash completion string
 pub(super) fn generate_bash_completion_string(command_name: &str) -> Result<String> {
+    if command_name == "daft-go" {
+        return Ok(generate_bash_daft_go_completion());
+    }
+
     let mut output = String::new();
     let has_branches = matches!(
         command_name,
@@ -134,6 +138,35 @@ pub(super) fn generate_bash_completion_string(command_name: &str) -> Result<Stri
     }
 
     Ok(output)
+}
+
+fn generate_bash_daft_go_completion() -> String {
+    let cmd = get_command_for_name("daft-go").expect("daft-go command must exist");
+    let (all_flags, _, _) = extract_flags(&cmd);
+    let flags_joined = all_flags.join(" ");
+
+    format!(
+        r#"_daft_go() {{
+    local cur prev words cword
+    _init_completion || return
+
+    if [[ "$cur" == -* ]]; then
+        local flags="{flags_joined}"
+        COMPREPLY=( $(compgen -W "$flags" -- "$cur") )
+        return 0
+    fi
+
+    local raw
+    raw=$(daft __complete daft-go "$cur" --position "$cword" --fetch-on-miss 2>/dev/null | cut -f1)
+    if [[ -n "$raw" ]]; then
+        COMPREPLY=( $(compgen -W "$raw" -- "$cur") )
+        compopt -o nosort 2>/dev/null || true
+        return 0
+    fi
+}}
+complete -F _daft_go daft-go
+"#
+    )
 }
 
 pub(super) const DAFT_BASH_COMPLETIONS: &str = r#"# daft subcommand completions

--- a/src/commands/completions/bash.rs
+++ b/src/commands/completions/bash.rs
@@ -1,23 +1,16 @@
-use super::{extract_flags, get_command_for_name};
+use super::{extract_flags, get_command_for_name, uses_fetch_on_miss, uses_rich_completions};
 use anyhow::{Context, Result};
 
 /// Generate bash completion string
 pub(super) fn generate_bash_completion_string(command_name: &str) -> Result<String> {
-    if command_name == "daft-go" {
-        return Ok(generate_bash_daft_go_completion());
+    // Rich completion commands get cut -f1 + nosort to preserve group ordering.
+    if uses_rich_completions(command_name) {
+        return Ok(generate_bash_rich_completion(command_name));
     }
 
     let mut output = String::new();
-    let has_branches = matches!(
-        command_name,
-        "git-worktree-checkout"
-            | "git-worktree-carry"
-            | "git-worktree-fetch"
-            | "daft-go"
-            | "daft-start"
-            | "daft-remove"
-            | "daft-rename"
-    );
+    // daft-start still uses simple branch-prefix patterns (not rich).
+    let has_branches = command_name == "daft-start";
 
     let func_name = command_name.replace('-', "_");
 
@@ -140,13 +133,23 @@ pub(super) fn generate_bash_completion_string(command_name: &str) -> Result<Stri
     Ok(output)
 }
 
-fn generate_bash_daft_go_completion() -> String {
-    let cmd = get_command_for_name("daft-go").expect("daft-go command must exist");
+/// Generate a bash completion script with rich grouped output for any command
+/// that uses the `name\tgroup\tdescription` protocol.
+fn generate_bash_rich_completion(command_name: &str) -> String {
+    let cmd = get_command_for_name(command_name)
+        .unwrap_or_else(|| panic!("Unknown rich-completion command: {command_name}"));
     let (all_flags, _, _) = extract_flags(&cmd);
     let flags_joined = all_flags.join(" ");
 
+    let func_name = command_name.replace('-', "_");
+    let fetch_flag = if uses_fetch_on_miss(command_name) {
+        " --fetch-on-miss"
+    } else {
+        ""
+    };
+
     format!(
-        r#"_daft_go() {{
+        r#"_{func_name}() {{
     local cur prev words cword
     _init_completion || return
 
@@ -157,14 +160,14 @@ fn generate_bash_daft_go_completion() -> String {
     fi
 
     local raw
-    raw=$(daft __complete daft-go "$cur" --position "$cword" --fetch-on-miss 2>/dev/null | cut -f1)
+    raw=$(daft __complete {command_name} "$cur" --position "$cword"{fetch_flag} 2>/dev/null | cut -f1)
     if [[ -n "$raw" ]]; then
         COMPREPLY=( $(compgen -W "$raw" -- "$cur") )
         compopt -o nosort 2>/dev/null || true
         return 0
     fi
 }}
-complete -F _daft_go daft-go
+complete -F _{func_name} {command_name}
 "#
     )
 }

--- a/src/commands/completions/bash.rs
+++ b/src/commands/completions/bash.rs
@@ -148,7 +148,7 @@ fn generate_bash_rich_completion(command_name: &str) -> String {
         ""
     };
 
-    format!(
+    let mut output = format!(
         r#"_{func_name}() {{
     local cur prev words cword
     _init_completion || return
@@ -169,7 +169,31 @@ fn generate_bash_rich_completion(command_name: &str) -> String {
 }}
 complete -F _{func_name} {command_name}
 "#
-    )
+    );
+
+    // Register for git subcommand invocation (git worktree-checkout)
+    if command_name.starts_with("git-") {
+        let git_subcommand = command_name.trim_start_matches("git-");
+        output.push_str(&format!(
+            "# Also register for 'git {}' invocation\n",
+            git_subcommand
+        ));
+        output.push_str("if declare -f __git_complete >/dev/null 2>&1; then\n");
+        output.push_str(&format!(
+            "    __git_complete git-{} _{}\n",
+            git_subcommand, func_name
+        ));
+        output.push_str("fi\n");
+    }
+
+    // Register completions for shortcut aliases
+    for shortcut in crate::shortcuts::SHORTCUTS {
+        if shortcut.command == command_name {
+            output.push_str(&format!("complete -F _{func_name} {}\n", shortcut.alias));
+        }
+    }
+
+    output
 }
 
 pub(super) const DAFT_BASH_COMPLETIONS: &str = r#"# daft subcommand completions

--- a/src/commands/completions/fig.rs
+++ b/src/commands/completions/fig.rs
@@ -1,4 +1,4 @@
-use super::{get_command_for_name, get_flag_descriptions, COMMANDS};
+use super::{get_command_for_name, get_flag_descriptions, uses_rich_completions, COMMANDS};
 use anyhow::{Context, Result};
 use clap::Command;
 use serde::Serialize;
@@ -146,16 +146,7 @@ pub(super) fn generate_fig_completion_string(command_name: &str) -> Result<Strin
     let cmd =
         get_command_for_name(command_name).context(format!("Unknown command: {command_name}"))?;
 
-    let has_branches = matches!(
-        command_name,
-        "git-worktree-checkout"
-            | "git-worktree-carry"
-            | "git-worktree-fetch"
-            | "daft-go"
-            | "daft-start"
-            | "daft-remove"
-            | "daft-rename"
-    );
+    let has_branches = uses_rich_completions(command_name) || command_name == "daft-start";
 
     let about = cmd.get_about().map(|a| a.to_string());
 

--- a/src/commands/completions/fish.rs
+++ b/src/commands/completions/fish.rs
@@ -244,13 +244,16 @@ fn generate_fish_rich_completion(command_name: &str) -> Result<String> {
     let mut output = String::new();
     // Dynamic branch completion with grouped output
     output.push_str("# Dynamic branch name completion\n");
+    // Worktree lines: name\tworktree\tage\tauthor\tpath (5 fields)
+    // Local/remote: name\tgroup\tage\tauthor (4 fields)
+    // Fish display: name\tage · author · path (worktree) or name\tage · author
     output.push_str(&format!(
-        "complete -c {command_name} -f -a \"(daft __complete {command_name} (commandline -ct) --position 1{fetch_flag} 2>/dev/null | awk -F'\\t' '{{printf \\\"%s\\t%s · %s\\n\\\", $1, $3, $2}}')\"\n",
+        "complete -c {command_name} -f -a \"(daft __complete {command_name} (commandline -ct) --position 1{fetch_flag} 2>/dev/null | awk -F'\\t' '{{if (NF>=5) printf \\\"%s\\t%s · %s · %s\\n\\\",$1,$3,$4,$5; else printf \\\"%s\\t%s · %s\\n\\\",$1,$3,$4}}')\"\n",
     ));
     // Git subcommand invocation (git worktree-checkout) — only for git-* commands
     if is_git_command {
         output.push_str(&format!(
-            "complete -c git -n '__fish_seen_subcommand_from {git_subcommand}' -f -a \"(daft __complete {command_name} (commandline -ct) --position 1{fetch_flag} 2>/dev/null | awk -F'\\t' '{{printf \\\"%s\\t%s · %s\\n\\\", $1, $3, $2}}')\"\n",
+            "complete -c git -n '__fish_seen_subcommand_from {git_subcommand}' -f -a \"(daft __complete {command_name} (commandline -ct) --position 1{fetch_flag} 2>/dev/null | awk -F'\\t' '{{if (NF>=5) printf \\\"%s\\t%s · %s · %s\\n\\\",$1,$3,$4,$5; else printf \\\"%s\\t%s · %s\\n\\\",$1,$3,$4}}')\"\n",
         ));
     }
     output.push('\n');
@@ -317,12 +320,12 @@ complete -c daft -n '__fish_use_subcommand' -a 'list' -d 'List worktrees with st
 complete -c daft -n '__fish_use_subcommand' -a 'eject' -d 'Convert back to traditional layout'
 complete -c daft -n '__fish_use_subcommand' -a 'config' -d 'Configure daft settings'
 complete -c daft -n '__fish_use_subcommand' -a 'shared' -d 'Manage shared files across worktrees'
-complete -c daft -n '__fish_seen_subcommand_from go' -f -a "(daft __complete daft-go (commandline -ct) --position 1 --fetch-on-miss 2>/dev/null | awk -F'\t' '{printf \"%s\t%s · %s\n\", $1, $3, $2}')"
+complete -c daft -n '__fish_seen_subcommand_from go' -f -a "(daft __complete daft-go (commandline -ct) --position 1 --fetch-on-miss 2>/dev/null | awk -F'\t' '{if (NF>=5) printf \"%s\t%s · %s · %s\n\",$1,$3,$4,$5; else printf \"%s\t%s · %s\n\",$1,$3,$4}')"
 complete -c daft -n '__fish_seen_subcommand_from start' -f -a "(daft __complete daft-start '' 2>/dev/null)"
-complete -c daft -n '__fish_seen_subcommand_from carry' -f -a "(daft __complete git-worktree-carry (commandline -ct) --position 1 2>/dev/null | awk -F'\t' '{printf \"%s\t%s · %s\n\", $1, $3, $2}')"
-complete -c daft -n '__fish_seen_subcommand_from update' -f -a "(daft __complete git-worktree-fetch (commandline -ct) --position 1 2>/dev/null | awk -F'\t' '{printf \"%s\t%s · %s\n\", $1, $3, $2}')"
-complete -c daft -n '__fish_seen_subcommand_from remove' -f -a "(daft __complete daft-remove (commandline -ct) --position 1 2>/dev/null | awk -F'\t' '{printf \"%s\t%s · %s\n\", $1, $3, $2}')"
-complete -c daft -n '__fish_seen_subcommand_from rename' -f -a "(daft __complete daft-rename (commandline -ct) --position 1 2>/dev/null | awk -F'\t' '{printf \"%s\t%s · %s\n\", $1, $3, $2}')"
+complete -c daft -n '__fish_seen_subcommand_from carry' -f -a "(daft __complete git-worktree-carry (commandline -ct) --position 1 2>/dev/null | awk -F'\t' '{if (NF>=5) printf \"%s\t%s · %s · %s\n\",$1,$3,$4,$5; else printf \"%s\t%s · %s\n\",$1,$3,$4}')"
+complete -c daft -n '__fish_seen_subcommand_from update' -f -a "(daft __complete git-worktree-fetch (commandline -ct) --position 1 2>/dev/null | awk -F'\t' '{if (NF>=5) printf \"%s\t%s · %s · %s\n\",$1,$3,$4,$5; else printf \"%s\t%s · %s\n\",$1,$3,$4}')"
+complete -c daft -n '__fish_seen_subcommand_from remove' -f -a "(daft __complete daft-remove (commandline -ct) --position 1 2>/dev/null | awk -F'\t' '{if (NF>=5) printf \"%s\t%s · %s · %s\n\",$1,$3,$4,$5; else printf \"%s\t%s · %s\n\",$1,$3,$4}')"
+complete -c daft -n '__fish_seen_subcommand_from rename' -f -a "(daft __complete daft-rename (commandline -ct) --position 1 2>/dev/null | awk -F'\t' '{if (NF>=5) printf \"%s\t%s · %s · %s\n\",$1,$3,$4,$5; else printf \"%s\t%s · %s\n\",$1,$3,$4}')"
 complete -c daft -n '__fish_seen_subcommand_from layout; and not __fish_seen_subcommand_from default list show transform' -f -a 'default list show transform'
 complete -c daft -n '__fish_seen_subcommand_from layout; and __fish_seen_subcommand_from show' -F
 complete -c daft -n '__fish_seen_subcommand_from layout; and __fish_seen_subcommand_from transform' -f -a "(daft __complete layout-transform '' 2>/dev/null)"

--- a/src/commands/completions/fish.rs
+++ b/src/commands/completions/fish.rs
@@ -3,6 +3,10 @@ use anyhow::{Context, Result};
 
 /// Generate fish completion string
 pub(super) fn generate_fish_completion_string(command_name: &str) -> Result<String> {
+    if command_name == "daft-go" {
+        return Ok(generate_fish_daft_go_completion());
+    }
+
     let mut output = String::new();
     let has_branches = matches!(
         command_name,
@@ -221,6 +225,58 @@ fn generate_verb_alias_flag_completions() -> String {
     output
 }
 
+/// Generate bespoke fish completion for `daft-go`.
+///
+/// Passes `--fetch-on-miss` to `daft __complete` and reshuffles the
+/// tab-separated `name\tgroup\tage` output into fish's `name\tdescription`
+/// format where the description reads `<age> · <group>`.
+fn generate_fish_daft_go_completion() -> String {
+    use super::get_flag_descriptions;
+    use clap::CommandFactory;
+    let cmd = crate::commands::checkout::GoArgs::command();
+    let flag_descriptions = get_flag_descriptions(&cmd);
+
+    let mut output = String::new();
+    // Dynamic branch completion with grouped output
+    output.push_str("# Dynamic branch name completion\n");
+    output.push_str(
+        "complete -c daft-go -f -a \"(daft __complete daft-go (commandline -ct) --position 1 --fetch-on-miss 2>/dev/null | awk -F'\\t' '{printf \\\"%s\\t%s · %s\\n\\\", $1, $3, $2}')\"\n",
+    );
+    output.push('\n');
+    output.push_str("# Static flag completions (extracted from clap)\n");
+
+    // Flag completions (from clap introspection)
+    for (short, long, desc) in flag_descriptions {
+        let description = desc.unwrap_or_default();
+        if !short.is_empty() && !long.is_empty() {
+            let short_char = short.trim_start_matches('-');
+            let long_name = long.trim_start_matches("--");
+            output.push_str(&format!(
+                "complete -c daft-go -s {short_char} -l {long_name} -d '{description}'\n"
+            ));
+        } else if !long.is_empty() {
+            let long_name = long.trim_start_matches("--");
+            output.push_str(&format!(
+                "complete -c daft-go -l {long_name} -d '{description}'\n"
+            ));
+        } else if !short.is_empty() {
+            let short_char = short.trim_start_matches('-');
+            output.push_str(&format!(
+                "complete -c daft-go -s {short_char} -d '{description}'\n"
+            ));
+        }
+    }
+
+    // Register completions for shortcut aliases (wraps the full command)
+    for shortcut in crate::shortcuts::SHORTCUTS {
+        if shortcut.command == "daft-go" {
+            output.push_str(&format!("complete -c {} -w daft-go\n", shortcut.alias));
+        }
+    }
+
+    output
+}
+
 const DAFT_FISH_COMPLETIONS: &str = r#"# daft subcommand completions
 complete -c daft -f
 complete -c daft -n '__fish_use_subcommand' -s V -l version -d 'Print version information'
@@ -247,7 +303,7 @@ complete -c daft -n '__fish_use_subcommand' -a 'list' -d 'List worktrees with st
 complete -c daft -n '__fish_use_subcommand' -a 'eject' -d 'Convert back to traditional layout'
 complete -c daft -n '__fish_use_subcommand' -a 'config' -d 'Configure daft settings'
 complete -c daft -n '__fish_use_subcommand' -a 'shared' -d 'Manage shared files across worktrees'
-complete -c daft -n '__fish_seen_subcommand_from go' -f -a "(daft __complete daft-go '' 2>/dev/null)"
+complete -c daft -n '__fish_seen_subcommand_from go' -f -a "(daft __complete daft-go (commandline -ct) --position 1 --fetch-on-miss 2>/dev/null | awk -F'\t' '{printf \"%s\t%s · %s\n\", $1, $3, $2}')"
 complete -c daft -n '__fish_seen_subcommand_from start' -f -a "(daft __complete daft-start '' 2>/dev/null)"
 complete -c daft -n '__fish_seen_subcommand_from carry update' -f -a "(daft __complete git-worktree-checkout '' 2>/dev/null)"
 complete -c daft -n '__fish_seen_subcommand_from remove' -f -a "(daft __complete daft-remove '' 2>/dev/null)"

--- a/src/commands/completions/fish.rs
+++ b/src/commands/completions/fish.rs
@@ -244,16 +244,18 @@ fn generate_fish_rich_completion(command_name: &str) -> Result<String> {
     let mut output = String::new();
     // Dynamic branch completion with grouped output
     output.push_str("# Dynamic branch name completion\n");
-    // Worktree lines: name\tworktree\tage\tauthor\tpath (5 fields)
+    // Worktree lines: name[*?]\tworktree\tage\tauthor\tpath (5 fields)
     // Local/remote: name\tgroup\tage\tauthor (4 fields)
-    // Fish display: name\tage · author · path (worktree) or name\tage · author
+    // Fish display: clean_name\t[*?] age · author · path (worktree) or name\tage · author
+    // Strip *? from name for completion value — these are invalid in git branch names.
+    let awk_body = "{{c=$1; sub(/[*?]+$/,\\\"\\\",c); s=substr($1,length(c)+1); if (NF>=5) printf \\\"%s\\t%s %s · %s · %s\\n\\\",c,s,$3,$4,$5; else printf \\\"%s\\t%s %s · %s\\n\\\",c,s,$3,$4}}";
     output.push_str(&format!(
-        "complete -c {command_name} -f -a \"(daft __complete {command_name} (commandline -ct) --position 1{fetch_flag} 2>/dev/null | awk -F'\\t' '{{if (NF>=5) printf \\\"%s\\t%s · %s · %s\\n\\\",$1,$3,$4,$5; else printf \\\"%s\\t%s · %s\\n\\\",$1,$3,$4}}')\"\n",
+        "complete -c {command_name} -f -a \"(daft __complete {command_name} (commandline -ct) --position 1{fetch_flag} 2>/dev/null | awk -F'\\t' '{awk_body}')\"\n",
     ));
     // Git subcommand invocation (git worktree-checkout) — only for git-* commands
     if is_git_command {
         output.push_str(&format!(
-            "complete -c git -n '__fish_seen_subcommand_from {git_subcommand}' -f -a \"(daft __complete {command_name} (commandline -ct) --position 1{fetch_flag} 2>/dev/null | awk -F'\\t' '{{if (NF>=5) printf \\\"%s\\t%s · %s · %s\\n\\\",$1,$3,$4,$5; else printf \\\"%s\\t%s · %s\\n\\\",$1,$3,$4}}')\"\n",
+            "complete -c git -n '__fish_seen_subcommand_from {git_subcommand}' -f -a \"(daft __complete {command_name} (commandline -ct) --position 1{fetch_flag} 2>/dev/null | awk -F'\\t' '{awk_body}')\"\n",
         ));
     }
     output.push('\n');
@@ -320,12 +322,12 @@ complete -c daft -n '__fish_use_subcommand' -a 'list' -d 'List worktrees with st
 complete -c daft -n '__fish_use_subcommand' -a 'eject' -d 'Convert back to traditional layout'
 complete -c daft -n '__fish_use_subcommand' -a 'config' -d 'Configure daft settings'
 complete -c daft -n '__fish_use_subcommand' -a 'shared' -d 'Manage shared files across worktrees'
-complete -c daft -n '__fish_seen_subcommand_from go' -f -a "(daft __complete daft-go (commandline -ct) --position 1 --fetch-on-miss 2>/dev/null | awk -F'\t' '{if (NF>=5) printf \"%s\t%s · %s · %s\n\",$1,$3,$4,$5; else printf \"%s\t%s · %s\n\",$1,$3,$4}')"
+complete -c daft -n '__fish_seen_subcommand_from go' -f -a "(daft __complete daft-go (commandline -ct) --position 1 --fetch-on-miss 2>/dev/null | awk -F'\t' '{c=$1; sub(/[*?]+$/,\"\",c); s=substr($1,length(c)+1); if (NF>=5) printf \"%s\t%s %s · %s · %s\n\",c,s,$3,$4,$5; else printf \"%s\t%s %s · %s\n\",c,s,$3,$4}')"
 complete -c daft -n '__fish_seen_subcommand_from start' -f -a "(daft __complete daft-start '' 2>/dev/null)"
-complete -c daft -n '__fish_seen_subcommand_from carry' -f -a "(daft __complete git-worktree-carry (commandline -ct) --position 1 2>/dev/null | awk -F'\t' '{if (NF>=5) printf \"%s\t%s · %s · %s\n\",$1,$3,$4,$5; else printf \"%s\t%s · %s\n\",$1,$3,$4}')"
-complete -c daft -n '__fish_seen_subcommand_from update' -f -a "(daft __complete git-worktree-fetch (commandline -ct) --position 1 2>/dev/null | awk -F'\t' '{if (NF>=5) printf \"%s\t%s · %s · %s\n\",$1,$3,$4,$5; else printf \"%s\t%s · %s\n\",$1,$3,$4}')"
-complete -c daft -n '__fish_seen_subcommand_from remove' -f -a "(daft __complete daft-remove (commandline -ct) --position 1 2>/dev/null | awk -F'\t' '{if (NF>=5) printf \"%s\t%s · %s · %s\n\",$1,$3,$4,$5; else printf \"%s\t%s · %s\n\",$1,$3,$4}')"
-complete -c daft -n '__fish_seen_subcommand_from rename' -f -a "(daft __complete daft-rename (commandline -ct) --position 1 2>/dev/null | awk -F'\t' '{if (NF>=5) printf \"%s\t%s · %s · %s\n\",$1,$3,$4,$5; else printf \"%s\t%s · %s\n\",$1,$3,$4}')"
+complete -c daft -n '__fish_seen_subcommand_from carry' -f -a "(daft __complete git-worktree-carry (commandline -ct) --position 1 2>/dev/null | awk -F'\t' '{c=$1; sub(/[*?]+$/,\"\",c); s=substr($1,length(c)+1); if (NF>=5) printf \"%s\t%s %s · %s · %s\n\",c,s,$3,$4,$5; else printf \"%s\t%s %s · %s\n\",c,s,$3,$4}')"
+complete -c daft -n '__fish_seen_subcommand_from update' -f -a "(daft __complete git-worktree-fetch (commandline -ct) --position 1 2>/dev/null | awk -F'\t' '{c=$1; sub(/[*?]+$/,\"\",c); s=substr($1,length(c)+1); if (NF>=5) printf \"%s\t%s %s · %s · %s\n\",c,s,$3,$4,$5; else printf \"%s\t%s %s · %s\n\",c,s,$3,$4}')"
+complete -c daft -n '__fish_seen_subcommand_from remove' -f -a "(daft __complete daft-remove (commandline -ct) --position 1 2>/dev/null | awk -F'\t' '{c=$1; sub(/[*?]+$/,\"\",c); s=substr($1,length(c)+1); if (NF>=5) printf \"%s\t%s %s · %s · %s\n\",c,s,$3,$4,$5; else printf \"%s\t%s %s · %s\n\",c,s,$3,$4}')"
+complete -c daft -n '__fish_seen_subcommand_from rename' -f -a "(daft __complete daft-rename (commandline -ct) --position 1 2>/dev/null | awk -F'\t' '{c=$1; sub(/[*?]+$/,\"\",c); s=substr($1,length(c)+1); if (NF>=5) printf \"%s\t%s %s · %s · %s\n\",c,s,$3,$4,$5; else printf \"%s\t%s %s · %s\n\",c,s,$3,$4}')"
 complete -c daft -n '__fish_seen_subcommand_from layout; and not __fish_seen_subcommand_from default list show transform' -f -a 'default list show transform'
 complete -c daft -n '__fish_seen_subcommand_from layout; and __fish_seen_subcommand_from show' -F
 complete -c daft -n '__fish_seen_subcommand_from layout; and __fish_seen_subcommand_from transform' -f -a "(daft __complete layout-transform '' 2>/dev/null)"

--- a/src/commands/completions/fish.rs
+++ b/src/commands/completions/fish.rs
@@ -1,23 +1,19 @@
-use super::{get_command_for_name, get_flag_descriptions, VERB_ALIAS_GROUPS};
+use super::{
+    get_command_for_name, get_flag_descriptions, uses_fetch_on_miss, uses_rich_completions,
+    VERB_ALIAS_GROUPS,
+};
 use anyhow::{Context, Result};
 
 /// Generate fish completion string
 pub(super) fn generate_fish_completion_string(command_name: &str) -> Result<String> {
-    if command_name == "daft-go" {
-        return Ok(generate_fish_daft_go_completion());
+    // Rich completion commands get awk-reshuffled descriptions.
+    if uses_rich_completions(command_name) {
+        return generate_fish_rich_completion(command_name);
     }
 
     let mut output = String::new();
-    let has_branches = matches!(
-        command_name,
-        "git-worktree-checkout"
-            | "git-worktree-carry"
-            | "git-worktree-fetch"
-            | "daft-go"
-            | "daft-start"
-            | "daft-remove"
-            | "daft-rename"
-    );
+    // daft-start still uses simple branch-prefix patterns (not rich).
+    let has_branches = command_name == "daft-start";
 
     // Extract git subcommand name for dual registration (git-* commands only)
     let git_subcommand = command_name.trim_start_matches("git-");
@@ -225,23 +221,38 @@ fn generate_verb_alias_flag_completions() -> String {
     output
 }
 
-/// Generate bespoke fish completion for `daft-go`.
+/// Generate a fish completion script with rich grouped output for any command
+/// that uses the `name\tgroup\tdescription` protocol.
 ///
-/// Passes `--fetch-on-miss` to `daft __complete` and reshuffles the
-/// tab-separated `name\tgroup\tage` output into fish's `name\tdescription`
-/// format where the description reads `<age> · <group>`.
-fn generate_fish_daft_go_completion() -> String {
-    use super::get_flag_descriptions;
-    use clap::CommandFactory;
-    let cmd = crate::commands::checkout::GoArgs::command();
+/// Reshuffles the tab-separated output into fish's `name\tdescription` format
+/// where the description reads `<age> · <group>`.
+fn generate_fish_rich_completion(command_name: &str) -> Result<String> {
+    let cmd =
+        get_command_for_name(command_name).context(format!("Unknown command: {command_name}"))?;
     let flag_descriptions = get_flag_descriptions(&cmd);
+
+    let fetch_flag = if uses_fetch_on_miss(command_name) {
+        " --fetch-on-miss"
+    } else {
+        ""
+    };
+
+    // Extract git subcommand name for dual registration (git-* commands only)
+    let git_subcommand = command_name.trim_start_matches("git-");
+    let is_git_command = command_name.starts_with("git-");
 
     let mut output = String::new();
     // Dynamic branch completion with grouped output
     output.push_str("# Dynamic branch name completion\n");
-    output.push_str(
-        "complete -c daft-go -f -a \"(daft __complete daft-go (commandline -ct) --position 1 --fetch-on-miss 2>/dev/null | awk -F'\\t' '{printf \\\"%s\\t%s · %s\\n\\\", $1, $3, $2}')\"\n",
-    );
+    output.push_str(&format!(
+        "complete -c {command_name} -f -a \"(daft __complete {command_name} (commandline -ct) --position 1{fetch_flag} 2>/dev/null | awk -F'\\t' '{{printf \\\"%s\\t%s · %s\\n\\\", $1, $3, $2}}')\"\n",
+    ));
+    // Git subcommand invocation (git worktree-checkout) — only for git-* commands
+    if is_git_command {
+        output.push_str(&format!(
+            "complete -c git -n '__fish_seen_subcommand_from {git_subcommand}' -f -a \"(daft __complete {command_name} (commandline -ct) --position 1{fetch_flag} 2>/dev/null | awk -F'\\t' '{{printf \\\"%s\\t%s · %s\\n\\\", $1, $3, $2}}')\"\n",
+        ));
+    }
     output.push('\n');
     output.push_str("# Static flag completions (extracted from clap)\n");
 
@@ -252,29 +263,32 @@ fn generate_fish_daft_go_completion() -> String {
             let short_char = short.trim_start_matches('-');
             let long_name = long.trim_start_matches("--");
             output.push_str(&format!(
-                "complete -c daft-go -s {short_char} -l {long_name} -d '{description}'\n"
+                "complete -c {command_name} -s {short_char} -l {long_name} -d '{description}'\n"
             ));
         } else if !long.is_empty() {
             let long_name = long.trim_start_matches("--");
             output.push_str(&format!(
-                "complete -c daft-go -l {long_name} -d '{description}'\n"
+                "complete -c {command_name} -l {long_name} -d '{description}'\n"
             ));
         } else if !short.is_empty() {
             let short_char = short.trim_start_matches('-');
             output.push_str(&format!(
-                "complete -c daft-go -s {short_char} -d '{description}'\n"
+                "complete -c {command_name} -s {short_char} -d '{description}'\n"
             ));
         }
     }
 
     // Register completions for shortcut aliases (wraps the full command)
     for shortcut in crate::shortcuts::SHORTCUTS {
-        if shortcut.command == "daft-go" {
-            output.push_str(&format!("complete -c {} -w daft-go\n", shortcut.alias));
+        if shortcut.command == command_name {
+            output.push_str(&format!(
+                "complete -c {} -w {command_name}\n",
+                shortcut.alias
+            ));
         }
     }
 
-    output
+    Ok(output)
 }
 
 const DAFT_FISH_COMPLETIONS: &str = r#"# daft subcommand completions
@@ -305,9 +319,10 @@ complete -c daft -n '__fish_use_subcommand' -a 'config' -d 'Configure daft setti
 complete -c daft -n '__fish_use_subcommand' -a 'shared' -d 'Manage shared files across worktrees'
 complete -c daft -n '__fish_seen_subcommand_from go' -f -a "(daft __complete daft-go (commandline -ct) --position 1 --fetch-on-miss 2>/dev/null | awk -F'\t' '{printf \"%s\t%s · %s\n\", $1, $3, $2}')"
 complete -c daft -n '__fish_seen_subcommand_from start' -f -a "(daft __complete daft-start '' 2>/dev/null)"
-complete -c daft -n '__fish_seen_subcommand_from carry update' -f -a "(daft __complete git-worktree-checkout '' 2>/dev/null)"
-complete -c daft -n '__fish_seen_subcommand_from remove' -f -a "(daft __complete daft-remove '' 2>/dev/null)"
-complete -c daft -n '__fish_seen_subcommand_from rename' -f -a "(daft __complete daft-rename '' 2>/dev/null)"
+complete -c daft -n '__fish_seen_subcommand_from carry' -f -a "(daft __complete git-worktree-carry (commandline -ct) --position 1 2>/dev/null | awk -F'\t' '{printf \"%s\t%s · %s\n\", $1, $3, $2}')"
+complete -c daft -n '__fish_seen_subcommand_from update' -f -a "(daft __complete git-worktree-fetch (commandline -ct) --position 1 2>/dev/null | awk -F'\t' '{printf \"%s\t%s · %s\n\", $1, $3, $2}')"
+complete -c daft -n '__fish_seen_subcommand_from remove' -f -a "(daft __complete daft-remove (commandline -ct) --position 1 2>/dev/null | awk -F'\t' '{printf \"%s\t%s · %s\n\", $1, $3, $2}')"
+complete -c daft -n '__fish_seen_subcommand_from rename' -f -a "(daft __complete daft-rename (commandline -ct) --position 1 2>/dev/null | awk -F'\t' '{printf \"%s\t%s · %s\n\", $1, $3, $2}')"
 complete -c daft -n '__fish_seen_subcommand_from layout; and not __fish_seen_subcommand_from default list show transform' -f -a 'default list show transform'
 complete -c daft -n '__fish_seen_subcommand_from layout; and __fish_seen_subcommand_from show' -F
 complete -c daft -n '__fish_seen_subcommand_from layout; and __fish_seen_subcommand_from transform' -f -a "(daft __complete layout-transform '' 2>/dev/null)"

--- a/src/commands/completions/mod.rs
+++ b/src/commands/completions/mod.rs
@@ -519,20 +519,28 @@ mod tests {
     }
 
     #[test]
-    fn zsh_daft_go_uses_compadd_groups() {
+    fn zsh_daft_go_uses_compadd_groups_with_colored_headers() {
         let script =
             zsh::generate_zsh_completion_string("daft-go").expect("generator must succeed");
         assert!(
-            script.contains("compadd -V worktree"),
-            "daft-go zsh must use compadd -V for worktree group"
+            script.contains("-V worktree"),
+            "daft-go zsh must use -V worktree group"
         );
         assert!(
-            script.contains("compadd -V local"),
-            "daft-go zsh must use compadd -V for local group"
+            script.contains("-V local"),
+            "daft-go zsh must use -V local group"
         );
         assert!(
-            script.contains("compadd -V remote"),
-            "daft-go zsh must use compadd -V for remote group"
+            script.contains("-V remote"),
+            "daft-go zsh must use -V remote group"
+        );
+        assert!(
+            script.contains("-X '%F{green}worktree%f'"),
+            "daft-go zsh must have colored worktree header via -X"
+        );
+        assert!(
+            script.contains("-X '%F{blue}local branch%f'"),
+            "daft-go zsh must have colored local header via -X"
         );
         assert!(
             !script.contains("\n    _describe"),

--- a/src/commands/completions/mod.rs
+++ b/src/commands/completions/mod.rs
@@ -519,19 +519,23 @@ mod tests {
     }
 
     #[test]
-    fn zsh_daft_go_uses_tags_with_per_group_list_colors() {
+    fn zsh_daft_go_uses_tags_for_worktree_color() {
         let script =
             zsh::generate_zsh_completion_string("daft-go").expect("generator must succeed");
-        // Uses _tags + _requested for per-group coloring (not _describe)
+        // Worktrees use _tags + _requested for cyan via list-colors
         assert!(
-            script.contains("_tags \"${avail_tags[@]}\""),
-            "daft-go zsh must register tags via _tags"
+            script.contains("_tags daft-go-wt"),
+            "daft-go zsh must register worktree tag"
         );
         assert!(
             script.contains("_requested daft-go-wt"),
             "daft-go zsh must use _requested for worktree tag"
         );
-        // Groups still use -V for ordering
+        assert!(
+            script.contains("daft-go-wt' list-colors '=*=36'"),
+            "daft-go zsh must set cyan list-colors for worktree tag"
+        );
+        // Groups use -V for ordering (worktree first)
         assert!(
             script.contains("-V worktree"),
             "daft-go zsh must use -V worktree group"
@@ -544,20 +548,7 @@ mod tests {
             script.contains("-V remote"),
             "daft-go zsh must use -V remote group"
         );
-        // Per-tag list-colors with git branch colors (cyan, green, red)
-        assert!(
-            script.contains("daft-go-wt' list-colors '=(#b)([^ ]##)( *)=0=36=0'"),
-            "daft-go zsh must set cyan list-colors for worktree tag"
-        );
-        assert!(
-            script.contains("daft-go-local' list-colors '=(#b)([^ ]##)( *)=0=32=0'"),
-            "daft-go zsh must set green list-colors for local tag"
-        );
-        assert!(
-            script.contains("daft-go-remote' list-colors '=(#b)([^ ]##)( *)=0=31=0'"),
-            "daft-go zsh must set red list-colors for remote tag"
-        );
-        // No group headers — colors are on items themselves
+        // No group headers, no _describe
         assert!(
             !script.contains("-X "),
             "daft-go must NOT use -X group headers"

--- a/src/commands/completions/mod.rs
+++ b/src/commands/completions/mod.rs
@@ -499,6 +499,34 @@ mod tests {
     use super::*;
 
     #[test]
+    fn zsh_daft_go_emits_describe_per_group() {
+        let script =
+            zsh::generate_zsh_completion_string("daft-go").expect("generator must succeed");
+        assert!(
+            script.contains("_describe -t worktree"),
+            "daft-go zsh completion must call _describe with the worktree tag"
+        );
+        assert!(
+            script.contains("_describe -t local"),
+            "daft-go zsh completion must call _describe with the local tag"
+        );
+        assert!(
+            script.contains("_describe -t remote"),
+            "daft-go zsh completion must call _describe with the remote tag"
+        );
+    }
+
+    #[test]
+    fn zsh_daft_go_passes_fetch_on_miss_flag() {
+        let script =
+            zsh::generate_zsh_completion_string("daft-go").expect("generator must succeed");
+        assert!(
+            script.contains("--fetch-on-miss"),
+            "daft-go zsh completion must pass --fetch-on-miss to daft __complete"
+        );
+    }
+
+    #[test]
     fn zsh_gates_flag_completions_on_leading_dash() {
         let commands = [
             "git-worktree-checkout",

--- a/src/commands/completions/mod.rs
+++ b/src/commands/completions/mod.rs
@@ -499,6 +499,26 @@ mod tests {
     use super::*;
 
     #[test]
+    fn bash_daft_go_uses_nosort_and_fetch_on_miss() {
+        let script =
+            bash::generate_bash_completion_string("daft-go").expect("generator must succeed");
+        assert!(
+            script.contains("--fetch-on-miss"),
+            "daft-go bash completion must pass --fetch-on-miss to daft __complete"
+        );
+        assert!(
+            script.contains("compopt -o nosort"),
+            "daft-go bash completion must attempt compopt -o nosort to \
+             preserve group ordering"
+        );
+        assert!(
+            script.contains("cut -f1"),
+            "daft-go bash completion must strip tab-separated group/desc \
+             columns with cut -f1"
+        );
+    }
+
+    #[test]
     fn zsh_daft_go_emits_describe_per_group() {
         let script =
             zsh::generate_zsh_completion_string("daft-go").expect("generator must succeed");

--- a/src/commands/completions/mod.rs
+++ b/src/commands/completions/mod.rs
@@ -547,6 +547,30 @@ mod tests {
     }
 
     #[test]
+    fn fish_daft_go_passes_fetch_on_miss_and_awk_reshuffles() {
+        let script =
+            fish::generate_fish_completion_string("daft-go").expect("generator must succeed");
+        assert!(
+            script.contains("--fetch-on-miss"),
+            "daft-go fish completion must pass --fetch-on-miss"
+        );
+        assert!(
+            script.contains("awk"),
+            "daft-go fish completion must reshuffle tab-separated columns via awk"
+        );
+    }
+
+    #[test]
+    fn fish_daft_umbrella_passes_fetch_on_miss_for_go() {
+        let fish_completions = fish::generate_daft_fish_completions();
+        assert!(
+            fish_completions.contains("daft __complete daft-go")
+                && fish_completions.contains("--fetch-on-miss"),
+            "daft go subcommand in umbrella fish completions must pass --fetch-on-miss"
+        );
+    }
+
+    #[test]
     fn zsh_gates_flag_completions_on_leading_dash() {
         let commands = [
             "git-worktree-checkout",

--- a/src/commands/completions/mod.rs
+++ b/src/commands/completions/mod.rs
@@ -80,6 +80,26 @@ pub(super) fn get_command_for_name(command_name: &str) -> Option<Command> {
     }
 }
 
+/// Whether a command uses the rich (grouped, tab-separated) completion
+/// protocol with worktree/local/remote groups and metadata.
+pub(super) fn uses_rich_completions(command_name: &str) -> bool {
+    matches!(
+        command_name,
+        "daft-go"
+            | "git-worktree-checkout"
+            | "daft-remove"
+            | "daft-rename"
+            | "git-worktree-carry"
+            | "git-worktree-fetch"
+            | "git-worktree-branch"
+    )
+}
+
+/// Whether a command should pass `--fetch-on-miss` to `daft __complete`.
+pub(super) fn uses_fetch_on_miss(command_name: &str) -> bool {
+    matches!(command_name, "daft-go")
+}
+
 /// Extract flag strings from a clap Command for shell completions
 /// Returns a tuple of (short_and_long_flags, short_flags, long_flags)
 pub(super) fn extract_flags(cmd: &Command) -> (Vec<String>, Vec<String>, Vec<String>) {
@@ -600,6 +620,102 @@ mod tests {
             combined.contains("__daft_go_impl"),
             "zsh umbrella must call __daft_go_impl for the `go` verb alias"
         );
+    }
+
+    #[test]
+    fn rich_commands_use_compadd_v_groups_in_zsh() {
+        // Every rich-completion command should use compadd -V for group ordering.
+        let rich_commands = [
+            "git-worktree-checkout",
+            "git-worktree-carry",
+            "git-worktree-fetch",
+            "daft-go",
+            "daft-remove",
+            "daft-rename",
+        ];
+        for cmd in rich_commands {
+            let script = zsh::generate_zsh_completion_string(cmd)
+                .unwrap_or_else(|e| panic!("generator must succeed for {cmd}: {e}"));
+            assert!(
+                script.contains("-V worktree"),
+                "{cmd} zsh must use -V worktree group"
+            );
+        }
+    }
+
+    #[test]
+    fn only_daft_go_passes_fetch_on_miss_in_all_shells() {
+        let non_go_rich = [
+            "git-worktree-checkout",
+            "git-worktree-carry",
+            "git-worktree-fetch",
+            "daft-remove",
+            "daft-rename",
+        ];
+        for cmd in non_go_rich {
+            let zsh = zsh::generate_zsh_completion_string(cmd)
+                .unwrap_or_else(|e| panic!("zsh generator must succeed for {cmd}: {e}"));
+            assert!(
+                !zsh.contains("--fetch-on-miss"),
+                "{cmd} zsh must NOT pass --fetch-on-miss"
+            );
+            let bash = bash::generate_bash_completion_string(cmd)
+                .unwrap_or_else(|e| panic!("bash generator must succeed for {cmd}: {e}"));
+            assert!(
+                !bash.contains("--fetch-on-miss"),
+                "{cmd} bash must NOT pass --fetch-on-miss"
+            );
+            let fish = fish::generate_fish_completion_string(cmd)
+                .unwrap_or_else(|e| panic!("fish generator must succeed for {cmd}: {e}"));
+            assert!(
+                !fish.contains("--fetch-on-miss"),
+                "{cmd} fish must NOT pass --fetch-on-miss"
+            );
+        }
+    }
+
+    #[test]
+    fn fish_rich_commands_use_awk_reshuffle() {
+        let rich_commands = [
+            "git-worktree-checkout",
+            "git-worktree-carry",
+            "git-worktree-fetch",
+            "daft-go",
+            "daft-remove",
+            "daft-rename",
+        ];
+        for cmd in rich_commands {
+            let script = fish::generate_fish_completion_string(cmd)
+                .unwrap_or_else(|e| panic!("fish generator must succeed for {cmd}: {e}"));
+            assert!(
+                script.contains("awk"),
+                "{cmd} fish must reshuffle tab-separated columns via awk"
+            );
+        }
+    }
+
+    #[test]
+    fn bash_rich_commands_use_cut_and_nosort() {
+        let rich_commands = [
+            "git-worktree-checkout",
+            "git-worktree-carry",
+            "git-worktree-fetch",
+            "daft-go",
+            "daft-remove",
+            "daft-rename",
+        ];
+        for cmd in rich_commands {
+            let script = bash::generate_bash_completion_string(cmd)
+                .unwrap_or_else(|e| panic!("bash generator must succeed for {cmd}: {e}"));
+            assert!(
+                script.contains("cut -f1"),
+                "{cmd} bash must strip group/desc columns with cut -f1"
+            );
+            assert!(
+                script.contains("compopt -o nosort"),
+                "{cmd} bash must use compopt -o nosort to preserve group ordering"
+            );
+        }
     }
 
     #[test]

--- a/src/commands/completions/mod.rs
+++ b/src/commands/completions/mod.rs
@@ -499,21 +499,34 @@ mod tests {
     use super::*;
 
     #[test]
-    fn zsh_daft_go_gates_flags_on_leading_dash() {
-        let script =
-            zsh::generate_zsh_completion_string("daft-go").expect("generator must succeed");
-        let flags_pos = script
-            .find("compadd -a flags")
-            .expect("generated script must contain `compadd -a flags`");
-        let guard_pos = script.find("[[ \"$curword\" == -* ]]").expect(
-            "generated script must gate flag completion on a leading \
-                 dash before adding flags (zsh flag-leak regression)",
-        );
-        assert!(
-            guard_pos < flags_pos,
-            "flag-gating guard must appear before `compadd -a flags`, \
-             otherwise flags leak into branch completions. \
-             guard_pos={guard_pos} flags_pos={flags_pos}",
-        );
+    fn zsh_gates_flag_completions_on_leading_dash() {
+        let commands = [
+            "git-worktree-checkout",
+            "git-worktree-carry",
+            "git-worktree-fetch",
+            "daft-go",
+            "daft-start",
+            "daft-remove",
+            "daft-rename",
+        ];
+        for cmd in commands {
+            let script = zsh::generate_zsh_completion_string(cmd)
+                .unwrap_or_else(|e| panic!("generator must succeed for {cmd}: {e}"));
+            let flags_pos = script.find("compadd -a flags").unwrap_or_else(|| {
+                panic!("generated script for {cmd} must contain `compadd -a flags`")
+            });
+            let guard_pos = script.find("[[ \"$curword\" == -* ]]").unwrap_or_else(|| {
+                panic!(
+                    "generated script for {cmd} must gate flag completion on a leading dash \
+before adding flags (zsh flag-leak regression)"
+                )
+            });
+            assert!(
+                guard_pos < flags_pos,
+                "flag-gating guard must appear before `compadd -a flags` for {cmd}, \
+                 otherwise flags leak into branch completions. \
+                 guard_pos={guard_pos} flags_pos={flags_pos}",
+            );
+        }
     }
 }

--- a/src/commands/completions/mod.rs
+++ b/src/commands/completions/mod.rs
@@ -519,20 +519,24 @@ mod tests {
     }
 
     #[test]
-    fn zsh_daft_go_uses_compadd_groups() {
+    fn zsh_daft_go_uses_describe_per_group() {
         let script =
             zsh::generate_zsh_completion_string("daft-go").expect("generator must succeed");
         assert!(
-            script.contains("compadd -V worktree"),
-            "daft-go zsh completion must use compadd -V worktree for group ordering"
+            script.contains("_describe '' wt_items"),
+            "daft-go zsh completion must call _describe for worktree group"
         );
         assert!(
-            script.contains("compadd -V local"),
-            "daft-go zsh completion must use compadd -V local for group ordering"
+            script.contains("_describe '' local_items"),
+            "daft-go zsh completion must call _describe for local group"
         );
         assert!(
-            script.contains("compadd -V remote"),
-            "daft-go zsh completion must use compadd -V remote for group ordering"
+            script.contains("_describe '' remote_items"),
+            "daft-go zsh completion must call _describe for remote group"
+        );
+        assert!(
+            !script.contains("_describe -t"),
+            "daft-go must NOT use _describe -t (causes tag-retry 3x repetition)"
         );
     }
 

--- a/src/commands/completions/mod.rs
+++ b/src/commands/completions/mod.rs
@@ -589,6 +589,19 @@ mod tests {
     }
 
     #[test]
+    fn zsh_umbrella_delegates_go_to_daft_go_impl() {
+        let combined = format!(
+            "{}\n{}",
+            zsh::generate_zsh_completion_string("daft-go").unwrap(),
+            zsh::DAFT_ZSH_COMPLETIONS,
+        );
+        assert!(
+            combined.contains("__daft_go_impl"),
+            "zsh umbrella must call __daft_go_impl for the `go` verb alias"
+        );
+    }
+
+    #[test]
     fn zsh_gates_flag_completions_on_leading_dash() {
         let commands = [
             "git-worktree-checkout",

--- a/src/commands/completions/mod.rs
+++ b/src/commands/completions/mod.rs
@@ -571,6 +571,24 @@ mod tests {
     }
 
     #[test]
+    fn zsh_daft_go_emits_zstyle_colors_per_group() {
+        let script =
+            zsh::generate_zsh_completion_string("daft-go").expect("generator must succeed");
+        assert!(
+            script.contains(":*:daft-go:*:worktree"),
+            "zsh daft-go must emit a zstyle line for the worktree group"
+        );
+        assert!(
+            script.contains(":*:daft-go:*:local"),
+            "zsh daft-go must emit a zstyle line for the local group"
+        );
+        assert!(
+            script.contains(":*:daft-go:*:remote"),
+            "zsh daft-go must emit a zstyle line for the remote group"
+        );
+    }
+
+    #[test]
     fn zsh_gates_flag_completions_on_leading_dash() {
         let commands = [
             "git-worktree-checkout",

--- a/src/commands/completions/mod.rs
+++ b/src/commands/completions/mod.rs
@@ -523,15 +523,15 @@ mod tests {
         let script =
             zsh::generate_zsh_completion_string("daft-go").expect("generator must succeed");
         assert!(
-            script.contains("_describe '' wt_items"),
+            script.contains("_describe 'worktree' wt_items"),
             "daft-go zsh completion must call _describe for worktree group"
         );
         assert!(
-            script.contains("_describe '' local_items"),
+            script.contains("_describe 'local branch' local_items"),
             "daft-go zsh completion must call _describe for local group"
         );
         assert!(
-            script.contains("_describe '' remote_items"),
+            script.contains("_describe 'remote branch' remote_items"),
             "daft-go zsh completion must call _describe for remote group"
         );
         assert!(

--- a/src/commands/completions/mod.rs
+++ b/src/commands/completions/mod.rs
@@ -519,20 +519,20 @@ mod tests {
     }
 
     #[test]
-    fn zsh_daft_go_emits_describe_per_group() {
+    fn zsh_daft_go_uses_compadd_groups() {
         let script =
             zsh::generate_zsh_completion_string("daft-go").expect("generator must succeed");
         assert!(
-            script.contains("_describe -t worktree"),
-            "daft-go zsh completion must call _describe with the worktree tag"
+            script.contains("compadd -V worktree"),
+            "daft-go zsh completion must use compadd -V worktree for group ordering"
         );
         assert!(
-            script.contains("_describe -t local"),
-            "daft-go zsh completion must call _describe with the local tag"
+            script.contains("compadd -V local"),
+            "daft-go zsh completion must use compadd -V local for group ordering"
         );
         assert!(
-            script.contains("_describe -t remote"),
-            "daft-go zsh completion must call _describe with the remote tag"
+            script.contains("compadd -V remote"),
+            "daft-go zsh completion must use compadd -V remote for group ordering"
         );
     }
 
@@ -570,23 +570,9 @@ mod tests {
         );
     }
 
-    #[test]
-    fn zsh_daft_go_emits_zstyle_colors_per_group() {
-        let script =
-            zsh::generate_zsh_completion_string("daft-go").expect("generator must succeed");
-        assert!(
-            script.contains(":*:daft-go:*:worktree"),
-            "zsh daft-go must emit a zstyle line for the worktree group"
-        );
-        assert!(
-            script.contains(":*:daft-go:*:local"),
-            "zsh daft-go must emit a zstyle line for the local group"
-        );
-        assert!(
-            script.contains(":*:daft-go:*:remote"),
-            "zsh daft-go must emit a zstyle line for the remote group"
-        );
-    }
+    // zstyle coloring was removed — compadd -V groups don't interact
+    // with zsh's tag system, so per-tag zstyle list-colors wouldn't apply.
+    // Colors may be revisited via a different mechanism in a follow-up.
 
     #[test]
     fn zsh_umbrella_delegates_go_to_daft_go_impl() {

--- a/src/commands/completions/mod.rs
+++ b/src/commands/completions/mod.rs
@@ -519,9 +519,19 @@ mod tests {
     }
 
     #[test]
-    fn zsh_daft_go_uses_compadd_groups_with_colored_headers() {
+    fn zsh_daft_go_uses_tags_with_per_group_list_colors() {
         let script =
             zsh::generate_zsh_completion_string("daft-go").expect("generator must succeed");
+        // Uses _tags + _requested for per-group coloring (not _describe)
+        assert!(
+            script.contains("_tags \"${avail_tags[@]}\""),
+            "daft-go zsh must register tags via _tags"
+        );
+        assert!(
+            script.contains("_requested daft-go-wt"),
+            "daft-go zsh must use _requested for worktree tag"
+        );
+        // Groups still use -V for ordering
         assert!(
             script.contains("-V worktree"),
             "daft-go zsh must use -V worktree group"
@@ -534,13 +544,23 @@ mod tests {
             script.contains("-V remote"),
             "daft-go zsh must use -V remote group"
         );
+        // Per-tag list-colors with git branch colors (cyan, green, red)
         assert!(
-            script.contains("-X '%F{green}worktree%f'"),
-            "daft-go zsh must have colored worktree header via -X"
+            script.contains("daft-go-wt' list-colors '=(#b)([^ ]##)( *)=0=36=0'"),
+            "daft-go zsh must set cyan list-colors for worktree tag"
         );
         assert!(
-            script.contains("-X '%F{blue}local branch%f'"),
-            "daft-go zsh must have colored local header via -X"
+            script.contains("daft-go-local' list-colors '=(#b)([^ ]##)( *)=0=32=0'"),
+            "daft-go zsh must set green list-colors for local tag"
+        );
+        assert!(
+            script.contains("daft-go-remote' list-colors '=(#b)([^ ]##)( *)=0=31=0'"),
+            "daft-go zsh must set red list-colors for remote tag"
+        );
+        // No group headers — colors are on items themselves
+        assert!(
+            !script.contains("-X "),
+            "daft-go must NOT use -X group headers"
         );
         assert!(
             !script.contains("\n    _describe"),

--- a/src/commands/completions/mod.rs
+++ b/src/commands/completions/mod.rs
@@ -493,3 +493,27 @@ fn print_post_install_message(target: &CompletionTarget) -> Result<()> {
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zsh_daft_go_gates_flags_on_leading_dash() {
+        let script =
+            zsh::generate_zsh_completion_string("daft-go").expect("generator must succeed");
+        let flags_pos = script
+            .find("compadd -a flags")
+            .expect("generated script must contain `compadd -a flags`");
+        let guard_pos = script.find("[[ \"$curword\" == -* ]]").expect(
+            "generated script must gate flag completion on a leading \
+                 dash before adding flags (zsh flag-leak regression)",
+        );
+        assert!(
+            guard_pos < flags_pos,
+            "flag-gating guard must appear before `compadd -a flags`, \
+             otherwise flags leak into branch completions. \
+             guard_pos={guard_pos} flags_pos={flags_pos}",
+        );
+    }
+}

--- a/src/commands/completions/mod.rs
+++ b/src/commands/completions/mod.rs
@@ -519,24 +519,24 @@ mod tests {
     }
 
     #[test]
-    fn zsh_daft_go_uses_describe_per_group() {
+    fn zsh_daft_go_uses_compadd_groups() {
         let script =
             zsh::generate_zsh_completion_string("daft-go").expect("generator must succeed");
         assert!(
-            script.contains("_describe 'worktree' wt_items"),
-            "daft-go zsh completion must call _describe for worktree group"
+            script.contains("compadd -V worktree"),
+            "daft-go zsh must use compadd -V for worktree group"
         );
         assert!(
-            script.contains("_describe 'local branch' local_items"),
-            "daft-go zsh completion must call _describe for local group"
+            script.contains("compadd -V local"),
+            "daft-go zsh must use compadd -V for local group"
         );
         assert!(
-            script.contains("_describe 'remote branch' remote_items"),
-            "daft-go zsh completion must call _describe for remote group"
+            script.contains("compadd -V remote"),
+            "daft-go zsh must use compadd -V for remote group"
         );
         assert!(
-            !script.contains("_describe -t"),
-            "daft-go must NOT use _describe -t (causes tag-retry 3x repetition)"
+            !script.contains("\n    _describe"),
+            "daft-go must NOT call _describe (triggers tag-retry 3x repetition)"
         );
     }
 

--- a/src/commands/completions/mod.rs
+++ b/src/commands/completions/mod.rs
@@ -519,22 +519,9 @@ mod tests {
     }
 
     #[test]
-    fn zsh_daft_go_uses_tags_for_worktree_color() {
+    fn zsh_daft_go_uses_compadd_groups_with_worktree_header() {
         let script =
             zsh::generate_zsh_completion_string("daft-go").expect("generator must succeed");
-        // Worktrees use _tags + _requested for cyan via list-colors
-        assert!(
-            script.contains("_tags daft-go-wt"),
-            "daft-go zsh must register worktree tag"
-        );
-        assert!(
-            script.contains("_requested daft-go-wt"),
-            "daft-go zsh must use _requested for worktree tag"
-        );
-        assert!(
-            script.contains("daft-go-wt' list-colors '=*=36'"),
-            "daft-go zsh must set cyan list-colors for worktree tag"
-        );
         // Groups use -V for ordering (worktree first)
         assert!(
             script.contains("-V worktree"),
@@ -548,10 +535,16 @@ mod tests {
             script.contains("-V remote"),
             "daft-go zsh must use -V remote group"
         );
-        // No group headers, no _describe
+        // Cyan header for worktree group only (prompt escapes via -X)
         assert!(
-            !script.contains("-X "),
-            "daft-go must NOT use -X group headers"
+            script.contains("-X '%F{cyan}worktrees%f'"),
+            "daft-go zsh must have cyan worktree header via -X"
+        );
+        // No headers for local/remote groups (only worktree has -X)
+        assert_eq!(
+            script.matches("compadd -X").count(),
+            1,
+            "daft-go must only have one compadd -X (worktrees)"
         );
         assert!(
             !script.contains("\n    _describe"),

--- a/src/commands/completions/mod.rs
+++ b/src/commands/completions/mod.rs
@@ -519,7 +519,7 @@ mod tests {
     }
 
     #[test]
-    fn zsh_daft_go_uses_compadd_groups_with_worktree_header() {
+    fn zsh_daft_go_uses_compadd_groups_no_headers() {
         let script =
             zsh::generate_zsh_completion_string("daft-go").expect("generator must succeed");
         // Groups use -V for ordering (worktree first)
@@ -535,16 +535,15 @@ mod tests {
             script.contains("-V remote"),
             "daft-go zsh must use -V remote group"
         );
-        // Cyan header for worktree group only (prompt escapes via -X)
+        // Worktree display has three columns: name, age, path
         assert!(
-            script.contains("-X '%F{cyan}worktrees%f'"),
-            "daft-go zsh must have cyan worktree header via -X"
+            script.contains("wt_ages") && script.contains("wt_paths"),
+            "daft-go zsh must split worktree desc into age and path"
         );
-        // No headers for local/remote groups (only worktree has -X)
-        assert_eq!(
-            script.matches("compadd -X").count(),
-            1,
-            "daft-go must only have one compadd -X (worktrees)"
+        // No group headers
+        assert!(
+            !script.contains("-X "),
+            "daft-go must NOT use -X group headers"
         );
         assert!(
             !script.contains("\n    _describe"),

--- a/src/commands/completions/zsh.rs
+++ b/src/commands/completions/zsh.rs
@@ -255,18 +255,17 @@ __daft_go_impl() {{
         group="${{rest%%$'\t'*}}"
         desc="${{rest#*$'\t'}}"
         case "$group" in
-            worktree) wt_items+=("$name:worktree") ;;
-            local)    local_items+=("$name:local · $desc") ;;
-            remote)   remote_items+=("$name:remote · $desc") ;;
+            worktree) wt_items+=("$name:$desc") ;;
+            local)    local_items+=("$name:$desc") ;;
+            remote)   remote_items+=("$name:$desc") ;;
         esac
     done
 
     # _describe without -t avoids zsh's tag-retry mechanism.
-    # Empty first arg suppresses the group header.
-    # Items in name:description format get auto-aligned columns.
-    (( ${{#wt_items}} ))    && _describe '' wt_items
-    (( ${{#local_items}} )) && _describe '' local_items
-    (( ${{#remote_items}} )) && _describe '' remote_items
+    # Group names show as headers; items get auto-aligned columns.
+    (( ${{#wt_items}} ))     && _describe 'worktree' wt_items
+    (( ${{#local_items}} ))  && _describe 'local branch' local_items
+    (( ${{#remote_items}} )) && _describe 'remote branch' remote_items
 }}
 
 _daft_go() {{

--- a/src/commands/completions/zsh.rs
+++ b/src/commands/completions/zsh.rs
@@ -249,13 +249,16 @@ __{func_name}_impl() {{
     fi
 
     local -a raw
-    local -a wt_names wt_ages wt_paths local_names local_descs remote_names remote_descs
+    local -a wt_names wt_ages wt_authors wt_paths
+    local -a local_names local_ages local_authors
+    local -a remote_names remote_ages remote_authors
     raw=(${{(f)"$(daft __complete {command_name} "$curword" --position "$cword"{fetch_flag} 2>/dev/null)"}})
 
     # First pass: collect names and descriptions per group.
-    # Worktree lines have 4 fields: name\tworktree\tage\tpath
-    # Local/remote lines have 3 fields: name\tgroup\tage
-    local line name rest group desc max_len=0 len age_len max_age_len=0
+    # Worktree lines have 5 fields: name\tworktree\tage\tauthor\tpath
+    # Local/remote lines have 4 fields: name\tgroup\tage\tauthor
+    local line name rest group desc max_len=0 len
+    local age_len max_age_len=0 auth_len max_auth_len=0
     for line in "${{raw[@]}}"; do
         name="${{line%%$'\t'*}}"
         rest="${{line#*$'\t'}}"
@@ -266,42 +269,64 @@ __{func_name}_impl() {{
         case "$group" in
             worktree)
                 wt_names+=("$name")
-                # desc is "age\tpath" — split on tab
+                # desc is "age\tauthor\tpath" — split on tabs
                 wt_ages+=("${{desc%%$'\t'*}}")
-                wt_paths+=("${{desc#*$'\t'}}")
+                local wt_rest="${{desc#*$'\t'}}"
+                wt_authors+=("${{wt_rest%%$'\t'*}}")
+                wt_paths+=("${{wt_rest#*$'\t'}}")
                 age_len=${{#${{desc%%$'\t'*}}}}
                 (( age_len > max_age_len )) && max_age_len=$age_len
+                auth_len=${{#${{wt_rest%%$'\t'*}}}}
+                (( auth_len > max_auth_len )) && max_auth_len=$auth_len
                 ;;
             local)
                 local_names+=("$name")
-                local_descs+=("$desc")
+                # desc is "age\tauthor"
+                local_ages+=("${{desc%%$'\t'*}}")
+                local_authors+=("${{desc#*$'\t'}}")
+                age_len=${{#${{desc%%$'\t'*}}}}
+                (( age_len > max_age_len )) && max_age_len=$age_len
+                auth_len=${{#${{desc#*$'\t'}}}}
+                (( auth_len > max_auth_len )) && max_auth_len=$auth_len
                 ;;
             remote)
                 remote_names+=("$name")
-                remote_descs+=("$desc")
+                # desc is "age\tauthor"
+                remote_ages+=("${{desc%%$'\t'*}}")
+                remote_authors+=("${{desc#*$'\t'}}")
+                age_len=${{#${{desc%%$'\t'*}}}}
+                (( age_len > max_age_len )) && max_age_len=$age_len
+                auth_len=${{#${{desc#*$'\t'}}}}
+                (( auth_len > max_auth_len )) && max_auth_len=$auth_len
                 ;;
         esac
     done
 
     # Second pass: build padded display strings.
-    # Worktrees: three columns (name, age, path).
-    # Local/remote: two columns (name, age).
+    # Worktrees: four columns (name, age, author, path).
+    # Local/remote: three columns (name, age, author).
     local -a wt_display local_display remote_display
-    local i pad apad
+    local i pad apad authpad
     (( max_len += 2 ))
     (( max_age_len += 2 ))
+    (( max_auth_len += 2 ))
     for (( i=1; i<=${{#wt_names}}; i++ )); do
         pad=$(( max_len - ${{#wt_names[$i]}} ))
         apad=$(( max_age_len - ${{#wt_ages[$i]}} ))
-        wt_display+=("${{wt_names[$i]}}${{(l:$pad:: :)}}  ${{wt_ages[$i]}}${{(l:$apad:: :)}}  ${{wt_paths[$i]}}")
+        authpad=$(( max_auth_len - ${{#wt_authors[$i]}} ))
+        wt_display+=("${{wt_names[$i]}}${{(l:$pad:: :)}}  ${{wt_ages[$i]}}${{(l:$apad:: :)}}  ${{wt_authors[$i]}}${{(l:$authpad:: :)}}  ${{wt_paths[$i]}}")
     done
     for (( i=1; i<=${{#local_names}}; i++ )); do
         pad=$(( max_len - ${{#local_names[$i]}} ))
-        local_display+=("${{local_names[$i]}}${{(l:$pad:: :)}}  ${{local_descs[$i]}}")
+        apad=$(( max_age_len - ${{#local_ages[$i]}} ))
+        authpad=$(( max_auth_len - ${{#local_authors[$i]}} ))
+        local_display+=("${{local_names[$i]}}${{(l:$pad:: :)}}  ${{local_ages[$i]}}${{(l:$apad:: :)}}  ${{local_authors[$i]}}")
     done
     for (( i=1; i<=${{#remote_names}}; i++ )); do
         pad=$(( max_len - ${{#remote_names[$i]}} ))
-        remote_display+=("${{remote_names[$i]}}${{(l:$pad:: :)}}  ${{remote_descs[$i]}}")
+        apad=$(( max_age_len - ${{#remote_ages[$i]}} ))
+        authpad=$(( max_auth_len - ${{#remote_authors[$i]}} ))
+        remote_display+=("${{remote_names[$i]}}${{(l:$pad:: :)}}  ${{remote_ages[$i]}}${{(l:$apad:: :)}}  ${{remote_authors[$i]}}")
     done
 
     # -V preserves group insertion order: worktrees first, then local, then remote.

--- a/src/commands/completions/zsh.rs
+++ b/src/commands/completions/zsh.rs
@@ -1,8 +1,12 @@
 use super::{extract_flags, get_command_for_name};
 use anyhow::{Context, Result};
+use clap::CommandFactory;
 
 /// Generate zsh completion string
 pub(super) fn generate_zsh_completion_string(command_name: &str) -> Result<String> {
+    if command_name == "daft-go" {
+        return Ok(generate_zsh_daft_go_completion());
+    }
     let mut output = String::new();
     let has_branches = matches!(
         command_name,
@@ -216,6 +220,59 @@ pub(super) fn generate_zsh_completion_string(command_name: &str) -> Result<Strin
     }
 
     Ok(output)
+}
+
+fn generate_zsh_daft_go_completion() -> String {
+    let cmd = crate::commands::checkout::GoArgs::command();
+    let (all_flags, _, _) = extract_flags(&cmd);
+    let flags_block: String = all_flags
+        .iter()
+        .map(|f| format!("            '{f}'\n"))
+        .collect();
+
+    format!(
+        r#"#compdef daft-go
+
+__daft_go_impl() {{
+    local curword="${{words[$CURRENT]}}"
+    local cword=$((CURRENT - 1))
+
+    if [[ "$curword" == -* ]]; then
+        local -a flags
+        flags=(
+{flags_block}        )
+        compadd -a flags
+        return
+    fi
+
+    local -a raw wt_items local_items remote_items
+    raw=(${{(f)"$(daft __complete daft-go "$curword" --position "$cword" --fetch-on-miss 2>/dev/null)"}})
+
+    local line name rest group desc
+    for line in "${{raw[@]}}"; do
+        name="${{line%%$'\t'*}}"
+        rest="${{line#*$'\t'}}"
+        group="${{rest%%$'\t'*}}"
+        desc="${{rest#*$'\t'}}"
+        case "$group" in
+            worktree) wt_items+=("$name:$desc") ;;
+            local)    local_items+=("$name:$desc") ;;
+            remote)   remote_items+=("$name:$desc") ;;
+        esac
+    done
+
+    _describe -t worktree '' wt_items
+    _describe -t local    '' local_items
+    _describe -t remote   '' remote_items
+}}
+
+_daft_go() {{
+    __daft_go_impl
+}}
+
+compdef _daft_go daft-go
+"#
+    )
 }
 
 pub(super) const DAFT_ZSH_COMPLETIONS: &str = r#"# daft subcommand completions

--- a/src/commands/completions/zsh.rs
+++ b/src/commands/completions/zsh.rs
@@ -233,7 +233,7 @@ fn generate_zsh_rich_completion(command_name: &str) -> String {
         ""
     };
 
-    format!(
+    let mut output = format!(
         r#"#compdef {command_name}
 
 __{func_name}_impl() {{
@@ -346,7 +346,25 @@ _{func_name}() {{
 
 compdef _{func_name} {command_name}
 "#
-    )
+    );
+
+    // Wrapper for git subcommand invocation (git worktree-checkout).
+    // Git's completion system expects _git-<subcommand>.
+    if command_name.starts_with("git-") {
+        let git_func_name = format!("_git-{}", command_name.trim_start_matches("git-"));
+        output.push_str(&format!("{git_func_name}() {{\n"));
+        output.push_str(&format!("    __{func_name}_impl\n"));
+        output.push_str("}\n\n");
+    }
+
+    // Register completions for shortcut aliases
+    for shortcut in crate::shortcuts::SHORTCUTS {
+        if shortcut.command == command_name {
+            output.push_str(&format!("compdef _{func_name} {}\n", shortcut.alias));
+        }
+    }
+
+    output
 }
 
 pub(super) const DAFT_ZSH_COMPLETIONS: &str = r#"# daft subcommand completions

--- a/src/commands/completions/zsh.rs
+++ b/src/commands/completions/zsh.rs
@@ -169,8 +169,9 @@ pub(super) fn generate_zsh_completion_string(command_name: &str) -> Result<Strin
     }
 
     output.push_str("    # Flag completions (extracted from clap)\n");
-    output.push_str("    local -a flags\n");
-    output.push_str("    flags=(\n");
+    output.push_str("    if [[ \"$curword\" == -* ]]; then\n");
+    output.push_str("        local -a flags\n");
+    output.push_str("        flags=(\n");
 
     // Use clap introspection to get flags
     let cmd =
@@ -178,11 +179,12 @@ pub(super) fn generate_zsh_completion_string(command_name: &str) -> Result<Strin
     let (all_flags, _, _) = extract_flags(&cmd);
 
     for flag in all_flags {
-        output.push_str(&format!("        '{}'\n", flag));
+        output.push_str(&format!("            '{}'\n", flag));
     }
 
-    output.push_str("    )\n");
-    output.push_str("    compadd -a flags\n");
+    output.push_str("        )\n");
+    output.push_str("        compadd -a flags\n");
+    output.push_str("    fi\n");
     output.push_str("}\n");
     output.push('\n');
 

--- a/src/commands/completions/zsh.rs
+++ b/src/commands/completions/zsh.rs
@@ -249,7 +249,7 @@ __{func_name}_impl() {{
     fi
 
     local -a raw
-    local -a wt_names wt_ages wt_authors wt_paths
+    local -a wt_names wt_raw_names wt_ages wt_authors wt_paths
     local -a local_names local_ages local_authors
     local -a remote_names remote_ages remote_authors
     raw=(${{(f)"$(daft __complete {command_name} "$curword" --position "$cword"{fetch_flag} 2>/dev/null)"}})
@@ -257,7 +257,9 @@ __{func_name}_impl() {{
     # First pass: collect names and descriptions per group.
     # Worktree lines have 5 fields: name\tworktree\tage\tauthor\tpath
     # Local/remote lines have 4 fields: name\tgroup\tage\tauthor
-    local line name rest group desc max_len=0 len
+    # Worktree names may have *? dirty indicators — strip for completion
+    # value, keep for display. (* and ? are invalid in git branch names.)
+    local line name rest group desc max_len=0 len clean_name
     local age_len max_age_len=0 auth_len max_auth_len=0
     for line in "${{raw[@]}}"; do
         name="${{line%%$'\t'*}}"
@@ -268,7 +270,10 @@ __{func_name}_impl() {{
         (( len > max_len )) && max_len=$len
         case "$group" in
             worktree)
-                wt_names+=("$name")
+                # Strip *? for completion value, keep raw for display
+                clean_name="${{name%%[*?]*}}"
+                wt_names+=("$clean_name")
+                wt_raw_names+=("$name")
                 # desc is "age\tauthor\tpath" — split on tabs
                 wt_ages+=("${{desc%%$'\t'*}}")
                 local wt_rest="${{desc#*$'\t'}}"
@@ -303,7 +308,7 @@ __{func_name}_impl() {{
     done
 
     # Second pass: build padded display strings.
-    # Worktrees: four columns (name, age, author, path).
+    # Worktrees: four columns (name, age, author, path) — uses raw name with indicators.
     # Local/remote: three columns (name, age, author).
     local -a wt_display local_display remote_display
     local i pad apad authpad
@@ -311,10 +316,10 @@ __{func_name}_impl() {{
     (( max_age_len += 2 ))
     (( max_auth_len += 2 ))
     for (( i=1; i<=${{#wt_names}}; i++ )); do
-        pad=$(( max_len - ${{#wt_names[$i]}} ))
+        pad=$(( max_len - ${{#wt_raw_names[$i]}} ))
         apad=$(( max_age_len - ${{#wt_ages[$i]}} ))
         authpad=$(( max_auth_len - ${{#wt_authors[$i]}} ))
-        wt_display+=("${{wt_names[$i]}}${{(l:$pad:: :)}}  ${{wt_ages[$i]}}${{(l:$apad:: :)}}  ${{wt_authors[$i]}}${{(l:$authpad:: :)}}  ${{wt_paths[$i]}}")
+        wt_display+=("${{wt_raw_names[$i]}}${{(l:$pad:: :)}}  ${{wt_ages[$i]}}${{(l:$apad:: :)}}  ${{wt_authors[$i]}}${{(l:$authpad:: :)}}  ${{wt_paths[$i]}}")
     done
     for (( i=1; i<=${{#local_names}}; i++ )); do
         pad=$(( max_len - ${{#local_names[$i]}} ))

--- a/src/commands/completions/zsh.rs
+++ b/src/commands/completions/zsh.rs
@@ -1,23 +1,16 @@
-use super::{extract_flags, get_command_for_name};
+use super::{extract_flags, get_command_for_name, uses_fetch_on_miss, uses_rich_completions};
 use anyhow::{Context, Result};
-use clap::CommandFactory;
 
 /// Generate zsh completion string
 pub(super) fn generate_zsh_completion_string(command_name: &str) -> Result<String> {
-    if command_name == "daft-go" {
-        return Ok(generate_zsh_daft_go_completion());
+    // Rich completion commands get the grouped parsing (compadd -V).
+    if uses_rich_completions(command_name) {
+        return Ok(generate_zsh_rich_completion(command_name));
     }
+
     let mut output = String::new();
-    let has_branches = matches!(
-        command_name,
-        "git-worktree-checkout"
-            | "git-worktree-carry"
-            | "git-worktree-fetch"
-            | "daft-go"
-            | "daft-start"
-            | "daft-remove"
-            | "daft-rename"
-    );
+    // daft-start still uses simple branch-prefix patterns (not rich).
+    let has_branches = command_name == "daft-start";
 
     let func_name = command_name.replace('-', "_");
 
@@ -222,18 +215,28 @@ pub(super) fn generate_zsh_completion_string(command_name: &str) -> Result<Strin
     Ok(output)
 }
 
-fn generate_zsh_daft_go_completion() -> String {
-    let cmd = crate::commands::checkout::GoArgs::command();
+/// Generate a zsh completion script with rich grouped output for any command
+/// that uses the `name\tgroup\tdescription` protocol.
+fn generate_zsh_rich_completion(command_name: &str) -> String {
+    let cmd = get_command_for_name(command_name)
+        .unwrap_or_else(|| panic!("Unknown rich-completion command: {command_name}"));
     let (all_flags, _, _) = extract_flags(&cmd);
     let flags_block: String = all_flags
         .iter()
         .map(|f| format!("            '{f}'\n"))
         .collect();
 
-    format!(
-        r#"#compdef daft-go
+    let func_name = command_name.replace('-', "_");
+    let fetch_flag = if uses_fetch_on_miss(command_name) {
+        " --fetch-on-miss"
+    } else {
+        ""
+    };
 
-__daft_go_impl() {{
+    format!(
+        r#"#compdef {command_name}
+
+__{func_name}_impl() {{
     local curword="${{words[$CURRENT]}}"
     local cword=$((CURRENT - 1))
 
@@ -247,7 +250,7 @@ __daft_go_impl() {{
 
     local -a raw
     local -a wt_names wt_ages wt_paths local_names local_descs remote_names remote_descs
-    raw=(${{(f)"$(daft __complete daft-go "$curword" --position "$cword" --fetch-on-miss 2>/dev/null)"}})
+    raw=(${{(f)"$(daft __complete {command_name} "$curword" --position "$cword"{fetch_flag} 2>/dev/null)"}})
 
     # First pass: collect names and descriptions per group.
     # Worktree lines have 4 fields: name\tworktree\tage\tpath
@@ -307,11 +310,11 @@ __daft_go_impl() {{
     (( ${{#remote_names}} )) && compadd -V remote -l -d remote_display -a remote_names
 }}
 
-_daft_go() {{
-    __daft_go_impl
+_{func_name}() {{
+    __{func_name}_impl
 }}
 
-compdef _daft_go daft-go
+compdef _{func_name} {command_name}
 "#
     )
 }

--- a/src/commands/completions/zsh.rs
+++ b/src/commands/completions/zsh.rs
@@ -233,12 +233,6 @@ fn generate_zsh_daft_go_completion() -> String {
     format!(
         r#"#compdef daft-go
 
-# Per-group colors for `daft go` completions. Scoped to daft-go so the
-# user's global completion colors are untouched. `zstyle -d` to disable.
-zstyle ':completion:*:*:daft-go:*:worktree' list-colors '=(#b)(*)=0=1;32'
-zstyle ':completion:*:*:daft-go:*:local'    list-colors '=(#b)(*)=0=1;34'
-zstyle ':completion:*:*:daft-go:*:remote'   list-colors '=(#b)(*)=0=2;37'
-
 __daft_go_impl() {{
     local curword="${{words[$CURRENT]}}"
     local cword=$((CURRENT - 1))
@@ -251,7 +245,8 @@ __daft_go_impl() {{
         return
     fi
 
-    local -a raw wt_items local_items remote_items
+    local -a raw
+    local -a wt_names wt_descs local_names local_descs remote_names remote_descs
     raw=(${{(f)"$(daft __complete daft-go "$curword" --position "$cword" --fetch-on-miss 2>/dev/null)"}})
 
     local line name rest group desc
@@ -261,15 +256,24 @@ __daft_go_impl() {{
         group="${{rest%%$'\t'*}}"
         desc="${{rest#*$'\t'}}"
         case "$group" in
-            worktree) wt_items+=("$name:$desc") ;;
-            local)    local_items+=("$name:$desc") ;;
-            remote)   remote_items+=("$name:$desc") ;;
+            worktree)
+                wt_names+=("$name")
+                wt_descs+=("$name ($desc)")
+                ;;
+            local)
+                local_names+=("$name")
+                local_descs+=("$name ($desc)")
+                ;;
+            remote)
+                remote_names+=("$name")
+                remote_descs+=("$name ($desc)")
+                ;;
         esac
     done
 
-    _describe -t worktree '' wt_items
-    _describe -t local    '' local_items
-    _describe -t remote   '' remote_items
+    (( ${{#wt_names}} ))     && compadd -V worktree -l -d wt_descs -a wt_names
+    (( ${{#local_names}} ))  && compadd -V local -l -d local_descs -a local_names
+    (( ${{#remote_names}} )) && compadd -V remote -l -d remote_descs -a remote_names
 }}
 
 _daft_go() {{

--- a/src/commands/completions/zsh.rs
+++ b/src/commands/completions/zsh.rs
@@ -245,27 +245,58 @@ __daft_go_impl() {{
         return
     fi
 
-    local -a raw wt_items local_items remote_items
+    local -a raw
+    local -a wt_names wt_descs local_names local_descs remote_names remote_descs
     raw=(${{(f)"$(daft __complete daft-go "$curword" --position "$cword" --fetch-on-miss 2>/dev/null)"}})
 
-    local line name rest group desc
+    # First pass: collect names and descriptions per group.
+    local line name rest group desc max_len=0 len
     for line in "${{raw[@]}}"; do
         name="${{line%%$'\t'*}}"
         rest="${{line#*$'\t'}}"
         group="${{rest%%$'\t'*}}"
         desc="${{rest#*$'\t'}}"
+        len=${{#name}}
+        (( len > max_len )) && max_len=$len
         case "$group" in
-            worktree) wt_items+=("$name:$desc") ;;
-            local)    local_items+=("$name:$desc") ;;
-            remote)   remote_items+=("$name:$desc") ;;
+            worktree)
+                wt_names+=("$name")
+                wt_descs+=("$desc")
+                ;;
+            local)
+                local_names+=("$name")
+                local_descs+=("$desc")
+                ;;
+            remote)
+                remote_names+=("$name")
+                remote_descs+=("$desc")
+                ;;
         esac
     done
 
-    # _describe without -t avoids zsh's tag-retry mechanism.
-    # Group names show as headers; items get auto-aligned columns.
-    (( ${{#wt_items}} ))     && _describe 'worktree' wt_items
-    (( ${{#local_items}} ))  && _describe 'local branch' local_items
-    (( ${{#remote_items}} )) && _describe 'remote branch' remote_items
+    # Second pass: build padded display strings with group label + age.
+    local -a wt_display local_display remote_display
+    local i pad
+    (( max_len += 2 ))
+    for (( i=1; i<=${{#wt_names}}; i++ )); do
+        pad=$(( max_len - ${{#wt_names[$i]}} ))
+        wt_display+=("${{wt_names[$i]}}${{(l:$pad:: :)}}  \e[32mworktree\e[0m")
+    done
+    for (( i=1; i<=${{#local_names}}; i++ )); do
+        pad=$(( max_len - ${{#local_names[$i]}} ))
+        local_display+=("${{local_names[$i]}}${{(l:$pad:: :)}}  \e[34mlocal\e[0m · ${{local_descs[$i]}}")
+    done
+    for (( i=1; i<=${{#remote_names}}; i++ )); do
+        pad=$(( max_len - ${{#remote_names[$i]}} ))
+        remote_display+=("${{remote_names[$i]}}${{(l:$pad:: :)}}  \e[2;37mremote\e[0m · ${{remote_descs[$i]}}")
+    done
+
+    # compadd -V preserves group order, -l shows one-per-line,
+    # -d uses display array, -a uses names array.
+    # No _describe — it triggers zsh's tag-retry mechanism.
+    (( ${{#wt_names}} ))     && compadd -V worktree -l -d wt_display -a wt_names
+    (( ${{#local_names}} ))  && compadd -V local -l -d local_display -a local_names
+    (( ${{#remote_names}} )) && compadd -V remote -l -d remote_display -a remote_names
 }}
 
 _daft_go() {{

--- a/src/commands/completions/zsh.rs
+++ b/src/commands/completions/zsh.rs
@@ -236,11 +236,8 @@ fn generate_zsh_daft_go_completion() -> String {
 # Load complist for colored completions
 zmodload -i zsh/complist
 
-# Per-tag list-colors (git branch colors): worktree=cyan, local=green, remote=red.
-# The (|b) backreference pattern colors only the branch name, not the description.
-zstyle ':completion:*:*:*:*:daft-go-wt' list-colors '=(#b)([^ ]##)( *)=0=36=0'
-zstyle ':completion:*:*:*:*:daft-go-local' list-colors '=(#b)([^ ]##)( *)=0=32=0'
-zstyle ':completion:*:*:*:*:daft-go-remote' list-colors '=(#b)([^ ]##)( *)=0=31=0'
+# Color worktree completions cyan (ANSI 36), matching git color.branch.worktree.
+zstyle ':completion:*:*:*:*:daft-go-wt' list-colors '=*=36'
 
 __daft_go_impl() {{
     local curword="${{words[$CURRENT]}}"
@@ -300,20 +297,18 @@ __daft_go_impl() {{
         remote_display+=("${{remote_names[$i]}}${{(l:$pad:: :)}}  ${{remote_descs[$i]}}")
     done
 
-    # Register only non-empty groups as tags for per-group coloring.
-    local -a avail_tags
-    (( ${{#wt_names}} )) && avail_tags+=(daft-go-wt)
-    (( ${{#local_names}} )) && avail_tags+=(daft-go-local)
-    (( ${{#remote_names}} )) && avail_tags+=(daft-go-remote)
+    # Worktrees: use _tags so list-colors can target the daft-go-wt tag (cyan).
+    if (( ${{#wt_names}} )); then
+        _tags daft-go-wt
+        while _tags; do
+            _requested daft-go-wt && \
+                compadd -V worktree -l -d wt_display -a wt_names
+        done
+    fi
 
-    (( ${{#avail_tags}} )) || return
-
-    _tags "${{avail_tags[@]}}"
-    while _tags; do
-        _requested daft-go-wt && compadd -V worktree -l -d wt_display -a wt_names
-        _requested daft-go-local && compadd -V local -l -d local_display -a local_names
-        _requested daft-go-remote && compadd -V remote -l -d remote_display -a remote_names
-    done
+    # Local and remote: plain compadd (default color).
+    (( ${{#local_names}} ))  && compadd -V local -l -d local_display -a local_names
+    (( ${{#remote_names}} )) && compadd -V remote -l -d remote_display -a remote_names
 }}
 
 _daft_go() {{

--- a/src/commands/completions/zsh.rs
+++ b/src/commands/completions/zsh.rs
@@ -245,8 +245,7 @@ __daft_go_impl() {{
         return
     fi
 
-    local -a raw
-    local -a wt_names wt_descs local_names local_descs remote_names remote_descs
+    local -a raw wt_items local_items remote_items
     raw=(${{(f)"$(daft __complete daft-go "$curword" --position "$cword" --fetch-on-miss 2>/dev/null)"}})
 
     local line name rest group desc
@@ -256,24 +255,18 @@ __daft_go_impl() {{
         group="${{rest%%$'\t'*}}"
         desc="${{rest#*$'\t'}}"
         case "$group" in
-            worktree)
-                wt_names+=("$name")
-                wt_descs+=("$name (worktree)")
-                ;;
-            local)
-                local_names+=("$name")
-                local_descs+=("$name (local · $desc)")
-                ;;
-            remote)
-                remote_names+=("$name")
-                remote_descs+=("$name (remote · $desc)")
-                ;;
+            worktree) wt_items+=("$name:worktree") ;;
+            local)    local_items+=("$name:local · $desc") ;;
+            remote)   remote_items+=("$name:remote · $desc") ;;
         esac
     done
 
-    (( ${{#wt_names}} ))     && compadd -V worktree -l -d wt_descs -a wt_names
-    (( ${{#local_names}} ))  && compadd -V local -l -d local_descs -a local_names
-    (( ${{#remote_names}} )) && compadd -V remote -l -d remote_descs -a remote_names
+    # _describe without -t avoids zsh's tag-retry mechanism.
+    # Empty first arg suppresses the group header.
+    # Items in name:description format get auto-aligned columns.
+    (( ${{#wt_items}} ))    && _describe '' wt_items
+    (( ${{#local_items}} )) && _describe '' local_items
+    (( ${{#remote_items}} )) && _describe '' remote_items
 }}
 
 _daft_go() {{

--- a/src/commands/completions/zsh.rs
+++ b/src/commands/completions/zsh.rs
@@ -233,13 +233,6 @@ fn generate_zsh_daft_go_completion() -> String {
     format!(
         r#"#compdef daft-go
 
-# Per-group colors via list-colors zstyle. compadd -V <group> uses
-# the group name as a tag, so these patterns target each group.
-# Worktree = green, local = blue, remote = dim gray.
-zstyle ':completion:*:worktree' list-colors '=(#b)(*)=32'
-zstyle ':completion:*:local' list-colors '=(#b)(*)=34'
-zstyle ':completion:*:remote' list-colors '=(#b)(*)=2;37'
-
 __daft_go_impl() {{
     local curword="${{words[$CURRENT]}}"
     local cword=$((CURRENT - 1))
@@ -281,29 +274,29 @@ __daft_go_impl() {{
         esac
     done
 
-    # Second pass: build padded display strings with group label + age.
+    # Second pass: build padded display strings with age.
     local -a wt_display local_display remote_display
     local i pad
     (( max_len += 2 ))
     for (( i=1; i<=${{#wt_names}}; i++ )); do
         pad=$(( max_len - ${{#wt_names[$i]}} ))
-        wt_display+=("${{wt_names[$i]}}${{(l:$pad:: :)}}  worktree")
+        wt_display+=("${{wt_names[$i]}}${{(l:$pad:: :)}}  ${{wt_descs[$i]}}")
     done
     for (( i=1; i<=${{#local_names}}; i++ )); do
         pad=$(( max_len - ${{#local_names[$i]}} ))
-        local_display+=("${{local_names[$i]}}${{(l:$pad:: :)}}  local · ${{local_descs[$i]}}")
+        local_display+=("${{local_names[$i]}}${{(l:$pad:: :)}}  ${{local_descs[$i]}}")
     done
     for (( i=1; i<=${{#remote_names}}; i++ )); do
         pad=$(( max_len - ${{#remote_names[$i]}} ))
-        remote_display+=("${{remote_names[$i]}}${{(l:$pad:: :)}}  remote · ${{remote_descs[$i]}}")
+        remote_display+=("${{remote_names[$i]}}${{(l:$pad:: :)}}  ${{remote_descs[$i]}}")
     done
 
     # compadd -V preserves group order, -l shows one-per-line,
     # -d uses display array, -a uses names array.
-    # Colors come from list-colors zstyle (above), not ANSI in display strings.
-    (( ${{#wt_names}} ))     && compadd -V worktree -l -d wt_display -a wt_names
-    (( ${{#local_names}} ))  && compadd -V local -l -d local_display -a local_names
-    (( ${{#remote_names}} )) && compadd -V remote -l -d remote_display -a remote_names
+    # -X with %F prompt escapes adds colored group headers.
+    (( ${{#wt_names}} ))     && compadd -X '%F{{green}}worktree%f' -V worktree -l -d wt_display -a wt_names
+    (( ${{#local_names}} ))  && compadd -X '%F{{blue}}local branch%f' -V local -l -d local_display -a local_names
+    (( ${{#remote_names}} )) && compadd -X '%F{{245}}remote branch%f' -V remote -l -d remote_display -a remote_names
 }}
 
 _daft_go() {{

--- a/src/commands/completions/zsh.rs
+++ b/src/commands/completions/zsh.rs
@@ -233,12 +233,6 @@ fn generate_zsh_daft_go_completion() -> String {
     format!(
         r#"#compdef daft-go
 
-# Load complist for colored completions
-zmodload -i zsh/complist
-
-# Color worktree completions cyan (ANSI 36), matching git color.branch.worktree.
-zstyle ':completion:*:*:*:*:daft-go-wt' list-colors '=*=36'
-
 __daft_go_impl() {{
     local curword="${{words[$CURRENT]}}"
     local cword=$((CURRENT - 1))
@@ -297,16 +291,9 @@ __daft_go_impl() {{
         remote_display+=("${{remote_names[$i]}}${{(l:$pad:: :)}}  ${{remote_descs[$i]}}")
     done
 
-    # Worktrees: use _tags so list-colors can target the daft-go-wt tag (cyan).
-    if (( ${{#wt_names}} )); then
-        _tags daft-go-wt
-        while _tags; do
-            _requested daft-go-wt && \
-                compadd -V worktree -l -d wt_display -a wt_names
-        done
-    fi
-
-    # Local and remote: plain compadd (default color).
+    # -V preserves group insertion order: worktrees first, then local, then remote.
+    # -X with %F prompt escapes adds a cyan header for the worktree group.
+    (( ${{#wt_names}} ))     && compadd -X '%F{{cyan}}worktrees%f' -V worktree -l -d wt_display -a wt_names
     (( ${{#local_names}} ))  && compadd -V local -l -d local_display -a local_names
     (( ${{#remote_names}} )) && compadd -V remote -l -d remote_display -a remote_names
 }}

--- a/src/commands/completions/zsh.rs
+++ b/src/commands/completions/zsh.rs
@@ -233,6 +233,15 @@ fn generate_zsh_daft_go_completion() -> String {
     format!(
         r#"#compdef daft-go
 
+# Load complist for colored completions
+zmodload -i zsh/complist
+
+# Per-tag list-colors (git branch colors): worktree=cyan, local=green, remote=red.
+# The (|b) backreference pattern colors only the branch name, not the description.
+zstyle ':completion:*:*:*:*:daft-go-wt' list-colors '=(#b)([^ ]##)( *)=0=36=0'
+zstyle ':completion:*:*:*:*:daft-go-local' list-colors '=(#b)([^ ]##)( *)=0=32=0'
+zstyle ':completion:*:*:*:*:daft-go-remote' list-colors '=(#b)([^ ]##)( *)=0=31=0'
+
 __daft_go_impl() {{
     local curword="${{words[$CURRENT]}}"
     local cword=$((CURRENT - 1))
@@ -291,12 +300,20 @@ __daft_go_impl() {{
         remote_display+=("${{remote_names[$i]}}${{(l:$pad:: :)}}  ${{remote_descs[$i]}}")
     done
 
-    # compadd -V preserves group order, -l shows one-per-line,
-    # -d uses display array, -a uses names array.
-    # -X with %F prompt escapes adds colored group headers.
-    (( ${{#wt_names}} ))     && compadd -X '%F{{green}}worktree%f' -V worktree -l -d wt_display -a wt_names
-    (( ${{#local_names}} ))  && compadd -X '%F{{blue}}local branch%f' -V local -l -d local_display -a local_names
-    (( ${{#remote_names}} )) && compadd -X '%F{{245}}remote branch%f' -V remote -l -d remote_display -a remote_names
+    # Register only non-empty groups as tags for per-group coloring.
+    local -a avail_tags
+    (( ${{#wt_names}} )) && avail_tags+=(daft-go-wt)
+    (( ${{#local_names}} )) && avail_tags+=(daft-go-local)
+    (( ${{#remote_names}} )) && avail_tags+=(daft-go-remote)
+
+    (( ${{#avail_tags}} )) || return
+
+    _tags "${{avail_tags[@]}}"
+    while _tags; do
+        _requested daft-go-wt && compadd -V worktree -l -d wt_display -a wt_names
+        _requested daft-go-local && compadd -V local -l -d local_display -a local_names
+        _requested daft-go-remote && compadd -V remote -l -d remote_display -a remote_names
+    done
 }}
 
 _daft_go() {{

--- a/src/commands/completions/zsh.rs
+++ b/src/commands/completions/zsh.rs
@@ -233,6 +233,13 @@ fn generate_zsh_daft_go_completion() -> String {
     format!(
         r#"#compdef daft-go
 
+# Per-group colors via list-colors zstyle. compadd -V <group> uses
+# the group name as a tag, so these patterns target each group.
+# Worktree = green, local = blue, remote = dim gray.
+zstyle ':completion:*:worktree' list-colors '=(#b)(*)=32'
+zstyle ':completion:*:local' list-colors '=(#b)(*)=34'
+zstyle ':completion:*:remote' list-colors '=(#b)(*)=2;37'
+
 __daft_go_impl() {{
     local curword="${{words[$CURRENT]}}"
     local cword=$((CURRENT - 1))
@@ -280,20 +287,20 @@ __daft_go_impl() {{
     (( max_len += 2 ))
     for (( i=1; i<=${{#wt_names}}; i++ )); do
         pad=$(( max_len - ${{#wt_names[$i]}} ))
-        wt_display+=("${{wt_names[$i]}}${{(l:$pad:: :)}}  \e[32mworktree\e[0m")
+        wt_display+=("${{wt_names[$i]}}${{(l:$pad:: :)}}  worktree")
     done
     for (( i=1; i<=${{#local_names}}; i++ )); do
         pad=$(( max_len - ${{#local_names[$i]}} ))
-        local_display+=("${{local_names[$i]}}${{(l:$pad:: :)}}  \e[34mlocal\e[0m · ${{local_descs[$i]}}")
+        local_display+=("${{local_names[$i]}}${{(l:$pad:: :)}}  local · ${{local_descs[$i]}}")
     done
     for (( i=1; i<=${{#remote_names}}; i++ )); do
         pad=$(( max_len - ${{#remote_names[$i]}} ))
-        remote_display+=("${{remote_names[$i]}}${{(l:$pad:: :)}}  \e[2;37mremote\e[0m · ${{remote_descs[$i]}}")
+        remote_display+=("${{remote_names[$i]}}${{(l:$pad:: :)}}  remote · ${{remote_descs[$i]}}")
     done
 
     # compadd -V preserves group order, -l shows one-per-line,
     # -d uses display array, -a uses names array.
-    # No _describe — it triggers zsh's tag-retry mechanism.
+    # Colors come from list-colors zstyle (above), not ANSI in display strings.
     (( ${{#wt_names}} ))     && compadd -V worktree -l -d wt_display -a wt_names
     (( ${{#local_names}} ))  && compadd -V local -l -d local_display -a local_names
     (( ${{#remote_names}} )) && compadd -V remote -l -d remote_display -a remote_names

--- a/src/commands/completions/zsh.rs
+++ b/src/commands/completions/zsh.rs
@@ -258,15 +258,15 @@ __daft_go_impl() {{
         case "$group" in
             worktree)
                 wt_names+=("$name")
-                wt_descs+=("$name ($desc)")
+                wt_descs+=("$name (worktree)")
                 ;;
             local)
                 local_names+=("$name")
-                local_descs+=("$name ($desc)")
+                local_descs+=("$name (local · $desc)")
                 ;;
             remote)
                 remote_names+=("$name")
-                remote_descs+=("$name ($desc)")
+                remote_descs+=("$name (remote · $desc)")
                 ;;
         esac
     done

--- a/src/commands/completions/zsh.rs
+++ b/src/commands/completions/zsh.rs
@@ -246,11 +246,13 @@ __daft_go_impl() {{
     fi
 
     local -a raw
-    local -a wt_names wt_descs local_names local_descs remote_names remote_descs
+    local -a wt_names wt_ages wt_paths local_names local_descs remote_names remote_descs
     raw=(${{(f)"$(daft __complete daft-go "$curword" --position "$cword" --fetch-on-miss 2>/dev/null)"}})
 
     # First pass: collect names and descriptions per group.
-    local line name rest group desc max_len=0 len
+    # Worktree lines have 4 fields: name\tworktree\tage\tpath
+    # Local/remote lines have 3 fields: name\tgroup\tage
+    local line name rest group desc max_len=0 len age_len max_age_len=0
     for line in "${{raw[@]}}"; do
         name="${{line%%$'\t'*}}"
         rest="${{line#*$'\t'}}"
@@ -261,7 +263,11 @@ __daft_go_impl() {{
         case "$group" in
             worktree)
                 wt_names+=("$name")
-                wt_descs+=("$desc")
+                # desc is "age\tpath" — split on tab
+                wt_ages+=("${{desc%%$'\t'*}}")
+                wt_paths+=("${{desc#*$'\t'}}")
+                age_len=${{#${{desc%%$'\t'*}}}}
+                (( age_len > max_age_len )) && max_age_len=$age_len
                 ;;
             local)
                 local_names+=("$name")
@@ -274,13 +280,17 @@ __daft_go_impl() {{
         esac
     done
 
-    # Second pass: build padded display strings with age.
+    # Second pass: build padded display strings.
+    # Worktrees: three columns (name, age, path).
+    # Local/remote: two columns (name, age).
     local -a wt_display local_display remote_display
-    local i pad
+    local i pad apad
     (( max_len += 2 ))
+    (( max_age_len += 2 ))
     for (( i=1; i<=${{#wt_names}}; i++ )); do
         pad=$(( max_len - ${{#wt_names[$i]}} ))
-        wt_display+=("${{wt_names[$i]}}${{(l:$pad:: :)}}  ${{wt_descs[$i]}}")
+        apad=$(( max_age_len - ${{#wt_ages[$i]}} ))
+        wt_display+=("${{wt_names[$i]}}${{(l:$pad:: :)}}  ${{wt_ages[$i]}}${{(l:$apad:: :)}}  ${{wt_paths[$i]}}")
     done
     for (( i=1; i<=${{#local_names}}; i++ )); do
         pad=$(( max_len - ${{#local_names[$i]}} ))
@@ -292,8 +302,7 @@ __daft_go_impl() {{
     done
 
     # -V preserves group insertion order: worktrees first, then local, then remote.
-    # -X with %F prompt escapes adds a cyan header for the worktree group.
-    (( ${{#wt_names}} ))     && compadd -X '%F{{cyan}}worktrees%f' -V worktree -l -d wt_display -a wt_names
+    (( ${{#wt_names}} ))     && compadd -V worktree -l -d wt_display -a wt_names
     (( ${{#local_names}} ))  && compadd -V local -l -d local_display -a local_names
     (( ${{#remote_names}} )) && compadd -V remote -l -d remote_display -a remote_names
 }}

--- a/src/commands/completions/zsh.rs
+++ b/src/commands/completions/zsh.rs
@@ -233,6 +233,12 @@ fn generate_zsh_daft_go_completion() -> String {
     format!(
         r#"#compdef daft-go
 
+# Per-group colors for `daft go` completions. Scoped to daft-go so the
+# user's global completion colors are untouched. `zstyle -d` to disable.
+zstyle ':completion:*:*:daft-go:*:worktree' list-colors '=(#b)(*)=0=1;32'
+zstyle ':completion:*:*:daft-go:*:local'    list-colors '=(#b)(*)=0=1;34'
+zstyle ':completion:*:*:daft-go:*:remote'   list-colors '=(#b)(*)=0=2;37'
+
 __daft_go_impl() {{
     local curword="${{words[$CURRENT]}}"
     local cword=$((CURRENT - 1))

--- a/src/completion_spinner.rs
+++ b/src/completion_spinner.rs
@@ -1,0 +1,77 @@
+//! Single-line braille-dot spinner drawn directly to `/dev/tty`.
+
+use std::io::Write;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+const FRAMES: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+pub(crate) fn frame_for_tick(tick: usize) -> &'static str {
+    FRAMES[tick % FRAMES.len()]
+}
+
+pub struct Spinner {
+    stop_flag: Arc<AtomicBool>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl Spinner {
+    pub fn start(label: &str) -> Option<Self> {
+        let mut tty = std::fs::OpenOptions::new()
+            .write(true)
+            .open("/dev/tty")
+            .ok()?;
+        let stop_flag = Arc::new(AtomicBool::new(false));
+        let flag = stop_flag.clone();
+        let label = label.to_string();
+        let thread = thread::spawn(move || {
+            let mut tick = 0usize;
+            while !flag.load(Ordering::Relaxed) {
+                let frame = frame_for_tick(tick);
+                let _ = write!(tty, "\r{frame} {label}");
+                let _ = tty.flush();
+                tick += 1;
+                thread::sleep(Duration::from_millis(100));
+            }
+            let _ = write!(tty, "\r\x1b[K");
+            let _ = tty.flush();
+        });
+        Some(Self {
+            stop_flag,
+            thread: Some(thread),
+        })
+    }
+
+    pub fn stop(mut self) {
+        self.stop_flag.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.thread.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+impl Drop for Spinner {
+    fn drop(&mut self) {
+        self.stop_flag.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.thread.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn spinner_frames_cycle_through_braille_dots() {
+        let frames: Vec<&str> = (0..20).map(frame_for_tick).collect();
+        assert_eq!(frames[0], "⠋");
+        assert_eq!(frames[1], "⠙");
+        assert_eq!(frames[9], "⠏");
+        assert_eq!(frames[10], "⠋", "frame sequence must wrap at 10");
+        assert_eq!(frames[19], "⠏");
+    }
+}

--- a/src/core/columns.rs
+++ b/src/core/columns.rs
@@ -343,12 +343,14 @@ impl CompletionColumn {
         ]
     }
 
-    /// The default column set (matches pre-config behavior).
+    /// The default column set for branch completions.
     pub fn completion_defaults() -> &'static [CompletionColumn] {
         &[
             CompletionColumn::Age,
             CompletionColumn::Author,
             CompletionColumn::Path,
+            CompletionColumn::TrackedChanges,
+            CompletionColumn::Untracked,
         ]
     }
 
@@ -751,7 +753,9 @@ mod tests {
             &[
                 CompletionColumn::Age,
                 CompletionColumn::Author,
-                CompletionColumn::Path
+                CompletionColumn::Path,
+                CompletionColumn::TrackedChanges,
+                CompletionColumn::Untracked,
             ]
         );
     }
@@ -779,19 +783,20 @@ mod tests {
     }
 
     #[test]
-    fn completion_column_parse_modifier_add() {
-        let cols = CompletionColumnSelection::parse("+tracked-changes").unwrap();
-        assert!(cols.contains(&CompletionColumn::TrackedChanges));
-        // Defaults are preserved
+    fn completion_column_parse_modifier_remove_and_readd() {
+        // Remove tracked-changes (which is in defaults), verify it's gone
+        let cols = CompletionColumnSelection::parse("-tracked-changes").unwrap();
+        assert!(!cols.contains(&CompletionColumn::TrackedChanges));
         assert!(cols.contains(&CompletionColumn::Age));
-        assert!(cols.contains(&CompletionColumn::Author));
-        assert!(cols.contains(&CompletionColumn::Path));
+        assert!(cols.contains(&CompletionColumn::Untracked));
     }
 
     #[test]
     fn completion_column_parse_modifier_remove() {
-        let cols = CompletionColumnSelection::parse("-author").unwrap();
+        let cols = CompletionColumnSelection::parse("-author,-tracked-changes,-untracked").unwrap();
         assert!(!cols.contains(&CompletionColumn::Author));
+        assert!(!cols.contains(&CompletionColumn::TrackedChanges));
+        assert!(!cols.contains(&CompletionColumn::Untracked));
         assert!(cols.contains(&CompletionColumn::Age));
         assert!(cols.contains(&CompletionColumn::Path));
     }

--- a/src/core/columns.rs
+++ b/src/core/columns.rs
@@ -315,6 +315,198 @@ impl ColumnSelection {
     }
 }
 
+/// A column that can appear in rich branch completions, controlled by
+/// `daft.completions.branches.columns`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CompletionColumn {
+    /// Relative age of the branch tip commit.
+    Age,
+    /// Author name of the branch tip commit.
+    Author,
+    /// Worktree path (only shown for worktree group entries).
+    Path,
+    /// Append `*` to branch name if the worktree has modified tracked files.
+    TrackedChanges,
+    /// Append `?` to branch name if the worktree has untracked files.
+    Untracked,
+}
+
+impl CompletionColumn {
+    /// All columns in canonical display order.
+    pub fn all() -> &'static [CompletionColumn] {
+        &[
+            CompletionColumn::Age,
+            CompletionColumn::Author,
+            CompletionColumn::Path,
+            CompletionColumn::TrackedChanges,
+            CompletionColumn::Untracked,
+        ]
+    }
+
+    /// The default column set (matches pre-config behavior).
+    pub fn completion_defaults() -> &'static [CompletionColumn] {
+        &[
+            CompletionColumn::Age,
+            CompletionColumn::Author,
+            CompletionColumn::Path,
+        ]
+    }
+
+    /// Canonical display position (used to order columns in modifier mode).
+    pub fn canonical_position(self) -> u8 {
+        match self {
+            Self::Age => 1,
+            Self::Author => 2,
+            Self::Path => 3,
+            Self::TrackedChanges => 4,
+            Self::Untracked => 5,
+        }
+    }
+
+    /// CLI-facing name for this column.
+    pub fn cli_name(self) -> &'static str {
+        match self {
+            Self::Age => "age",
+            Self::Author => "author",
+            Self::Path => "path",
+            Self::TrackedChanges => "tracked-changes",
+            Self::Untracked => "untracked",
+        }
+    }
+
+    /// All valid CLI column names, for use in error messages.
+    pub fn valid_names() -> String {
+        Self::all()
+            .iter()
+            .map(|c| c.cli_name())
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+}
+
+impl fmt::Display for CompletionColumn {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.cli_name())
+    }
+}
+
+impl FromStr for CompletionColumn {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_lowercase().as_str() {
+            "age" => Ok(Self::Age),
+            "author" => Ok(Self::Author),
+            "path" => Ok(Self::Path),
+            "tracked-changes" => Ok(Self::TrackedChanges),
+            "untracked" => Ok(Self::Untracked),
+            _ => Err(format!(
+                "unknown completion column '{}'\n  valid columns: {}",
+                s.trim(),
+                Self::valid_names()
+            )),
+        }
+    }
+}
+
+/// Parser for `daft.completions.branches.columns` config values.
+pub struct CompletionColumnSelection;
+
+impl CompletionColumnSelection {
+    /// Parse a comma-separated column spec into a resolved column list.
+    /// Supports replace mode (`age,path`) and modifier mode (`+tracked-changes,-author`).
+    pub fn parse(input: &str) -> Result<Vec<CompletionColumn>, String> {
+        let tokens: Vec<&str> = input.split(',').map(|s| s.trim()).collect();
+        if tokens.is_empty() || tokens.iter().all(|t| t.is_empty()) {
+            return Err("no columns specified".to_string());
+        }
+
+        let has_modifier = tokens
+            .iter()
+            .any(|t| t.starts_with('+') || t.starts_with('-'));
+        let has_plain = tokens
+            .iter()
+            .any(|t| !t.starts_with('+') && !t.starts_with('-') && !t.is_empty());
+
+        if has_modifier && has_plain {
+            return Err("cannot mix column names with +/- modifiers\n  \
+                 use either replace mode:   age,path,tracked-changes\n  \
+                 or modifier mode:          +tracked-changes,-author"
+                .to_string());
+        }
+
+        if has_modifier {
+            Self::parse_modifier(&tokens)
+        } else {
+            Self::parse_replace(&tokens)
+        }
+    }
+
+    fn parse_replace(tokens: &[&str]) -> Result<Vec<CompletionColumn>, String> {
+        let mut result = Vec::new();
+        let mut seen = std::collections::HashSet::new();
+
+        for token in tokens {
+            if token.is_empty() {
+                continue;
+            }
+            let col: CompletionColumn = token.parse()?;
+            if !seen.insert(col) {
+                return Err(format!("duplicate column '{}'", col.cli_name()));
+            }
+            result.push(col);
+        }
+
+        if result.is_empty() {
+            return Err("no columns specified".to_string());
+        }
+
+        Ok(result)
+    }
+
+    fn parse_modifier(tokens: &[&str]) -> Result<Vec<CompletionColumn>, String> {
+        let defaults = CompletionColumn::completion_defaults();
+        let mut active: std::collections::HashSet<CompletionColumn> =
+            defaults.iter().copied().collect();
+
+        for token in tokens {
+            if token.is_empty() {
+                continue;
+            }
+            let (prefix, name) = if let Some(rest) = token.strip_prefix('+') {
+                ('+', rest)
+            } else if let Some(rest) = token.strip_prefix('-') {
+                ('-', rest)
+            } else {
+                return Err(format!("expected +/- prefix on '{token}'"));
+            };
+
+            let col: CompletionColumn = name.parse()?;
+
+            match prefix {
+                '+' => {
+                    active.insert(col);
+                }
+                '-' => {
+                    active.remove(&col);
+                }
+                _ => unreachable!(),
+            }
+        }
+
+        if active.is_empty() {
+            let modifiers = tokens.join(",");
+            return Err(format!(
+                "no columns remaining after applying modifiers\n  modifiers: {modifiers}"
+            ));
+        }
+
+        let mut result: Vec<CompletionColumn> = active.into_iter().collect();
+        result.sort_by_key(|c| c.canonical_position());
+        Ok(result)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -548,5 +740,77 @@ mod tests {
         let col: ListColumn = "hash".parse().unwrap();
         assert_eq!(col, ListColumn::Hash);
         assert_eq!(col.cli_name(), "hash");
+    }
+
+    // CompletionColumn tests
+
+    #[test]
+    fn completion_column_defaults() {
+        assert_eq!(
+            CompletionColumn::completion_defaults(),
+            &[
+                CompletionColumn::Age,
+                CompletionColumn::Author,
+                CompletionColumn::Path
+            ]
+        );
+    }
+
+    #[test]
+    fn completion_column_parse_replace() {
+        let cols = CompletionColumnSelection::parse("age,path").unwrap();
+        assert_eq!(cols, vec![CompletionColumn::Age, CompletionColumn::Path]);
+    }
+
+    #[test]
+    fn completion_column_parse_replace_with_status() {
+        let cols =
+            CompletionColumnSelection::parse("age,author,path,tracked-changes,untracked").unwrap();
+        assert_eq!(
+            cols,
+            vec![
+                CompletionColumn::Age,
+                CompletionColumn::Author,
+                CompletionColumn::Path,
+                CompletionColumn::TrackedChanges,
+                CompletionColumn::Untracked,
+            ]
+        );
+    }
+
+    #[test]
+    fn completion_column_parse_modifier_add() {
+        let cols = CompletionColumnSelection::parse("+tracked-changes").unwrap();
+        assert!(cols.contains(&CompletionColumn::TrackedChanges));
+        // Defaults are preserved
+        assert!(cols.contains(&CompletionColumn::Age));
+        assert!(cols.contains(&CompletionColumn::Author));
+        assert!(cols.contains(&CompletionColumn::Path));
+    }
+
+    #[test]
+    fn completion_column_parse_modifier_remove() {
+        let cols = CompletionColumnSelection::parse("-author").unwrap();
+        assert!(!cols.contains(&CompletionColumn::Author));
+        assert!(cols.contains(&CompletionColumn::Age));
+        assert!(cols.contains(&CompletionColumn::Path));
+    }
+
+    #[test]
+    fn completion_column_parse_unknown() {
+        let err = CompletionColumnSelection::parse("bogus").unwrap_err();
+        assert!(err.contains("unknown completion column"));
+    }
+
+    #[test]
+    fn completion_column_parse_mixed_mode_error() {
+        let err = CompletionColumnSelection::parse("age,+tracked-changes").unwrap_err();
+        assert!(err.contains("cannot mix"));
+    }
+
+    #[test]
+    fn completion_column_parse_duplicate_error() {
+        let err = CompletionColumnSelection::parse("age,age").unwrap_err();
+        assert!(err.contains("duplicate"));
     }
 }

--- a/src/core/settings.rs
+++ b/src/core/settings.rs
@@ -260,6 +260,12 @@ pub mod keys {
             format!("daft.hooks.{hook_name}.{setting}")
         }
     }
+
+    /// Completions config keys.
+    pub mod completions {
+        /// Config key for completions.branches.columns setting.
+        pub const BRANCHES_COLUMNS: &str = "daft.completions.branches.columns";
+    }
 }
 
 /// User-configurable settings for daft commands.

--- a/src/core/settings.rs
+++ b/src/core/settings.rs
@@ -124,6 +124,9 @@ pub mod defaults {
     /// Default value for go.autoStart setting.
     pub const GO_AUTO_START: bool = false;
 
+    /// Default value for go.fetchOnMiss setting.
+    pub const GO_FETCH_ON_MISS: bool = true;
+
     /// Default value for list.stat setting.
     pub const LIST_STAT: Stat = Stat::Summary;
 
@@ -183,6 +186,9 @@ pub mod keys {
 
     /// Config key for go.autoStart setting.
     pub const GO_AUTO_START: &str = "daft.go.autoStart";
+
+    /// Config key for go.fetchOnMiss setting.
+    pub const GO_FETCH_ON_MISS: &str = "daft.go.fetchOnMiss";
 
     /// Config key for list.stat setting.
     pub const LIST_STAT: &str = "daft.list.stat";
@@ -303,6 +309,10 @@ pub struct DaftSettings {
     /// Automatically create worktree when branch not found in go command.
     pub go_auto_start: bool,
 
+    /// Whether `daft go` completion should run `git fetch` when the typed
+    /// prefix has no local matches. Controlled by `daft.go.fetchOnMiss`.
+    pub go_fetch_on_miss: bool,
+
     /// Default statistics mode for list command.
     pub list_stat: Stat,
 
@@ -350,6 +360,7 @@ impl Default for DaftSettings {
             multi_remote_default: defaults::MULTI_REMOTE_DEFAULT_REMOTE.to_string(),
             use_gitoxide: defaults::USE_GITOXIDE,
             go_auto_start: defaults::GO_AUTO_START,
+            go_fetch_on_miss: defaults::GO_FETCH_ON_MISS,
             list_stat: defaults::LIST_STAT,
             sync_stat: defaults::SYNC_STAT,
             prune_stat: defaults::PRUNE_STAT,
@@ -436,6 +447,10 @@ impl DaftSettings {
 
         if let Some(value) = git.config_get(keys::GO_AUTO_START)? {
             settings.go_auto_start = parse_bool(&value, defaults::GO_AUTO_START);
+        }
+
+        if let Some(value) = git.config_get(keys::GO_FETCH_ON_MISS)? {
+            settings.go_fetch_on_miss = parse_bool(&value, defaults::GO_FETCH_ON_MISS);
         }
 
         if let Some(value) = git.config_get(keys::LIST_STAT)? {
@@ -569,6 +584,10 @@ impl DaftSettings {
 
         if let Some(value) = git.config_get_global(keys::GO_AUTO_START)? {
             settings.go_auto_start = parse_bool(&value, defaults::GO_AUTO_START);
+        }
+
+        if let Some(value) = git.config_get_global(keys::GO_FETCH_ON_MISS)? {
+            settings.go_fetch_on_miss = parse_bool(&value, defaults::GO_FETCH_ON_MISS);
         }
 
         if let Some(value) = git.config_get_global(keys::LIST_STAT)? {
@@ -977,5 +996,15 @@ mod tests {
         assert!(settings.list_columns.is_none());
         assert!(settings.sync_columns.is_none());
         assert!(settings.prune_columns.is_none());
+    }
+
+    #[test]
+    fn default_settings_have_go_fetch_on_miss_true() {
+        let settings = DaftSettings::default();
+        assert!(
+            settings.go_fetch_on_miss,
+            "go.fetchOnMiss must default to true — the fetch-on-miss spinner \
+             path is opt-out, not opt-in"
+        );
     }
 }

--- a/src/git/config.rs
+++ b/src/git/config.rs
@@ -34,26 +34,11 @@ impl GitCommand {
         Ok(())
     }
 
-    /// Get a git config value from the current repository (respects local + global config)
+    /// Get a git config value from the current repository (respects local + global config).
+    ///
+    /// Always uses gitoxide for in-process config reading — no subprocess overhead.
     pub fn config_get(&self, key: &str) -> Result<Option<String>> {
-        if self.use_gitoxide {
-            return oxide::config_get(&self.gix_repo()?, key);
-        }
-        let output = Command::new("git")
-            .args(["config", "--get", key])
-            .output()
-            .context("Failed to execute git config command")?;
-
-        if output.status.success() {
-            let value = String::from_utf8(output.stdout)
-                .context("Failed to parse git config output")?
-                .trim()
-                .to_string();
-            Ok(Some(value))
-        } else {
-            // Exit code 1 means the key was not found, which is not an error
-            Ok(None)
-        }
+        oxide::config_get(&self.gix_repo()?, key)
     }
 
     /// Set a git config value in global config
@@ -71,26 +56,11 @@ impl GitCommand {
         Ok(())
     }
 
-    /// Get a git config value from global config only
+    /// Get a git config value from global config only.
+    ///
+    /// Always uses gitoxide for in-process config reading — no subprocess overhead.
     pub fn config_get_global(&self, key: &str) -> Result<Option<String>> {
-        if self.use_gitoxide {
-            return oxide::config_get_global(key);
-        }
-        let output = Command::new("git")
-            .args(["config", "--global", "--get", key])
-            .output()
-            .context("Failed to execute git config command")?;
-
-        if output.status.success() {
-            let value = String::from_utf8(output.stdout)
-                .context("Failed to parse git config output")?
-                .trim()
-                .to_string();
-            Ok(Some(value))
-        } else {
-            // Exit code 1 means the key was not found, which is not an error
-            Ok(None)
-        }
+        oxide::config_get_global(key)
     }
 
     /// Get the tracking remote for a branch.

--- a/src/git/oxide.rs
+++ b/src/git/oxide.rs
@@ -253,6 +253,52 @@ pub fn has_uncommitted_changes(repo: &Repository) -> Result<bool> {
     Ok(false)
 }
 
+/// Check a worktree for tracked changes and untracked files separately.
+///
+/// Returns `(has_tracked_changes, has_untracked)` where:
+/// - `has_tracked_changes` is true if there are modified/staged/removed
+///   tracked files or conflicts
+/// - `has_untracked` is true if untracked files exist (excluding empty dirs)
+///
+/// Opens the worktree as a fresh `gix::Repository` so it can be called
+/// from any thread (each thread gets its own repo instance).
+pub fn worktree_dirty_status(worktree_path: &std::path::Path) -> Result<(bool, bool)> {
+    use gix::status::index_worktree::iter::Summary;
+    use gix::status::UntrackedFiles;
+
+    let repo = gix::open(worktree_path)
+        .with_context(|| format!("Failed to open repository at {}", worktree_path.display()))?;
+
+    let status = repo
+        .status(gix::progress::Discard)
+        .context("Failed to get repository status")?;
+
+    let iter = status
+        .untracked_files(UntrackedFiles::Files)
+        .dirwalk_options(|opts| opts.emit_empty_directories(false))
+        .into_index_worktree_iter(Vec::<gix::bstr::BString>::new())
+        .context("Failed to iterate status")?;
+
+    let mut has_tracked = false;
+    let mut has_untracked = false;
+    for item_result in iter {
+        let item = match item_result {
+            Ok(i) => i,
+            Err(_) => continue,
+        };
+        match item.summary() {
+            Some(Summary::Added) => has_untracked = true,
+            Some(_) => has_tracked = true,
+            None => {} // NeedsUpdate — not a real change
+        }
+        if has_tracked && has_untracked {
+            break;
+        }
+    }
+
+    Ok((has_tracked, has_untracked))
+}
+
 /// Gitoxide-native commit metadata retrieval for a named ref.
 ///
 /// Returns `(timestamp, short_hash, subject)` where:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,7 @@ pub fn get_clap_args(expected_cmd: &str) -> Vec<String> {
 }
 
 pub mod commands;
+pub mod completion_spinner;
 pub mod core;
 pub mod doctor;
 pub mod exec;

--- a/test-plans/go-completions.md
+++ b/test-plans/go-completions.md
@@ -1,0 +1,66 @@
+---
+branch: fix/go-completions
+---
+
+# daft go Completion Overhaul
+
+## Setup
+
+- [ ] Install the current build via `mise run dev`.
+- [ ] In a test repo with >= 3 worktrees, >= 2 local-only branches, and >= 5
+      remote-only branches, open a new zsh shell and a new bash shell.
+
+## Group ordering
+
+- [ ] `daft go <TAB>` in zsh lists worktrees first, then local branches, then
+      remote branches, in that order.
+- [ ] Same in bash (flat list but preserving the order).
+- [ ] Same in fish.
+- [ ] The current worktree's branch does NOT appear in the worktree group.
+
+## Descriptions and colors
+
+- [ ] zsh: each entry shows a relative age ("3 days ago", etc.) in the
+      description column.
+- [ ] zsh: worktree entries are bright green, local are bright blue, remote are
+      dim gray.
+- [ ] fish: each entry shows `<age> · <group>` in the description.
+- [ ] bash: no descriptions, but no flags leaked into the branch list.
+
+## Flag gating
+
+- [ ] `daft go -<TAB>` in zsh shows ONLY flags, no branches.
+- [ ] `daft go -<TAB>` in bash shows ONLY flags, no branches.
+- [ ] `daft go <TAB>` (no dash) shows ONLY branches, no flags.
+
+## Fetch-on-miss + spinner
+
+- [ ] Find a remote-only branch that's NOT in your local `refs/remotes/` (ask
+      someone to push a branch, or delete your local remote ref with
+      `git update-ref -d refs/remotes/origin/<branch>`).
+- [ ] Type `daft go <prefix-of-that-branch><TAB>`. Expected: a braille-dot
+      spinner with "Fetching refs from origin..." appears on the terminal for
+      the duration of the fetch, then clears.
+- [ ] After the fetch completes, the completion list now includes the remote
+      branch.
+- [ ] Immediately type the same completion again. Expected: no spinner this time
+      (cooldown).
+- [ ] Wait 30+ seconds and retry. Expected: spinner reappears.
+- [ ] `git config daft.go.fetchOnMiss false` — expected: spinner never appears,
+      regardless of cooldown.
+- [ ] Reset with `git config --unset daft.go.fetchOnMiss`.
+
+## Multi-remote mode
+
+- [ ] Enable multi-remote via `daft multi-remote enable`.
+- [ ] `daft go <TAB>` — remote-only entries now show `<remote>/<branch>`
+      verbatim instead of stripped form.
+- [ ] Disable multi-remote again via `daft multi-remote disable`.
+
+## Non-interactive invocation
+
+- [ ] `daft __complete daft-go "" --position 1 | head` inside a repository emits
+      tab-separated lines with three columns each.
+- [ ] The same command with `--fetch-on-miss` and a non-matching prefix does NOT
+      draw a spinner (no /dev/tty when stdout is piped) and still emits any
+      matching output.

--- a/tests/integration/test_completions.sh
+++ b/tests/integration/test_completions.sh
@@ -120,7 +120,7 @@ test_bash_dynamic_wiring() {
     local output
     output=$("$DAFT_BIN" completions bash --command=git-worktree-checkout 2>&1)
 
-    if [[ "$output" == *'daft __complete'* ]] && [[ "$output" == *'branches='* ]]; then
+    if [[ "$output" == *'daft __complete'* ]] && [[ "$output" == *'raw='* ]]; then
         pass_test
     else
         fail_test "Bash completion missing 'daft __complete' call for dynamic branches"
@@ -134,7 +134,7 @@ test_zsh_dynamic_wiring() {
     local output
     output=$("$DAFT_BIN" completions zsh --command=git-worktree-checkout 2>&1)
 
-    if [[ "$output" == *'daft __complete'* ]] && [[ "$output" == *'branches='* ]]; then
+    if [[ "$output" == *'daft __complete'* ]] && [[ "$output" == *'raw='* ]]; then
         pass_test
     else
         fail_test "Zsh completion missing 'daft __complete' call for dynamic branches"
@@ -417,7 +417,7 @@ test_carry_dynamic_completion() {
     local output
     output=$("$DAFT_BIN" completions bash --command=git-worktree-carry 2>&1)
 
-    if [[ "$output" == *'daft __complete'* ]] && [[ "$output" == *'branches='* ]]; then
+    if [[ "$output" == *'daft __complete'* ]] && [[ "$output" == *'raw='* ]]; then
         pass_test
     else
         fail_test "Carry command missing dynamic branch completion"

--- a/tests/manual/scenarios/completions/bash.yml
+++ b/tests/manual/scenarios/completions/bash.yml
@@ -16,7 +16,7 @@ steps:
       exit_code: 0
       output_contains:
         - "daft __complete"
-        - "branches="
+        - "raw="
 
   - name: Bash git subcommand registration for checkout
     run: daft completions bash --command=git-worktree-checkout 2>&1
@@ -39,7 +39,7 @@ steps:
       exit_code: 0
       output_contains:
         - "daft __complete"
-        - "branches="
+        - "raw="
 
   - name: shell-init bash includes completion functions
     run: daft shell-init bash 2>&1

--- a/tests/manual/scenarios/completions/go-grouped.yml
+++ b/tests/manual/scenarios/completions/go-grouped.yml
@@ -1,0 +1,137 @@
+name: Grouped go completions
+description:
+  daft __complete daft-go emits tab-separated grouped output with correct
+  ordering, deduplication, and current-worktree exclusion
+
+steps:
+  - name:
+      Set up a git repo with worktrees, local branches, and a remote-only branch
+    run: |
+      set -e
+      mkdir -p $WORK_DIR/origin.git
+      cd $WORK_DIR/origin.git
+      git init --bare
+      git symbolic-ref HEAD refs/heads/master
+
+      # Bootstrap: populate the bare origin via a temp clone
+      cd $WORK_DIR
+      git clone origin.git bootstrap
+      cd $WORK_DIR/bootstrap
+      echo "content" > README.md
+      git add README.md
+      git commit -m "Initial commit"
+      git push origin master
+
+      # Push feat/worktree-branch (will have a linked worktree in the work clone)
+      git checkout -b feat/worktree-branch
+      git commit --allow-empty -m "worktree branch"
+      git push origin feat/worktree-branch
+      git checkout master
+
+      # Push remote-only (will NOT be checked out locally)
+      git checkout -b remote-only
+      git commit --allow-empty -m "remote-only"
+      git push origin remote-only
+      git checkout master
+
+      # Clean up bootstrap: cd away first so the shell is not left in a
+      # deleted directory (which causes getcwd errors on subsequent commands)
+      cd $WORK_DIR
+      rm -rf $WORK_DIR/bootstrap
+
+      # Create the working clone
+      git clone $WORK_DIR/origin.git $WORK_DIR/work
+
+      # Create a local-only branch (not pushed to remote)
+      cd $WORK_DIR/work
+      git checkout -b local-only
+      git commit --allow-empty -m "local-only"
+      git checkout master
+
+      # Track feat/worktree-branch locally
+      git checkout feat/worktree-branch
+      git checkout master
+
+      # Add a linked worktree for feat/worktree-branch
+      git worktree add $WORK_DIR/feat-worktree feat/worktree-branch
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/work"
+        - "$WORK_DIR/feat-worktree"
+
+  - name: Completion from master worktree lists worktree group first
+    run: daft __complete daft-go "" --position 1 2>&1
+    cwd: "$WORK_DIR/work"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "feat/worktree-branch\tworktree\t"
+
+  - name: Completion from master worktree lists local group second
+    run: daft __complete daft-go "" --position 1 2>&1
+    cwd: "$WORK_DIR/work"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "local-only\tlocal\t"
+        - "master\tlocal\t"
+
+  - name: Completion from master worktree lists remote group third
+    run: daft __complete daft-go "" --position 1 2>&1
+    cwd: "$WORK_DIR/work"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "remote-only\tremote\t"
+
+  - name:
+      Completion from master worktree excludes current branch from worktree
+      group
+    run: daft __complete daft-go "" --position 1 2>&1
+    cwd: "$WORK_DIR/work"
+    expect:
+      exit_code: 0
+      output_not_contains:
+        - "master\tworktree\t"
+
+  - name: Completion deduplicates feat/worktree-branch from local group
+    run: daft __complete daft-go "" --position 1 2>&1
+    cwd: "$WORK_DIR/work"
+    expect:
+      exit_code: 0
+      output_not_contains:
+        - "feat/worktree-branch\tlocal\t"
+
+  - name:
+      Completion deduplicates remote-only from remote after appearing in local
+    run: daft __complete daft-go "" --position 1 2>&1
+    cwd: "$WORK_DIR/work"
+    expect:
+      exit_code: 0
+      output_not_contains:
+        - "remote-only\tlocal\t"
+
+  - name:
+      Completion from feat-worktree excludes feat/worktree-branch from worktree
+      group
+    run: daft __complete daft-go "" --position 1 2>&1
+    cwd: "$WORK_DIR/feat-worktree"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "master\tworktree\t"
+      output_not_contains:
+        - "feat/worktree-branch\tworktree\t"
+
+  - name: Prefix filtering returns only matching entries
+    run: daft __complete daft-go "feat" --position 1 2>&1
+    cwd: "$WORK_DIR/work"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "feat/worktree-branch\tworktree\t"
+      output_not_contains:
+        - "master\t"
+        - "local-only\t"
+        - "remote-only\t"

--- a/tests/manual/scenarios/completions/zsh.yml
+++ b/tests/manual/scenarios/completions/zsh.yml
@@ -16,7 +16,7 @@ steps:
       exit_code: 0
       output_contains:
         - "daft __complete"
-        - "branches="
+        - "raw="
 
   - name: Zsh git subcommand registration for checkout
     run: daft completions zsh --command=git-worktree-checkout 2>&1


### PR DESCRIPTION
## Summary

- Overhaul `daft go` completions: replace flat branch lists with grouped display (worktree/local/remote) showing commit age, author, and relative worktree paths
- Extend rich completions to all branch-completing commands: `remove`, `rename`, `checkout`, `carry`, `fetch`, `branch`
- Replace git subprocesses with gitoxide for all completion data (refs, config, status) — total completion time ~3ms
- Add `daft.completions.branches.columns` config key to control visible columns (`age`, `author`, `path`, `tracked-changes`, `untracked`)
- Add `tracked-changes` (`*`) and `untracked` (`?`) dirty status indicators on worktree branch names, using parallel gitoxide status checks (~8ms for 4 worktrees)

## Test plan

- [x] `mise run fmt && mise run clippy` — clean
- [x] `mise run test:unit` — 1019 tests pass
- [ ] Live test: `daft __complete daft-go "" --position 1` shows grouped output with age, author, relative paths
- [ ] Live test: `git config daft.completions.branches.columns "+tracked-changes,+untracked"` then verify `*`/`?` on dirty worktrees
- [ ] Live test: `git config daft.completions.branches.columns "age,path"` then verify author column hidden
- [ ] Verify zsh tab completion renders grouped columns correctly
- [ ] Verify fish tab completion shows descriptions correctly
- [ ] `DAFT_COMPLETE_TIMINGS=1 daft __complete daft-go "" --position 1` confirms ~3ms default, ~11ms with status

🤖 Generated with [Claude Code](https://claude.com/claude-code)