### PR TITLE
fix(tests): tolerate per-test cleanup races in integration suite

### DIFF
--- a/tests/integration/test_framework.sh
+++ b/tests/integration/test_framework.sh
@@ -328,8 +328,11 @@ run_test() {
         FAILED_TESTS+=("$test_name")
     fi
     
-    # Clean up test directory
-    rm -rf "$test_work_dir"
+    # Tolerate failure: on macOS, a lingering daft subprocess handle inside
+    # the dir makes `rm -rf` exit non-zero, which `set -e` would otherwise
+    # turn into a silent mid-suite abort. Trap-based final cleanup catches
+    # whatever survives.
+    rm -rf "$test_work_dir" 2>/dev/null || true
 }
 
 # Create a test remote repository


### PR DESCRIPTION
## Summary

- Suppress per-test cleanup errors in `tests/integration/test_framework.sh:332` so a lingering subprocess handle (fetch/lock/mmap, etc.) doesn't trigger `set -e` and silently abort the matrix entry on macOS.
- The trap-based final cleanup at suite end still wipes whatever survives, so no actual leakage.

## Why

`mise run test:integration` flakes non-deterministically on macOS: whichever bash leg (`default` or `gitoxide`) runs first aborts mid-suite right after `fetch_force` passes. Standalone runs of either leg pass. Reproduced on `master` (528521c5), so this is pre-existing test infrastructure, not a feature regression.

The failing leg's last lines are:

```
[✓] Integration test passed: fetch_force
rm: .../test_<ts>/test-repo-fetch-force/.git/objects/pack: Directory not empty
...
```

`fetch_force` spawns several `git-worktree-fetch` invocations in a short window; on macOS one of those subprocesses occasionally still has an open handle inside `$test_work_dir` when `run_test`'s cleanup runs. `rm -rf` exits non-zero, `set -eo pipefail` (`test_framework.sh:6`) propagates, and `test_all.sh` aborts with no failed assertion — the matrix entry exits FAIL with no diagnostic.

This is the symptomatic fix from issue #379 (option 1). Per-entry `TEMP_BASE_DIR` isolation (option 2) is a worthwhile follow-up if cross-leg flakes resurface.

## Test plan

- [x] `mise run fmt:check`
- [x] `mise run clippy`
- [x] `mise run test:unit` (1175 passed)
- [ ] CI runs the full integration matrix; watch for the flake recurring

No regression test added: the flake is timing/handle-dependent and reliably reproducing it would require staging a subprocess that holds an fd inside the test dir — more scaffolding than the symptomatic fix warrants.

Fixes #379

🤖 Generated with [Claude Code](https://claude.com/claude-code)