### PR TITLE
fix(sync): exclude rebase base branch from push

### DIFF
--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -330,6 +330,12 @@ fn run_sequential(args: Args, settings: DaftSettings) -> Result<()> {
     if args.push {
         // When ownership filtering is active, skip unowned branches from push.
         let mut push_skip = conflicted_branches.clone();
+        // Never push the rebase base branch: it was used only as a local rebase
+        // target, and pushing it could clobber commits other devs landed between
+        // fetch and sync completion.
+        if let Some(ref base) = args.rebase {
+            push_skip.insert(base.clone());
+        }
         if let Some(ref included) = included_branches {
             // Collect all worktree branches and skip those not included.
             let git_tmp = GitCommand::new(output.is_quiet()).with_gitoxide(settings.use_gitoxide);

--- a/src/core/worktree/sync_dag.rs
+++ b/src/core/worktree/sync_dag.rs
@@ -297,8 +297,14 @@ impl SyncDag {
         }
 
         // 5. Push tasks ONLY for owned worktrees (if push is enabled).
+        // The rebase base branch is excluded: daft only used its locally-fetched
+        // tip as a rebase target, so pushing it could overwrite commits other
+        // contributors landed between fetch and sync completion.
         if push {
             for (branch, path, last_idx) in &last_task_indices {
+                if rebase_branch.as_ref() == Some(branch) {
+                    continue;
+                }
                 push_task(
                     SyncTask {
                         id: TaskId::Push(branch.clone()),
@@ -864,23 +870,19 @@ mod tests {
 
         let dag = SyncDag::build_sync(worktrees, vec![], gone, Some("master".into()), true);
 
-        // 1 fetch + 3 updates + 2 rebases + 3 pushes = 9 tasks
-        assert_eq!(dag.tasks.len(), 9);
+        // 1 fetch + 3 updates + 2 rebases + 2 pushes = 8 tasks.
+        // master is the rebase base, so it gets neither a Rebase nor a Push task —
+        // pushing the base branch could clobber commits landed by other devs
+        // between the initial fetch and sync completion.
+        assert_eq!(dag.tasks.len(), 8);
 
-        // Push(master) depends on Update(master), not Rebase (master is the base branch)
-        let push_master_idx = dag
-            .tasks
-            .iter()
-            .position(|t| t.id == TaskId::Push("master".into()))
-            .unwrap();
-        let update_master_idx = dag
-            .tasks
-            .iter()
-            .position(|t| t.id == TaskId::Update("master".into()))
-            .unwrap();
-        assert!(dag
-            .dependencies_of(push_master_idx)
-            .contains(&update_master_idx));
+        // No Push(master) task — base branch is excluded from push.
+        assert!(
+            !dag.tasks
+                .iter()
+                .any(|t| t.id == TaskId::Push("master".into())),
+            "rebase base branch must not be pushed"
+        );
 
         // Push(feat/a) depends on Rebase(feat/a)
         let push_feat_a_idx = dag
@@ -897,6 +899,20 @@ mod tests {
             dag.dependencies_of(push_feat_a_idx)
                 .contains(&rebase_feat_a_idx),
             "Push(feat/a) should depend on Rebase(feat/a)"
+        );
+    }
+
+    #[test]
+    fn rebase_base_branch_excluded_from_push_even_when_only_owned_branch() {
+        // Edge case: if the base branch is the only owned worktree, no push tasks
+        // should be emitted at all — there is nothing else to push, and the base
+        // branch itself must not be pushed.
+        let worktrees = vec![("master".into(), Some(PathBuf::from("/p/master")))];
+        let dag = SyncDag::build_sync(worktrees, vec![], vec![], Some("master".into()), true);
+
+        assert!(
+            !dag.tasks.iter().any(|t| matches!(t.id, TaskId::Push(_))),
+            "no push tasks expected when the only owned branch is the rebase base"
         );
     }
 

--- a/tests/manual/scenarios/sync/rebase-base-not-pushed.yml
+++ b/tests/manual/scenarios/sync/rebase-base-not-pushed.yml
@@ -1,0 +1,78 @@
+name: "Sync rebase base branch is not pushed"
+description:
+  "When --rebase BRANCH and --push are combined, BRANCH itself must not be
+  pushed — it was only used as a local rebase target. Pushing it could clobber
+  commits landed by other contributors between fetch and sync completion."
+
+repos:
+  - name: rebase-base-push-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone the repository
+    run: git-worktree-clone --layout contained $REMOTE_REBASE_BASE_PUSH_REPO
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/rebase-base-push-repo/main"
+
+  - name: Set local user email so develop is "owned"
+    run: git config user.email "me@example.com"
+    cwd: "$WORK_DIR/rebase-base-push-repo/main"
+    expect:
+      exit_code: 0
+
+  - name: Checkout develop branch
+    run: git-worktree-checkout develop
+    cwd: "$WORK_DIR/rebase-base-push-repo/main"
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/rebase-base-push-repo/develop"
+
+  - name: Make an owned commit on develop
+    run: |
+      echo "owned change" > owned.txt
+      git add owned.txt
+      GIT_AUTHOR_EMAIL="me@example.com" GIT_COMMITTER_EMAIL="me@example.com" \
+        git commit -m "Owned commit on develop"
+    cwd: "$WORK_DIR/rebase-base-push-repo/develop"
+    expect:
+      exit_code: 0
+
+  - name: Advance main on remote to simulate another contributor's commit
+    run: |
+      tmp=$(mktemp -d)
+      git clone "$REMOTE_REBASE_BASE_PUSH_REPO" "$tmp" 2>/dev/null
+      cd "$tmp"
+      echo "remote main change" > remote-advance.txt
+      git add remote-advance.txt
+      git commit -m "Other dev advanced main on remote" 2>/dev/null
+      git push origin main 2>/dev/null
+      rm -rf "$tmp"
+    expect:
+      exit_code: 0
+
+  - name: Record remote main ref before sync
+    run: |
+      git ls-remote "$REMOTE_REBASE_BASE_PUSH_REPO" main | awk '{print $1}' > /tmp/daft-rebase-base-push-main-before
+    cwd: "$WORK_DIR/rebase-base-push-repo/main"
+    expect:
+      exit_code: 0
+
+  - name: Run sync with --rebase main --push (force sequential path)
+    run: |
+      git-worktree-sync --rebase main --push --force-with-lease --verbose --verbose 2>&1
+    cwd: "$WORK_DIR/rebase-base-push-repo/main"
+    expect:
+      exit_code: 0
+
+  - name: Verify remote main was NOT touched by daft
+    run: |
+      before=$(cat /tmp/daft-rebase-base-push-main-before)
+      after=$(git ls-remote "$REMOTE_REBASE_BASE_PUSH_REPO" main | awk '{print $1}')
+      echo "before=$before after=$after"
+      [ "$before" = "$after" ]
+    cwd: "$WORK_DIR/rebase-base-push-repo/main"
+    expect:
+      exit_code: 0


### PR DESCRIPTION
## Summary

`daft sync --rebase BRANCH --push` was pushing `BRANCH` itself alongside the rebased branches. In multi-dev environments this opens a race window between the initial fetch and sync completion: another contributor can advance the remote `BRANCH`, and our locally-fetched tip (combined with `--force-with-lease`) can end up overwriting their work.

The base branch is only consulted as a local rebase target — daft has no mandate to publish it.

- **TUI path** (`SyncDag::build_sync`): filter the base branch out of the push loop.
- **Sequential path** (`run_sequential`): insert `args.rebase` into `push_skip` before `run_push_phase`.

## Test plan

- [x] Unit: updated `build_sync_dag_with_push_and_rebase` to assert no `Push(master)` task when `master` is the rebase base
- [x] Unit: new `rebase_base_branch_excluded_from_push_even_when_only_owned_branch` edge-case
- [x] YAML scenario `sync:rebase-base-not-pushed`: advances remote `main` between clone and sync, asserts the remote ref is byte-identical after `daft sync --rebase main --push --force-with-lease -vv`
- [x] Existing `sync:rebase-conflict-skips-push` and `sync:ownership-rebase-push` still pass
- [x] `mise run fmt`, `mise run clippy`, `mise run test:unit` all clean