### PR TITLE
fix: keep outer spinner alive across hook boundary

### DIFF
--- a/src/core/progress.rs
+++ b/src/core/progress.rs
@@ -103,11 +103,85 @@ impl ProgressSink for CommandBridge<'_> {
 impl HookRunner for CommandBridge<'_> {
     fn run_hook(&mut self, ctx: &crate::hooks::HookContext) -> anyhow::Result<HookOutcome> {
         let presenter: Arc<dyn JobPresenter> = CliPresenter::auto(&self.output_config);
-        let result = self.executor.execute(ctx, self.output, presenter)?;
+        // The hook executor may render its own indicatif MultiProgress, which
+        // would fight the outer command spinner for the stderr cursor. Hide
+        // the outer spinner across the hook boundary so step-label updates
+        // after the hook (e.g. "Removing worktree at <path>") stay visible.
+        self.output.pause_spinner();
+        let exec_result = self.executor.execute(ctx, self.output, presenter);
+        self.output.resume_spinner();
+        let result = exec_result?;
         Ok(HookOutcome {
             success: result.success,
             skipped: result.skipped,
             skip_reason: result.skip_reason.clone(),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hooks::{HookContext, HookExecutor, HookType, HooksConfig};
+    use crate::output::{OutputEntry, TestOutput};
+    use std::path::PathBuf;
+
+    /// Regression test: the outer spinner must be paused around hook execution
+    /// so the hook's own progress UI (indicatif MultiProgress) does not clobber
+    /// it. Without this, step-label updates like "Removing worktree at <path>"
+    /// stay invisible after a pre-remove hook finishes, leaving the user with
+    /// an unexplained pause during the filesystem-delete phase.
+    #[test]
+    fn run_hook_brackets_executor_with_spinner_pause_resume() {
+        let mut output = TestOutput::new();
+        output.start_spinner("Deleting branches...");
+
+        // Hooks globally disabled so execute() short-circuits without touching
+        // the filesystem. The wrapping must happen regardless of the inner
+        // outcome — that is the contract under test.
+        let hooks_config = HooksConfig {
+            enabled: false,
+            ..HooksConfig::default()
+        };
+        let executor = HookExecutor::new(hooks_config).expect("create executor");
+
+        let ctx = HookContext::new(
+            HookType::PreRemove,
+            "test-remove",
+            PathBuf::from("/tmp/project"),
+            PathBuf::from("/tmp/project/.git"),
+            "origin",
+            PathBuf::from("/tmp/project"),
+            PathBuf::from("/tmp/project/feature"),
+            "feature",
+        );
+
+        {
+            let mut bridge = CommandBridge::new(&mut output, executor);
+            bridge.run_hook(&ctx).expect("run_hook");
+        }
+
+        let entries = output.entries();
+        let start_idx = entries
+            .iter()
+            .position(|e| matches!(e, OutputEntry::SpinnerStart(_)))
+            .expect("SpinnerStart entry missing");
+        let pause_idx = entries
+            .iter()
+            .position(|e| matches!(e, OutputEntry::SpinnerPause))
+            .expect("SpinnerPause entry missing — run_hook must suspend the outer spinner");
+        let resume_idx = entries
+            .iter()
+            .position(|e| matches!(e, OutputEntry::SpinnerResume))
+            .expect("SpinnerResume entry missing — run_hook must resume the outer spinner");
+
+        assert!(
+            start_idx < pause_idx,
+            "spinner must be started before being paused"
+        );
+        assert!(
+            pause_idx < resume_idx,
+            "pause must come before resume around hook execution"
+        );
     }
 }

--- a/src/output/cli.rs
+++ b/src/output/cli.rs
@@ -23,6 +23,8 @@ use std::time::Duration;
 pub struct CliOutput {
     config: OutputConfig,
     spinner: Option<ProgressBar>,
+    /// Message of a spinner hidden by `pause_spinner`, waiting to be restored.
+    paused_spinner_message: Option<String>,
 }
 
 impl CliOutput {
@@ -31,6 +33,7 @@ impl CliOutput {
         Self {
             config,
             spinner: None,
+            paused_spinner_message: None,
         }
     }
 
@@ -239,6 +242,27 @@ impl Output for CliOutput {
             let _ = std::io::stderr().write_all(b"\x1b[2K\r");
             let _ = std::io::stderr().flush();
         }
+        // NOTE: do not touch `paused_spinner_message` here. The hook executor
+        // defensively calls finish_spinner() before rendering its own progress
+        // UI; clearing the saved message would turn the subsequent
+        // resume_spinner() into a no-op and leave the user staring at a blank
+        // terminal during the fs-delete phase.
+    }
+
+    fn pause_spinner(&mut self) {
+        if let Some(spinner) = self.spinner.take() {
+            self.paused_spinner_message = Some(spinner.message());
+            spinner.finish_and_clear();
+            use std::io::Write;
+            let _ = std::io::stderr().write_all(b"\x1b[2K\r");
+            let _ = std::io::stderr().flush();
+        }
+    }
+
+    fn resume_spinner(&mut self) {
+        if let Some(msg) = self.paused_spinner_message.take() {
+            self.start_spinner(&msg);
+        }
     }
 
     fn cd_path(&mut self, path: &Path) {
@@ -278,6 +302,23 @@ impl Drop for CliOutput {
 }
 
 #[cfg(test)]
+impl CliOutput {
+    /// Inject a spinner manually for tests. In test builds, `start_spinner` is
+    /// a no-op (gated on `cfg!(test)`), so exercising pause/resume semantics
+    /// requires bypassing that guard.
+    pub(crate) fn inject_spinner_for_test(&mut self, msg: &str) {
+        let pb = ProgressBar::new_spinner();
+        pb.set_message(msg.to_string());
+        self.spinner = Some(pb);
+    }
+
+    /// Expose the internal paused-message field for tests.
+    pub(crate) fn paused_message_for_test(&self) -> Option<&str> {
+        self.paused_spinner_message.as_deref()
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -308,5 +349,32 @@ mod tests {
         let output = CliOutput::new(config);
         assert!(output.is_quiet());
         assert!(output.is_verbose());
+    }
+
+    /// Regression: the hook executor (src/hooks/executor.rs:421,
+    /// yaml_executor/mod.rs:217) defensively calls `finish_spinner` before
+    /// rendering its own progress UI. If `finish_spinner` clears
+    /// `paused_spinner_message`, the subsequent `resume_spinner` becomes a
+    /// no-op and the user sees nothing during the long fs-delete phase that
+    /// follows a pre-remove hook.
+    #[test]
+    fn finish_spinner_preserves_paused_message_across_hook_call() {
+        let mut output = CliOutput::default_output();
+        output.inject_spinner_for_test("Deleting branches...");
+
+        output.pause_spinner();
+        assert_eq!(
+            output.paused_message_for_test(),
+            Some("Deleting branches...")
+        );
+
+        // Simulate the defensive clear performed inside HookExecutor::execute.
+        output.finish_spinner();
+
+        assert_eq!(
+            output.paused_message_for_test(),
+            Some("Deleting branches..."),
+            "paused message must survive finish_spinner so resume_spinner can restart the outer spinner after the hook",
+        );
     }
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -170,6 +170,20 @@ pub trait Output {
     /// Called explicitly before printing results, and also on `Drop` as safety net.
     fn finish_spinner(&mut self);
 
+    /// Temporarily hide the active spinner so another component (e.g. a hook's
+    /// own `indicatif::MultiProgress`) can render without fighting for the
+    /// same stderr cursor. The current spinner message is remembered so
+    /// `resume_spinner` can restore it. No-op when no spinner is active.
+    fn pause_spinner(&mut self) {
+        let _ = self;
+    }
+
+    /// Restore the spinner previously hidden by `pause_spinner`. No-op if no
+    /// spinner was paused.
+    fn resume_spinner(&mut self) {
+        let _ = self;
+    }
+
     // ─────────────────────────────────────────────────────────────────────────
     // Special Output
     // ─────────────────────────────────────────────────────────────────────────

--- a/src/output/test.rs
+++ b/src/output/test.rs
@@ -44,6 +44,10 @@ pub enum OutputEntry {
     SpinnerStart(String),
     /// Spinner finished
     SpinnerFinish,
+    /// Spinner paused (temporarily hidden)
+    SpinnerPause,
+    /// Spinner resumed after a pause
+    SpinnerResume,
 }
 
 /// Test output implementation that captures all output for assertions.
@@ -389,6 +393,14 @@ impl Output for TestOutput {
 
     fn finish_spinner(&mut self) {
         self.entries.push(OutputEntry::SpinnerFinish);
+    }
+
+    fn pause_spinner(&mut self) {
+        self.entries.push(OutputEntry::SpinnerPause);
+    }
+
+    fn resume_spinner(&mut self) {
+        self.entries.push(OutputEntry::SpinnerResume);
     }
 
     fn is_quiet(&self) -> bool {


### PR DESCRIPTION
## Summary

- `daft remove` (and any command running a lifecycle hook while an outer spinner is active) fell silent during the filesystem-delete phase after the pre-remove hook finished, leaving an unexplained pause between the hook summary and the `Deleted <branch>` line.
- Root cause: the hook's own `indicatif::MultiProgress` shared stderr with the command-level `ProgressBar`, so the outer spinner's steady ticks no longer redrew once the hook renderer relinquished the terminal. Step-label updates like `Removing worktree at <path>` were being written to a spinner that had effectively stopped painting.
- Fix: `CommandBridge::run_hook` now brackets `HookExecutor::execute` with `pause_spinner` / `resume_spinner`. `CliOutput` stashes the active message on pause, clears the spinner cleanly, and rebuilds a fresh `ProgressBar` on resume with the preserved label.
- Secondary bug (caught during iteration): the hook executor defensively calls `output.finish_spinner()` before drawing its own UI. The initial patch cleared `paused_spinner_message` inside `finish_spinner`, silently defusing the subsequent `resume_spinner`. `finish_spinner` no longer touches the paused-message field; ownership of that field belongs exclusively to the pause/resume pair.

## Test plan

- [x] `cargo test -p daft --lib -- core::progress::tests::run_hook_brackets_executor_with_spinner_pause_resume` — asserts pause/resume brackets `executor.execute`
- [x] `cargo test -p daft --lib -- output::cli::tests::finish_spinner_preserves_paused_message_across_hook_call` — regression against the defensive `finish_spinner` clobbering saved state
- [x] Both regression tests bisected: fail on pre-fix, pass on fix
- [x] `mise run clippy` — clean
- [x] `mise run fmt:check` — clean
- [ ] Manual TTY verification: `daft remove <branch>` in a sandbox with a `worktree-pre-remove` hook — expect a ticking spinner labeled `Removing worktree at <path>...` during the previously silent pause
- [ ] Follow-up (not in this PR): non-TTY / `--quiet` paths still have no activity line for the fs-delete phase

## Notes

- Scope kept to interactive-TTY rendering. Non-TTY and `--quiet` were deliberately left out; they're a separate UX decision worth its own PR.
- Default no-op trait methods on `Output` keep `BufferingOutput` (TUI path) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)