### PR TITLE
fix(ci): skip cargo package verify in release-plz

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -6,6 +6,11 @@ git_release_enable = false
 pr_labels = ["release"]
 # We don't publish to crates.io
 publish = false
+# Skip the cargo package --verify compile step. release-plz runs it in a temp
+# worktree without honoring our committed Cargo.lock, so it re-resolves from
+# scratch and lands on a broken winnow / gix-object combo that our lockfile
+# avoids. Since publish = false, the verify compile buys us nothing.
+publish_no_verify = true
 # Use git tags for version comparison instead of cargo registry
 # This is required because our crates.io version (0.1.5) is stale
 git_only = true


### PR DESCRIPTION
## Summary

- Release-plz's `release-pr` job has been failing on every push since `1e9dc5be` ("commit Cargo.lock and bump gix to 0.82").
- Root cause: release-plz runs `cargo package --verify` in a temp worktree that doesn't honor our committed `Cargo.lock`. The fresh re-resolution lands on `gix-object 0.58.0` plus the conflicting `winnow 0.7` / `winnow 1.0` combo our committed lockfile avoids, and the verify compile fails with `E0308: mismatched types` in `gix-object/src/parse.rs`.
- Fix: set `publish_no_verify = true` in `release-plz.toml`. We already have `publish = false` and `git_only = true`, so the verify compile is wasted work and the only thing the failure blocks is the release PR itself.

Fixes the failures on runs `24902568140`, `24904539960`, `24935294546`, and `24935994208`.

## Test plan

- [ ] Merge to `master` and confirm the next Release-plz workflow run goes green
- [ ] Verify the auto-created release PR still gets the `release` label and triggers the man-page regeneration step