### PR TITLE
chore: fix clippy warnings new in Rust 1.95

### DIFF
--- a/src/commands/config/remote_sync.rs
+++ b/src/commands/config/remote_sync.rs
@@ -270,15 +270,14 @@ impl TuiState {
                 self.settings.push = false;
                 self.settings.delete_remote = false;
             }
-            ITEM_CUSTOM => {
+            ITEM_CUSTOM
                 // Selecting "Custom" doesn't change checkboxes, just allows
                 // individual toggling. If currently all-on or all-off, flip one
                 // checkbox to make it truly custom.
-                if self.radio_selection() != RadioSelection::Custom {
+                if self.radio_selection() != RadioSelection::Custom => {
                     // Toggle fetch to break the all-same pattern
                     self.settings.fetch = !self.settings.fetch;
                 }
-            }
             ITEM_FETCH => self.settings.fetch = !self.settings.fetch,
             ITEM_PUSH => self.settings.push = !self.settings.push,
             ITEM_DELETE => self.settings.delete_remote = !self.settings.delete_remote,

--- a/src/git/oxide.rs
+++ b/src/git/oxide.rs
@@ -477,19 +477,15 @@ pub fn ls_remote_symref(repo: &Repository, remote_url: &str) -> Result<String> {
                 target,
                 object,
                 ..
-            } => {
-                if full_ref_name.as_bstr() == "HEAD" {
-                    output.push_str(&format!("ref: {target}\tHEAD\n"));
-                    output.push_str(&format!("{object}\tHEAD\n"));
-                }
+            } if full_ref_name.as_bstr() == "HEAD" => {
+                output.push_str(&format!("ref: {target}\tHEAD\n"));
+                output.push_str(&format!("{object}\tHEAD\n"));
             }
             gix::protocol::handshake::Ref::Direct {
                 full_ref_name,
                 object,
-            } => {
-                if full_ref_name.as_bstr() == "HEAD" {
-                    output.push_str(&format!("{object}\tHEAD\n"));
-                }
+            } if full_ref_name.as_bstr() == "HEAD" => {
+                output.push_str(&format!("{object}\tHEAD\n"));
             }
             _ => {}
         }

--- a/src/output/tui/shared_picker/add_modal.rs
+++ b/src/output/tui/shared_picker/add_modal.rs
@@ -488,7 +488,7 @@ fn index_files(
         });
     }
 
-    all_entries.sort_by(|a, b| a.rel_path.to_lowercase().cmp(&b.rel_path.to_lowercase()));
+    all_entries.sort_by_key(|a| a.rel_path.to_lowercase());
     let _ = tx.send(all_entries);
 }
 
@@ -553,50 +553,36 @@ pub fn show_add_modal(
                     }
                 }
             }
