### PR TITLE
fix(exec): center header, fix stuck timer, brighten command preview

### DIFF
--- a/src/core/worktree/exec/list_renderer.rs
+++ b/src/core/worktree/exec/list_renderer.rs
@@ -15,31 +15,36 @@ pub fn render_header<W: Sink>(
     target_count: usize,
     pipeline: &[CommandSpec],
 ) -> std::io::Result<()> {
+    writeln!(sink, "{}", format_header_line(target_count, pipeline.len()))
+}
+
+const HEADER_WIDTH: usize = 60;
+const HEADER_MIN_SIDE_DASHES: usize = 4;
+
+/// Format the scope-summary divider with the summary horizontally centered
+/// inside the divider. Width is fixed; padding on either side of the summary
+/// is balanced (right side absorbs the remainder when the gap is odd).
+pub(super) fn format_header_line(target_count: usize, command_count: usize) -> String {
     let wt_label = if target_count == 1 {
         "worktree"
     } else {
         "worktrees"
     };
-    let cmd_label = if pipeline.len() == 1 {
+    let cmd_label = if command_count == 1 {
         "command"
     } else {
         "commands"
     };
-    let summary = format!(
-        "{} {} · {} {}",
-        target_count,
-        wt_label,
-        pipeline.len(),
-        cmd_label,
-    );
-    const TOTAL_WIDTH: usize = 60;
-    const PREFIX_DASHES: usize = 8;
-    let summary_cols = summary.chars().count() + 2;
-    let suffix_dashes = TOTAL_WIDTH.saturating_sub(PREFIX_DASHES + summary_cols);
-    writeln!(
-        sink,
+    let summary = format!("{target_count} {wt_label} · {command_count} {cmd_label}");
+    let summary_cols = summary.chars().count() + 2; // include surrounding spaces
+    let total_dashes = HEADER_WIDTH
+        .saturating_sub(summary_cols)
+        .max(HEADER_MIN_SIDE_DASHES * 2);
+    let prefix_dashes = total_dashes / 2;
+    let suffix_dashes = total_dashes - prefix_dashes;
+    format!(
         "{} {summary} {}",
-        "─".repeat(PREFIX_DASHES),
+        "─".repeat(prefix_dashes),
         "─".repeat(suffix_dashes),
     )
 }
@@ -101,4 +106,50 @@ pub fn render_failed_output_dump<W: Sink>(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn split_dashes(line: &str, summary: &str) -> (usize, usize) {
+        let needle = format!(" {summary} ");
+        let idx = line.find(&needle).expect("summary not found in header");
+        let prefix = line[..idx].chars().count();
+        let suffix = line[idx + needle.len()..].chars().count();
+        (prefix, suffix)
+    }
+
+    #[test]
+    fn header_summary_is_horizontally_centered() {
+        // Regression: previously the header used 8 fixed leading dashes,
+        // which left the summary visibly left-of-center. After the fix,
+        // prefix and suffix dash counts must differ by at most 1.
+        let line = format_header_line(4, 1);
+        let (prefix, suffix) = split_dashes(&line, "4 worktrees · 1 command");
+        assert!(
+            prefix.abs_diff(suffix) <= 1,
+            "expected centered divider, got prefix={prefix} suffix={suffix}: {line}"
+        );
+    }
+
+    #[test]
+    fn header_total_width_matches_constant() {
+        let line = format_header_line(2, 3);
+        assert_eq!(
+            line.chars().count(),
+            HEADER_WIDTH,
+            "header line must occupy {HEADER_WIDTH} columns"
+        );
+    }
+
+    #[test]
+    fn header_handles_summary_overflowing_total_width() {
+        // If the summary itself is wider than HEADER_WIDTH, fall back to
+        // the minimum side dashes rather than producing a malformed line.
+        let line = format_header_line(12345678, 87654321);
+        let (prefix, suffix) = split_dashes(&line, "12345678 worktrees · 87654321 commands");
+        assert!(prefix >= HEADER_MIN_SIDE_DASHES);
+        assert!(suffix >= HEADER_MIN_SIDE_DASHES);
+    }
 }

--- a/src/output/hook_progress/interactive.rs
+++ b/src/output/hook_progress/interactive.rs
@@ -6,7 +6,9 @@ use crate::settings::HookOutputConfig;
 use crate::styles;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use std::collections::HashMap;
-use std::time::{Duration, Instant};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
 
 struct JobState {
     spinner: ProgressBar,
@@ -14,8 +16,14 @@ struct JobState {
     tail_lines: Vec<ProgressBar>,
     trailer: Option<ProgressBar>,
     output_buffer: Vec<String>,
-    start_time: Instant,
     command_preview: Option<String>,
+    /// Set to true once the spinner template has been swapped to include
+    /// the elapsed-time suffix. Driven by a per-job background thread so
+    /// the swap fires on a wall-clock deadline regardless of whether the
+    /// job has emitted any output. Only consumed by tests; the production
+    /// path observes the swap via the spinner re-rendering.
+    #[cfg_attr(not(test), allow(dead_code))]
+    timer_promoted: Arc<AtomicBool>,
 }
 
 pub struct HookProgressRenderer {
@@ -130,8 +138,7 @@ impl HookProgressRenderer {
 
         let display_name = match command_preview {
             Some(cmd) if self.use_color => format!(
-                "{ORANGE}{name}{}  {arrow} {DARK_GREY}{cmd}{}",
-                styles::RESET,
+                "{ORANGE}{name}{}  {arrow} {cmd}",
                 styles::RESET,
                 arrow = self.arrow_str,
             ),
@@ -171,6 +178,23 @@ impl HookProgressRenderer {
         trailer.set_style(self.trailer_style.clone());
         trailer.set_message(String::new());
 
+        // Spawn a one-shot promoter that swaps the spinner template to include
+        // the elapsed-time suffix once the configured delay elapses. This must
+        // run on a wall-clock deadline rather than being gated on output
+        // arrival, because long-running silent jobs (e.g. `cargo build` stuck
+        // on `Compiling …` for tens of seconds) would otherwise never get a
+        // visible timer.
+        let timer_promoted = Arc::new(AtomicBool::new(false));
+        let delay = Duration::from_secs(u64::from(self.config.timer_delay_secs));
+        let promoted_for_thread = Arc::clone(&timer_promoted);
+        let spinner_for_thread = spinner.clone();
+        let timer_style = self.spinner_style_with_timer.clone();
+        std::thread::spawn(move || {
+            std::thread::sleep(delay);
+            spinner_for_thread.set_style(timer_style);
+            promoted_for_thread.store(true, Ordering::SeqCst);
+        });
+
         // Separator and tail bars are created lazily in update_job_output as output arrives.
         self.jobs.insert(
             name.to_string(),
@@ -180,31 +204,27 @@ impl HookProgressRenderer {
                 tail_lines: Vec::new(),
                 trailer: Some(trailer),
                 output_buffer: Vec::new(),
-                start_time: Instant::now(),
                 command_preview: command_preview.map(str::to_string),
+                timer_promoted,
             },
         );
     }
 
     pub fn update_job_output(&mut self, name: &str, line: &str) {
-        // Phase 1: buffer line, update timer, determine growth needs.
-        // Clone ProgressBar anchors before releasing the jobs borrow so
-        // Phase 2/3 can call self.mp without a conflicting borrow.
-        // ProgressBar is Arc-based; cloning is cheap.
+        // Phase 1: buffer line, determine growth needs. Clone ProgressBar
+        // anchors before releasing the jobs borrow so Phase 2/3 can call
+        // self.mp without a conflicting borrow. ProgressBar is Arc-based;
+        // cloning is cheap.
+        // The spinner-style swap to include `{elapsed_precise}` is handled
+        // by the per-job promoter thread spawned in
+        // `start_job_with_description` — driving it from this function would
+        // miss long-running silent jobs that produce no further output.
         let (needs_sep, needs_tail, spinner_clone, last_anchor_clone) = {
             let Some(state) = self.jobs.get_mut(name) else {
                 return;
             };
 
             state.output_buffer.push(line.to_string());
-
-            if state.start_time.elapsed()
-                >= Duration::from_secs(u64::from(self.config.timer_delay_secs))
-            {
-                state
-                    .spinner
-                    .set_style(self.spinner_style_with_timer.clone());
-            }
 
             // Nothing to display when quiet or tail_lines == 0.
             if self.config.quiet || self.config.tail_lines == 0 {
@@ -503,6 +523,14 @@ impl HookProgressRenderer {
         self.jobs
             .get(name)
             .map(|s| s.trailer.is_some())
+            .unwrap_or(false)
+    }
+
+    #[cfg(test)]
+    pub fn timer_promoted(&self, name: &str) -> bool {
+        self.jobs
+            .get(name)
+            .map(|s| s.timer_promoted.load(Ordering::SeqCst))
             .unwrap_or(false)
     }
 

--- a/src/output/hook_progress/mod.rs
+++ b/src/output/hook_progress/mod.rs
@@ -571,6 +571,34 @@ mod tests {
     }
 
     #[test]
+    fn timer_promotes_on_wall_clock_even_without_output() {
+        // Regression for daft exec spinners that never showed an elapsed
+        // timer when the job was long-running but silent (e.g. cargo
+        // compiling a single crate for tens of seconds with no new stdout).
+        // The promotion must fire on a wall-clock deadline driven from
+        // `start_job`, not from `update_job_output`.
+        let config = HookOutputConfig {
+            timer_delay_secs: 0,
+            ..Default::default()
+        };
+        let mut renderer = HookProgressRenderer::new_hidden(&config);
+        renderer.start_job("silent-job", None);
+
+        // Promotion is performed by a detached thread; poll briefly rather
+        // than relying on a timing-fragile fixed sleep.
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        while !renderer.timer_promoted("silent-job") && std::time::Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(
+            renderer.timer_promoted("silent-job"),
+            "spinner timer must be promoted on a wall-clock deadline even when the job emits no output"
+        );
+
+        renderer.finish_job_success("silent-job", Duration::from_secs(1));
+    }
+
+    #[test]
     fn plain_compact_finalization_cancelled_records_outcome() {
         let mut renderer = PlainHookRenderer::new();
         renderer.set_compact_finalization(true);


### PR DESCRIPTION
## Summary

Three rendering fixes to the live UI of `daft exec` against multiple worktrees:

- **Header centering** — the scope-summary line previously used a fixed 8-char prefix, leaving the summary visibly left-of-center. Prefix/suffix dashes are now balanced so the summary sits in the middle of the 60-column divider.
- **Stuck spinner timer** — the elapsed-time suffix was promoted onto the spinner only inside `update_job_output`, so a long-running silent job (`Compiling daft …` for tens of seconds with no fresh stdout) never received the `[HH:MM:SS]` suffix. Promotion is now driven by a per-job one-shot thread that fires on a wall-clock deadline.
- **Readable command preview** — the in-flight `❯ <cmd>` rendered in DARK_GREY (palette 240), which is barely distinguishable from the background on dark themes. The color is dropped so the in-flight preview matches the post-run rows, which already use the default foreground.

## Test plan

- [x] `mise run fmt:check`
- [x] `mise run clippy`
- [x] `mise run test:unit` — 1179 passed
- [x] `mise run test:manual --ci` — 440 scenarios / 1561 steps passed
- [x] New regression tests:
  - `format_header_line` centering invariant + total-width preservation + overflow-summary fallback
  - `timer_promotes_on_wall_clock_even_without_output` — proves the timer suffix appears even when the job emits no stdout past the threshold
- [ ] Manual visual check of `daft exec --all -- mise dev` against ≥2 worktrees on a slow build

🤖 Generated with [Claude Code](https://claude.com/claude-code)