### PR TITLE
chore: release v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.8.0](https://github.com/avihut/daft/compare/v1.7.2...v1.8.0) - 2026-04-25
+
+### Features
+
+- multi-format emit support (--format, --template) ([#377](https://github.com/avihut/daft/pull/377))
+- *(exec)* run commands across multiple worktrees ([#381](https://github.com/avihut/daft/pull/381))
+
+### Bug Fixes
+
+- *(tests)* tolerate per-test cleanup races in integration suite ([#401](https://github.com/avihut/daft/pull/401))
+- *(shell-init)* resolve daft binary live, drop eager path cache ([#403](https://github.com/avihut/daft/pull/403))
+- *(exec)* center header, fix stuck timer, brighten command preview ([#404](https://github.com/avihut/daft/pull/404))
+- *(ci)* skip cargo package verify in release-plz ([#405](https://github.com/avihut/daft/pull/405))
+
+### Miscellaneous
+
+- commit Cargo.lock and bump gix to 0.82 ([#382](https://github.com/avihut/daft/pull/382))
+
 ### BREAKING
 
 - The `--json` flag is removed from `daft list` and `daft release-notes`. Use

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "daft"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "daft"
-version = "1.7.2"
+version = "1.8.0"
 edition = "2021"
 description = "A comprehensive Git extensions toolkit that enhances developer workflows, starting with powerful worktree management"
 authors = ["avihu <avihu@users.noreply.github.com>"]

--- a/man/daft-adopt.1
+++ b/man/daft-adopt.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH daft-adopt 1  "daft-adopt 1.7.2" 
+.TH daft-adopt 1  "daft-adopt 1.8.0" 
 .SH NAME
 daft\-adopt \- Convert a traditional repository to worktree\-based layout
 .SH SYNOPSIS
@@ -92,4 +92,4 @@ Print version
 [\fIREPOSITORY_PATH\fR]
 Path to the repository to convert (defaults to current directory)
 .SH VERSION
-v1.7.2
+v1.8.0

--- a/man/daft-carry.1
+++ b/man/daft-carry.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH daft-carry 1  "daft-carry 1.7.2" 
+.TH daft-carry 1  "daft-carry 1.8.0" 
 .SH NAME
 daft\-carry \- Transfer uncommitted changes to other worktrees
 .SH SYNOPSIS
@@ -38,4 +38,4 @@ Print version
 <\fITARGETS\fR>
 Target worktree(s) by directory name or branch name
 .SH VERSION
-v1.7.2
+v1.8.0

--- a/man/daft-clone.1
+++ b/man/daft-clone.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH daft-clone 1  "daft-clone 1.7.2" 
+.TH daft-clone 1  "daft-clone 1.8.0" 
 .SH NAME
 daft\-clone \- Clone a repository into a worktree\-based directory structure
 .SH SYNOPSIS
@@ -69,4 +69,4 @@ Print version
 <\fIREPOSITORY_URL\fR>
 The repository URL to clone (HTTPS or SSH)
 .SH VERSION
-v1.7.2
+v1.8.0

--- a/man/daft-eject.1
+++ b/man/daft-eject.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH daft-eject 1  "daft-eject 1.7.2" 
+.TH daft-eject 1  "daft-eject 1.8.0" 
 .SH NAME
 daft\-eject \- Convert a worktree\-based repository back to traditional layout
 .SH SYNOPSIS
@@ -67,4 +67,4 @@ Print version
 [\fIREPOSITORY_PATH\fR]
 Path to the repository to convert (defaults to current directory)
 .SH VERSION
-v1.7.2
+v1.8.0

--- a/man/daft-exec.1
+++ b/man/daft-exec.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH daft-exec 1  "daft-exec 1.7.2" 
+.TH daft-exec 1  "daft-exec 1.8.0" 
 .SH NAME
 daft\-exec \- Run a command across one or more worktrees
 .SH SYNOPSIS
@@ -64,4 +64,4 @@ EXAMPLES:
     Pass\-through to an interactive program (single target):
         daft exec feat/auth \-\- claude
 .SH VERSION
-v1.7.2
+v1.8.0

--- a/man/daft-go.1
+++ b/man/daft-go.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH "daft go" 1  "daft go 1.7.2" 
+.TH "daft go" 1  "daft go 1.8.0" 
 .SH NAME
 daft go \- Open a worktree for an existing branch, or create one with \-b
 .SH SYNOPSIS
@@ -78,4 +78,4 @@ Branch to open; use \*(Aq\-\*(Aq for previous worktree
 [\fIBASE_BRANCH_NAME\fR]
 Base branch for \-b (defaults to current branch)
 .SH VERSION
-v1.7.2
+v1.8.0

--- a/man/daft-init.1
+++ b/man/daft-init.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH daft-init 1  "daft-init 1.7.2" 
+.TH daft-init 1  "daft-init 1.8.0" 
 .SH NAME
 daft\-init \- Initialize a new repository in the worktree\-based directory structure
 .SH SYNOPSIS
@@ -59,4 +59,4 @@ Print version
 <\fIREPOSITORY_NAME\fR>
 Name for the new repository directory
 .SH VERSION
-v1.7.2
+v1.8.0

--- a/man/daft-list.1
+++ b/man/daft-list.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH daft-list 1  "daft-list 1.7.2" 
+.TH daft-list 1  "daft-list 1.8.0" 
 .SH NAME
 daft\-list \- List all worktrees with status information
 .SH SYNOPSIS
@@ -127,4 +127,4 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 \fB\-V\fR, \fB\-\-version\fR
 Print version
 .SH VERSION
-v1.7.2
+v1.8.0

--- a/man/daft-prune.1
+++ b/man/daft-prune.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH daft-prune 1  "daft-prune 1.7.2" 
+.TH daft-prune 1  "daft-prune 1.8.0" 
 .SH NAME
 daft\-prune \- Remove worktrees and branches for deleted remote branches
 .SH SYNOPSIS
@@ -58,4 +58,4 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 \fB\-V\fR, \fB\-\-version\fR
 Print version
 .SH VERSION
-v1.7.2
+v1.8.0

--- a/man/daft-release-notes.1
+++ b/man/daft-release-notes.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH daft-release-notes 1  "daft-release-notes 1.7.2" 
+.TH daft-release-notes 1  "daft-release-notes 1.8.0" 
 .SH NAME
 daft\-release\-notes \- Display release notes from the changelog
 .SH SYNOPSIS
@@ -66,4 +66,4 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 [\fIVERSION\fR]
 Show notes for a specific version (e.g., "1.0.5" or "v1.0.5")
 .SH VERSION
-v1.7.2
+v1.8.0

--- a/man/daft-remove.1
+++ b/man/daft-remove.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH "daft remove" 1  "daft remove 1.7.2" 
+.TH "daft remove" 1  "daft remove 1.8.0" 
 .SH NAME
 daft remove \- Delete branches and their worktrees
 .SH SYNOPSIS
@@ -62,4 +62,4 @@ Print version
 <\fIBRANCHES\fR>
 Branches or worktree paths to delete
 .SH VERSION
-v1.7.2
+v1.8.0

--- a/man/daft-rename.1
+++ b/man/daft-rename.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH "daft rename" 1  "daft rename 1.7.2" 
+.TH "daft rename" 1  "daft rename 1.8.0" 
 .SH NAME
 daft rename \- Rename a branch and move its worktree
 .SH SYNOPSIS
@@ -45,4 +45,4 @@ Source branch or worktree path
 <\fINEW_BRANCH\fR>
 New branch name
 .SH VERSION
-v1.7.2
+v1.8.0

--- a/man/daft-shared.1
+++ b/man/daft-shared.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH daft-shared 1  "daft-shared 1.7.2" 
+.TH daft-shared 1  "daft-shared 1.8.0" 
 .SH NAME
 daft\-shared \- Manage shared files across worktrees
 .SH SYNOPSIS
@@ -48,4 +48,4 @@ Interactive TUI for managing shared file state across worktrees
 daft\-shared\-help(1)
 Print this message or the help of the given subcommand(s)
 .SH VERSION
-v1.7.2
+v1.8.0

--- a/man/daft-start.1
+++ b/man/daft-start.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH "daft start" 1  "daft start 1.7.2" 
+.TH "daft start" 1  "daft start 1.8.0" 
 .SH NAME
 daft start \- Create a new branch and worktree
 .SH SYNOPSIS
@@ -60,4 +60,4 @@ Name for the new branch
 [\fIBASE_BRANCH_NAME\fR]
 Branch to use as the base; defaults to the current branch
 .SH VERSION
-v1.7.2
+v1.8.0

--- a/man/daft-sync.1
+++ b/man/daft-sync.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH daft-sync 1  "daft-sync 1.7.2" 
+.TH daft-sync 1  "daft-sync 1.8.0" 
 .SH NAME
 daft\-sync \- Synchronize worktrees with remote (prune + update all)
 .SH SYNOPSIS
@@ -75,4 +75,4 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 \fB\-V\fR, \fB\-\-version\fR
 Print version
 .SH VERSION
-v1.7.2
+v1.8.0

--- a/man/daft-update.1
+++ b/man/daft-update.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH daft-update 1  "daft-update 1.7.2" 
+.TH daft-update 1  "daft-update 1.8.0" 
 .SH NAME
 daft\-update \- Update worktree branches from their remote tracking branches
 .SH SYNOPSIS
@@ -64,4 +64,4 @@ Target worktree(s) by name or refspec (source:destination)
 [\fIPULL_ARGS\fR]
 Additional arguments to pass to git pull
 .SH VERSION
-v1.7.2
+v1.8.0

--- a/man/git-worktree-branch-delete.1
+++ b/man/git-worktree-branch-delete.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-branch-delete 1  "git-worktree-branch-delete 1.7.2" 
+.TH git-worktree-branch-delete 1  "git-worktree-branch-delete 1.8.0" 
 .SH NAME
 git\-worktree\-branch\-delete \- Delete branches and their worktrees
 .SH SYNOPSIS
@@ -59,4 +59,4 @@ Print version
 <\fIBRANCHES\fR>
 Branches to delete (names or worktree paths)
 .SH VERSION
-v1.7.2
+v1.8.0

--- a/man/git-worktree-branch.1
+++ b/man/git-worktree-branch.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-branch 1  "git-worktree-branch 1.7.2" 
+.TH git-worktree-branch 1  "git-worktree-branch 1.8.0" 
 .SH NAME
 git\-worktree\-branch \- Delete or rename branches and their worktrees
 .SH SYNOPSIS
@@ -94,4 +94,4 @@ Print version
 [\fIBRANCHES\fR]
 Branches (delete mode) or source + new\-name (rename mode)
 .SH VERSION
-v1.7.2
+v1.8.0

--- a/man/git-worktree-carry.1
+++ b/man/git-worktree-carry.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-carry 1  "git-worktree-carry 1.7.2" 
+.TH git-worktree-carry 1  "git-worktree-carry 1.8.0" 
 .SH NAME
 git\-worktree\-carry \- Transfer uncommitted changes to other worktrees
 .SH SYNOPSIS
@@ -38,4 +38,4 @@ Print version
 <\fITARGETS\fR>
 Target worktree(s) by directory name or branch name
 .SH VERSION
-v1.7.2
+v1.8.0

--- a/man/git-worktree-checkout.1
+++ b/man/git-worktree-checkout.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-checkout 1  "git-worktree-checkout 1.7.2" 
+.TH git-worktree-checkout 1  "git-worktree-checkout 1.8.0" 
 .SH NAME
 git\-worktree\-checkout \- Create a worktree for an existing branch, or a new branch with \-b
 .SH SYNOPSIS
@@ -82,4 +82,4 @@ Name of the branch to check out (or create with \-b); use \*(Aq\-\*(Aq for previ
 [\fIBASE_BRANCH_NAME\fR]
 Branch to use as the base for the new branch (only with \-b); defaults to the current branch
 .SH VERSION
-v1.7.2
+v1.8.0

--- a/man/git-worktree-clone.1
+++ b/man/git-worktree-clone.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-clone 1  "git-worktree-clone 1.7.2" 
+.TH git-worktree-clone 1  "git-worktree-clone 1.8.0" 
 .SH NAME
 git\-worktree\-clone \- Clone a repository into a worktree\-based directory structure
 .SH SYNOPSIS
@@ -69,4 +69,4 @@ Print version
 <\fIREPOSITORY_URL\fR>
 The repository URL to clone (HTTPS or SSH)
 .SH VERSION
-v1.7.2
+v1.8.0

--- a/man/git-worktree-exec.1
+++ b/man/git-worktree-exec.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-exec 1  "git-worktree-exec 1.7.2" 
+.TH git-worktree-exec 1  "git-worktree-exec 1.8.0" 
 .SH NAME
 git\-worktree\-exec \- Run a command across one or more worktrees
 .SH SYNOPSIS
@@ -64,4 +64,4 @@ EXAMPLES:
     Pass\-through to an interactive program (single target):
         daft exec feat/auth \-\- claude
 .SH VERSION
-v1.7.2
+v1.8.0

--- a/man/git-worktree-fetch.1
+++ b/man/git-worktree-fetch.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-fetch 1  "git-worktree-fetch 1.7.2" 
+.TH git-worktree-fetch 1  "git-worktree-fetch 1.8.0" 
 .SH NAME
 git\-worktree\-fetch \- Update worktree branches from their remote tracking branches
 .SH SYNOPSIS
@@ -64,4 +64,4 @@ Target worktree(s) by name or refspec (source:destination)
 [\fIPULL_ARGS\fR]
 Additional arguments to pass to git pull
 .SH VERSION
-v1.7.2
+v1.8.0

--- a/man/git-worktree-flow-adopt.1
+++ b/man/git-worktree-flow-adopt.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-flow-adopt 1  "git-worktree-flow-adopt 1.7.2" 
+.TH git-worktree-flow-adopt 1  "git-worktree-flow-adopt 1.8.0" 
 .SH NAME
 git\-worktree\-flow\-adopt \- Convert a traditional repository to worktree\-based layout
 .SH SYNOPSIS
@@ -92,4 +92,4 @@ Print version
 [\fIREPOSITORY_PATH\fR]
 Path to the repository to convert (defaults to current directory)
 .SH VERSION
-v1.7.2
+v1.8.0

--- a/man/git-worktree-flow-eject.1
+++ b/man/git-worktree-flow-eject.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-flow-eject 1  "git-worktree-flow-eject 1.7.2" 
+.TH git-worktree-flow-eject 1  "git-worktree-flow-eject 1.8.0" 
 .SH NAME
 git\-worktree\-flow\-eject \- Convert a worktree\-based repository back to traditional layout
 .SH SYNOPSIS
@@ -67,4 +67,4 @@ Print version
 [\fIREPOSITORY_PATH\fR]
 Path to the repository to convert (defaults to current directory)
 .SH VERSION
-v1.7.2
+v1.8.0

--- a/man/git-worktree-init.1
+++ b/man/git-worktree-init.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-init 1  "git-worktree-init 1.7.2" 
+.TH git-worktree-init 1  "git-worktree-init 1.8.0" 
 .SH NAME
 git\-worktree\-init \- Initialize a new repository in the worktree\-based directory structure
 .SH SYNOPSIS
@@ -59,4 +59,4 @@ Print version
 <\fIREPOSITORY_NAME\fR>
 Name for the new repository directory
 .SH VERSION
-v1.7.2
+v1.8.0

--- a/man/git-worktree-list.1
+++ b/man/git-worktree-list.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-list 1  "git-worktree-list 1.7.2" 
+.TH git-worktree-list 1  "git-worktree-list 1.8.0" 
 .SH NAME
 git\-worktree\-list \- List all worktrees with status information
 .SH SYNOPSIS
@@ -127,4 +127,4 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 \fB\-V\fR, \fB\-\-version\fR
 Print version
 .SH VERSION
-v1.7.2
+v1.8.0

--- a/man/git-worktree-prune.1
+++ b/man/git-worktree-prune.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-prune 1  "git-worktree-prune 1.7.2" 
+.TH git-worktree-prune 1  "git-worktree-prune 1.8.0" 
 .SH NAME
 git\-worktree\-prune \- Remove worktrees and branches for deleted remote branches
 .SH SYNOPSIS
@@ -58,4 +58,4 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 \fB\-V\fR, \fB\-\-version\fR
 Print version
 .SH VERSION
-v1.7.2
+v1.8.0

--- a/man/git-worktree-sync.1
+++ b/man/git-worktree-sync.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-sync 1  "git-worktree-sync 1.7.2" 
+.TH git-worktree-sync 1  "git-worktree-sync 1.8.0" 
 .SH NAME
 git\-worktree\-sync \- Synchronize worktrees with remote (prune + update all)
 .SH SYNOPSIS
@@ -75,4 +75,4 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 \fB\-V\fR, \fB\-\-version\fR
 Print version
 .SH VERSION
-v1.7.2
+v1.8.0

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -10,7 +10,7 @@ clap = { version = "4.5", features = ["derive"] }
 clap_mangen = "0.3"
 crossterm = "0.29"
 ctrlc = "3.5.2"
-daft = { path = "..", version = "1.7.2" }
+daft = { path = "..", version = "1.8.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 


### PR DESCRIPTION
## Summary

Hand-cut release PR for **v1.8.0**, mirroring the structure release-plz produces (`chore: release v1.8.0` + `chore: regenerate man pages and CLI docs for new version`). This is needed to break the broken-baseline cycle in the Release-plz workflow:

- `release-plz release-pr` packages the previous tag (`v1.7.2`) for diff/changelog computation. v1.7.2's `Cargo.toml` pins `gix = "0.81"` and has no committed `Cargo.lock`, so fresh resolution lands on the broken `winnow` / `gix-object 0.58` combo and the verify compile fails.
- After this PR merges, the `release-plz-release` job will tag v1.8.0. From the next push onward, `release-pr` diffs against v1.8.0 (gix 0.82 + committed `Cargo.lock`) and the verify compile works.

### Changes

- `Cargo.toml`: `1.7.2` → `1.8.0`
- `xtask/Cargo.toml`: path-dep `daft = { version = "1.8.0" }`
- `Cargo.lock`: daft entry updated
- `CHANGELOG.md`: new `## [1.8.0]` section. The auto-generated commit list (Features / Bug Fixes / Miscellaneous) goes above the human-curated `### BREAKING` and `### Added` notes, which were already in `## [Unreleased]` and now belong under v1.8.0.
- `man/`: regenerated with the new version

The `revert: drop publish_no_verify` commit (#406) is intentionally not in the changelog — `revert:` isn't a configured commit type in `release-plz.toml`'s `[changelog]` parser. It's the inverse of #405, which is listed.

## Test plan

- [ ] CI green on this PR
- [ ] After merge: `release-plz-release` job creates the `v1.8.0` git tag
- [ ] cargo-dist builds binaries for the new release
- [ ] Subsequent push to master no longer fails the Release-plz workflow