### PR TITLE
ci: allow manual dispatch of release-plz workflow

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -3,6 +3,7 @@ name: Release-plz
 on:
   push:
     branches: [master]
+  workflow_dispatch:
 
 jobs:
   # Create GitHub releases for new versions (runs when release PR is merged)


### PR DESCRIPTION
## Summary

Adds `workflow_dispatch:` to the Release-plz workflow trigger list. Lets us re-run the workflow on demand from the GitHub UI or `gh workflow run release-plz.yml`, without needing an organic push to master.

Immediate motivation: after merging the v1.8.0 release (#407), the post-merge workflow run lost a race — the `release-plz-pr` job ran in parallel with `release-plz-release` and started before the v1.8.0 git tag was written, so it still saw v1.7.2 as the latest tag and hit the same broken-baseline cargo verify failure. With this change we can re-trigger after the tag is in place to verify the release pipeline is unblocked.

Long-term it's just good hygiene to be able to re-run release machinery without faking a commit.

## Test plan

- [ ] CI green on this PR (no behavioral change)
- [ ] After merge, `gh workflow run release-plz.yml --ref master` triggers a clean run, and that run's `release-pr` job uses v1.8.0 as the diff baseline and succeeds