### PR TITLE
fix(hooks): skip prompt when trust level unchanged

### DIFF
--- a/src/commands/hooks/trust.rs
+++ b/src/commands/hooks/trust.rs
@@ -50,6 +50,14 @@ pub(super) fn cmd_set_trust(
         output.info(&format!("{}", project_root.display()));
         output.info(&format!("  Hooks: {hooks_str}"));
 
+        if current_level == new_level {
+            output.info(&format!(
+                "  Trust: already at {}, nothing to do.",
+                styled_trust_level(current_level)
+            ));
+            return Ok(());
+        }
+
         if !force {
             print!(
                 "  Trust: {} -> {}? [y/N] ",

--- a/tests/manual/scenarios/hooks/trust-noop.yml
+++ b/tests/manual/scenarios/hooks/trust-noop.yml
@@ -1,0 +1,69 @@
+name: Hooks trust no-op when level unchanged
+description:
+  daft hooks trust short-circuits without prompting when current level matches
+  target
+
+repos:
+  - name: test-hooks-trust-noop
+    default_branch: main
+    branches:
+      - name: main
+        files:
+          - path: README.md
+            content: "# Trust no-op test"
+        commits:
+          - message: "Initial commit"
+    daft_yml: |
+      hooks:
+        worktree-post-create:
+          jobs:
+            - name: setup
+              run: echo done
+
+steps:
+  - name: Clone the repository
+    run: git-worktree-clone --layout contained $REMOTE_TEST_HOOKS_TRUST_NOOP
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-hooks-trust-noop/main"
+
+  - name: Trust the repository (first time)
+    run: daft hooks trust --force 2>&1
+    cwd: "$WORK_DIR/test-hooks-trust-noop/main"
+    expect:
+      exit_code: 0
+
+  - name: Re-trust without --force and without stdin should no-op, not prompt
+    run: daft hooks trust < /dev/null 2>&1
+    cwd: "$WORK_DIR/test-hooks-trust-noop/main"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "already at"
+        - "nothing to do"
+
+  - name: Verify status still reports allow
+    run: daft hooks status 2>&1
+    cwd: "$WORK_DIR/test-hooks-trust-noop/main"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "allow"
+
+  - name:
+      Prompt-level no-op on an untrusted repo (implicit deny -> deny would
+      differ; allow -> prompt should change)
+    run: daft hooks prompt --force 2>&1
+    cwd: "$WORK_DIR/test-hooks-trust-noop/main"
+    expect:
+      exit_code: 0
+
+  - name: Re-run prompt without --force on already-prompt repo no-ops
+    run: daft hooks prompt < /dev/null 2>&1
+    cwd: "$WORK_DIR/test-hooks-trust-noop/main"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "already at"
+        - "nothing to do"


### PR DESCRIPTION
## Summary

- `daft hooks trust` and `daft hooks prompt` now short-circuit when the
  target level matches the current level, printing
  `Trust: already at <level>, nothing to do.` and returning without a
  confirmation prompt or trust-database write.
- Guard lives at the top of `cmd_set_trust` in `src/commands/hooks/trust.rs`,
  before any prompt logic, so it applies with or without `--force`.
- `cmd_deny` already handles the equivalent no-op via `has_explicit_trust`.

## Test plan

- [x] `mise run fmt`
- [x] `mise run clippy`
- [x] `mise run test:manual -- --ci hooks:trust-noop` — new regression
      scenario runs `daft hooks trust` twice and `daft hooks prompt` twice,
      asserting that the second invocation exits 0 and contains
      "already at" / "nothing to do" without blocking on stdin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)