-            KeyCode::Up => {
-                if count > 0 && modal.cursor > 0 {
-                    modal.cursor -= 1;
-                    modal.clamp_scroll();
-                }
+            KeyCode::Up if count > 0 && modal.cursor > 0 => {
+                modal.cursor -= 1;
+                modal.clamp_scroll();
             }
-            KeyCode::Down => {
-                if count > 0 && modal.cursor < count - 1 {
-                    modal.cursor += 1;
-                    modal.clamp_scroll();
-                }
+            KeyCode::Down if count > 0 && modal.cursor < count - 1 => {
+                modal.cursor += 1;
+                modal.clamp_scroll();
             }
-            KeyCode::Right => {
-                if modal.search.is_empty() {
-                    modal.expand_current();
-                }
+            KeyCode::Right if modal.search.is_empty() => {
+                modal.expand_current();
             }
-            KeyCode::Left => {
-                if modal.search.is_empty() {
-                    modal.collapse_current();
-                    modal.clamp_scroll();
-                }
+            KeyCode::Left if modal.search.is_empty() => {
+                modal.collapse_current();
+                modal.clamp_scroll();
             }
-            KeyCode::PageUp => {
-                if count > 0 {
-                    let page = modal.list_height.max(1);
-                    modal.cursor = modal.cursor.saturating_sub(page);
-                    modal.clamp_scroll();
-                }
+            KeyCode::PageUp if count > 0 => {
+                let page = modal.list_height.max(1);
+                modal.cursor = modal.cursor.saturating_sub(page);
+                modal.clamp_scroll();
             }
-            KeyCode::PageDown => {
-                if count > 0 {
-                    let page = modal.list_height.max(1);
-                    modal.cursor = (modal.cursor + page).min(count - 1);
-                    modal.clamp_scroll();
-                }
+            KeyCode::PageDown if count > 0 => {
+                let page = modal.list_height.max(1);
+                modal.cursor = (modal.cursor + page).min(count - 1);
+                modal.clamp_scroll();
             }
-            KeyCode::Backspace => {
-                if !modal.search.is_empty() {
-                    modal.search.pop();
-                    modal.search_dirty = true;
-                    modal.cursor = 0;
-                    modal.scroll = 0;
-                }
+            KeyCode::Backspace if !modal.search.is_empty() => {
+                modal.search.pop();
+                modal.search_dirty = true;
+                modal.cursor = 0;
+                modal.scroll = 0;
             }
             KeyCode::Char(c) => {
                 modal.search.push(c);

--- a/src/output/tui/shared_picker/manage_mode.rs
+++ b/src/output/tui/shared_picker/manage_mode.rs
@@ -918,10 +918,8 @@ impl PickerMode for ManageMode {
                     state.move_up(all);
                 }
             }
-            KeyCode::Tab => {
-                if !state.is_virtual_tab() {
-                    state.toggle_panel();
-                }
+            KeyCode::Tab if !state.is_virtual_tab() => {
+                state.toggle_panel();
             }
             _ => {}
         }

--- a/src/output/tui/shared_picker/remove_modal.rs
+++ b/src/output/tui/shared_picker/remove_modal.rs
@@ -110,21 +110,17 @@ pub fn show_remove_modal(
                     focused = ModalOption::DeleteAll;
                 }
             }
-            KeyCode::Right | KeyCode::Char('l') => {
-                if focused == ModalOption::Materialize && !expanded {
-                    expanded = true;
-                    wt_cursor = 0;
-                }
+            KeyCode::Right | KeyCode::Char('l')
+                if focused == ModalOption::Materialize && !expanded =>
+            {
+                expanded = true;
+                wt_cursor = 0;
             }
-            KeyCode::Left | KeyCode::Char('h') => {
-                if expanded {
-                    expanded = false;
-                }
+            KeyCode::Left | KeyCode::Char('h') if expanded => {
+                expanded = false;
             }
-            KeyCode::Char(' ') => {
-                if expanded && focused == ModalOption::Materialize {
-                    checks[wt_cursor] = !checks[wt_cursor];
-                }
+            KeyCode::Char(' ') if expanded && focused == ModalOption::Materialize => {
+                checks[wt_cursor] = !checks[wt_cursor];
             }
             _ => {}
         }


### PR DESCRIPTION
## Summary

- CI's clippy step has rolled to Rust 1.95 and started failing on master-tip commits with 15 `collapsible_match` and one `sort_by_key` lint.
- All 15 changes are mechanical, produced by `cargo clippy --fix`. Guards (`KeyCode::Up if count > 0 && cursor > 0`) replace the inner `if` bodies, and `sort_by_key(|a| a.rel_path.to_lowercase())` replaces the equivalent `sort_by` closure.
- No behavior change. Files touched: `src/commands/config/remote_sync.rs`, `src/git/oxide.rs`, `src/output/tui/shared_picker/{add_modal,manage_mode,remove_modal}.rs`.

This is splitting off the lint churn from #367 (the spinner fix) so each PR stays scoped.

## Test plan

- [x] `cargo clippy --tests -- -D warnings` on Rust 1.95 (stable toolchain installed via rustup) — clean
- [x] `mise run fmt:check` — clean
- [x] Unit tests still pass
- [ ] CI passes on this PR (what this PR is here to verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)