### PR TITLE
docs: refresh daft help and add man page examples

### DIFF
--- a/man/daft.1
+++ b/man/daft.1
@@ -10,27 +10,7 @@ daft is a comprehensive Git extensions toolkit that enhances developer workflows
 .PP
 Run \*(Aqdaft\*(Aq with no arguments to see a categorized command overview.
 .PP
-GETTING STARTED
-.PP
-Clone a repository into a worktree layout:
-.PP
-	daft clone <url>
-.PP
-Or adopt an existing repository:
-.PP
-	daft adopt
-.PP
-Switch to a branch (each branch gets its own directory):
-.PP
-	daft go <branch>
-.PP
-Create a new branch:
-.PP
-	daft start <branch>
-.PP
-SHELL INTEGRATION
-.PP
-Enable automatic cd into new worktrees:
+To enable automatic cd into new worktrees, add the shell integration:
 .PP
 	eval "$(daft shell\-init zsh)"
 .PP
@@ -39,6 +19,46 @@ See daft\-shell\-init(1) for details.
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help (see a summary with \*(Aq\-h\*(Aq)
+.SH EXAMPLES
+Clone a repository into a worktree\-based layout:
+.PP
+	daft clone git@github.com:user/repo.git
+.PP
+Initialize a new repository in the worktree layout:
+.PP
+	daft init my\-project
+.PP
+Create a new branch with its own worktree:
+.PP
+	daft start feature/login
+.PP
+Switch to an existing branch's worktree:
+.PP
+	daft go feature/login
+.PP
+List all worktrees with status info:
+.PP
+	daft list
+.PP
+Update the current worktree from its remote:
+.PP
+	daft update
+.PP
+Sync every worktree with its remote (prune + update all):
+.PP
+	daft sync
+.PP
+Transfer uncommitted changes to another worktree:
+.PP
+	daft carry feature/login
+.PP
+Delete a branch and its worktree:
+.PP
+	daft remove feature/login
+.PP
+Rename a branch and move its worktree:
+.PP
+	daft rename feature/login feature/auth
 .SH SUBCOMMANDS
 .TP
 daft\-clone(1)

--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -1,7 +1,9 @@
-/// Documentation command for `git daft`
+/// Documentation command for `daft` and `git daft`
 ///
 /// Shows daft commands in git-style help format, dynamically extracting
-/// descriptions from clap command definitions.
+/// descriptions from clap command definitions. Renders a different command
+/// surface depending on whether the binary is invoked as `daft` (daft-verb
+/// style) or as `git daft` (Git `worktree-<command>` style).
 use anyhow::Result;
 use clap::{Command, CommandFactory};
 use std::path::Path;
@@ -10,11 +12,30 @@ use crate::commands::{
     carry, checkout, clone, config, doctor, fetch, flow_adopt, flow_eject, hooks, init, layout,
     list, multi_remote, prune, release_notes, shared, shell_init, shortcuts, sync, worktree_branch,
 };
+use crate::styles;
+
+/// Invocation style determines which command surface to render.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Mode {
+    /// Invoked as `daft` — render short daft-verb commands (go, start, list, ...).
+    Daft,
+    /// Invoked as `git daft` — render Git-style worktree-<command> entries.
+    GitDaft,
+}
+
+/// How a category's commands are rendered.
+enum CategoryLayout {
+    /// One command per line with aligned `about` descriptions.
+    List,
+    /// Commands joined on a single line; `about` strings are omitted.
+    Inline,
+}
 
 /// A category of commands with a title and list of commands.
 struct CommandCategory {
     title: &'static str,
     commands: Vec<CommandEntry>,
+    layout: CategoryLayout,
 }
 
 /// A single command entry with its display name and clap Command.
@@ -23,11 +44,132 @@ struct CommandEntry {
     command: Command,
 }
 
-/// Get all command categories with their commands.
-fn get_command_categories() -> Vec<CommandCategory> {
+/// Get category layout for `daft` invocation — daft-verb style, everyday
+/// commands at the top.
+fn get_daft_categories() -> Vec<CommandCategory> {
+    vec![
+        CommandCategory {
+            title: "work on branches (each branch gets its own directory)",
+            layout: CategoryLayout::List,
+            commands: vec![
+                CommandEntry {
+                    display_name: "go",
+                    command: checkout::GoArgs::command(),
+                },
+                CommandEntry {
+                    display_name: "start",
+                    command: checkout::StartArgs::command(),
+                },
+            ],
+        },
+        CommandCategory {
+            title: "maintain your worktrees",
+            layout: CategoryLayout::List,
+            commands: vec![
+                CommandEntry {
+                    display_name: "list",
+                    command: list::Args::command(),
+                },
+                CommandEntry {
+                    display_name: "rename",
+                    command: worktree_branch::RenameArgs::command(),
+                },
+                CommandEntry {
+                    display_name: "remove",
+                    command: worktree_branch::RemoveArgs::command(),
+                },
+                CommandEntry {
+                    display_name: "update",
+                    command: fetch::Args::command(),
+                },
+                CommandEntry {
+                    display_name: "prune",
+                    command: prune::Args::command(),
+                },
+                CommandEntry {
+                    display_name: "sync",
+                    command: sync::Args::command(),
+                },
+            ],
+        },
+        CommandCategory {
+            title: "share changes across worktrees",
+            layout: CategoryLayout::List,
+            commands: vec![CommandEntry {
+                display_name: "carry",
+                command: carry::Args::command(),
+            }],
+        },
+        CommandCategory {
+            title: "start a worktree-based repository",
+            layout: CategoryLayout::List,
+            commands: vec![
+                CommandEntry {
+                    display_name: "clone",
+                    command: clone::Args::command(),
+                },
+                CommandEntry {
+                    display_name: "init",
+                    command: init::Args::command(),
+                },
+            ],
+        },
+        CommandCategory {
+            title: "share configuration across worktrees",
+            layout: CategoryLayout::List,
+            commands: vec![CommandEntry {
+                display_name: "shared",
+                command: shared::Args::command(),
+            }],
+        },
+        CommandCategory {
+            title: "manage daft configuration",
+            layout: CategoryLayout::Inline,
+            commands: vec![
+                CommandEntry {
+                    display_name: "config",
+                    command: config::remote_sync::Args::command(),
+                },
+                CommandEntry {
+                    display_name: "hooks",
+                    command: hooks::Args::command(),
+                },
+                CommandEntry {
+                    display_name: "layout",
+                    command: layout::LayoutArgs::command(),
+                },
+                CommandEntry {
+                    display_name: "multi-remote",
+                    command: multi_remote::Args::command(),
+                },
+                CommandEntry {
+                    display_name: "shell-init",
+                    command: shell_init::Args::command(),
+                },
+                CommandEntry {
+                    display_name: "setup shortcuts",
+                    command: shortcuts::Args::command(),
+                },
+                CommandEntry {
+                    display_name: "doctor",
+                    command: doctor::Args::command(),
+                },
+                CommandEntry {
+                    display_name: "release-notes",
+                    command: release_notes::Args::command(),
+                },
+            ],
+        },
+    ]
+}
+
+/// Get category layout for `git daft` invocation — Git-style
+/// `worktree-<command>` entries and the short-aliases footer.
+fn get_git_daft_categories() -> Vec<CommandCategory> {
     vec![
         CommandCategory {
             title: "start a worktree-based repository",
+            layout: CategoryLayout::List,
             commands: vec![
                 CommandEntry {
                     display_name: "worktree-clone",
@@ -45,6 +187,7 @@ fn get_command_categories() -> Vec<CommandCategory> {
         },
         CommandCategory {
             title: "work on branches (each branch gets its own directory)",
+            layout: CategoryLayout::List,
             commands: vec![CommandEntry {
                 display_name: "worktree-checkout",
                 command: checkout::Args::command(),
@@ -52,6 +195,7 @@ fn get_command_categories() -> Vec<CommandCategory> {
         },
         CommandCategory {
             title: "share changes across worktrees",
+            layout: CategoryLayout::List,
             commands: vec![CommandEntry {
                 display_name: "worktree-carry",
                 command: carry::Args::command(),
@@ -59,6 +203,7 @@ fn get_command_categories() -> Vec<CommandCategory> {
         },
         CommandCategory {
             title: "maintain your worktrees",
+            layout: CategoryLayout::List,
             commands: vec![
                 CommandEntry {
                     display_name: "worktree-list",
@@ -88,6 +233,7 @@ fn get_command_categories() -> Vec<CommandCategory> {
         },
         CommandCategory {
             title: "share configuration across worktrees",
+            layout: CategoryLayout::List,
             commands: vec![CommandEntry {
                 display_name: "daft shared",
                 command: shared::Args::command(),
@@ -95,6 +241,7 @@ fn get_command_categories() -> Vec<CommandCategory> {
         },
         CommandCategory {
             title: "manage daft configuration",
+            layout: CategoryLayout::List,
             commands: vec![
                 CommandEntry {
                     display_name: "daft hooks",
@@ -140,14 +287,41 @@ fn get_about(cmd: &Command) -> String {
         .unwrap_or_else(|| "(no description)".to_string())
 }
 
-/// Calculate the maximum display name length for proper alignment.
-fn max_display_name_len(categories: &[CommandCategory]) -> usize {
+/// Maximum display-name length across `List`-layout categories (used for
+/// column alignment). `Inline` categories are skipped — their names are
+/// joined on a single line and don't participate in column alignment.
+fn max_list_display_name_len(categories: &[CommandCategory]) -> usize {
     categories
         .iter()
-        .flat_map(|cat| cat.commands.iter())
-        .map(|entry| entry.display_name.len())
+        .filter(|c| matches!(c.layout, CategoryLayout::List))
+        .flat_map(|c| c.commands.iter())
+        .map(|e| e.display_name.len())
         .max()
         .unwrap_or(20)
+}
+
+/// Wrap text in bold+underline (clap's `header`/`usage` style) when color is enabled.
+fn bold_underline(text: &str, use_color: bool) -> String {
+    if use_color {
+        format!(
+            "{}{}{}{}",
+            styles::BOLD,
+            styles::UNDERLINE,
+            text,
+            styles::RESET
+        )
+    } else {
+        text.to_string()
+    }
+}
+
+/// Wrap text in bold (clap's `literal` style) when color is enabled.
+fn bold(text: &str, use_color: bool) -> String {
+    if use_color {
+        styles::bold(text)
+    } else {
+        text.to_string()
+    }
 }
 
 pub fn run() -> Result<()> {
@@ -160,36 +334,103 @@ pub fn run() -> Result<()> {
         .and_then(|n| n.to_str())
         .unwrap_or("daft");
 
-    // Determine primary/secondary invocation style based on how we were called
-    let (primary, secondary) = if program_name == "git-daft" {
-        ("git", "daft")
+    let mode = if program_name == "git-daft" {
+        Mode::GitDaft
     } else {
-        ("daft", "git")
+        Mode::Daft
     };
 
-    println!("usage: daft <command> [<args>]");
-    println!("   or: {primary} worktree-<command> [<args>]");
-    println!("   or: {secondary} worktree-<command> [<args>]");
+    match mode {
+        Mode::Daft => render_daft(),
+        Mode::GitDaft => render_git_daft(),
+    }
+}
+
+/// Render daft-style help (invoked as `daft`): short verbs, everyday
+/// commands first, clap-matching styling.
+fn render_daft() -> Result<()> {
+    let use_color = styles::colors_enabled();
+    let categories = get_daft_categories();
+    let max_len = max_list_display_name_len(&categories);
+
+    println!(
+        "{} daft <command> [<args>]",
+        bold_underline("usage:", use_color)
+    );
 
     println!();
     println!("These are common daft commands used in various situations:");
 
-    let categories = get_command_categories();
-    let max_len = max_display_name_len(&categories);
+    for category in &categories {
+        println!();
+        println!("{}", bold_underline(category.title, use_color));
+
+        match category.layout {
+            CategoryLayout::List => {
+                for entry in &category.commands {
+                    let about = get_about(&entry.command);
+                    // Pad from raw display_name length — ANSI escapes are
+                    // zero-width visually but would otherwise skew `{:width$}`.
+                    let pad = " ".repeat(max_len.saturating_sub(entry.display_name.len()));
+                    let name = bold(entry.display_name, use_color);
+                    println!("   {name}{pad}   {about}");
+                }
+            }
+            CategoryLayout::Inline => {
+                let names: Vec<String> = category
+                    .commands
+                    .iter()
+                    .map(|e| bold(e.display_name, use_color))
+                    .collect();
+                println!("   {}", names.join(", "));
+            }
+        }
+    }
+
+    println!();
+    println!(
+        "'daft {} --help' to read about a specific command.",
+        bold("<command>", use_color)
+    );
+    println!("Equivalent 'git worktree-<command>' forms also exist — run 'git daft' to see them.");
+    println!("See https://github.com/avihut/daft for documentation.");
+
+    Ok(())
+}
+
+/// Render Git-style help (invoked as `git daft`): `worktree-<command>`
+/// entries and the short-aliases footer. Unstyled, like today.
+fn render_git_daft() -> Result<()> {
+    println!("usage: daft <command> [<args>]");
+    println!("   or: git worktree-<command> [<args>]");
+    println!("   or: daft worktree-<command> [<args>]");
+
+    println!();
+    println!("These are common daft commands used in various situations:");
+
+    let categories = get_git_daft_categories();
+    let max_len = max_list_display_name_len(&categories);
 
     for category in &categories {
         println!();
         println!("{}", category.title);
 
-        for entry in &category.commands {
-            let about = get_about(&entry.command);
-            // Pad the display name for alignment
-            println!(
-                "   {:width$}   {}",
-                entry.display_name,
-                about,
-                width = max_len
-            );
+        match category.layout {
+            CategoryLayout::List => {
+                for entry in &category.commands {
+                    let about = get_about(&entry.command);
+                    println!(
+                        "   {:width$}   {}",
+                        entry.display_name,
+                        about,
+                        width = max_len
+                    );
+                }
+            }
+            CategoryLayout::Inline => {
+                let names: Vec<&str> = category.commands.iter().map(|e| e.display_name).collect();
+                println!("   {}", names.join(", "));
+            }
         }
     }
 
@@ -200,7 +441,7 @@ pub fn run() -> Result<()> {
     println!("   clone, init, carry, update, list, prune, rename, sync, remove, adopt, eject");
 
     println!();
-    println!("'{primary} worktree-<command> --help' to read about a specific command.");
+    println!("'git worktree-<command> --help' to read about a specific command.");
     println!("See https://github.com/avihut/daft for documentation.");
 
     Ok(())

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -409,6 +409,90 @@ fn main() -> Result<()> {
     }
 }
 
+/// Escape roff-sensitive characters. `clap_mangen` applies the same
+/// treatment to text it renders, so post-inserted sections should match.
+fn roff_escape(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('-', "\\-")
+}
+
+/// Build a `.SH EXAMPLES` section from `(comment, command)` pairs and splice
+/// it into a rendered man page just before `.SH SUBCOMMANDS`, following the
+/// indented-command style already used elsewhere in the top-level page.
+fn insert_examples_section(roff: &str, examples: &[(&str, &str)]) -> String {
+    if examples.is_empty() {
+        return roff.to_string();
+    }
+
+    let mut section = String::new();
+    section.push_str(".SH EXAMPLES\n");
+    for (i, (comment, cmd)) in examples.iter().enumerate() {
+        if i > 0 {
+            section.push_str(".PP\n");
+        }
+        section.push_str(&roff_escape(comment));
+        section.push('\n');
+        section.push_str(".PP\n");
+        section.push('\t');
+        section.push_str(&roff_escape(cmd));
+        section.push('\n');
+    }
+
+    // Insert before `.SH SUBCOMMANDS` when present; otherwise append.
+    if let Some(idx) = roff.find("\n.SH SUBCOMMANDS") {
+        let (before, after) = roff.split_at(idx + 1);
+        format!("{before}{section}{after}")
+    } else {
+        let mut out = roff.to_string();
+        if !out.ends_with('\n') {
+            out.push('\n');
+        }
+        out.push_str(&section);
+        out
+    }
+}
+
+/// Top-level man-page examples. Rendered into `.SH EXAMPLES` by
+/// [`insert_examples_section`], one block per `(comment, command)` pair.
+const DAFT_MAN_EXAMPLES: &[(&str, &str)] = &[
+    (
+        "Clone a repository into a worktree-based layout:",
+        "daft clone git@github.com:user/repo.git",
+    ),
+    (
+        "Initialize a new repository in the worktree layout:",
+        "daft init my-project",
+    ),
+    (
+        "Create a new branch with its own worktree:",
+        "daft start feature/login",
+    ),
+    (
+        "Switch to an existing branch's worktree:",
+        "daft go feature/login",
+    ),
+    ("List all worktrees with status info:", "daft list"),
+    (
+        "Update the current worktree from its remote:",
+        "daft update",
+    ),
+    (
+        "Sync every worktree with its remote (prune + update all):",
+        "daft sync",
+    ),
+    (
+        "Transfer uncommitted changes to another worktree:",
+        "daft carry feature/login",
+    ),
+    (
+        "Delete a branch and its worktree:",
+        "daft remove feature/login",
+    ),
+    (
+        "Rename a branch and move its worktree:",
+        "daft rename feature/login feature/auth",
+    ),
+];
+
 /// Build a top-level `daft` clap Command with all subcommands for man page generation.
 fn build_top_level_command() -> clap::Command {
     use clap::CommandFactory;
@@ -421,17 +505,7 @@ fn build_top_level_command() -> clap::Command {
              subcommands (git worktree-clone, git worktree-checkout, ...) and short \
              verb aliases (daft clone, daft go, daft start, ...).\n\n\
              Run 'daft' with no arguments to see a categorized command overview.\n\n\
-             GETTING STARTED\n\n\
-             Clone a repository into a worktree layout:\n\n\
-             \tdaft clone <url>\n\n\
-             Or adopt an existing repository:\n\n\
-             \tdaft adopt\n\n\
-             Switch to a branch (each branch gets its own directory):\n\n\
-             \tdaft go <branch>\n\n\
-             Create a new branch:\n\n\
-             \tdaft start <branch>\n\n\
-             SHELL INTEGRATION\n\n\
-             Enable automatic cd into new worktrees:\n\n\
+             To enable automatic cd into new worktrees, add the shell integration:\n\n\
              \teval \"$(daft shell-init zsh)\"\n\n\
              See daft-shell-init(1) for details.",
         )
@@ -551,8 +625,11 @@ fn generate_man_pages(output_dir: &PathBuf, command: Option<&str>) -> Result<()>
         let mut buffer = Vec::new();
         man.render(&mut buffer)?;
 
+        let roff = String::from_utf8(buffer).context("Generated man page is not valid UTF-8")?;
+        let roff = insert_examples_section(&roff, DAFT_MAN_EXAMPLES);
+
         let file_path = output_dir.join("daft.1");
-        fs::write(&file_path, &buffer)
+        fs::write(&file_path, roff.as_bytes())
             .with_context(|| format!("Failed to write man page: {}", file_path.display()))?;
 
         eprintln!("Generated: {}", file_path.display());
@@ -1044,6 +1121,37 @@ mod tests {
     #[test]
     fn test_unknown_command_returns_none() {
         assert!(get_command_for_name("unknown-command").is_none());
+    }
+
+    #[test]
+    fn test_insert_examples_section_splices_before_subcommands() {
+        let roff = ".SH OPTIONS\nstuff\n.SH SUBCOMMANDS\nsubs\n";
+        let out = insert_examples_section(
+            roff,
+            &[("Clone into a worktree layout:", "daft clone <url>")],
+        );
+        let ex_idx = out.find(".SH EXAMPLES").expect("EXAMPLES section missing");
+        let sub_idx = out.find(".SH SUBCOMMANDS").expect("SUBCOMMANDS missing");
+        assert!(ex_idx < sub_idx, "EXAMPLES must precede SUBCOMMANDS");
+        // Hyphens escaped (matches clap_mangen's output style).
+        assert!(out.contains("daft clone \\<url\\>") || out.contains("daft clone <url>"));
+        assert!(out.contains("worktree layout"));
+    }
+
+    #[test]
+    fn test_insert_examples_section_empty_is_noop() {
+        let roff = ".SH OPTIONS\nx\n.SH SUBCOMMANDS\n";
+        assert_eq!(insert_examples_section(roff, &[]), roff);
+    }
+
+    #[test]
+    fn test_insert_examples_section_escapes_hyphens() {
+        let out = insert_examples_section(
+            ".SH SUBCOMMANDS\n",
+            &[("Start a long-lived branch:", "daft start feature-x")],
+        );
+        assert!(out.contains("long\\-lived"));
+        assert!(out.contains("feature\\-x"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Top-level `daft` help** restructured around short verbs (go, start, list, rename, remove, update, prune, sync, carry, clone, init, shared), with everyday commands on top, a collapsed config block at the bottom, and clap-matching bold+underline styling for headings. Deprecated `adopt`/`eject` removed from the daft-mode surface.
- **`git daft` help** unchanged: keeps the Git-style `worktree-<command>` listing and short-aliases footer — it's a better surface for users coming from the Git CLI.
- **`daft(1)` man page** gains a dedicated `EXAMPLES` section (spliced in before `SUBCOMMANDS`) covering clone, init, start, go, list, update, sync, carry, remove, and rename. The duplicated GETTING STARTED block in DESCRIPTION is removed.
- Added three unit tests around the new `insert_examples_section` helper (splice position, no-op on empty, hyphen escaping).

## Test plan

- [x] `mise run fmt:check` clean
- [x] `mise run clippy` clean (zero warnings)
- [x] `mise run test:unit` passes
- [x] `cargo test --package xtask` passes (50 existing + 3 new)
- [x] `mise run man:verify` passes (lefthook ran it on commit)
- [x] Visually inspected `daft` vs `git daft` output (color and `NO_COLOR`)
- [x] Rendered `man daft.1` — EXAMPLES section lays out cleanly after OPTIONS

🤖 Generated with [Claude Code](https://claude.com/claude-code)