### PR TITLE
chore: revert publish_no_verify in release-plz.toml

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -6,11 +6,6 @@ git_release_enable = false
 pr_labels = ["release"]
 # We don't publish to crates.io
 publish = false
-# Skip the cargo package --verify compile step. release-plz runs it in a temp
-# worktree without honoring our committed Cargo.lock, so it re-resolves from
-# scratch and lands on a broken winnow / gix-object combo that our lockfile
-# avoids. Since publish = false, the verify compile buys us nothing.
-publish_no_verify = true
 # Use git tags for version comparison instead of cargo registry
 # This is required because our crates.io version (0.1.5) is stale
 git_only = true


### PR DESCRIPTION
## Summary

- Reverts the `publish_no_verify = true` change from #405.
- Per the release-plz docs, that option only governs `cargo publish` — release-plz still runs `cargo package --verify` in the `release-pr` diff path, so the option doesn't gate the failure.
- The actual failure is that `release-pr` packages the previous released tag (`v1.7.2`), whose `Cargo.toml` pins `gix = "0.81"` and which has no committed `Cargo.lock`. Fresh resolution lands on the broken `winnow` / `gix-object 0.58` combo. Fix is to cut a release so the diff baseline becomes a tag that has `gix 0.82` + lockfile — sent in a separate PR.

## Test plan

- [ ] CI passes (the change is a tiny TOML edit in a config file CI doesn't lint)
- [ ] After merge, Release-plz workflow still fails identically until the v1.8.0 PR lands — that's expected