### PR TITLE
fix(update-check): drop git-style "hint:" prefix from notification

### DIFF
--- a/src/update_check.rs
+++ b/src/update_check.rs
@@ -131,13 +131,10 @@ pub fn print_notification(notification: &UpdateNotification) {
     let latest = styles::green(&notification.latest_version);
 
     eprintln!();
-    eprintln!("hint: A new version of daft is available: {current} {arrow} {latest}");
+    eprintln!("A new version of daft is available: {current} {arrow} {latest}");
+    eprintln!("To update: {}", styles::cyan(&notification.update_command));
     eprintln!(
-        "hint: To update: {}",
-        styles::cyan(&notification.update_command)
-    );
-    eprintln!(
-        "hint: To disable: {}",
+        "To disable: {}",
         styles::dim("git config --global daft.updateCheck false")
     );
 }


### PR DESCRIPTION
## Summary
- The update notification lines were prefixed with `hint:` to mimic Git's hint style — that convention isn't meaningful for daft's own output, so drop it.
- Affects the three `eprintln!` lines in `print_notification` (new version banner, update command, disable instructions).

## Test plan
- [x] `mise run fmt`
- [x] `mise run clippy`
- [x] `mise run test:unit`
- [ ] Verify notification output manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)