### PR TITLE
feat: shared infrastructure for live list population (#402)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -871,3 +871,17 @@ Unsupported combinations print a clear error listing the supported set.
 
 Use `--template '<tera-template>'` for custom output. Tera syntax: `{{ var }}`,
 `{% for x in items %}...{% endfor %}`, `{% if %}...{% endif %}`.
+
+## Cache files
+
+`daft list` writes content-addressed JSON caches under
+`<git-common-dir>/.daft/cache/<kind>/` so warm-cache runs avoid re-forking slow
+git commands. Each entry's filename embeds the SHAs that fully define its inputs
+(e.g. `<base_sha>-<head_sha>.json` for ahead/behind counts), so a cache hit is
+provably correct — there is no TTL or manual invalidation. The cache is safe to
+delete at any time; daft will re-populate it on the next run.
+
+Cached cells: base/remote ahead-behind, base/remote line stats, last-commit
+metadata. Working-tree-dependent cells (`Changes`, `Size`) are NOT cached
+because their inputs cannot be captured as a SHA — they always recompute and
+show the `·` skeleton glyph until the result arrives.

--- a/docs/superpowers/plans/2026-04-25-live-list-population-phase-1-shared-infra.md
+++ b/docs/superpowers/plans/2026-04-25-live-list-population-phase-1-shared-infra.md
@@ -1,0 +1,1990 @@
+# Live List Population — Phase 1: Shared Infrastructure Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the shared infrastructure for live cell-by-cell population —
+streaming collector, typed patch events, `LiveTable` widget extracted from the
+existing TUI state — with **no user-visible behavior change**. Existing
+prune/sync integration tests must pass unchanged at the end of this phase.
+
+**Architecture:** Introduce a `FieldSet` bitmask that bridges three layers
+(collector subsets, patch deltas, sort dependencies). Add a phase-agnostic
+streaming collector that takes a `FieldSet` + branch list and emits
+`WorktreeInfoUpdated { patch, source }` events through the existing `DagEvent`
+channel. Extract the worktree-rows core of today's `TuiState` into a new
+`LiveTable` widget that owns row rendering, sort, partition, patch application,
+and loading glyphs. Rename today's `TuiState` → `OperationTableState`; have it
+embed a `LiveTable` and continue to handle phase + hook events itself. Replace
+`TaskCompleted::updated_info` with orchestrator-emitted
+`WorktreeInfoUpdated { source: PostTask }` patches.
+
+**Tech Stack:** Rust, ratatui 0.30, crossterm 0.29, std::sync::mpsc,
+std::thread::scope. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-04-25-live-list-population-design.md`
+
+**Phase 1 of 3.** Phases 2 (`daft list` live UX) and 3 (migrate prune/sync to
+streaming seed) ship under separate plans, written when those phases begin. This
+phase is verifiable by existing tests passing; it adds infrastructure but
+changes no command's behavior.
+
+---
+
+## File Structure
+
+**New files:**
+
+- `src/core/worktree/info_field.rs` — `FieldSet` u32 newtype with const members
+  and standard set operations. Module re-exported from
+  `src/core/worktree/mod.rs`.
+- `src/core/worktree/list_stream.rs` — Streaming collector. Public API:
+  `CollectorRequest`, `CollectorTarget`, `CollectorContext`, `CollectorHandle`,
+  `spawn(req, tx) -> CollectorHandle`.
+- `src/output/tui/live_table.rs` — `LiveTable` widget extracted from `TuiState`.
+  Owns worktree rows, sort, partition, patch application, loading-glyph state.
+  Public API: `LiveTable::new`, `apply_event`, `tick`, `render`, `into_rows`,
+  `LiveTableConfig`.
+
+**Modified files:**
+
+- `src/core/worktree/mod.rs` — re-export `info_field` and `list_stream` modules.
+- `src/core/worktree/list.rs` — add
+  `WorktreeInfo::apply_patch(&mut self, &WorktreeInfoPatch) -> FieldSet`.
+- `src/core/sort.rs` — add `SortSpec::required_fields(&self) -> FieldSet`.
+- `src/core/worktree/sync_dag.rs` — add `WorktreeInfoPatch` enum, `PatchSource`
+  enum, `DagEvent::WorktreeInfoUpdated`, `DagEvent::WorktreeInfoCollectionDone`.
+  Remove `TaskCompleted::updated_info` field.
+- `src/output/tui/state.rs` — rename `TuiState` → `OperationTableState`; move
+  worktree-rows logic into `LiveTable`; forward
+  `WorktreeInfoUpdated`/`WorktreeInfoCollectionDone` to the embedded
+  `LiveTable`; existing phase/hook event arms unchanged. Update all field
+  accesses across the project.
+- `src/output/tui/operation_table.rs` — update field/type names from the rename;
+  add `pin_default_branch` and `partition_by_owner` to `TableConfig`, default to
+  current behavior (true / true).
+- `src/output/tui/driver.rs` — update `TuiRenderer` references to use
+  `OperationTableState` instead of `TuiState`.
+- `src/output/tui/render.rs`, `src/output/tui/presenter.rs` — update field
+  accesses for the rename + LiveTable extraction.
+- `src/output/tui/mod.rs` — re-export `LiveTable`, `LiveTableConfig`; re-export
+  `OperationTableState` (formerly `TuiState`).
+- `src/commands/sync.rs` — orchestrator: replace each
+  `TaskCompleted::updated_info: Some(Box<WorktreeInfo>)` emission with a matched
+  set of `DagEvent::WorktreeInfoUpdated { source: PostTask(phase) }` events for
+  the fields each task touches (table in spec).
+- `src/commands/prune.rs` — same: prune tasks remove the row, no patch needed;
+  the field on `TaskCompleted` is removed entirely.
+- `src/core/worktree/sync_dag.rs` — DagExecutor's task closure no longer returns
+  `Option<Box<WorktreeInfo>>`; signature updated; tests adjusted.
+
+**Tests:**
+
+- `src/core/worktree/info_field.rs` — unit: bitwise ops, `intersects`,
+  `contains`, predefined subsets.
+- `src/core/sort.rs` — unit: `required_fields` per `SortColumn` variant.
+- `src/core/worktree/list.rs` — unit: `apply_patch` truth table per
+  `WorktreeInfoPatch` variant.
+- `src/core/worktree/list_stream.rs` — unit + fixture-repo integration: spawn
+  collector against the existing test fixtures, assert the multiset of patches
+  emitted for a given `FieldSet`.
+- `src/output/tui/live_table.rs` — unit: `apply_event` for `WorktreeInfoUpdated`
+  (sort re-eval, partition shuffle, stale-source suppression),
+  `WorktreeInfoCollectionDone` (loading glyphs cleared).
+- `src/output/tui/state.rs` — existing `TuiState` tests adapted to the rename +
+  LiveTable boundary.
+- `src/core/worktree/sync_dag.rs` — existing channel-based tests adapted to the
+  new task closure signature.
+
+---
+
+## Task 1: `FieldSet` newtype + tests
+
+**Files:**
+
+- Create: `src/core/worktree/info_field.rs`
+- Modify: `src/core/worktree/mod.rs`
+
+A u32-backed bitmask. No `bitflags` dep — just const members + manual ops. This
+is the shared vocabulary for collector subsets, patch deltas, and sort
+dependencies.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/core/worktree/info_field.rs`:
+
+```rust
+//! Bitmask identifying fields of `WorktreeInfo` for the live-population
+//! pipeline. Used in three places: (1) the streaming collector takes one as
+//! input to scope its work, (2) `WorktreeInfo::apply_patch` returns one to
+//! signal which fields changed, (3) `SortSpec::required_fields` returns one
+//! to declare its sort dependencies.
+
+use std::ops::{BitAnd, BitOr, BitOrAssign, Not};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FieldSet(u32);
+
+impl FieldSet {
+    pub const EMPTY: Self = Self(0);
+
+    pub const BASE_AHEAD_BEHIND:   Self = Self(1 << 0);
+    pub const REMOTE_AHEAD_BEHIND: Self = Self(1 << 1);
+    pub const CHANGES:             Self = Self(1 << 2);
+    pub const LAST_COMMIT:         Self = Self(1 << 3);
+    pub const BRANCH_AGE:          Self = Self(1 << 4);
+    pub const OWNER:               Self = Self(1 << 5);
+    pub const BASE_LINES:          Self = Self(1 << 6);
+    pub const CHANGES_LINES:       Self = Self(1 << 7);
+    pub const REMOTE_LINES:        Self = Self(1 << 8);
+    pub const SIZE:                Self = Self(1 << 9);
+    pub const MTIME:               Self = Self(1 << 10);
+
+    /// Fields whose values can change after a `git fetch`.
+    pub const REMOTE_DERIVED: Self = Self(
+        Self::REMOTE_AHEAD_BEHIND.0 | Self::REMOTE_LINES.0,
+    );
+
+    /// Fields whose values can change after any per-branch task
+    /// (Update / Rebase / Push). Used by the orchestrator for post-task
+    /// re-runs.
+    pub const VOLATILE: Self = Self(
+        Self::BASE_AHEAD_BEHIND.0
+            | Self::REMOTE_AHEAD_BEHIND.0
+            | Self::CHANGES.0
+            | Self::LAST_COMMIT.0
+            | Self::BASE_LINES.0
+            | Self::CHANGES_LINES.0
+            | Self::REMOTE_LINES.0,
+    );
+
+    /// All fields. Used by the initial Collector run.
+    pub const ALL: Self = Self(u32::MAX);
+
+    pub const fn contains(self, other: Self) -> bool {
+        (self.0 & other.0) == other.0
+    }
+
+    pub const fn intersects(self, other: Self) -> bool {
+        (self.0 & other.0) != 0
+    }
+
+    pub const fn is_empty(self) -> bool {
+        self.0 == 0
+    }
+}
+
+impl BitOr for FieldSet {
+    type Output = Self;
+    fn bitor(self, rhs: Self) -> Self { Self(self.0 | rhs.0) }
+}
+
+impl BitOrAssign for FieldSet {
+    fn bitor_assign(&mut self, rhs: Self) { self.0 |= rhs.0; }
+}
+
+impl BitAnd for FieldSet {
+    type Output = Self;
+    fn bitand(self, rhs: Self) -> Self { Self(self.0 & rhs.0) }
+}
+
+impl Not for FieldSet {
+    type Output = Self;
+    fn not(self) -> Self { Self(!self.0) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_contains_nothing_and_intersects_nothing() {
+        assert!(FieldSet::EMPTY.is_empty());
+        assert!(!FieldSet::EMPTY.contains(FieldSet::SIZE));
+        assert!(!FieldSet::EMPTY.intersects(FieldSet::SIZE));
+    }
+
+    #[test]
+    fn or_combines_members() {
+        let s = FieldSet::SIZE | FieldSet::OWNER;
+        assert!(s.contains(FieldSet::SIZE));
+        assert!(s.contains(FieldSet::OWNER));
+        assert!(!s.contains(FieldSet::CHANGES));
+    }
+
+    #[test]
+    fn intersects_returns_true_for_any_overlap() {
+        let a = FieldSet::SIZE | FieldSet::OWNER;
+        let b = FieldSet::OWNER | FieldSet::CHANGES;
+        assert!(a.intersects(b));
+    }
+
+    #[test]
+    fn intersects_returns_false_for_disjoint_sets() {
+        let a = FieldSet::SIZE;
+        let b = FieldSet::OWNER;
+        assert!(!a.intersects(b));
+    }
+
+    #[test]
+    fn remote_derived_subset_contains_only_remote_fields() {
+        assert!(FieldSet::REMOTE_DERIVED.contains(FieldSet::REMOTE_AHEAD_BEHIND));
+        assert!(FieldSet::REMOTE_DERIVED.contains(FieldSet::REMOTE_LINES));
+        assert!(!FieldSet::REMOTE_DERIVED.contains(FieldSet::SIZE));
+        assert!(!FieldSet::REMOTE_DERIVED.contains(FieldSet::CHANGES));
+    }
+
+    #[test]
+    fn volatile_subset_excludes_size_and_owner_and_age() {
+        assert!(!FieldSet::VOLATILE.contains(FieldSet::SIZE));
+        assert!(!FieldSet::VOLATILE.contains(FieldSet::OWNER));
+        assert!(!FieldSet::VOLATILE.contains(FieldSet::BRANCH_AGE));
+    }
+
+    #[test]
+    fn all_contains_every_known_member() {
+        for member in [
+            FieldSet::BASE_AHEAD_BEHIND, FieldSet::REMOTE_AHEAD_BEHIND,
+            FieldSet::CHANGES, FieldSet::LAST_COMMIT, FieldSet::BRANCH_AGE,
+            FieldSet::OWNER, FieldSet::BASE_LINES, FieldSet::CHANGES_LINES,
+            FieldSet::REMOTE_LINES, FieldSet::SIZE, FieldSet::MTIME,
+        ] {
+            assert!(FieldSet::ALL.contains(member));
+        }
+    }
+}
+```
+
+Add to `src/core/worktree/mod.rs`:
+
+```rust
+pub mod info_field;
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `cargo test --lib core::worktree::info_field` Expected: all 7 tests pass.
+
+- [ ] **Step 3: Run clippy + fmt**
+
+Run: `mise run fmt && mise run clippy` Expected: zero warnings, zero diff.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/core/worktree/info_field.rs src/core/worktree/mod.rs
+git commit -m "feat(core): add FieldSet bitmask for live-population pipeline (#402)"
+```
+
+---
+
+## Task 2: `SortSpec::required_fields`
+
+**Files:**
+
+- Modify: `src/core/sort.rs`
+
+Maps each sort column to the `FieldSet` needed to compute it. Used by
+`LiveTable` to decide whether an arriving patch should trigger a re-sort.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/core/sort.rs`:
+
+```rust
+#[cfg(test)]
+mod required_fields_tests {
+    use super::*;
+    use crate::core::worktree::info_field::FieldSet;
+
+    fn fields_for(input: &str) -> FieldSet {
+        SortSpec::parse(input).unwrap().required_fields()
+    }
+
+    #[test]
+    fn branch_path_hash_require_no_dynamic_fields() {
+        // These sort by data already present from porcelain.
+        assert_eq!(fields_for("branch"), FieldSet::EMPTY);
+        assert_eq!(fields_for("path"),   FieldSet::EMPTY);
+        assert_eq!(fields_for("hash"),   FieldSet::LAST_COMMIT);
+    }
+
+    #[test]
+    fn size_requires_size() {
+        assert_eq!(fields_for("size"), FieldSet::SIZE);
+    }
+
+    #[test]
+    fn age_requires_branch_age() {
+        assert_eq!(fields_for("age"), FieldSet::BRANCH_AGE);
+    }
+
+    #[test]
+    fn owner_requires_owner() {
+        assert_eq!(fields_for("owner"), FieldSet::OWNER);
+    }
+
+    #[test]
+    fn last_commit_requires_last_commit() {
+        assert_eq!(fields_for("commit"), FieldSet::LAST_COMMIT);
+    }
+
+    #[test]
+    fn activity_requires_last_commit_and_mtime() {
+        assert_eq!(
+            fields_for("activity"),
+            FieldSet::LAST_COMMIT | FieldSet::MTIME,
+        );
+    }
+
+    #[test]
+    fn base_changes_remote_each_require_their_cluster() {
+        assert_eq!(fields_for("base"),    FieldSet::BASE_AHEAD_BEHIND);
+        assert_eq!(fields_for("changes"), FieldSet::CHANGES);
+        assert_eq!(fields_for("remote"),  FieldSet::REMOTE_AHEAD_BEHIND);
+    }
+
+    #[test]
+    fn multi_key_unions_required_fields() {
+        // +owner,-size: requires both OWNER and SIZE.
+        let f = fields_for("+owner,-size");
+        assert!(f.contains(FieldSet::OWNER));
+        assert!(f.contains(FieldSet::SIZE));
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --lib core::sort::required_fields_tests` Expected: compile
+error — `required_fields` does not exist.
+
+- [ ] **Step 3: Implement `required_fields`**
+
+In `src/core/sort.rs`, inside `impl SortSpec` (after `compare`):
+
+```rust
+/// Returns the set of `WorktreeInfo` fields needed to evaluate this sort
+/// spec. Used by `LiveTable` to skip re-sorts when a patch lands on a
+/// cell unrelated to the current sort order.
+pub fn required_fields(&self) -> crate::core::worktree::info_field::FieldSet {
+    use crate::core::worktree::info_field::FieldSet;
+    let mut acc = FieldSet::EMPTY;
+    for key in &self.keys {
+        acc |= match key.column {
+            SortColumn::Branch     => FieldSet::EMPTY,
+            SortColumn::Path       => FieldSet::EMPTY,
+            SortColumn::Size       => FieldSet::SIZE,
+            SortColumn::Age        => FieldSet::BRANCH_AGE,
+            SortColumn::Owner      => FieldSet::OWNER,
+            SortColumn::Hash       => FieldSet::LAST_COMMIT,
+            SortColumn::Activity   => FieldSet::LAST_COMMIT | FieldSet::MTIME,
+            SortColumn::LastCommit => FieldSet::LAST_COMMIT,
+            SortColumn::Base       => FieldSet::BASE_AHEAD_BEHIND,
+            SortColumn::Changes    => FieldSet::CHANGES,
+            SortColumn::Remote     => FieldSet::REMOTE_AHEAD_BEHIND,
+        };
+    }
+    acc
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --lib core::sort::required_fields_tests` Expected: all 8 tests
+pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/sort.rs
+git commit -m "feat(core): add SortSpec::required_fields for live re-sort gating (#402)"
+```
+
+---
+
+## Task 3: `WorktreeInfoPatch` and `PatchSource` enums
+
+**Files:**
+
+- Modify: `src/core/worktree/sync_dag.rs`
+
+Typed cell-cluster deltas plus the source tag used for staleness suppression in
+`LiveTable`. No producer or consumer wiring yet — this task introduces the types
+only, so downstream tasks have a stable target.
+
+- [ ] **Step 1: Add the enums**
+
+In `src/core/worktree/sync_dag.rs`, near the existing `DagEvent` enum
+declaration, add:
+
+```rust
+use crate::core::worktree::list::BranchOwner;
+
+/// A typed delta over `WorktreeInfo`. Each variant maps 1:1 to one
+/// underlying git/FS call cluster in the streaming collector.
+#[derive(Debug, Clone)]
+pub enum WorktreeInfoPatch {
+    BaseAheadBehind(Option<(usize, usize)>),
+    RemoteAheadBehind(Option<(usize, usize)>),
+    Changes { staged: usize, unstaged: usize, untracked: usize },
+    LastCommit {
+        timestamp: Option<i64>,
+        hash: Option<String>,
+        subject: String,
+    },
+    BranchAge(Option<i64>),
+    Owner(Option<BranchOwner>),
+    BaseLines(Option<(usize, usize)>),
+    ChangesLines {
+        staged: (usize, usize),
+        unstaged: (usize, usize),
+    },
+    RemoteLines(Option<(usize, usize)>),
+    Size(Option<u64>),
+    Mtime(Option<i64>),
+}
+
+/// Why a patch was emitted. `LiveTable` uses this to suppress stale
+/// patches: a `Collector` patch arriving after a `PostFetch` patch covering
+/// the same field on the same branch is dropped. Priority order:
+/// `PostTask > PostFetch > Collector`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PatchSource {
+    Collector,
+    PostFetch,
+    PostTask(OperationPhase),
+}
+
+impl PatchSource {
+    /// Higher = more authoritative. Used for staleness suppression.
+    pub fn priority(self) -> u8 {
+        match self {
+            Self::Collector  => 0,
+            Self::PostFetch  => 1,
+            Self::PostTask(_) => 2,
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Verify compilation**
+
+Run: `cargo check --lib` Expected: compiles cleanly (the types are unused but
+valid).
+
+- [ ] **Step 3: Add a smoke test**
+
+In `src/core/worktree/sync_dag.rs` `#[cfg(test)] mod tests` (existing):
+
+```rust
+#[test]
+fn patch_source_priority_ordering() {
+    assert!(PatchSource::PostTask(OperationPhase::Push).priority()
+            > PatchSource::PostFetch.priority());
+    assert!(PatchSource::PostFetch.priority()
+            > PatchSource::Collector.priority());
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run:
+`cargo test --lib core::worktree::sync_dag::tests::patch_source_priority_ordering`
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/worktree/sync_dag.rs
+git commit -m "feat(core): add WorktreeInfoPatch and PatchSource types (#402)"
+```
+
+---
+
+## Task 4: `WorktreeInfo::apply_patch`
+
+**Files:**
+
+- Modify: `src/core/worktree/list.rs`
+
+Maps a typed patch into in-place mutations on `WorktreeInfo`, returning the
+`FieldSet` of fields whose value actually changed.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the existing `#[cfg(test)] mod tests` in `src/core/worktree/list.rs`
+(the test module `build_emit_table_*` lives in `src/commands/list.rs`; the right
+module here is the one inside `src/core/worktree/list.rs` — create one if
+missing):
+
+```rust
+#[cfg(test)]
+mod apply_patch_tests {
+    use super::*;
+    use crate::core::worktree::info_field::FieldSet;
+    use crate::core::worktree::sync_dag::WorktreeInfoPatch;
+
+    fn empty_info() -> WorktreeInfo {
+        WorktreeInfo::empty("test")
+    }
+
+    #[test]
+    fn base_ahead_behind_some_fills_both_and_returns_the_field() {
+        let mut info = empty_info();
+        let touched = info.apply_patch(&WorktreeInfoPatch::BaseAheadBehind(Some((3, 1))));
+        assert_eq!(info.ahead, Some(3));
+        assert_eq!(info.behind, Some(1));
+        assert_eq!(touched, FieldSet::BASE_AHEAD_BEHIND);
+    }
+
+    #[test]
+    fn base_ahead_behind_none_clears_both() {
+        let mut info = empty_info();
+        info.ahead = Some(5);
+        info.behind = Some(2);
+        let touched = info.apply_patch(&WorktreeInfoPatch::BaseAheadBehind(None));
+        assert_eq!(info.ahead, None);
+        assert_eq!(info.behind, None);
+        assert_eq!(touched, FieldSet::BASE_AHEAD_BEHIND);
+    }
+
+    #[test]
+    fn changes_fills_three_fields() {
+        let mut info = empty_info();
+        let touched = info.apply_patch(&WorktreeInfoPatch::Changes {
+            staged: 2, unstaged: 1, untracked: 4,
+        });
+        assert_eq!((info.staged, info.unstaged, info.untracked), (2, 1, 4));
+        assert_eq!(touched, FieldSet::CHANGES);
+    }
+
+    #[test]
+    fn last_commit_fills_three_fields() {
+        let mut info = empty_info();
+        let touched = info.apply_patch(&WorktreeInfoPatch::LastCommit {
+            timestamp: Some(1700000000),
+            hash: Some("abc1234".into()),
+            subject: "fix bug".into(),
+        });
+        assert_eq!(info.last_commit_timestamp, Some(1700000000));
+        assert_eq!(info.last_commit_hash, Some("abc1234".into()));
+        assert_eq!(info.last_commit_subject, "fix bug");
+        assert_eq!(touched, FieldSet::LAST_COMMIT);
+    }
+
+    #[test]
+    fn size_fills_size_bytes() {
+        let mut info = empty_info();
+        let touched = info.apply_patch(&WorktreeInfoPatch::Size(Some(2048)));
+        assert_eq!(info.size_bytes, Some(2048));
+        assert_eq!(touched, FieldSet::SIZE);
+    }
+
+    #[test]
+    fn changes_lines_fills_four_fields() {
+        let mut info = empty_info();
+        let touched = info.apply_patch(&WorktreeInfoPatch::ChangesLines {
+            staged: (10, 2),
+            unstaged: (5, 1),
+        });
+        assert_eq!(info.staged_lines_inserted, Some(10));
+        assert_eq!(info.staged_lines_deleted, Some(2));
+        assert_eq!(info.unstaged_lines_inserted, Some(5));
+        assert_eq!(info.unstaged_lines_deleted, Some(1));
+        assert_eq!(touched, FieldSet::CHANGES_LINES);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --lib core::worktree::list::apply_patch_tests` Expected:
+compile error — `apply_patch` does not exist.
+
+- [ ] **Step 3: Implement `apply_patch`**
+
+Add to `impl WorktreeInfo` in `src/core/worktree/list.rs` (near the existing
+helper methods around line 181):
+
+```rust
+/// Apply a typed patch in place. Returns the `FieldSet` of fields whose
+/// value changed (the caller — typically `LiveTable` — uses this to
+/// decide whether to re-sort).
+pub fn apply_patch(
+    &mut self,
+    patch: &crate::core::worktree::sync_dag::WorktreeInfoPatch,
+) -> crate::core::worktree::info_field::FieldSet {
+    use crate::core::worktree::info_field::FieldSet;
+    use crate::core::worktree::sync_dag::WorktreeInfoPatch as P;
+
+    match patch {
+        P::BaseAheadBehind(v) => {
+            (self.ahead, self.behind) = match v {
+                Some((a, b)) => (Some(*a), Some(*b)),
+                None => (None, None),
+            };
+            FieldSet::BASE_AHEAD_BEHIND
+        }
+        P::RemoteAheadBehind(v) => {
+            (self.remote_ahead, self.remote_behind) = match v {
+                Some((a, b)) => (Some(*a), Some(*b)),
+                None => (None, None),
+            };
+            FieldSet::REMOTE_AHEAD_BEHIND
+        }
+        P::Changes { staged, unstaged, untracked } => {
+            self.staged = *staged;
+            self.unstaged = *unstaged;
+            self.untracked = *untracked;
+            FieldSet::CHANGES
+        }
+        P::LastCommit { timestamp, hash, subject } => {
+            self.last_commit_timestamp = *timestamp;
+            self.last_commit_hash = hash.clone();
+            self.last_commit_subject = subject.clone();
+            FieldSet::LAST_COMMIT
+        }
+        P::BranchAge(v) => {
+            self.branch_creation_timestamp = *v;
+            FieldSet::BRANCH_AGE
+        }
+        P::Owner(v) => {
+            self.owner = v.clone();
+            FieldSet::OWNER
+        }
+        P::BaseLines(v) => {
+            (self.base_lines_inserted, self.base_lines_deleted) = match v {
+                Some((i, d)) => (Some(*i), Some(*d)),
+                None => (None, None),
+            };
+            FieldSet::BASE_LINES
+        }
+        P::ChangesLines { staged, unstaged } => {
+            self.staged_lines_inserted = Some(staged.0);
+            self.staged_lines_deleted = Some(staged.1);
+            self.unstaged_lines_inserted = Some(unstaged.0);
+            self.unstaged_lines_deleted = Some(unstaged.1);
+            FieldSet::CHANGES_LINES
+        }
+        P::RemoteLines(v) => {
+            (self.remote_lines_inserted, self.remote_lines_deleted) = match v {
+                Some((i, d)) => (Some(*i), Some(*d)),
+                None => (None, None),
+            };
+            FieldSet::REMOTE_LINES
+        }
+        P::Size(v) => {
+            self.size_bytes = *v;
+            FieldSet::SIZE
+        }
+        P::Mtime(v) => {
+            self.working_tree_mtime = *v;
+            FieldSet::MTIME
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --lib core::worktree::list::apply_patch_tests` Expected: all 6
+tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/worktree/list.rs
+git commit -m "feat(core): add WorktreeInfo::apply_patch (#402)"
+```
+
+---
+
+## Task 5: New `DagEvent` variants
+
+**Files:**
+
+- Modify: `src/core/worktree/sync_dag.rs`
+
+Add the two new variants. Existing `apply_event` callsites in
+`src/output/tui/state.rs` will need ignore-arms added so the project still
+compiles; the actual handling lands in Task 9.
+
+- [ ] **Step 1: Extend `DagEvent`**
+
+In `src/core/worktree/sync_dag.rs`, inside the `pub enum DagEvent` declaration,
+append:
+
+```rust
+    /// A patch landed for `branch_name` from `source`. Carries one cluster
+    /// of cells produced by a single underlying git/FS call.
+    WorktreeInfoUpdated {
+        branch_name: String,
+        patch: WorktreeInfoPatch,
+        source: PatchSource,
+    },
+
+    /// The initial `source=Collector` run completed. Subset re-runs
+    /// (`PostFetch`, `PostTask`) do not emit this — they end silently.
+    WorktreeInfoCollectionDone,
+```
+
+- [ ] **Step 2: Add no-op ignore arms in `TuiState::apply_event`**
+
+In `src/output/tui/state.rs`, inside the `match event { ... }` in `apply_event`,
+add at the end (before the final `}` of the match):
+
+```rust
+            DagEvent::WorktreeInfoUpdated { .. } => {
+                // Forwarded to LiveTable in Task 9 — ignore for now.
+            }
+            DagEvent::WorktreeInfoCollectionDone => {
+                // Handled in Task 9.
+            }
+```
+
+- [ ] **Step 3: Verify compilation**
+
+Run: `cargo build` Expected: compiles cleanly.
+
+- [ ] **Step 4: Run full unit test suite**
+
+Run: `mise run test:unit` Expected: all existing tests pass (no behavior
+change).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/worktree/sync_dag.rs src/output/tui/state.rs
+git commit -m "feat(core): add WorktreeInfoUpdated and WorktreeInfoCollectionDone events (#402)"
+```
+
+---
+
+## Task 6: Streaming collector — types and skeleton
+
+**Files:**
+
+- Create: `src/core/worktree/list_stream.rs`
+- Modify: `src/core/worktree/mod.rs`
+
+Public API surface only: `CollectorRequest`, `CollectorTarget`,
+`CollectorContext`, `CollectorHandle`, `spawn`. Worker logic in Task 7.
+
+- [ ] **Step 1: Create `list_stream.rs` with the public types**
+
+Create `src/core/worktree/list_stream.rs`:
+
+```rust
+//! Streaming collector for `WorktreeInfo` cells.
+//!
+//! Spawns one worker thread per branch, each running cluster calls in a
+//! fixed cheap-first order and emitting `DagEvent::WorktreeInfoUpdated`
+//! patches into a shared channel. Cancellation is cooperative between
+//! cluster calls. Re-runnable: callers invoke `spawn` again with a
+//! narrower `FieldSet` and a different `PatchSource` to drive post-fetch
+//! and post-task refreshes.
+
+use crate::{
+    core::{
+        ownership::OwnershipStrategy,
+        worktree::{
+            info_field::FieldSet,
+            list::EntryKind,
+            sync_dag::{DagEvent, PatchSource},
+        },
+    },
+    git::GitCommand,
+};
+use std::{
+    path::PathBuf,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        mpsc, Arc,
+    },
+    thread::{self, JoinHandle},
+};
+
+use super::list::Stat;
+
+#[derive(Debug, Clone)]
+pub struct CollectorTarget {
+    /// Branch name. `""` for detached (sandbox) entries.
+    pub branch_name: String,
+    pub path: Option<PathBuf>,
+    pub kind: EntryKind,
+    pub is_detached: bool,
+}
+
+pub struct CollectorContext {
+    pub git: GitCommand,
+    pub base_branch: String,
+    pub remote_name: String,
+    pub ownership_strategy: OwnershipStrategy,
+    pub user_email: Option<String>,
+}
+
+pub struct CollectorRequest {
+    pub targets: Vec<CollectorTarget>,
+    pub fields: FieldSet,
+    pub stat: Stat,
+    pub source: PatchSource,
+    pub ctx: Arc<CollectorContext>,
+}
+
+pub struct CollectorHandle {
+    cancel: Arc<AtomicBool>,
+    handles: Vec<JoinHandle<()>>,
+    /// Collector-only sentinel sender (kept alive by handle so the
+    /// completion event fires only after all workers have observably
+    /// joined or cancelled).
+    sentinel: Option<(mpsc::Sender<DagEvent>, PatchSource)>,
+}
+
+impl CollectorHandle {
+    /// Request cooperative cancellation. Workers exit between cluster calls.
+    pub fn cancel(&self) {
+        self.cancel.store(true, Ordering::Relaxed);
+    }
+
+    /// Wait for all workers to finish. Emits
+    /// `DagEvent::WorktreeInfoCollectionDone` if and only if the spawning
+    /// run was `source=Collector`.
+    pub fn join(mut self) {
+        for h in self.handles.drain(..) {
+            let _ = h.join();
+        }
+        if let Some((tx, source)) = self.sentinel.take() {
+            if matches!(source, PatchSource::Collector) {
+                let _ = tx.send(DagEvent::WorktreeInfoCollectionDone);
+            }
+        }
+    }
+}
+
+/// Spawn workers for the request. Workers stream patches into `tx`.
+/// The caller MUST call `CollectorHandle::join` (or drop the handle, which
+/// silently joins) for the completion sentinel to fire.
+pub fn spawn(req: CollectorRequest, tx: mpsc::Sender<DagEvent>) -> CollectorHandle {
+    let cancel = Arc::new(AtomicBool::new(false));
+    let CollectorRequest { targets, fields, stat, source, ctx } = req;
+
+    let mut handles = Vec::with_capacity(targets.len());
+    for target in targets {
+        let tx = tx.clone();
+        let ctx = Arc::clone(&ctx);
+        let cancel = Arc::clone(&cancel);
+        handles.push(thread::spawn(move || {
+            run_worker(target, fields, stat, source, ctx, cancel, tx);
+        }));
+    }
+
+    CollectorHandle {
+        cancel,
+        handles,
+        sentinel: Some((tx, source)),
+    }
+}
+
+fn run_worker(
+    target: CollectorTarget,
+    _fields: FieldSet,
+    _stat: Stat,
+    _source: PatchSource,
+    _ctx: Arc<CollectorContext>,
+    _cancel: Arc<AtomicBool>,
+    _tx: mpsc::Sender<DagEvent>,
+) {
+    // Cluster calls land in Task 7. For now: no-op.
+    let _ = target;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_request_emits_only_completion_sentinel() {
+        let (tx, rx) = mpsc::channel();
+        let ctx = Arc::new(CollectorContext {
+            git: GitCommand::new(false),
+            base_branch: "master".into(),
+            remote_name: "origin".into(),
+            ownership_strategy: OwnershipStrategy::default(),
+            user_email: None,
+        });
+        let handle = spawn(
+            CollectorRequest {
+                targets: vec![],
+                fields: FieldSet::ALL,
+                stat: Stat::Summary,
+                source: PatchSource::Collector,
+                ctx,
+            },
+            tx,
+        );
+        handle.join();
+
+        let events: Vec<DagEvent> = rx.iter().collect();
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], DagEvent::WorktreeInfoCollectionDone));
+    }
+
+    #[test]
+    fn post_fetch_run_does_not_emit_completion_sentinel() {
+        let (tx, rx) = mpsc::channel();
+        let ctx = Arc::new(CollectorContext {
+            git: GitCommand::new(false),
+            base_branch: "master".into(),
+            remote_name: "origin".into(),
+            ownership_strategy: OwnershipStrategy::default(),
+            user_email: None,
+        });
+        let handle = spawn(
+            CollectorRequest {
+                targets: vec![],
+                fields: FieldSet::REMOTE_DERIVED,
+                stat: Stat::Summary,
+                source: PatchSource::PostFetch,
+                ctx,
+            },
+            tx,
+        );
+        handle.join();
+
+        let events: Vec<DagEvent> = rx.iter().collect();
+        assert_eq!(events.len(), 0);
+    }
+}
+```
+
+Add to `src/core/worktree/mod.rs`:
+
+```rust
+pub mod list_stream;
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cargo test --lib core::worktree::list_stream` Expected: 2 tests pass.
+
+- [ ] **Step 3: Run clippy + fmt**
+
+Run: `mise run fmt && mise run clippy` Expected: zero warnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/core/worktree/list_stream.rs src/core/worktree/mod.rs
+git commit -m "feat(core): add streaming collector skeleton (#402)"
+```
+
+---
+
+## Task 7: Streaming collector — worker cluster calls
+
+**Files:**
+
+- Modify: `src/core/worktree/list_stream.rs`
+
+Implement the per-worker loop. Cluster order:
+`BASE_AHEAD_BEHIND → CHANGES → LAST_COMMIT → BRANCH_AGE → OWNER → REMOTE_AHEAD_BEHIND`
+then `Stat::Lines` clusters then `SIZE → MTIME`. Each cluster call uses the
+existing helper from `src/core/worktree/list.rs` (cross-module visibility is
+needed — make the helpers `pub(crate)` if not already).
+
+- [ ] **Step 1: Make `list.rs` helpers crate-visible**
+
+In `src/core/worktree/list.rs`, change the visibility of the following free
+functions from `fn` to `pub(crate) fn`:
+
+- `get_ahead_behind` (line 301)
+- `get_commit_metadata` (line 330)
+- `get_branch_creation_timestamp` (line 445)
+- `count_changed_files` (line 492)
+- `get_upstream_ahead_behind` (line 547)
+- `count_changed_lines` (line 590)
+- `get_base_line_counts` (line 616)
+- `get_remote_line_counts` (line 639)
+- `compute_directory_size` (line 660)
+- `max_mtime_of_files` (line 723)
+
+Also change the `ChangedFiles` struct and any of its public fields used by
+`count_changed_files` to `pub(crate)`.
+
+Run: `cargo build` Expected: compiles cleanly.
+
+- [ ] **Step 2: Implement the worker loop**
+
+Replace the no-op `run_worker` body in `src/core/worktree/list_stream.rs` with:
+
+```rust
+fn run_worker(
+    target: CollectorTarget,
+    fields: FieldSet,
+    stat: Stat,
+    source: PatchSource,
+    ctx: Arc<CollectorContext>,
+    cancel: Arc<AtomicBool>,
+    tx: mpsc::Sender<DagEvent>,
+) {
+    use crate::core::ownership;
+    use crate::core::worktree::list::{
+        count_changed_files, count_changed_lines, compute_directory_size,
+        get_ahead_behind, get_base_line_counts, get_branch_creation_timestamp,
+        get_commit_metadata, get_remote_line_counts, get_upstream_ahead_behind,
+        max_mtime_of_files,
+    };
+    use crate::core::worktree::sync_dag::WorktreeInfoPatch as P;
+
+    macro_rules! emit {
+        ($patch:expr) => {{
+            if cancel.load(Ordering::Relaxed) { return; }
+            let _ = tx.send(DagEvent::WorktreeInfoUpdated {
+                branch_name: target.branch_name.clone(),
+                patch: $patch,
+                source,
+            });
+        }};
+    }
+
+    let path = target.path.as_deref();
+
+    // 1. BASE_AHEAD_BEHIND (skip detached)
+    if fields.contains(FieldSet::BASE_AHEAD_BEHIND) && !target.is_detached {
+        if let Some(p) = path {
+            let v = get_ahead_behind(&ctx.base_branch, &target.branch_name, p);
+            emit!(P::BaseAheadBehind(v));
+        }
+    }
+
+    // 2. CHANGES
+    if fields.contains(FieldSet::CHANGES) {
+        if let Some(p) = path {
+            let c = count_changed_files(p);
+            emit!(P::Changes {
+                staged: c.staged, unstaged: c.unstaged, untracked: c.untracked
+            });
+        }
+    }
+
+    // 3. LAST_COMMIT
+    if fields.contains(FieldSet::LAST_COMMIT) {
+        if let Some(p) = path {
+            let (timestamp, hash, subject) = get_commit_metadata(p, &ctx.git);
+            emit!(P::LastCommit { timestamp, hash, subject });
+        }
+    }
+
+    // 4. BRANCH_AGE (skip detached)
+    if fields.contains(FieldSet::BRANCH_AGE) && !target.is_detached {
+        if let Some(p) = path {
+            let v = get_branch_creation_timestamp(&target.branch_name, p);
+            emit!(P::BranchAge(v));
+        }
+    }
+
+    // 5. OWNER (skip detached)
+    if fields.contains(FieldSet::OWNER) && !target.is_detached {
+        if let Some(p) = path {
+            let owner = ownership::resolve_owner_with_fallbacks(
+                &ctx.base_branch,
+                &target.branch_name,
+                p,
+                ctx.ownership_strategy,
+                ctx.user_email.as_deref(),
+                Some(&ctx.remote_name),
+            );
+            emit!(P::Owner(owner));
+        }
+    }
+
+    // 6. REMOTE_AHEAD_BEHIND (skip detached)
+    if fields.contains(FieldSet::REMOTE_AHEAD_BEHIND) && !target.is_detached {
+        if let Some(p) = path {
+            let v = get_upstream_ahead_behind(&target.branch_name, p);
+            emit!(P::RemoteAheadBehind(v));
+        }
+    }
+
+    // 7. Stat::Lines clusters
+    if matches!(stat, Stat::Lines) {
+        if fields.contains(FieldSet::BASE_LINES) && !target.is_detached {
+            if let Some(p) = path {
+                let v = get_base_line_counts(&ctx.base_branch, &target.branch_name, p);
+                emit!(P::BaseLines(v));
+            }
+        }
+        if fields.contains(FieldSet::CHANGES_LINES) {
+            if let Some(p) = path {
+                let (s, u) = count_changed_lines(p);
+                emit!(P::ChangesLines { staged: s, unstaged: u });
+            }
+        }
+        if fields.contains(FieldSet::REMOTE_LINES) && !target.is_detached {
+            if let Some(p) = path {
+                let v = get_remote_line_counts(&target.branch_name, p);
+                emit!(P::RemoteLines(v));
+            }
+        }
+    }
+
+    // 8. SIZE (slowest cluster)
+    if fields.contains(FieldSet::SIZE) {
+        if let Some(p) = path {
+            emit!(P::Size(compute_directory_size(p)));
+        }
+    }
+
+    // 9. MTIME
+    if fields.contains(FieldSet::MTIME) {
+        if let Some(p) = path {
+            // Re-count just to get the path list — cheap relative to mtime walk.
+            let c = count_changed_files(p);
+            if !c.paths.is_empty() {
+                emit!(P::Mtime(max_mtime_of_files(p, &c.paths)));
+            } else {
+                emit!(P::Mtime(None));
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Add a fixture-repo integration test**
+
+Use the existing test-fixture pattern from `src/core/worktree/list.rs` tests if
+one exists; otherwise scaffold a minimal one:
+
+```rust
+#[cfg(test)]
+mod fixture_tests {
+    use super::*;
+    use std::process::Command;
+    use tempfile::TempDir;
+
+    fn init_temp_repo() -> TempDir {
+        let dir = TempDir::new().unwrap();
+        let p = dir.path();
+        Command::new("git").arg("init").arg("-q").current_dir(p).status().unwrap();
+        Command::new("git").args(["config", "user.email", "test@test.com"])
+            .current_dir(p).status().unwrap();
+        Command::new("git").args(["config", "user.name", "test"])
+            .current_dir(p).status().unwrap();
+        std::fs::write(p.join("README"), "hello").unwrap();
+        Command::new("git").args(["add", "."]).current_dir(p).status().unwrap();
+        Command::new("git").args(["commit", "-q", "-m", "init"])
+            .current_dir(p).status().unwrap();
+        Command::new("git").args(["branch", "-M", "master"])
+            .current_dir(p).status().unwrap();
+        dir
+    }
+
+    #[test]
+    fn collector_emits_changes_and_last_commit_for_a_real_repo() {
+        let dir = init_temp_repo();
+        let (tx, rx) = mpsc::channel();
+        let ctx = Arc::new(CollectorContext {
+            git: GitCommand::new(false),
+            base_branch: "master".into(),
+            remote_name: "origin".into(),
+            ownership_strategy: OwnershipStrategy::default(),
+            user_email: Some("test@test.com".into()),
+        });
+        let target = CollectorTarget {
+            branch_name: "master".into(),
+            path: Some(dir.path().to_path_buf()),
+            kind: EntryKind::Worktree,
+            is_detached: false,
+        };
+        let fields = FieldSet::CHANGES | FieldSet::LAST_COMMIT;
+        let handle = spawn(
+            CollectorRequest {
+                targets: vec![target],
+                fields,
+                stat: Stat::Summary,
+                source: PatchSource::Collector,
+                ctx,
+            },
+            tx,
+        );
+        handle.join();
+
+        let events: Vec<DagEvent> = rx.iter().collect();
+        let patches: Vec<_> = events.iter()
+            .filter_map(|e| match e {
+                DagEvent::WorktreeInfoUpdated { patch, .. } => Some(patch),
+                _ => None,
+            })
+            .collect();
+
+        assert!(patches.iter().any(|p|
+            matches!(p, crate::core::worktree::sync_dag::WorktreeInfoPatch::Changes { .. })
+        ));
+        assert!(patches.iter().any(|p|
+            matches!(p, crate::core::worktree::sync_dag::WorktreeInfoPatch::LastCommit { .. })
+        ));
+        // Did NOT request SIZE — must not appear.
+        assert!(!patches.iter().any(|p|
+            matches!(p, crate::core::worktree::sync_dag::WorktreeInfoPatch::Size(_))
+        ));
+        assert!(matches!(events.last(), Some(DagEvent::WorktreeInfoCollectionDone)));
+    }
+}
+```
+
+(If `tempfile` is not yet a dev-dependency, check `Cargo.toml` and add
+`tempfile = "3"` under `[dev-dependencies]` only.)
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test --lib core::worktree::list_stream` Expected: all collector
+tests pass.
+
+- [ ] **Step 5: Run clippy + full unit suite**
+
+Run: `mise run clippy && mise run test:unit` Expected: zero warnings, all tests
+pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/core/worktree/list_stream.rs src/core/worktree/list.rs Cargo.toml Cargo.lock
+git commit -m "feat(core): implement streaming collector worker (#402)"
+```
+
+---
+
+## Task 8: Stale-source suppression helper
+
+**Files:**
+
+- Modify: `src/core/worktree/sync_dag.rs`
+
+Helper used by `LiveTable` in Task 9 to decide whether to apply a patch based on
+the per-(branch, field) source priority log.
+
+- [ ] **Step 1: Add the helper type**
+
+Append to `src/core/worktree/sync_dag.rs`:
+
+```rust
+use crate::core::worktree::info_field::FieldSet;
+use std::collections::HashMap;
+
+/// Tracks which `PatchSource` last wrote each (branch, field) pair.
+/// Used by `LiveTable` to suppress patches arriving from a lower-priority
+/// source after a higher-priority source has already filled a field.
+#[derive(Debug, Default)]
+pub struct PatchSourceLog {
+    last_writer: HashMap<String, Vec<(FieldSet, PatchSource)>>,
+}
+
+impl PatchSourceLog {
+    /// Returns `true` if `source` is allowed to write `fields` for `branch`.
+    /// Updates internal state to record the new write.
+    pub fn try_admit(
+        &mut self,
+        branch: &str,
+        fields: FieldSet,
+        source: PatchSource,
+    ) -> bool {
+        let entries = self.last_writer.entry(branch.to_string()).or_default();
+        // If any existing entry overlaps with `fields` and has a strictly
+        // higher priority, reject.
+        for (existing_fields, existing_source) in entries.iter() {
+            if existing_fields.intersects(fields)
+                && existing_source.priority() > source.priority()
+            {
+                return false;
+            }
+        }
+        // Admit. Record (fields, source); we don't bother garbage-collecting
+        // overlapping entries — `intersects` checks above are O(entries) and
+        // the entry count per branch is bounded by the number of patch
+        // clusters (~11).
+        entries.push((fields, source));
+        true
+    }
+}
+
+#[cfg(test)]
+mod patch_source_log_tests {
+    use super::*;
+
+    #[test]
+    fn collector_then_post_fetch_admits_post_fetch() {
+        let mut log = PatchSourceLog::default();
+        assert!(log.try_admit("a", FieldSet::REMOTE_AHEAD_BEHIND, PatchSource::Collector));
+        assert!(log.try_admit("a", FieldSet::REMOTE_AHEAD_BEHIND, PatchSource::PostFetch));
+    }
+
+    #[test]
+    fn post_fetch_then_collector_rejects_collector() {
+        let mut log = PatchSourceLog::default();
+        assert!(log.try_admit("a", FieldSet::REMOTE_AHEAD_BEHIND, PatchSource::PostFetch));
+        assert!(!log.try_admit("a", FieldSet::REMOTE_AHEAD_BEHIND, PatchSource::Collector));
+    }
+
+    #[test]
+    fn disjoint_field_sets_do_not_block_each_other() {
+        let mut log = PatchSourceLog::default();
+        assert!(log.try_admit("a", FieldSet::SIZE, PatchSource::PostFetch));
+        // Different field — Collector still allowed.
+        assert!(log.try_admit("a", FieldSet::CHANGES, PatchSource::Collector));
+    }
+
+    #[test]
+    fn different_branches_are_independent() {
+        let mut log = PatchSourceLog::default();
+        assert!(log.try_admit("a", FieldSet::SIZE, PatchSource::PostFetch));
+        assert!(log.try_admit("b", FieldSet::SIZE, PatchSource::Collector));
+    }
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cargo test --lib core::worktree::sync_dag::patch_source_log_tests`
+Expected: 4 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/core/worktree/sync_dag.rs
+git commit -m "feat(core): add PatchSourceLog for stale-patch suppression (#402)"
+```
+
+---
+
+## Task 9: Extract `LiveTable` from `TuiState`
+
+**Files:**
+
+- Create: `src/output/tui/live_table.rs`
+- Modify: `src/output/tui/state.rs`
+- Modify: `src/output/tui/mod.rs`
+- Modify: `src/output/tui/render.rs`
+
+Move the worktree-rows portion of `TuiState` into `LiveTable`. `TuiState` keeps
+phases + hook summaries and embeds a `LiveTable` for rows. Render code that
+touches rows moves to `LiveTable::render_rows`; phase/hook render stays in
+`render.rs` and reads through the embedded `LiveTable`.
+
+> **Scope note for the engineer:** This is the biggest task in the plan (~250
+> LOC moved). Approach in three sub-commits:
+>
+> 1. Create `LiveTable` with the moved fields and methods (no consumer rewires
+>    yet); add ignore-arms in `TuiState::apply_event` for the new events;
+>    `LiveTable` is dead code at this point.
+> 2. Rewire `TuiState` to embed `LiveTable`; update `TuiState::new` to construct
+>    the inner `LiveTable`; update field accesses across `render.rs` and any
+>    other consumers.
+> 3. Wire `WorktreeInfoUpdated` and `WorktreeInfoCollectionDone` arms in
+>    `TuiState::apply_event` to forward to `LiveTable::apply_event`.
+>
+> Each sub-commit must compile and pass `mise run test:unit`.
+
+- [ ] **Step 1: Create `LiveTable` with moved fields**
+
+Create `src/output/tui/live_table.rs`:
+
+```rust
+//! Worktree-rows widget shared by `daft list`, `daft prune`, and `daft sync`.
+//!
+//! Owns: row collection, sort, owner-partition, column selection, patch
+//! application, loading-glyph state. Knows nothing about phases or hook
+//! sub-rows — those live in the wrapping `OperationTable` / `TuiState`.
+
+use crate::{
+    core::{
+        sort::SortSpec,
+        worktree::{
+            info_field::FieldSet,
+            list::{EntryKind, Stat, WorktreeInfo},
+            sync_dag::{DagEvent, PatchSourceLog},
+        },
+    },
+    output::tui::columns::Column,
+};
+use std::path::PathBuf;
+
+use super::state::WorktreeRow;  // existing struct stays where it is
+
+#[derive(Clone)]
+pub struct LiveTableConfig {
+    pub stat: Stat,
+    pub columns: Option<Vec<Column>>,
+    pub columns_explicit: bool,
+    pub sort_spec: Option<SortSpec>,
+    /// `true` for prune/sync (anchor on the operation's trunk),
+    /// `false` for `daft list` (pure --sort).
+    pub pin_default_branch: bool,
+    /// `true` for prune/sync (split rows by `is_owned`),
+    /// `false` for `daft list` (no partition).
+    pub partition_by_owner: bool,
+    pub project_root: PathBuf,
+    pub cwd: PathBuf,
+}
+
+pub struct LiveTable {
+    pub rows: Vec<WorktreeRow>,
+    pub cfg: LiveTableConfig,
+    pub pending_resort: bool,
+    pub collection_complete: bool,
+    pub source_log: PatchSourceLog,
+    /// Per-row bitmask of "patches received". Used to render the loading
+    /// glyph for cells that are `None` AND have not yet received a patch.
+    pub received_patches: Vec<FieldSet>,
+    /// Index of the first row in the unowned section (or `None` if no
+    /// partition). Recomputed on each `tick` when `partition_by_owner` is
+    /// true.
+    pub unowned_start_index: Option<usize>,
+}
+
+impl LiveTable {
+    pub fn new(seed: Vec<WorktreeInfo>, cfg: LiveTableConfig) -> Self {
+        let received_patches = vec![FieldSet::EMPTY; seed.len()];
+        let rows: Vec<WorktreeRow> = seed.into_iter()
+            .map(WorktreeRow::idle)  // helper added below
+            .collect();
+        let mut t = Self {
+            rows, cfg, pending_resort: true, collection_complete: false,
+            source_log: PatchSourceLog::default(),
+            received_patches,
+            unowned_start_index: None,
+        };
+        t.resort_and_repartition();
+        t
+    }
+
+    pub fn apply_event(&mut self, event: &DagEvent) {
+        match event {
+            DagEvent::WorktreeInfoUpdated { branch_name, patch, source } => {
+                let touched = match self.find_row_idx(branch_name) {
+                    Some(idx) => {
+                        // Compute the FieldSet this patch claims to write
+                        // (without mutating yet) so we can consult the
+                        // source log first.
+                        let claim = patch_field_claim(patch);
+                        if !self.source_log.try_admit(branch_name, claim, *source) {
+                            return;
+                        }
+                        let touched = self.rows[idx].info.apply_patch(patch);
+                        self.received_patches[idx] |= touched;
+                        touched
+                    }
+                    None => return,
+                };
+                if let Some(spec) = &self.cfg.sort_spec {
+                    if touched.intersects(spec.required_fields()) {
+                        self.pending_resort = true;
+                    }
+                }
+                if self.cfg.partition_by_owner && touched.contains(FieldSet::OWNER) {
+                    self.pending_resort = true;
+                }
+            }
+            DagEvent::WorktreeInfoCollectionDone => {
+                self.collection_complete = true;
+                self.pending_resort = true;
+            }
+            _ => { /* not our concern — phase/hook events handled by wrapper */ }
+        }
+    }
+
+    pub fn tick(&mut self) {
+        if self.pending_resort {
+            self.resort_and_repartition();
+            self.pending_resort = false;
+        }
+    }
+
+    fn find_row_idx(&self, branch: &str) -> Option<usize> {
+        self.rows.iter().position(|r| r.info.name == branch)
+    }
+
+    fn resort_and_repartition(&mut self) {
+        let pin = self.cfg.pin_default_branch;
+        let sort_spec = self.cfg.sort_spec.clone();
+        // Stable sort to preserve relative order on ties.
+        let mut indexed: Vec<usize> = (0..self.rows.len()).collect();
+        indexed.sort_by(|&a, &b| {
+            let ra = &self.rows[a]; let rb = &self.rows[b];
+            // 1. Default branch first if pinned.
+            if pin {
+                let da = u8::from(!ra.info.is_default_branch);
+                let db = u8::from(!rb.info.is_default_branch);
+                let c = da.cmp(&db);
+                if c != std::cmp::Ordering::Equal { return c; }
+            }
+            // 2. Kind ordering: Worktree < LocalBranch < RemoteBranch.
+            let kind = |k: &EntryKind| match k {
+                EntryKind::Worktree => 0,
+                EntryKind::LocalBranch => 1,
+                EntryKind::RemoteBranch => 2,
+            };
+            let c = kind(&ra.info.kind).cmp(&kind(&rb.info.kind));
+            if c != std::cmp::Ordering::Equal { return c; }
+            // 3. User sort spec, or alphabetical fallback.
+            match &sort_spec {
+                Some(spec) => spec.compare(&ra.info, &rb.info),
+                None => ra.info.name.to_lowercase().cmp(&rb.info.name.to_lowercase()),
+            }
+        });
+
+        // Apply the permutation to both rows and received_patches.
+        let mut new_rows: Vec<WorktreeRow> = Vec::with_capacity(self.rows.len());
+        let mut new_recv: Vec<FieldSet> = Vec::with_capacity(self.received_patches.len());
+        for &i in &indexed {
+            new_rows.push(std::mem::replace(&mut self.rows[i], WorktreeRow::placeholder()));
+            new_recv.push(self.received_patches[i]);
+        }
+        self.rows = new_rows;
+        self.received_patches = new_recv;
+
+        // Recompute partition index.
+        self.unowned_start_index = if self.cfg.partition_by_owner {
+            self.rows.iter().position(|r| r.info.owner.is_none())
+        } else {
+            None
+        };
+    }
+
+    /// True when the cell for `field` on `row_idx` should render the
+    /// loading glyph. Only meaningful while !collection_complete.
+    pub fn is_cell_loading(&self, row_idx: usize, field: FieldSet) -> bool {
+        !self.collection_complete && !self.received_patches[row_idx].contains(field)
+    }
+}
+
+fn patch_field_claim(patch: &crate::core::worktree::sync_dag::WorktreeInfoPatch) -> FieldSet {
+    use crate::core::worktree::sync_dag::WorktreeInfoPatch as P;
+    match patch {
+        P::BaseAheadBehind(_)   => FieldSet::BASE_AHEAD_BEHIND,
+        P::RemoteAheadBehind(_) => FieldSet::REMOTE_AHEAD_BEHIND,
+        P::Changes { .. }       => FieldSet::CHANGES,
+        P::LastCommit { .. }    => FieldSet::LAST_COMMIT,
+        P::BranchAge(_)         => FieldSet::BRANCH_AGE,
+        P::Owner(_)             => FieldSet::OWNER,
+        P::BaseLines(_)         => FieldSet::BASE_LINES,
+        P::ChangesLines { .. }  => FieldSet::CHANGES_LINES,
+        P::RemoteLines(_)       => FieldSet::REMOTE_LINES,
+        P::Size(_)              => FieldSet::SIZE,
+        P::Mtime(_)             => FieldSet::MTIME,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::worktree::sync_dag::{PatchSource, WorktreeInfoPatch};
+
+    fn cfg() -> LiveTableConfig {
+        LiveTableConfig {
+            stat: Stat::Summary,
+            columns: None,
+            columns_explicit: false,
+            sort_spec: None,
+            pin_default_branch: true,
+            partition_by_owner: false,
+            project_root: PathBuf::from("/tmp"),
+            cwd: PathBuf::from("/tmp"),
+        }
+    }
+
+    fn info(name: &str) -> WorktreeInfo {
+        WorktreeInfo::empty(name)
+    }
+
+    #[test]
+    fn collection_done_sets_collection_complete() {
+        let mut t = LiveTable::new(vec![info("a")], cfg());
+        assert!(!t.collection_complete);
+        t.apply_event(&DagEvent::WorktreeInfoCollectionDone);
+        assert!(t.collection_complete);
+    }
+
+    #[test]
+    fn updated_event_for_unknown_branch_is_ignored() {
+        let mut t = LiveTable::new(vec![info("a")], cfg());
+        t.apply_event(&DagEvent::WorktreeInfoUpdated {
+            branch_name: "b".into(),
+            patch: WorktreeInfoPatch::Size(Some(123)),
+            source: PatchSource::Collector,
+        });
+        assert_eq!(t.rows[0].info.size_bytes, None);
+    }
+
+    #[test]
+    fn patch_applied_marks_received_for_loading_glyph() {
+        let mut t = LiveTable::new(vec![info("a")], cfg());
+        assert!(t.is_cell_loading(0, FieldSet::SIZE));
+        t.apply_event(&DagEvent::WorktreeInfoUpdated {
+            branch_name: "a".into(),
+            patch: WorktreeInfoPatch::Size(Some(123)),
+            source: PatchSource::Collector,
+        });
+        assert!(!t.is_cell_loading(0, FieldSet::SIZE));
+        assert_eq!(t.rows[0].info.size_bytes, Some(123));
+    }
+
+    #[test]
+    fn collector_patch_is_dropped_after_post_fetch_for_same_field() {
+        let mut t = LiveTable::new(vec![info("a")], cfg());
+        t.apply_event(&DagEvent::WorktreeInfoUpdated {
+            branch_name: "a".into(),
+            patch: WorktreeInfoPatch::RemoteAheadBehind(Some((5, 0))),
+            source: PatchSource::PostFetch,
+        });
+        // Collector patch arriving late must be ignored.
+        t.apply_event(&DagEvent::WorktreeInfoUpdated {
+            branch_name: "a".into(),
+            patch: WorktreeInfoPatch::RemoteAheadBehind(Some((1, 1))),
+            source: PatchSource::Collector,
+        });
+        assert_eq!(t.rows[0].info.remote_ahead, Some(5));
+        assert_eq!(t.rows[0].info.remote_behind, Some(0));
+    }
+}
+```
+
+- [ ] **Step 2: Add `WorktreeRow::idle` and `placeholder` helpers**
+
+In `src/output/tui/state.rs`, inside `impl WorktreeRow` (add the impl block if
+missing), append:
+
+```rust
+impl WorktreeRow {
+    pub(crate) fn idle(info: WorktreeInfo) -> Self {
+        Self {
+            info,
+            status: WorktreeStatus::Idle,
+            prev_terminal_status: None,
+            hook_warned: false,
+            hook_failed: false,
+            hook_sub_rows: Vec::new(),
+            failure_reason: None,
+        }
+    }
+
+    /// Used during the resort permutation. Replaced before any read.
+    pub(crate) fn placeholder() -> Self {
+        Self::idle(WorktreeInfo::empty(""))
+    }
+}
+```
+
+- [ ] **Step 3: Re-export `LiveTable`**
+
+In `src/output/tui/mod.rs`, add:
+
+```rust
+pub mod live_table;
+pub use live_table::{LiveTable, LiveTableConfig};
+```
+
+- [ ] **Step 4: Run unit tests**
+
+Run: `cargo test --lib output::tui::live_table` Expected: 4 tests pass.
+
+- [ ] **Step 5: Commit (sub-commit 1 of 3)**
+
+```bash
+git add src/output/tui/live_table.rs src/output/tui/state.rs src/output/tui/mod.rs
+git commit -m "feat(tui): introduce LiveTable widget (#402)"
+```
+
+- [ ] **Step 6: Embed `LiveTable` inside `TuiState`**
+
+In `src/output/tui/state.rs`:
+
+1. Remove the following fields from `TuiState`: `worktrees`, `project_root`,
+   `cwd`, `stat`, `columns`, `columns_explicit`, `unowned_start_index`,
+   `sort_spec`. (They live inside the embedded `LiveTable` now.)
+2. Add `pub live: LiveTable` to `TuiState`.
+3. Update `TuiState::new` to build a
+   `LiveTableConfig { pin_default_branch: true, partition_by_owner: true, ... }`
+   (preserves today's prune/sync behavior) and call
+   `LiveTable::new(worktree_infos, cfg)`.
+4. Update `TuiState::tick` to delegate to `self.live.tick()`.
+
+For every external read of the moved fields (in `src/output/tui/render.rs`,
+`src/output/tui/operation_table.rs`, etc.), replace `state.worktrees` with
+`state.live.rows`, `state.cwd` with `state.live.cfg.cwd`, etc.
+
+Run: `cargo build` Expected: compiles after all references are updated.
+
+Run: `mise run test:unit` Expected: all existing tests pass.
+
+- [ ] **Step 7: Commit (sub-commit 2 of 3)**
+
+```bash
+git add -u
+git commit -m "refactor(tui): embed LiveTable inside TuiState (#402)"
+```
+
+- [ ] **Step 8: Wire row events from `TuiState::apply_event`**
+
+In `src/output/tui/state.rs`, replace the no-op arms added in Task 5 with:
+
+```rust
+            DagEvent::WorktreeInfoUpdated { .. }
+            | DagEvent::WorktreeInfoCollectionDone => {
+                self.live.apply_event(event);
+            }
+```
+
+Run: `mise run test:unit && mise run clippy` Expected: zero warnings, all tests
+pass.
+
+- [ ] **Step 9: Commit (sub-commit 3 of 3)**
+
+```bash
+git add src/output/tui/state.rs
+git commit -m "feat(tui): forward WorktreeInfo events from TuiState to LiveTable (#402)"
+```
+
+---
+
+## Task 10: Add `pin_default_branch` and `partition_by_owner` to `TableConfig`
+
+**Files:**
+
+- Modify: `src/output/tui/operation_table.rs`
+
+`OperationTable` is the public wrapper used by prune/sync today. Surfacing the
+new config knobs here lets future callers (and `daft list` in Phase 2) pick
+non-default behavior. Defaults preserve today's behavior.
+
+- [ ] **Step 1: Extend `TableConfig`**
+
+In `src/output/tui/operation_table.rs`, add to `pub struct TableConfig`:
+
+```rust
+    /// Pin the default branch to the first row regardless of `--sort`.
+    /// Defaults to `true` (prune/sync behavior). `daft list` will set
+    /// `false` in Phase 2.
+    pub pin_default_branch: bool,
+    /// Split rows into "owned" and "unowned" sections by `info.owner`.
+    /// Defaults to `true` (prune/sync behavior). `daft list` will set
+    /// `false` in Phase 2.
+    pub partition_by_owner: bool,
+```
+
+Update `OperationTable::run` to thread these into the `LiveTableConfig`
+constructed inside `TuiState::new`. (May require widening `TuiState::new`'s
+parameter list — do that, and update callers.)
+
+- [ ] **Step 2: Update prune/sync callsites to set defaults explicitly**
+
+In `src/commands/prune.rs` and `src/commands/sync.rs`, where
+`TableConfig { ... }` is constructed, add:
+
+```rust
+            pin_default_branch: true,
+            partition_by_owner: true,
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `mise run test:unit` Expected: all existing tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/output/tui/operation_table.rs src/commands/prune.rs src/commands/sync.rs src/output/tui/state.rs
+git commit -m "feat(tui): add pin_default_branch and partition_by_owner config (#402)"
+```
+
+---
+
+## Task 11: Remove `TaskCompleted::updated_info`; sync/prune emit `PostTask` patches
+
+**Files:**
+
+- Modify: `src/core/worktree/sync_dag.rs`
+- Modify: `src/commands/sync.rs`
+- Modify: `src/commands/prune.rs`
+- Modify: `src/core/worktree/sync_dag.rs` (DagExecutor task closure signature)
+
+The orchestrator stops sending whole `WorktreeInfo` snapshots; it sends typed
+`PostTask` patches for the fields each task touches.
+
+| Task     | Fields re-emitted as `PostTask(phase)`                    |
+| -------- | --------------------------------------------------------- |
+| `Update` | `BASE_AHEAD_BEHIND`, `LAST_COMMIT`, `CHANGES`             |
+| `Rebase` | `BASE_AHEAD_BEHIND`, `LAST_COMMIT`, `REMOTE_AHEAD_BEHIND` |
+| `Push`   | `REMOTE_AHEAD_BEHIND`                                     |
+| `Prune`  | (row removed; no patch)                                   |
+
+- [ ] **Step 1: Drop `updated_info` from `TaskCompleted`**
+
+In `src/core/worktree/sync_dag.rs`, remove the
+`updated_info: Option<Box<WorktreeInfo>>` field from `DagEvent::TaskCompleted`.
+Update the `DagExecutor::run` task closure signature to drop the matching
+return-tuple element. Update internal sites that unwrap the field to ignore it.
+
+- [ ] **Step 2: Emit `PostTask` patches from sync's per-task handler**
+
+In `src/commands/sync.rs`, the orchestrator already builds an
+`Arc<DaftSettings>` plus the per-branch
+`worktree_map: HashMap<String, (PathBuf, bool)>`. Construct a small helper and
+call it from each per-branch task closure (Update, Rebase, Push):
+
+```rust
+fn spawn_post_task_refresh(
+    branch_name: &str,
+    phase: OperationPhase,
+    fields: FieldSet,
+    worktree_map: &HashMap<String, (PathBuf, bool)>,
+    settings: &Arc<DaftSettings>,
+    base_branch: &str,
+    user_email: Option<&str>,
+    stat: Stat,
+    tx: &mpsc::Sender<DagEvent>,
+) {
+    let Some((path, _is_main)) = worktree_map.get(branch_name) else { return };
+    let target = list_stream::CollectorTarget {
+        branch_name: branch_name.to_string(),
+        path: Some(path.clone()),
+        kind: EntryKind::Worktree,
+        is_detached: false,
+    };
+    let ctx = Arc::new(list_stream::CollectorContext {
+        git: GitCommand::new(false).with_gitoxide(settings.use_gitoxide),
+        base_branch: base_branch.to_string(),
+        remote_name: settings.remote.clone(),
+        ownership_strategy: settings.ownership_strategy,
+        user_email: user_email.map(|s| s.to_string()),
+    });
+    let handle = list_stream::spawn(
+        list_stream::CollectorRequest {
+            targets: vec![target],
+            fields,
+            stat,
+            source: PatchSource::PostTask(phase),
+            ctx,
+        },
+        tx.clone(),
+    );
+    handle.join();   // block briefly so patches land before the next task starts
+}
+```
+
+Call it from the Update / Rebase / Push branches of `executor.run`'s task
+closure with the field sets from the table above. Prune is a no-op (row
+removed).
+
+(`handle.join()` here is a deliberate small blocking wait — the per-task refresh
+is a few git calls and we want its patches to land before the next task starts
+so `LiveTable` doesn't briefly show stale values. If this shows up as a hot spot
+in benchmarks later, switch to dropping the handle and accepting the brief
+staleness window.)
+
+- [ ] **Step 3: Apply the same to prune (no-op for Prune task)**
+
+In `src/commands/prune.rs`, remove any `updated_info` construction. The prune
+task removes the row; emit no patch.
+
+- [ ] **Step 4: Update tests in `src/core/worktree/sync_dag.rs`**
+
+Existing `let events: Vec<DagEvent> = rx.iter().collect()` tests around line 776
+need to drop assertions about `updated_info`. Replace with assertions about the
+absence of the field and the new pattern.
+
+- [ ] **Step 5: Run unit + integration suite**
+
+Run: `mise run test:unit` Expected: all unit tests pass.
+
+Run: `mise run test:integration` Expected: all existing prune/sync integration
+tests pass with the new event shape (behavior unchanged).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/core/worktree/sync_dag.rs src/commands/sync.rs src/commands/prune.rs
+git commit -m "refactor(orchestrator): replace TaskCompleted::updated_info with PostTask patches (#402)"
+```
+
+---
+
+## Task 12: Final verification
+
+- [ ] **Step 1: Run the full CI matrix locally**
+
+Run: `mise run ci` Expected: zero warnings, all unit + integration tests pass.
+
+- [ ] **Step 2: Manual smoke test**
+
+Run: `mise run dev` then in another terminal:
+
+```bash
+cd /tmp && daft list   # should behave exactly as before today
+daft prune             # should behave exactly as before today
+daft sync              # should behave exactly as before today
+```
+
+Expected: identical UX to before this branch. No spinners removed yet (that
+lands in Phase 2/3); no new live behavior visible.
+
+- [ ] **Step 3: Push branch and open PR**
+
+```bash
+git push -u origin daft-402/feat/live-list-population
+gh pr create --title "feat: shared infrastructure for live list population (#402)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Phase 1 of 3 for #402. Adds shared infrastructure for the live cell-by-cell
+population work without changing any user-visible behavior. Phases 2
+(`daft list` live UX) and 3 (migrate prune/sync to streaming seed) ship in
+follow-up PRs.
+
+What lands:
+- `FieldSet` bitmask, `WorktreeInfoPatch`, `PatchSource`
+- `DagEvent::WorktreeInfoUpdated`, `DagEvent::WorktreeInfoCollectionDone`
+- `WorktreeInfo::apply_patch`, `SortSpec::required_fields`
+- Streaming collector (`src/core/worktree/list_stream.rs`)
+- `LiveTable` widget extracted from `TuiState`
+- `TaskCompleted::updated_info` removed; orchestrator now emits `PostTask`
+  patches with the same end-state information
+
+Existing prune/sync integration tests pass unchanged.
+
+Spec: `docs/superpowers/specs/2026-04-25-live-list-population-design.md`
+
+## Test plan
+- [x] `mise run test:unit` passes
+- [x] `mise run test:integration` passes
+- [x] `mise run clippy` zero warnings
+- [x] Manual smoke: `daft list`, `daft prune`, `daft sync` behave as before
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR opened against master, CI green.
+
+---
+
+## Self-Review Notes
+
+Performed inline before save:
+
+- **Spec coverage**: every Phase 1 deliverable in the spec maps to one or more
+  tasks (FieldSet=T1, required_fields=T2, patches+source=T3, apply_patch=T4,
+  DagEvent variants=T5, collector=T6+T7, source-log=T8, LiveTable=T9, config
+  knobs=T10, orchestrator migration=T11, verification=T12).
+- **Placeholders**: none. All steps include exact code + commands.
+- **Type consistency**: `FieldSet`, `WorktreeInfoPatch`, `PatchSource`,
+  `LiveTable`, `LiveTableConfig`, `CollectorRequest`, `CollectorTarget`,
+  `CollectorContext`, `CollectorHandle`, `PatchSourceLog` are used consistently
+  across tasks.
+- **Scope**: Phase 1 only. Phases 2 and 3 explicitly deferred to separate plans,
+  written when those phases begin.
+- **Ambiguity**: Task 9 calls out the three sub-commit decomposition explicitly
+  so the engineer doesn't try to land a single 250-LOC commit.

--- a/docs/superpowers/plans/2026-04-25-live-list-population-phase-1-shared-infra.md
+++ b/docs/superpowers/plans/2026-04-25-live-list-population-phase-1-shared-infra.md
@@ -819,7 +819,11 @@ pub struct CollectorTarget {
 }
 
 pub struct CollectorContext {
-    pub git: GitCommand,
+    /// Whether to use gitoxide for read paths. Workers construct their own
+    /// `GitCommand` because `gix::ThreadSafeRepository` contains `Rc<…>`
+    /// internally and is `Send` but not `Sync` — wrapping `GitCommand` in
+    /// `Arc<CollectorContext>` would block the closure's `Send` bound.
+    pub use_gitoxide: bool,
     pub base_branch: String,
     pub remote_name: String,
     pub ownership_strategy: OwnershipStrategy,
@@ -1038,6 +1042,12 @@ fn run_worker(
         max_mtime_of_files,
     };
     use crate::core::worktree::sync_dag::WorktreeInfoPatch as P;
+    use crate::git::GitCommand;
+
+    // Workers construct their own GitCommand: gix::ThreadSafeRepository is
+    // !Sync, so wrapping GitCommand in Arc<CollectorContext> would block the
+    // closure's Send bound. ctx.use_gitoxide carries the choice through.
+    let git = GitCommand::new(true).with_gitoxide(ctx.use_gitoxide);
 
     macro_rules! emit {
         ($patch:expr) => {{
@@ -1045,7 +1055,7 @@ fn run_worker(
             let _ = tx.send(DagEvent::WorktreeInfoUpdated {
                 branch_name: target.branch_name.clone(),
                 patch: $patch,
-                source,
+                source: source.clone(),  // PatchSource is Clone, not Copy.
             });
         }};
     }
@@ -1073,7 +1083,7 @@ fn run_worker(
     // 3. LAST_COMMIT
     if fields.contains(FieldSet::LAST_COMMIT) {
         if let Some(p) = path {
-            let (timestamp, hash, subject) = get_commit_metadata(p, &ctx.git);
+            let (timestamp, hash, subject) = get_commit_metadata(p, &git);
             emit!(P::LastCommit { timestamp, hash, subject });
         }
     }
@@ -1187,10 +1197,10 @@ mod fixture_tests {
         let dir = init_temp_repo();
         let (tx, rx) = mpsc::channel();
         let ctx = Arc::new(CollectorContext {
-            git: GitCommand::new(false),
+            use_gitoxide: false,
             base_branch: "master".into(),
             remote_name: "origin".into(),
-            ownership_strategy: OwnershipStrategy::default(),
+            ownership_strategy: OwnershipStrategy::RecencyPlurality,
             user_email: Some("test@test.com".into()),
         });
         let target = CollectorTarget {
@@ -1856,7 +1866,7 @@ fn spawn_post_task_refresh(
         is_detached: false,
     };
     let ctx = Arc::new(list_stream::CollectorContext {
-        git: GitCommand::new(false).with_gitoxide(settings.use_gitoxide),
+        use_gitoxide: settings.use_gitoxide,
         base_branch: base_branch.to_string(),
         remote_name: settings.remote.clone(),
         ownership_strategy: settings.ownership_strategy,

--- a/docs/superpowers/plans/2026-04-25-live-list-population-phase-1-shared-infra.md
+++ b/docs/superpowers/plans/2026-04-25-live-list-population-phase-1-shared-infra.md
@@ -1469,7 +1469,9 @@ impl LiveTable {
                         // (without mutating yet) so we can consult the
                         // source log first.
                         let claim = patch_field_claim(patch);
-                        if !self.source_log.try_admit(branch_name, claim, *source) {
+                        // PatchSource is Clone (not Copy) because it carries
+                        // OperationPhase which contains a String-bearing variant.
+                        if !self.source_log.try_admit(branch_name, claim, source.clone()) {
                             return;
                         }
                         let touched = self.rows[idx].info.apply_patch(patch);

--- a/docs/superpowers/plans/2026-04-26-list-cache-content-addressed.md
+++ b/docs/superpowers/plans/2026-04-26-list-cache-content-addressed.md
@@ -1,0 +1,1204 @@
+# Content-Addressed Cache for `daft list` Slow Cells — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make warm-cache `daft list` runs near-instant for ahead/behind,
+line-stat, and last-commit cells by caching their results under a
+`(sha-pair) → result` key, so repeat runs hit JSON files instead of forking
+`git rev-list` / `git diff` / `git log`.
+
+**Architecture:** Add a tiny on-disk cache layer at
+`<git-common-dir>/.daft/cache/<kind>/<key>.json`, mirroring worktrunk's design.
+Each cell becomes "resolve key SHAs → try cache → on miss, compute and write."
+The cache is **content-addressed** — the key fully captures the inputs, so a hit
+is provably correct (no TTL, no invalidation needed). Cells whose inputs include
+working-tree state (Size, Changes) are out of scope; they keep streaming as
+today and show the `·` skeleton glyph until computed.
+
+**Tech Stack:** Rust 2021, `serde` + `serde_json` (already deps), `std::fs`, no
+new crates.
+
+**Why this preserves the "skeleton over stale" rule:** content-addressed keys
+make staleness impossible — any state change that would invalidate a result also
+changes the key, producing a cache miss. A cache hit is byte-identical to a
+fresh fork of the underlying git command. Cells that _can't_ be
+content-addressed (Size, Changes) are deliberately excluded.
+
+---
+
+## File Structure
+
+| Path                                                     | Responsibility                                                                                                                                                                                                                                                           |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `src/core/cache.rs` _(new)_                              | Filesystem primitives: `cache_dir`, `read_json`, `write_json`, `clear_kind`. Torn-write tolerance, silent-failure write policy. Mirrors worktrunk's `cache.rs`.                                                                                                          |
+| `src/core/mod.rs` _(modify)_                             | Add `pub mod cache;`                                                                                                                                                                                                                                                     |
+| `src/core/worktree/cell_cache.rs` _(new)_                | Per-cell wrappers: `cached_base_ahead_behind`, `cached_remote_ahead_behind`, `cached_last_commit`, `cached_base_lines`, `cached_remote_lines`. Each resolves the SHAs needed for its key, calls `read_json`, falls back to the underlying compute fn, writes the result. |
+| `src/core/worktree/mod.rs` _(modify)_                    | Add `pub(crate) mod cell_cache;`                                                                                                                                                                                                                                         |
+| `src/core/worktree/list_stream.rs` _(modify)_            | Replace direct calls to `get_ahead_behind`, `get_upstream_ahead_behind`, `get_commit_metadata`, `get_base_line_counts`, `get_remote_line_counts` with the `cell_cache::cached_*` wrappers.                                                                               |
+| `tests/manual/scenarios/list/cache-warm-hit.yml` _(new)_ | YAML scenario: run `daft list` twice, assert cache files are written on first run and read on second.                                                                                                                                                                    |
+
+The cache module is intentionally tiny and lives at `core/cache.rs` rather than
+under `core/worktree/` so other commands (`prune`, `sync`) can adopt it later
+without import gymnastics. Per-cell logic lives next to the streaming collector
+that uses it.
+
+---
+
+## Task 1: Add cache primitives module
+
+**Files:**
+
+- Create: `src/core/cache.rs`
+- Modify: `src/core/mod.rs:1-30`
+- Test: `src/core/cache.rs` (`#[cfg(test)] mod tests`)
+
+- [ ] **Step 1: Write the failing tests**
+
+In `src/core/cache.rs`, add the following at the bottom of the file (you'll
+create the file in step 3 — for now just sketch the test bodies in a scratch
+buffer; we'll write them in place once the module exists):
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    struct Foo {
+        n: u32,
+        s: String,
+    }
+
+    #[test]
+    fn read_returns_none_for_missing_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("missing.json");
+        let read: Option<Foo> = read_json(&path);
+        assert!(read.is_none());
+    }
+
+    #[test]
+    fn write_then_read_round_trips() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("nested").join("entry.json");
+        let v = Foo { n: 7, s: "hello".into() };
+        write_json(&path, &v);
+        let got: Option<Foo> = read_json(&path);
+        assert_eq!(got, Some(v));
+    }
+
+    #[test]
+    fn read_returns_none_for_corrupt_json() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("bad.json");
+        std::fs::write(&path, b"{not-json").unwrap();
+        let got: Option<Foo> = read_json(&path);
+        assert!(got.is_none());
+    }
+
+    #[test]
+    fn write_creates_missing_parent_dirs() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("a").join("b").join("c").join("e.json");
+        write_json(&path, &Foo { n: 1, s: "x".into() });
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn cache_dir_uses_kind_under_git_common() {
+        let dir = TempDir::new().unwrap();
+        let p = cache_dir_for(dir.path(), "ahead-behind");
+        assert_eq!(p, dir.path().join(".daft").join("cache").join("ahead-behind"));
+    }
+
+    #[test]
+    fn clear_kind_removes_directory_contents() {
+        let dir = TempDir::new().unwrap();
+        let kind_dir = cache_dir_for(dir.path(), "k");
+        std::fs::create_dir_all(&kind_dir).unwrap();
+        std::fs::write(kind_dir.join("a.json"), "{}").unwrap();
+        std::fs::write(kind_dir.join("b.json"), "{}").unwrap();
+        clear_kind(dir.path(), "k").unwrap();
+        let entries: Vec<_> = std::fs::read_dir(&kind_dir).unwrap().collect();
+        assert!(entries.is_empty());
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to confirm the file doesn't exist yet**
+
+Run: `cargo test --lib core::cache 2>&1 | tail -10` Expected:
+`error[E0432]: unresolved import \`crate::core::cache\`` (the module doesn't
+exist yet).
+
+- [ ] **Step 3: Create `src/core/cache.rs`**
+
+```rust
+//! On-disk JSON cache primitives shared by the per-cell cache wrappers.
+//!
+//! Lives under `<git-common-dir>/.daft/cache/<kind>/`. Each kind owns its
+//! filename scheme (typically `{sha1}-{sha2}.json` for content-addressed pair
+//! caches) and its struct shape. This module owns only the filesystem
+//! mechanics so torn-write semantics and the silent-failure write policy live
+//! in one place.
+//!
+//! # Torn-write semantics
+//!
+//! Writes use `fs::write` directly, not temp-file-plus-rename. A crash mid-
+//! write produces a truncated file at the expected path, which `read_json`
+//! rejects as corrupt JSON — indistinguishable from a cache miss from the
+//! caller's perspective.
+//!
+//! # Error policy
+//!
+//! - `read_json` returns `None` on any failure (missing file, I/O error,
+//!   corrupt JSON). Corrupt JSON is logged at debug.
+//! - `write_json` degrades silently — a failed write just means the next
+//!   read recomputes.
+//! - `clear_kind` propagates I/O errors so a future `daft cache clear`
+//!   command could report failures.
+
+use serde::{de::DeserializeOwned, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// The directory for a named cache kind under the given git common dir.
+pub fn cache_dir_for(git_common_dir: &Path, kind: &str) -> PathBuf {
+    git_common_dir.join(".daft").join("cache").join(kind)
+}
+
+/// Read and deserialize a JSON cache entry. Returns `None` on any failure.
+pub fn read_json<T: DeserializeOwned>(path: &Path) -> Option<T> {
+    let json = fs::read_to_string(path).ok()?;
+    match serde_json::from_str::<T>(&json) {
+        Ok(value) => Some(value),
+        Err(e) => {
+            log::debug!("cache: corrupt entry at {}: {}", path.display(), e);
+            None
+        }
+    }
+}
+
+/// Serialize and write a JSON cache entry, creating parent dirs as needed.
+/// Degrades silently on any failure.
+pub fn write_json<T: Serialize>(path: &Path, value: &T) {
+    if let Some(parent) = path.parent() {
+        if let Err(e) = fs::create_dir_all(parent) {
+            log::debug!("cache: mkdir {} failed: {}", parent.display(), e);
+            return;
+        }
+    }
+    let json = match serde_json::to_string(value) {
+        Ok(j) => j,
+        Err(e) => {
+            log::debug!("cache: serialize {} failed: {}", path.display(), e);
+            return;
+        }
+    };
+    if let Err(e) = fs::write(path, json) {
+        log::debug!("cache: write {} failed: {}", path.display(), e);
+    }
+}
+
+/// Delete every regular file in the cache kind's directory. Errors propagate
+/// so callers can report partial failures.
+pub fn clear_kind(git_common_dir: &Path, kind: &str) -> std::io::Result<()> {
+    let dir = cache_dir_for(git_common_dir, kind);
+    let read = match fs::read_dir(&dir) {
+        Ok(r) => r,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(e),
+    };
+    for entry in read {
+        let entry = entry?;
+        if entry.file_type()?.is_file() {
+            fs::remove_file(entry.path())?;
+        }
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Wire up the module**
+
+In `src/core/mod.rs`, add `pub mod cache;` in alphabetical order (after
+`pub mod columns;` line if present, otherwise at the appropriate alpha
+position).
+
+```rust
+// Look for the existing `pub mod ...` block in core/mod.rs and add:
+pub mod cache;
+```
+
+- [ ] **Step 5: Run the tests to confirm they pass**
+
+Run: `cargo test --lib core::cache 2>&1 | tail -10` Expected:
+`test result: ok. 6 passed; 0 failed; 0 ignored`
+
+- [ ] **Step 6: Run clippy + fmt**
+
+Run: `mise run clippy && mise run fmt` Expected: clippy clean, fmt applies no
+changes (or only this file).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/core/cache.rs src/core/mod.rs
+git commit -m "feat(cache): add JSON cache primitives under .git/.daft/cache/ (#402)"
+```
+
+---
+
+## Task 2: Add SHA-resolution helpers
+
+The cell cache wrappers need each branch's HEAD SHA, the base branch's HEAD SHA,
+and (for remote cells) the upstream's HEAD SHA. Add small batched helpers so
+each lookup is O(1) `git` forks across the whole list, not O(N).
+
+**Files:**
+
+- Create: `src/core/worktree/cell_cache.rs` (skeleton; subsequent tasks add
+  per-cell wrappers)
+- Modify: `src/core/worktree/mod.rs` (add `pub(crate) mod cell_cache;`)
+- Test: `src/core/worktree/cell_cache.rs` (inline `#[cfg(test)] mod tests`)
+
+- [ ] **Step 1: Write the failing tests**
+
+In `src/core/worktree/cell_cache.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_ref_sha_returns_some_for_head() {
+        // Use the integration-test repo helper.
+        let repo = test_helpers::TempRepo::new_with_commits(1);
+        let sha = resolve_ref_sha(repo.path(), "HEAD");
+        assert!(sha.is_some());
+        assert_eq!(sha.as_deref().map(str::len), Some(40));
+    }
+
+    #[test]
+    fn resolve_ref_sha_returns_none_for_unknown_ref() {
+        let repo = test_helpers::TempRepo::new_with_commits(1);
+        let sha = resolve_ref_sha(repo.path(), "refs/heads/does-not-exist");
+        assert!(sha.is_none());
+    }
+}
+```
+
+You'll need to confirm whether a `test_helpers::TempRepo` helper already exists.
+If it doesn't, check `tests/integration/` for an existing helper or skip these
+unit tests and rely on the smoke scenario in Task 8 instead — leave a
+`// TODO(#402): add unit tests once a TempRepo helper exists` and don't fake it.
+
+To check:
+
+Run:
+`grep -rn "TempRepo\|temp_repo\|fn new_with_commits" src/ tests/ 2>&1 | head -5`
+
+If no helper exists, skip the unit test for `resolve_ref_sha` and rely on
+integration coverage in Task 8 instead.
+
+- [ ] **Step 2: Create `src/core/worktree/cell_cache.rs`**
+
+```rust
+//! Cache wrappers for the slow `daft list` cells.
+//!
+//! Each public `cached_*` function:
+//!   1. Resolves the SHAs that fully define the cell's inputs.
+//!   2. Reads the cache entry keyed by those SHAs.
+//!   3. On hit, returns the cached value.
+//!   4. On miss, calls the underlying compute fn, writes the result, returns
+//!      it.
+//!
+//! Cells covered (all are pure functions of their key SHAs):
+//!   - `cached_base_ahead_behind`   key: `(base_sha, head_sha)`
+//!   - `cached_remote_ahead_behind` key: `(head_sha, upstream_sha)`
+//!   - `cached_last_commit`         key: `head_sha`
+//!   - `cached_base_lines`          key: `(base_sha, head_sha)`
+//!   - `cached_remote_lines`        key: `(head_sha, upstream_sha)`
+//!
+//! Cells deliberately not cached (working-tree-dependent, would risk staleness):
+//!   - Changes (staged/unstaged/untracked counts)
+//!   - Size (filesystem walk)
+//!   - Branch age, owner (cheap enough already)
+
+use crate::core::cache;
+use std::path::Path;
+use std::process::Command;
+
+/// Resolve a ref to its 40-char SHA via `git rev-parse`. Returns `None` on
+/// any failure (unknown ref, git missing, non-utf8 output, etc.).
+pub(super) fn resolve_ref_sha(worktree_path: &Path, refname: &str) -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--verify", "--quiet", refname])
+        .current_dir(worktree_path)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let s = String::from_utf8(output.stdout).ok()?.trim().to_string();
+    if s.len() == 40 && s.chars().all(|c| c.is_ascii_hexdigit()) {
+        Some(s)
+    } else {
+        None
+    }
+}
+
+/// Build the path for a SHA-pair cache entry: `<git-common>/.daft/cache/<kind>/<a>-<b>.json`.
+/// SHAs are passed in their natural order — caller decides whether to sort.
+pub(super) fn pair_key_path(git_common_dir: &Path, kind: &str, a: &str, b: &str) -> std::path::PathBuf {
+    cache::cache_dir_for(git_common_dir, kind).join(format!("{a}-{b}.json"))
+}
+
+/// Build the path for a single-SHA cache entry: `<git-common>/.daft/cache/<kind>/<sha>.json`.
+pub(super) fn single_key_path(git_common_dir: &Path, kind: &str, sha: &str) -> std::path::PathBuf {
+    cache::cache_dir_for(git_common_dir, kind).join(format!("{sha}.json"))
+}
+```
+
+- [ ] **Step 3: Wire up the module**
+
+In `src/core/worktree/mod.rs`, add (alphabetically positioned among the existing
+`mod` declarations):
+
+```rust
+pub(crate) mod cell_cache;
+```
+
+- [ ] **Step 4: Run any unit tests you wrote in Step 1**
+
+Run: `cargo test --lib core::worktree::cell_cache 2>&1 | tail -10` Expected:
+passes (or, if you skipped per Step 1's note, no tests run for this module yet).
+
+- [ ] **Step 5: Build the whole crate**
+
+Run: `cargo build --bin daft 2>&1 | tail -10` Expected: clean build, no
+warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/core/worktree/cell_cache.rs src/core/worktree/mod.rs
+git commit -m "feat(cache): add SHA-resolution helpers for cell-cache wrappers (#402)"
+```
+
+---
+
+## Task 3: Cache wrapper for `cached_base_ahead_behind`
+
+**Files:**
+
+- Modify: `src/core/worktree/cell_cache.rs` (add the wrapper + tests)
+- Test: same file
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/core/worktree/cell_cache.rs` (inside `#[cfg(test)] mod tests`):
+
+```rust
+#[test]
+fn cached_base_ahead_behind_writes_and_reads_back() {
+    use tempfile::TempDir;
+
+    let common = TempDir::new().unwrap();
+    let common_dir = common.path();
+
+    // First call: simulate compute returning Some((3, 1)). It should be
+    // written to the cache.
+    let out = cached_base_ahead_behind(
+        common_dir, "abc1234", "def5678",
+        || Some((3, 1)),
+    );
+    assert_eq!(out, Some((3, 1)));
+
+    // The cache file should now exist.
+    let path = pair_key_path(common_dir, "base-ahead-behind", "abc1234", "def5678");
+    assert!(path.exists(), "cache file at {} not written", path.display());
+
+    // Second call with a panicking compute fn: cache hit should bypass it.
+    let out2 = cached_base_ahead_behind(
+        common_dir, "abc1234", "def5678",
+        || panic!("compute called on cache hit"),
+    );
+    assert_eq!(out2, Some((3, 1)));
+}
+
+#[test]
+fn cached_base_ahead_behind_does_not_cache_none() {
+    use tempfile::TempDir;
+
+    let common = TempDir::new().unwrap();
+    let common_dir = common.path();
+
+    // Compute returns None (e.g., git command failed). Don't poison the cache.
+    let out = cached_base_ahead_behind(
+        common_dir, "abc1234", "def5678",
+        || None,
+    );
+    assert_eq!(out, None);
+
+    let path = pair_key_path(common_dir, "base-ahead-behind", "abc1234", "def5678");
+    assert!(!path.exists(), "None should not be cached");
+}
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+Run:
+`cargo test --lib core::worktree::cell_cache::tests::cached_base_ahead_behind 2>&1 | tail -10`
+Expected: compile error (`cached_base_ahead_behind` not found) — that's the
+failure we want.
+
+- [ ] **Step 3: Implement the wrapper**
+
+Append to `src/core/worktree/cell_cache.rs` (above the `#[cfg(test)]` block):
+
+```rust
+/// Cached wrapper for `(base..head)` ahead/behind counts.
+///
+/// Cache key: `(base_sha, head_sha)`. The result is a pure function of these
+/// two SHAs, so a hit is provably correct — no TTL or invalidation needed.
+/// `None` results are NOT cached (the underlying git command may have failed
+/// transiently; we want the next run to retry).
+pub(crate) fn cached_base_ahead_behind<F>(
+    git_common_dir: &Path,
+    base_sha: &str,
+    head_sha: &str,
+    compute: F,
+) -> Option<(usize, usize)>
+where
+    F: FnOnce() -> Option<(usize, usize)>,
+{
+    let path = pair_key_path(git_common_dir, "base-ahead-behind", base_sha, head_sha);
+    if let Some(v) = cache::read_json::<(usize, usize)>(&path) {
+        return Some(v);
+    }
+    let computed = compute()?;
+    cache::write_json(&path, &computed);
+    Some(computed)
+}
+```
+
+- [ ] **Step 4: Run the tests to confirm they pass**
+
+Run: `cargo test --lib core::worktree::cell_cache 2>&1 | tail -10` Expected:
+`test result: ok. <N> passed; 0 failed`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/worktree/cell_cache.rs
+git commit -m "feat(cache): add cached_base_ahead_behind wrapper (#402)"
+```
+
+---
+
+## Task 4: Cache wrapper for `cached_remote_ahead_behind`
+
+Same shape as Task 3 with a different cache kind name. Distinct from base
+because the inputs (head + upstream) are different and it deserves its own kind
+subdir for human inspection / future per-kind clear.
+
+**Files:**
+
+- Modify: `src/core/worktree/cell_cache.rs`
+
+- [ ] **Step 1: Add the test**
+
+Append to the `#[cfg(test)] mod tests` block:
+
+```rust
+#[test]
+fn cached_remote_ahead_behind_writes_and_reads_back() {
+    use tempfile::TempDir;
+
+    let common = TempDir::new().unwrap();
+    let common_dir = common.path();
+
+    let out = cached_remote_ahead_behind(
+        common_dir, "head1234", "upst5678",
+        || Some((2, 4)),
+    );
+    assert_eq!(out, Some((2, 4)));
+
+    let path = pair_key_path(common_dir, "remote-ahead-behind", "head1234", "upst5678");
+    assert!(path.exists());
+
+    let out2 = cached_remote_ahead_behind(
+        common_dir, "head1234", "upst5678",
+        || panic!("compute called on cache hit"),
+    );
+    assert_eq!(out2, Some((2, 4)));
+}
+```
+
+- [ ] **Step 2: Confirm test fails (compile error)**
+
+Run:
+`cargo test --lib core::worktree::cell_cache::tests::cached_remote_ahead_behind 2>&1 | tail -10`
+Expected: compile error (`cached_remote_ahead_behind` not found).
+
+- [ ] **Step 3: Implement the wrapper**
+
+Append above the `#[cfg(test)]` block in `src/core/worktree/cell_cache.rs`:
+
+```rust
+/// Cached wrapper for upstream ahead/behind counts.
+///
+/// Cache key: `(head_sha, upstream_sha)`. Pure function — hit is provably
+/// correct. `None` results are not cached.
+pub(crate) fn cached_remote_ahead_behind<F>(
+    git_common_dir: &Path,
+    head_sha: &str,
+    upstream_sha: &str,
+    compute: F,
+) -> Option<(usize, usize)>
+where
+    F: FnOnce() -> Option<(usize, usize)>,
+{
+    let path = pair_key_path(git_common_dir, "remote-ahead-behind", head_sha, upstream_sha);
+    if let Some(v) = cache::read_json::<(usize, usize)>(&path) {
+        return Some(v);
+    }
+    let computed = compute()?;
+    cache::write_json(&path, &computed);
+    Some(computed)
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cargo test --lib core::worktree::cell_cache 2>&1 | tail -10` Expected: all
+tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/worktree/cell_cache.rs
+git commit -m "feat(cache): add cached_remote_ahead_behind wrapper (#402)"
+```
+
+---
+
+## Task 5: Cache wrapper for `cached_last_commit`
+
+Single-SHA key (HEAD SHA → `(timestamp, hash, subject)`). The cached `hash`
+value will always equal the key SHA, but storing it keeps the result-shape
+identical to `get_commit_metadata`'s return type, so the call sites don't need
+to special-case.
+
+**Files:**
+
+- Modify: `src/core/worktree/cell_cache.rs`
+
+- [ ] **Step 1: Add the test**
+
+Append to the `#[cfg(test)] mod tests` block:
+
+```rust
+#[test]
+fn cached_last_commit_writes_and_reads_back() {
+    use tempfile::TempDir;
+
+    let common = TempDir::new().unwrap();
+    let common_dir = common.path();
+
+    let computed = (Some(1700000000_i64), Some("abc1234".to_string()), "first commit".to_string());
+
+    let out = cached_last_commit(common_dir, "abc1234", || computed.clone());
+    assert_eq!(out, computed);
+
+    let path = single_key_path(common_dir, "last-commit", "abc1234");
+    assert!(path.exists());
+
+    // Cache hit short-circuits the compute closure.
+    let out2 = cached_last_commit(common_dir, "abc1234", || panic!("hit"));
+    assert_eq!(out2, computed);
+}
+
+#[test]
+fn cached_last_commit_does_not_cache_when_timestamp_missing() {
+    // If git returned no timestamp, the compute most likely failed. Don't
+    // poison the cache.
+    use tempfile::TempDir;
+
+    let common = TempDir::new().unwrap();
+    let common_dir = common.path();
+    let bad = (None, None, String::new());
+
+    let out = cached_last_commit(common_dir, "abc1234", || bad.clone());
+    assert_eq!(out, bad);
+
+    let path = single_key_path(common_dir, "last-commit", "abc1234");
+    assert!(!path.exists());
+}
+```
+
+- [ ] **Step 2: Confirm test fails**
+
+Run:
+`cargo test --lib core::worktree::cell_cache::tests::cached_last_commit 2>&1 | tail -10`
+Expected: compile error.
+
+- [ ] **Step 3: Implement the wrapper**
+
+Append above the `#[cfg(test)]` block:
+
+```rust
+/// Cached wrapper for `(timestamp, hash, subject)` of the commit at `head_sha`.
+///
+/// Cache key: `head_sha`. The cached `hash` field will always equal the key,
+/// but we store it for shape-compatibility with `get_commit_metadata`'s
+/// return type. Empty / `None` results are not cached (treated as failures).
+pub(crate) fn cached_last_commit<F>(
+    git_common_dir: &Path,
+    head_sha: &str,
+    compute: F,
+) -> (Option<i64>, Option<String>, String)
+where
+    F: FnOnce() -> (Option<i64>, Option<String>, String),
+{
+    let path = single_key_path(git_common_dir, "last-commit", head_sha);
+    if let Some(v) = cache::read_json::<(Option<i64>, Option<String>, String)>(&path) {
+        return v;
+    }
+    let computed = compute();
+    // Treat "no timestamp" as a failed lookup — don't poison the cache.
+    if computed.0.is_some() {
+        cache::write_json(&path, &computed);
+    }
+    computed
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test --lib core::worktree::cell_cache 2>&1 | tail -10` Expected: all
+pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/worktree/cell_cache.rs
+git commit -m "feat(cache): add cached_last_commit wrapper (#402)"
+```
+
+---
+
+## Task 6: Cache wrapper for `cached_base_lines`
+
+**Files:**
+
+- Modify: `src/core/worktree/cell_cache.rs`
+
+- [ ] **Step 1: Add the test**
+
+Append to the test block:
+
+```rust
+#[test]
+fn cached_base_lines_writes_and_reads_back() {
+    use tempfile::TempDir;
+
+    let common = TempDir::new().unwrap();
+    let common_dir = common.path();
+
+    let computed = (Some(120_usize), Some(45_usize));
+    let out = cached_base_lines(common_dir, "base", "head", || computed);
+    assert_eq!(out, computed);
+
+    let path = pair_key_path(common_dir, "base-lines", "base", "head");
+    assert!(path.exists());
+
+    let out2 = cached_base_lines(common_dir, "base", "head", || panic!("hit"));
+    assert_eq!(out2, computed);
+}
+```
+
+- [ ] **Step 2: Confirm fail**
+
+Run:
+`cargo test --lib core::worktree::cell_cache::tests::cached_base_lines 2>&1 | tail -10`
+Expected: compile error.
+
+- [ ] **Step 3: Implement**
+
+Append above `#[cfg(test)]`:
+
+```rust
+/// Cached wrapper for `(inserted, deleted)` line counts in `base..head`.
+///
+/// Cache key: `(base_sha, head_sha)`. Only writes the cache when at least
+/// one of the two values is `Some` (treats fully-`None` as failure).
+pub(crate) fn cached_base_lines<F>(
+    git_common_dir: &Path,
+    base_sha: &str,
+    head_sha: &str,
+    compute: F,
+) -> (Option<usize>, Option<usize>)
+where
+    F: FnOnce() -> (Option<usize>, Option<usize>),
+{
+    let path = pair_key_path(git_common_dir, "base-lines", base_sha, head_sha);
+    if let Some(v) = cache::read_json::<(Option<usize>, Option<usize>)>(&path) {
+        return v;
+    }
+    let computed = compute();
+    if computed.0.is_some() || computed.1.is_some() {
+        cache::write_json(&path, &computed);
+    }
+    computed
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test --lib core::worktree::cell_cache 2>&1 | tail -10` Expected: all
+pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/worktree/cell_cache.rs
+git commit -m "feat(cache): add cached_base_lines wrapper (#402)"
+```
+
+---
+
+## Task 7: Cache wrapper for `cached_remote_lines`
+
+Same shape as Task 6 with a different kind directory.
+
+**Files:**
+
+- Modify: `src/core/worktree/cell_cache.rs`
+
+- [ ] **Step 1: Add the test**
+
+```rust
+#[test]
+fn cached_remote_lines_writes_and_reads_back() {
+    use tempfile::TempDir;
+
+    let common = TempDir::new().unwrap();
+    let common_dir = common.path();
+
+    let computed = (Some(7_usize), Some(2_usize));
+    let out = cached_remote_lines(common_dir, "head", "upstream", || computed);
+    assert_eq!(out, computed);
+
+    let path = pair_key_path(common_dir, "remote-lines", "head", "upstream");
+    assert!(path.exists());
+
+    let out2 = cached_remote_lines(common_dir, "head", "upstream", || panic!("hit"));
+    assert_eq!(out2, computed);
+}
+```
+
+- [ ] **Step 2: Confirm fail**
+
+Run:
+`cargo test --lib core::worktree::cell_cache::tests::cached_remote_lines 2>&1 | tail -10`
+Expected: compile error.
+
+- [ ] **Step 3: Implement**
+
+```rust
+/// Cached wrapper for upstream line counts. Cache key: `(head_sha, upstream_sha)`.
+pub(crate) fn cached_remote_lines<F>(
+    git_common_dir: &Path,
+    head_sha: &str,
+    upstream_sha: &str,
+    compute: F,
+) -> (Option<usize>, Option<usize>)
+where
+    F: FnOnce() -> (Option<usize>, Option<usize>),
+{
+    let path = pair_key_path(git_common_dir, "remote-lines", head_sha, upstream_sha);
+    if let Some(v) = cache::read_json::<(Option<usize>, Option<usize>)>(&path) {
+        return v;
+    }
+    let computed = compute();
+    if computed.0.is_some() || computed.1.is_some() {
+        cache::write_json(&path, &computed);
+    }
+    computed
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test --lib core::worktree::cell_cache 2>&1 | tail -10` Expected: all
+pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/worktree/cell_cache.rs
+git commit -m "feat(cache): add cached_remote_lines wrapper (#402)"
+```
+
+---
+
+## Task 8: Wire wrappers into the streaming collector
+
+This task replaces the direct calls inside `run_branch_clusters` (or whatever
+the per-target slow-cluster fn is currently named) with `cached_*` calls. The
+collector resolves required SHAs once per target before the cluster.
+
+**Files:**
+
+- Modify: `src/core/worktree/list_stream.rs:130-260` (the `run_target` cluster
+  body — exact line numbers may shift; search for `BASE_AHEAD_BEHIND` /
+  `LAST_COMMIT` / `BASE_LINES` / `REMOTE_LINES`)
+
+- [ ] **Step 1: Read the current `run_target` (or equivalent) implementation**
+
+Run:
+`grep -n "fn run_target\|fn process_target\|fn cluster_for\|FieldSet::BASE_AHEAD_BEHIND" src/core/worktree/list_stream.rs | head -10`
+
+Open the file and read the cluster body — you need to know the surrounding
+context (where `target`, `git`, `ctx` come from, how patches are emitted) before
+making edits.
+
+- [ ] **Step 2: Add `git_common_dir` to `CollectorContext`**
+
+In `src/core/worktree/list_stream.rs`, find the `CollectorContext` struct
+definition. Add a new field:
+
+```rust
+pub struct CollectorContext {
+    pub use_gitoxide: bool,
+    pub base_branch: String,
+    pub remote_name: String,
+    pub ownership_strategy: OwnershipStrategy,
+    pub user_email: Option<String>,
+    pub git_common_dir: std::path::PathBuf, // NEW
+}
+```
+
+- [ ] **Step 3: Pass `git_common_dir` from every caller**
+
+Find every place that constructs `CollectorContext`. As of this branch there are
+at least three: `commands/list_live.rs`, `commands/sync.rs`, and
+`commands/prune.rs` (search with `grep`).
+
+Run: `grep -rn "CollectorContext {" src/`
+
+For each construction site, add the new field. The git common dir is already
+available via `crate::core::repo::get_git_common_dir()?` — every caller already
+runs in a context where this is fetched (e.g., `commands/list_live.rs:86` calls
+it). Add the field initializer using the existing variable.
+
+- [ ] **Step 4: Replace direct compute calls with cached wrappers**
+
+In the cluster body, where `BASE_AHEAD_BEHIND` is computed (currently around
+line 165-170), change:
+
+```rust
+if fields.contains(FieldSet::BASE_AHEAD_BEHIND) && !target.is_detached {
+    if let Some(p) = path {
+        let v = get_ahead_behind(&ctx.base_branch, &target.branch_name, p);
+        emit!(P::BaseAheadBehind(v));
+    }
+}
+```
+
+…to:
+
+```rust
+if fields.contains(FieldSet::BASE_AHEAD_BEHIND) && !target.is_detached {
+    if let Some(p) = path {
+        // Resolve the two key SHAs. If either lookup fails we skip the cache
+        // entirely and fall back to the direct compute path so we at least
+        // emit *something* for the cell.
+        let base_sha = crate::core::worktree::cell_cache::resolve_ref_sha(p, &ctx.base_branch);
+        let head_sha = crate::core::worktree::cell_cache::resolve_ref_sha(p, "HEAD");
+        let v = match (base_sha, head_sha) {
+            (Some(b), Some(h)) => crate::core::worktree::cell_cache::cached_base_ahead_behind(
+                &ctx.git_common_dir, &b, &h,
+                || get_ahead_behind(&ctx.base_branch, &target.branch_name, p),
+            ),
+            _ => get_ahead_behind(&ctx.base_branch, &target.branch_name, p),
+        };
+        emit!(P::BaseAheadBehind(v));
+    }
+}
+```
+
+Apply the analogous transform to:
+
+- `LAST_COMMIT` block (around line 185): resolve `HEAD` SHA →
+  `cached_last_commit`
+- `REMOTE_AHEAD_BEHIND` block (around line 220): resolve `HEAD` and
+  `<branch>@{upstream}` SHAs → `cached_remote_ahead_behind`
+- `BASE_LINES` block (around line 229): resolve base + HEAD →
+  `cached_base_lines`
+- `REMOTE_LINES` block (around line 244): resolve HEAD + upstream →
+  `cached_remote_lines`
+
+For `REMOTE_*`, use `&format!("{}@{{upstream}}", target.branch_name)` as the
+upstream refname (or `<branch>` if a more specific refname is already known to
+the cluster).
+
+- [ ] **Step 5: Build**
+
+Run: `cargo build --bin daft 2>&1 | tail -10` Expected: clean build.
+
+- [ ] **Step 6: Run the unit suite**
+
+Run: `mise run test:unit 2>&1 | grep -E "test result|FAILED" | tail -10`
+Expected: all tests pass.
+
+- [ ] **Step 7: Run clippy + fmt**
+
+Run: `mise run clippy && mise run fmt && mise run fmt:check 2>&1 | tail -3`
+Expected: clean.
+
+- [ ] **Step 8: Manual smoke test**
+
+```bash
+# In a scratch repo (not this one — see CLAUDE.md):
+TMP=$(mktemp -d)
+cd "$TMP" && git init -q && \
+  git -c user.email=t@t -c user.name=t commit --allow-empty -q -m initial && \
+  git -c user.email=t@t -c user.name=t commit --allow-empty -q -m second
+# Run daft list (ratherthan the live UI; we want to confirm cache writes)
+DAFT_NO_LIVE=1 /Users/avihu/Projects/daft/daft-402/feat/live-list-population/target/debug/daft list
+ls .git/.daft/cache/
+# Expected: directories like base-ahead-behind/, last-commit/, etc., with .json files inside.
+# Run a second time:
+DAFT_NO_LIVE=1 /Users/avihu/Projects/daft/daft-402/feat/live-list-population/target/debug/daft list
+# Expected: same files (mtimes unchanged for SHAs that didn't move; new files for new SHAs).
+cd / && rm -rf "$TMP"
+```
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/core/worktree/list_stream.rs src/commands/list_live.rs src/commands/sync.rs src/commands/prune.rs
+git commit -m "feat(cache): wire cell-cache wrappers into list_stream collector (#402)"
+```
+
+---
+
+## Task 9: Integration smoke test
+
+Add a YAML scenario that asserts the cache files appear after a `daft list` run.
+
+**Files:**
+
+- Create: `tests/manual/scenarios/list/cache-warm-hit.yml`
+
+- [ ] **Step 1: Read the YAML test schema reference**
+
+Run: `head -80 tests/README.md`
+
+Note the schema fields used by existing list scenarios.
+
+- [ ] **Step 2: Find a similar existing scenario to model after**
+
+Run: `ls tests/manual/scenarios/list/ | head -10`
+
+Open the closest existing list scenario and read it.
+
+- [ ] **Step 3: Write the new scenario**
+
+Create `tests/manual/scenarios/list/cache-warm-hit.yml`:
+
+```yaml
+name: list-cache-warm-hit
+description: |
+  Verifies that running `daft list` populates the on-disk cache under
+  .git/.daft/cache/ and that a second run hits those cache files.
+
+setup:
+  # A tiny repo with one extra commit so base..head ahead/behind has
+  # something non-trivial to cache.
+  - shell: |
+      git init -q .
+      git config user.email t@t
+      git config user.name t
+      git commit -q --allow-empty -m initial
+      git checkout -q -b feature
+      git commit -q --allow-empty -m feature-commit
+
+steps:
+  - name: First list run populates cache
+    run: daft list
+    env:
+      DAFT_NO_LIVE: "1"
+    assert:
+      exit_code: 0
+      shell: |
+        # At least one cache kind dir should exist with at least one .json file.
+        find .git/.daft/cache -type f -name '*.json' | head -1 | grep -q .
+
+  - name: Second list run hits cache
+    run: daft list
+    env:
+      DAFT_NO_LIVE: "1"
+    assert:
+      exit_code: 0
+```
+
+If the YAML schema in this repo differs from the example above, adapt the field
+names but keep the semantics: setup repo → run list → assert cache files exist →
+run list again → assert success.
+
+- [ ] **Step 4: Run the new scenario**
+
+Run: `mise run test:manual -- --ci list:cache-warm-hit` Expected: PASS.
+
+- [ ] **Step 5: Run the broader list scenario set to catch regressions**
+
+Run: `mise run test:manual -- --ci list 2>&1 | tail -20` Expected: all list
+scenarios pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/manual/scenarios/list/cache-warm-hit.yml
+git commit -m "test(list): assert .daft/cache entries materialize after run (#402)"
+```
+
+---
+
+## Task 10: Update SKILL.md and docs
+
+The cache directory is a new on-disk artifact that AI agents and users should be
+aware of. Document it briefly.
+
+**Files:**
+
+- Modify: `SKILL.md`
+- Modify: `docs/guide/configuration.md` (if there's an existing section on state
+  directories)
+
+- [ ] **Step 1: Find the right place in SKILL.md**
+
+Run: `grep -n "cache\|state\|.git/" SKILL.md | head -20`
+
+Look for an existing "State directories" / "Files daft writes" section. If none,
+add a new short section.
+
+- [ ] **Step 2: Add the cache section**
+
+Insert (or update an existing "State files" section):
+
+```markdown
+### Cache files
+
+`daft list` writes content-addressed JSON caches under
+`<git-common-dir>/.daft/cache/<kind>/` to make repeat runs fast. Each entry is
+keyed by the SHAs that fully define its inputs (e.g. `(base_sha, head_sha)` for
+ahead/behind counts), so a cache hit is provably correct — no TTL or manual
+invalidation is needed. The cache is safe to delete at any time; `daft list`
+will re-populate it on the next run.
+
+Cached cells: base/remote ahead-behind, base/remote line stats, last-commit
+metadata. Working-tree-dependent cells (`Changes`, `Size`) are NOT cached
+because their inputs aren't capturable as a SHA.
+```
+
+- [ ] **Step 3: Update `docs/guide/configuration.md` if it has a state-files
+      section**
+
+Run: `grep -n "state\|cache\|.daft" docs/guide/configuration.md`
+
+If there's a relevant section, mirror the SKILL.md addition there. If not, skip
+— don't fabricate one.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add SKILL.md docs/guide/configuration.md 2>/dev/null
+git commit -m "docs: describe new .daft/cache state directory (#402)"
+```
+
+---
+
+## Task 11: Final verification
+
+- [ ] **Step 1: Full unit suite**
+
+Run: `mise run test:unit 2>&1 | grep -E "test result|FAILED" | tail -10`
+Expected: all pass, count includes the new cache + cell_cache tests.
+
+- [ ] **Step 2: Clippy + fmt**
+
+Run: `mise run clippy && mise run fmt:check` Expected: both clean.
+
+- [ ] **Step 3: Manual perf check**
+
+```bash
+TMP=$(mktemp -d)
+cd "$TMP" && git init -q && \
+  git -c user.email=t@t -c user.name=t commit --allow-empty -q -m initial && \
+  git checkout -q -b feature && \
+  git -c user.email=t@t -c user.name=t commit --allow-empty -q -m feature-commit
+# Cold cache run
+time DAFT_NO_LIVE=1 /Users/avihu/Projects/daft/daft-402/feat/live-list-population/target/debug/daft list >/dev/null
+# Warm cache run — should be visibly faster
+time DAFT_NO_LIVE=1 /Users/avihu/Projects/daft/daft-402/feat/live-list-population/target/debug/daft list >/dev/null
+cd / && rm -rf "$TMP"
+```
+
+Expected: warm run notably faster than cold (no hard threshold; even a few
+hundred ms savings on the small repo is fine — the win scales with worktree
+count).
+
+- [ ] **Step 4: Push the branch**
+
+```bash
+git push
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+- ✅ Cache primitives (Task 1)
+- ✅ SHA resolution (Task 2)
+- ✅ Cache wrappers for the five SHA-pair / single-SHA cells (Tasks 3-7)
+- ✅ Wired into collector (Task 8)
+- ✅ Skeleton-over-stale preserved (no cache covers Size or Changes — both still
+  stream)
+- ✅ Integration test (Task 9)
+- ✅ Docs (Task 10)
+- ✅ Final verification (Task 11)
+
+**Placeholder scan:** No "TBD"; tests/code shown in full; "exact line numbers
+may shift, search for X" used where the file is large and current numbers may
+drift between today and execution — paired with concrete `grep` commands so the
+engineer can locate the right spot.
+
+**Type consistency:** `cached_*` fns mirror their underlying `get_*` return
+types exactly:
+
+- `cached_base_ahead_behind` → `Option<(usize, usize)>` (matches
+  `get_ahead_behind`)
+- `cached_remote_ahead_behind` → `Option<(usize, usize)>` (matches
+  `get_upstream_ahead_behind`)
+- `cached_last_commit` → `(Option<i64>, Option<String>, String)` (matches
+  `get_commit_metadata`)
+- `cached_base_lines` → `(Option<usize>, Option<usize>)` (matches
+  `get_base_line_counts`)
+- `cached_remote_lines` → `(Option<usize>, Option<usize>)` (matches
+  `get_remote_line_counts`)
+
+This means call-site changes are 1-line replacements wrapped in a closure — no
+shape conversion.

--- a/docs/superpowers/plans/2026-04-26-live-list-population-phase-2-daft-list-live-ux.md
+++ b/docs/superpowers/plans/2026-04-26-live-list-population-phase-2-daft-list-live-ux.md
@@ -1,0 +1,732 @@
+# Live List Population — Phase 2: `daft list` Live UX Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development to implement this plan.
+
+**Goal:** Land the live UX for `daft list` — cheap porcelain seed shows rows
+instantly, individual cells fill in as the streaming collector finishes them.
+TTY-only path; non-TTY (`--format`, piped stdout, `DAFT_NO_LIVE=1`) keeps
+today's blocking one-shot rendering.
+
+**Architecture:** Reuse Phase 1's `LiveTable` + `TuiState` + `TuiRenderer`
+infrastructure. `daft list`'s TTY path becomes: parse porcelain (sync) → parse
+`--branches`/`--remotes` (sync) → seed `LiveTable` rows → spawn
+`list_stream::spawn(ALL fields, Collector)` → drive render loop → exit on
+`WorktreeInfoCollectionDone` or `Ctrl-C`. `pin_default_branch: false`,
+`partition_by_owner: false` — `daft list` is a query view.
+
+**Tech Stack:** Rust, ratatui 0.30, crossterm 0.29, std::sync::mpsc,
+std::thread. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-04-25-live-list-population-design.md`
+
+**Phase 2 of 3.** Builds on Phase 1 (PR #410, branch
+`daft-402/feat/live-list-population`). Phase 3 (migrate prune/sync to streaming
+seed) ships under a separate plan immediately after Phase 2.
+
+---
+
+## File Structure
+
+**Modified files:**
+
+- `src/output/tui/state.rs` — add `mark_collection_done(&mut self)` and
+  `is_complete(&self) -> bool` helpers. The driver checks `is_complete` to know
+  when to exit (today it only checks `AllDone`).
+- `src/output/tui/driver.rs` — relax exit condition to also fire when
+  `state.is_complete()` returns true (which happens after
+  `WorktreeInfoCollectionDone` for the no-phases case). Header height
+  computation adjusted: when `state.phases.is_empty()`, header is zero-height
+  (no phase banners).
+- `src/output/tui/render.rs` — `render_header` no-ops when
+  `state.phases.is_empty()`. When `state.live.collection_complete` is false,
+  render the dim middle-dot `·` glyph for cells that are `None` AND haven't
+  received a patch yet (use `state.live.is_cell_loading(row_idx, field)`). After
+  `collection_complete`, `None` renders as today (blank).
+- `src/output/tui/render.rs` — add a "verbose footer" rendered below the table
+  when `state.show_hook_sub_rows` is true (re-using the verbose flag) showing
+  `inflight: N · elapsed: 1.2s`.
+- `src/commands/list.rs` — split `run()` into `run_blocking()` (today's full
+  collect → render path) and `run_live()` (new TTY path). Dispatch in `run()`:
+  if `args.emit.is_structured()` or stdout is not a TTY or `DAFT_NO_LIVE=1` is
+  set, call `run_blocking()`. Otherwise call `run_live()`.
+- `tests/manual/scenarios/list/live/` — new YAML scenario directory. Add at
+  least 3 scenarios that drive `daft list` via PTY and assert rows appear
+  immediately.
+
+**New files:**
+
+- `src/commands/list_live.rs` — extracted `run_live()` implementation. Keeps
+  `list.rs` focused on the dispatch + blocking path. Module declared from
+  `src/commands/mod.rs`.
+
+---
+
+## Task 1: `TuiState::is_complete` + `mark_collection_done` helpers
+
+**Files:**
+
+- Modify: `src/output/tui/state.rs`
+
+The driver needs to know when to exit. Today it checks `AllDone` (sent by the
+orchestrator). For `daft list` there's no orchestrator — exit happens on
+`WorktreeInfoCollectionDone`. Add a unified completion predicate.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the test module in `src/output/tui/state.rs`:
+
+```rust
+#[test]
+fn is_complete_false_until_all_done_or_collection_done() {
+    let state = state_with_no_worktrees();
+    assert!(!state.is_complete());
+}
+
+#[test]
+fn is_complete_true_after_all_done_event() {
+    let mut state = state_with_no_worktrees();
+    state.apply_event(&DagEvent::AllDone);
+    assert!(state.is_complete());
+}
+
+#[test]
+fn is_complete_true_after_collection_done_when_no_phases() {
+    let mut state = state_with_no_phases_no_worktrees();
+    state.apply_event(&DagEvent::WorktreeInfoCollectionDone);
+    assert!(state.is_complete());
+}
+
+#[test]
+fn is_complete_false_after_collection_done_when_phases_present() {
+    // When phases exist, completion still requires AllDone — collection
+    // finishing is just one input among many.
+    let mut state = state_with_no_worktrees();
+    state.apply_event(&DagEvent::WorktreeInfoCollectionDone);
+    assert!(!state.is_complete());
+}
+```
+
+You'll need test helpers `state_with_no_worktrees()` (uses today's default
+phases) and `state_with_no_phases_no_worktrees()` (empty phases vec). Add them
+next to the existing test fixtures.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --lib output::tui::state::tests::is_complete` Expected: compile
+error — `is_complete` does not exist.
+
+- [ ] **Step 3: Implement `is_complete`**
+
+In `src/output/tui/state.rs`, inside `impl TuiState`:
+
+```rust
+/// True when the table has reached a terminal state and the renderer
+/// should exit. For commands with phases (prune/sync/clone), this means
+/// `done` was set by `DagEvent::AllDone`. For phase-less commands
+/// (`daft list`), it also returns true once
+/// `live.collection_complete` is set by `WorktreeInfoCollectionDone`.
+pub fn is_complete(&self) -> bool {
+    self.done || (self.phases.is_empty() && self.live.collection_complete)
+}
+```
+
+(`done` is the existing field set by the `AllDone` arm.
+`live.collection_complete` is set by Phase 1's `LiveTable::apply_event`.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --lib output::tui::state::tests::is_complete` Expected: 4/4
+pass.
+
+Run: `cargo test --lib output::tui::state` to confirm no regression. Expected:
+all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/output/tui/state.rs
+git commit -m "feat(tui): add TuiState::is_complete unified completion predicate (#402)"
+```
+
+---
+
+## Task 2: Driver supports phase-less rendering
+
+**Files:**
+
+- Modify: `src/output/tui/driver.rs`
+
+`TuiRenderer::run` today exits only on `AllDone`. Switch it to exit on
+`state.is_complete()`. Also make `header_height` zero-aware so a phase-less
+state renders no header banner.
+
+- [ ] **Step 1: Update `header_height` calculation**
+
+In `TuiRenderer::run`, replace:
+
+```rust
+let header_height = self.state.phases.len() as u16 + 1;
+```
+
+with:
+
+```rust
+// `+1` is the phase header label row when phases exist; zero phases =
+// no header at all (daft list).
+let header_height = if self.state.phases.is_empty() {
+    0
+} else {
+    self.state.phases.len() as u16 + 1
+};
+```
+
+- [ ] **Step 2: Update exit conditions**
+
+Find every `is_done = matches!(event, DagEvent::AllDone);` and the follow-up
+branch that returns. Replace with checks against `self.state.is_complete()`
+AFTER `apply_event` runs:
+
+```rust
+self.state.apply_event(&event);
+if self.state.is_complete() {
+    // Final render — position cursor past all content.
+    let total_rows = self.total_rendered_rows();
+    // ... existing final-draw code ...
+    drop(terminal);
+    return Ok(self.state);
+}
+```
+
+(The rest of the final-draw block is unchanged.)
+
+- [ ] **Step 3: Verify no regression**
+
+Run: `cargo test --lib output::tui` and `cargo test --lib`. Expected: all tests
+pass.
+
+Run: `mise run test:integration` is too slow here — rely on later Task 8.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/output/tui/driver.rs
+git commit -m "feat(tui): driver supports phase-less rendering (daft list path) (#402)"
+```
+
+---
+
+## Task 3: Render header no-ops when phases empty
+
+**Files:**
+
+- Modify: `src/output/tui/render.rs`
+
+When `daft list` uses the renderer, it has no phases — `render_header` must
+early-return cleanly.
+
+- [ ] **Step 1: Inspect `render_header` signature**
+
+Read `src/output/tui/render.rs` and find
+`pub fn render_header(state: &TuiState, frame: &mut Frame, area: Rect)`. The
+function iterates `state.phases` and draws each.
+
+- [ ] **Step 2: Add early return**
+
+At the top of `render_header`, add:
+
+```rust
+if state.phases.is_empty() {
+    return;
+}
+```
+
+This is safe: in the phase-less path, `header_height` is 0 so `area` will be a
+zero-row Rect anyway, but explicit early return is clearer.
+
+- [ ] **Step 3: Verify**
+
+Run: `cargo test --lib output::tui::render` and `cargo test --lib`. Expected:
+all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/output/tui/render.rs
+git commit -m "feat(tui): render_header no-ops when phases are empty (#402)"
+```
+
+---
+
+## Task 4: Loading-glyph rendering for unfilled cells
+
+**Files:**
+
+- Modify: `src/output/tui/render.rs`
+
+While `state.live.collection_complete` is false, cells that are `None` AND
+haven't received their patch yet should render the dim middle-dot glyph `·`.
+After `collection_complete` (or for `None` cells whose patch arrived as `None`),
+render today's blank string.
+
+- [ ] **Step 1: Find `render_table` and the per-cell formatting calls**
+
+Read `src/output/tui/render.rs::render_table`. Identify the cell formatting
+helpers (likely in `src/output/format.rs` or similar) that render
+`Option<usize>` → `String`.
+
+- [ ] **Step 2: Add a `render_cell_with_loading` helper**
+
+In `src/output/tui/render.rs`, add:
+
+```rust
+use crate::core::worktree::info_field::FieldSet;
+
+/// Render a cell value with loading-glyph fallback. While the table is
+/// still streaming (!collection_complete) AND this cell has not yet
+/// received a patch, show a dim middle-dot. Otherwise show `formatted`
+/// (which may be the empty string for None cells whose patch arrived
+/// as None).
+fn render_cell_with_loading(
+    formatted: &str,
+    is_loading: bool,
+) -> String {
+    if formatted.is_empty() && is_loading {
+        // dim middle-dot — use ANSI dim escape; consistent with other
+        // dim styling in this module.
+        format!("\x1b[2m·\x1b[0m")
+    } else {
+        formatted.to_string()
+    }
+}
+```
+
+(Adjust the ANSI sequence to match what the existing render code uses for dim
+styling — search for `dim_style` or `Style::default().add_modifier` in the
+file.)
+
+- [ ] **Step 3: Wire it into per-cell formatting**
+
+In each per-cell call site within `render_table`, replace direct
+formatted-string writes with:
+
+```rust
+let formatted = format_ahead_behind(row.info.ahead, row.info.behind, ...);
+let cell = render_cell_with_loading(
+    &formatted,
+    state.live.is_cell_loading(row_idx, FieldSet::BASE_AHEAD_BEHIND),
+);
+```
+
+Repeat for each cell type with the matching `FieldSet`. Cells that correspond to
+no FieldSet (e.g., branch name from porcelain) skip the loading wrapper.
+
+- [ ] **Step 4: Add a test**
+
+Append to `src/output/tui/render.rs` test module:
+
+```rust
+#[test]
+fn render_cell_with_loading_returns_glyph_when_empty_and_loading() {
+    let out = render_cell_with_loading("", true);
+    assert!(out.contains("·"));
+}
+
+#[test]
+fn render_cell_with_loading_returns_formatted_when_present() {
+    let out = render_cell_with_loading("+3 -1", true);
+    assert_eq!(out, "+3 -1");
+}
+
+#[test]
+fn render_cell_with_loading_returns_empty_when_done() {
+    let out = render_cell_with_loading("", false);
+    assert_eq!(out, "");
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `cargo test --lib output::tui::render` Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/output/tui/render.rs
+git commit -m "feat(tui): render dim middle-dot for unfilled cells while streaming (#402)"
+```
+
+---
+
+## Task 5: Verbose footer
+
+**Files:**
+
+- Modify: `src/output/tui/render.rs`
+- Modify: `src/output/tui/driver.rs`
+
+When `state.show_hook_sub_rows` is true (the existing verbose flag), render a
+small footer below the table showing `inflight: N · elapsed: 1.2s`. `N` = count
+of rows where any cell is still loading. `elapsed` = time since the renderer
+started.
+
+- [ ] **Step 1: Track render start time**
+
+In `src/output/tui/driver.rs`, in `TuiRenderer::run`, capture `Instant::now()`
+at function entry as `render_start`. Pass it (or the elapsed duration on each
+draw) into a new field on `TuiState` so the renderer can read it. Simplest path:
+add `pub render_start_elapsed: Duration` to `TuiState`, updated in `tick()` from
+a constructor-stored `Instant`.
+
+- [ ] **Step 2: Add footer rendering**
+
+In `src/output/tui/render.rs`, add
+`pub fn render_footer(state: &TuiState, frame: &mut Frame, area: Rect)`:
+
+```rust
+pub fn render_footer(state: &TuiState, frame: &mut Frame, area: Rect) {
+    if !state.show_hook_sub_rows {
+        return;
+    }
+    let inflight: usize = state.live.received_patches.iter()
+        .filter(|fs| !fs.contains(FieldSet::ALL))
+        .count();
+    let elapsed_secs = state.render_start_elapsed.as_secs_f32();
+    let text = format!(" inflight: {inflight} · elapsed: {elapsed_secs:.1}s");
+    let line = ratatui::text::Line::from(text)
+        .style(ratatui::style::Style::default()
+            .add_modifier(ratatui::style::Modifier::DIM));
+    frame.render_widget(ratatui::widgets::Paragraph::new(line), area);
+}
+```
+
+- [ ] **Step 3: Wire footer into the layout**
+
+In `TuiRenderer::run`, when `state.show_hook_sub_rows` is true, extend the
+layout to reserve 1 extra row at the bottom and call
+`render::render_footer(...)` into it.
+
+- [ ] **Step 4: Test**
+
+Append to `render.rs` test module:
+
+```rust
+#[test]
+fn render_footer_skips_when_not_verbose() {
+    // Build a non-verbose state, render to a test buffer, assert empty.
+    // (Use ratatui's TestBackend.)
+}
+```
+
+(Implementation depends on how other render tests are structured — follow that
+pattern.)
+
+- [ ] **Step 5: Run tests**
+
+Run: `cargo test --lib output::tui` Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/output/tui/render.rs src/output/tui/driver.rs src/output/tui/state.rs
+git commit -m "feat(tui): add verbose footer with inflight count and elapsed time (#402)"
+```
+
+---
+
+## Task 6: `daft list` live path (`run_live`)
+
+**Files:**
+
+- Create: `src/commands/list_live.rs`
+- Modify: `src/commands/list.rs`
+- Modify: `src/commands/mod.rs`
+
+Split `daft list`'s `run()` into a dispatch + the existing `run_blocking()`
+body, then add `run_live()` as a sibling that drives the live UX. Dispatch in
+`run()`:
+
+```rust
+if args.emit.is_structured()
+    || std::env::var_os("DAFT_NO_LIVE").is_some()
+    || !std::io::IsTerminal::is_terminal(&std::io::stdout())
+{
+    run_blocking(args, settings)
+} else {
+    list_live::run_live(args, settings)
+}
+```
+
+`run_live` flow:
+
+1. Parse porcelain (sync) → `Vec<CollectorTarget>` and a parallel
+   `Vec<WorktreeInfo>` seed (only `name`, `path`, `kind`, `is_default_branch`,
+   `is_current` populated from porcelain).
+2. If `--branches`/`--remotes`/`--all`, run `git for-each-ref` to enumerate the
+   union (cheap and synchronous).
+3. Build
+   `LiveTableConfig { pin_default_branch: false, partition_by_owner: false, ... }`.
+4. Build
+   `TuiState::new(phases=[], worktree_infos, ..., pin_default_branch=false, partition_by_owner=false)`.
+5. Channel: `let (tx, rx) = mpsc::channel();`. Spawn the collector:
+   `let handle = list_stream::spawn(req, tx);`.
+6. Build `TuiRenderer::new(state, rx)` and call `.run()`.
+7. On Ctrl-C (handled by the existing `crossterm` event loop — integrate with
+   the renderer's event handling), call `handle.cancel()`, drain remaining
+   patches, render once more, exit 0.
+8. On clean completion (renderer exits because `is_complete()` true), call
+   `handle.join()`, exit 0.
+
+- [ ] **Step 1: Create `src/commands/list_live.rs` with the skeleton**
+
+Create the file with
+`pub fn run_live(args: list::Args, settings: DaftSettings) -> anyhow::Result<()>`.
+Mirror existing `daft list` structure for the cheap sync setup (porcelain parse,
+branch enum, column resolution, sort spec). For the slow data, build
+`CollectorTarget`s from porcelain entries and seed empty `WorktreeInfo` rows.
+
+(The full implementation will be ~150 LOC. Reference today's
+`src/commands/list.rs::run` lines 166-280 for porcelain parsing and column
+resolution. Reference `src/commands/sync.rs::run_tui` for the `OperationTable` /
+`TuiRenderer` wiring pattern.)
+
+- [ ] **Step 2: Add the dispatch in `list.rs::run`**
+
+Wrap today's body of `run()` in a new private function `run_blocking()`, then
+make `run()` itself the dispatcher:
+
+```rust
+pub fn run() -> Result<()> {
+    let args = Args::parse_from(crate::get_clap_args("git-worktree-list"));
+    init_logging(args.verbose);
+    let settings = DaftSettings::load()?;
+
+    if !is_git_repository()? {
+        anyhow::bail!("Not inside a Git repository");
+    }
+
+    if should_use_live(&args) {
+        list_live::run_live(args, settings)
+    } else {
+        run_blocking(args, settings)
+    }
+}
+
+fn should_use_live(args: &Args) -> bool {
+    use std::io::IsTerminal;
+    !args.emit.is_structured()
+        && std::env::var_os("DAFT_NO_LIVE").is_none()
+        && std::io::stdout().is_terminal()
+}
+```
+
+- [ ] **Step 3: Add `pub mod list_live;` to `src/commands/mod.rs`**
+
+- [ ] **Step 4: Verify build + non-live behavior unchanged**
+
+Run: `cargo build --bin daft` Expected: clean.
+
+Run: `DAFT_NO_LIVE=1 daft list 2>/dev/null` against this repo (or manually a
+temp repo) — should produce identical output to today's `daft list`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/commands/list.rs src/commands/list_live.rs src/commands/mod.rs
+git commit -m "feat(list): live cell-by-cell population for TTY paths (#402)"
+```
+
+---
+
+## Task 7: Ctrl-C handling in `run_live`
+
+**Files:**
+
+- Modify: `src/commands/list_live.rs` (or wherever the renderer event loop
+  lives)
+
+The renderer must observe Ctrl-C and gracefully cancel the collector. Today
+`TuiRenderer::run` doesn't poll `crossterm::event` — it polls the channel. Add a
+parallel poll for keyboard events.
+
+- [ ] **Step 1: Decide where to handle Ctrl-C**
+
+Two options: (a) Add Ctrl-C polling inside `TuiRenderer::run` (benefits
+prune/sync too). (b) Wrap the renderer in `list_live` and poll keyboard from
+outside.
+
+Pick (a). It's a small change and benefits other commands later.
+
+- [ ] **Step 2: Add a `cancel_signal: Option<Arc<AtomicBool>>` field to
+      `TuiRenderer`**
+
+In `src/output/tui/driver.rs`:
+
+```rust
+pub struct TuiRenderer {
+    state: TuiState,
+    receiver: mpsc::Receiver<DagEvent>,
+    extra_rows: u16,
+    cancel_signal: Option<Arc<AtomicBool>>,
+}
+
+impl TuiRenderer {
+    pub fn with_cancel_signal(mut self, cancel: Arc<AtomicBool>) -> Self {
+        self.cancel_signal = Some(cancel);
+        self
+    }
+    // ...
+}
+```
+
+In the render loop, between channel poll and tick, check
+`crossterm::event::poll(Duration::from_millis(0))` — if a `KeyEvent` with
+`Ctrl-C` arrives, set `cancel_signal` (if present) and break out of the loop
+after the next render.
+
+- [ ] **Step 3: Wire it from `run_live`**
+
+In `list_live::run_live`:
+
+```rust
+let cancel = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+let handle = list_stream::spawn(req, tx);
+// Plumb cancel through the renderer:
+let renderer = TuiRenderer::new(state, rx).with_cancel_signal(cancel.clone());
+let _final_state = renderer.run()?;
+// If Ctrl-C was pressed, cancel the collector explicitly.
+if cancel.load(Ordering::Relaxed) {
+    handle.cancel();
+}
+handle.join();
+Ok(())
+```
+
+(Actually the cancel signal IS the collector's cancel handle — pass
+`handle.cancel_flag()` to the renderer. Add a new method
+`CollectorHandle::cancel_flag(&self) -> Arc<AtomicBool>` that returns the same
+`Arc<AtomicBool>` the workers check. This keeps a single source of truth for
+cancellation.)
+
+- [ ] **Step 4: Test manually**
+
+Run `daft list` in this repo, hit Ctrl-C while still loading — should exit
+cleanly with whatever cells landed.
+
+- [ ] **Step 5: Add a unit test for the renderer's cancel handling**
+
+This is hard to unit-test without a real terminal. Skip if the test
+infrastructure doesn't support it. Manual test in step 4 covers it.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/output/tui/driver.rs src/commands/list_live.rs src/core/worktree/list_stream.rs
+git commit -m "feat(list): handle Ctrl-C in live UX with cooperative cancellation (#402)"
+```
+
+---
+
+## Task 8: New PTY-driven YAML scenarios for live `daft list`
+
+**Files:**
+
+- Create: `tests/manual/scenarios/list/live/instant_seed.yml`
+- Create: `tests/manual/scenarios/list/live/cells_fill_progressively.yml`
+- Create: `tests/manual/scenarios/list/live/no_live_env_var.yml`
+
+Add three scenarios to lock down the new behavior. Use the existing PTY scenario
+format from `tests/manual/scenarios/exec/`. Each scenario should:
+
+1. Set up a small fixture repo with 2-3 worktrees.
+2. Run `daft list` via PTY.
+3. Assert observable behavior.
+
+- [ ] **Step 1: `instant_seed.yml` — rows visible before any cell-fill**
+
+Scenario asserts that within ~50ms of launching `daft list`, the branch names
+and paths are visible (porcelain parse is sync) but cells that would require git
+calls (ahead/behind etc.) show the loading glyph `·`.
+
+- [ ] **Step 2: `cells_fill_progressively.yml` — all cells filled before the
+      command exits**
+
+Scenario asserts that after the command exits, no `·` glyphs remain in the
+output (all cells either filled or blank for actual nulls).
+
+- [ ] **Step 3: `no_live_env_var.yml` — `DAFT_NO_LIVE=1` falls back to blocking
+      output**
+
+Scenario sets `DAFT_NO_LIVE=1`, runs `daft list`, asserts the output matches
+today's blocking format (no `·` glyphs at any point during capture).
+
+- [ ] **Step 4: Run the scenarios**
+
+Run: `mise run test:manual -- --ci list/live` Expected: all scenarios pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/manual/scenarios/list/live/
+git commit -m "test(list): YAML scenarios for live cell-by-cell population (#402)"
+```
+
+---
+
+## Task 9: Final verification
+
+- [ ] **Step 1: Full unit + integration suite**
+
+Run: `mise run test:unit && mise run test:integration` Expected: all tests pass
+(with `DAFT_NO_LIVE=1` set in CI's integration runner if integration scenarios
+touch `daft list` — likely they do, since `list` is used as a setup command in
+many scenarios).
+
+- [ ] **Step 2: Clippy + fmt**
+
+Run: `mise run clippy && mise run fmt:check` Expected: zero warnings, clean.
+
+- [ ] **Step 3: Manual smoke test**
+
+Run `daft list` in this repo, observe rows appear instantly with loading glyphs
+that fill in as cells stream. Run with various flags (`--branches`, `--all`,
+`--columns +size`, `--sort -size`, `--format json`, piped to `cat`) and verify
+each behaves correctly.
+
+- [ ] **Step 4: Commit any test fixture / golden output adjustments**
+
+If integration tests need `DAFT_NO_LIVE=1` set in some places, do that in a
+focused commit.
+
+```bash
+git commit -m "test(integration): set DAFT_NO_LIVE=1 for stable golden output (#402)"
+```
+
+(Only if needed.)
+
+- [ ] **Step 5: Push and update PR description**
+
+```bash
+git push origin HEAD
+```
+
+Update the PR description (PR #410) to note Phase 2 inclusion via `gh pr edit`.
+
+---
+
+## Self-Review Notes
+
+Performed inline before save:
+
+- **Spec coverage**: Each Phase 2 deliverable from the spec maps to a task: live
+  UX (T6), TTY gating (T6), loading glyph (T4), verbose footer (T5),
+  cancellation (T7), PTY scenarios (T8), `--no-live` opt-out (T6),
+  `pin_default_branch: false`/`partition_by_owner: false` (T6), driver
+  phase-less support (T2-T3), unified completion predicate (T1).
+- **Placeholders**: none — all steps have concrete code or specific commands.
+- **Type consistency**: `is_complete`, `render_cell_with_loading`,
+  `render_footer`, `with_cancel_signal`, `should_use_live`, `run_live`,
+  `run_blocking` — used consistently across tasks.
+- **Scope**: Phase 2 only. Phase 3 (prune/sync migration) is a separate plan.
+- **Ambiguity**: Task 7's keyboard-event integration is the trickiest spot. The
+  plan offers two options and picks one.

--- a/docs/superpowers/plans/2026-04-26-live-list-population-phase-3-migrate-prune-sync.md
+++ b/docs/superpowers/plans/2026-04-26-live-list-population-phase-3-migrate-prune-sync.md
@@ -1,0 +1,433 @@
+# Live List Population — Phase 3: Migrate prune/sync to Streaming Seed
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development to implement this plan.
+
+**Goal:** Replace prune.rs and sync.rs's blocking `collect_worktree_info`
+pre-seed with the streaming collector running concurrently with the
+orchestrator. Cells fill in live during fetch/prune/update/rebase/push phases.
+Spinners removed.
+
+**Architecture:** Drop
+`let infos = if needs_spinner { spinner + collect_worktree_info } else { collect_worktree_info };`
+blocks from `prune.rs:run_tui` and `sync.rs::run_tui`. Replace with cheap
+porcelain parse → seed `LiveTable` → `list_stream::spawn(ALL fields, Collector)`
+running concurrently with the existing DAG orchestrator. Add
+`spawn_post_fetch_refresh` (sibling of `spawn_post_task_refresh`) called after
+`Fetch` phase completes — spawns `list_stream::spawn(REMOTE_DERIVED, PostFetch)`
+for all branches. Integration tests run with `DAFT_NO_LIVE=1` (no behavior
+change for non-TTY paths).
+
+**Tech Stack:** Same as Phase 1/2 — Rust, ratatui, mpsc, no new deps.
+
+**Spec:** `docs/superpowers/specs/2026-04-25-live-list-population-design.md`
+
+**Phase 3 of 3.** Builds on Phase 1 (PR #410) + Phase 2 (same PR).
+
+---
+
+## File Structure
+
+**Modified files:**
+
+- `src/commands/prune.rs` — drop the `needs_spinner` block in `run_tui()` (lines
+  ~221-254). Replace with cheap porcelain seed + collector spawn. After Fetch
+  phase, spawn post-fetch refresh.
+- `src/commands/sync.rs` — same pattern as prune.rs in `run_tui()` (lines
+  ~417-440). Add `spawn_post_fetch_refresh` helper sibling to the existing
+  `spawn_post_task_refresh`. Call it from the orchestrator thread after the
+  Fetch phase signals completion.
+- `src/commands/sync_shared.rs` — `run_fetch_phase` already emits Fetch phase
+  events. No changes here unless the orchestrator needs a hook to know when
+  fetch is done.
+- `src/commands/list.rs` — no changes (Phase 2 already covered `daft list`).
+- `tests/integration/run.sh` (or whatever the test driver is) — set
+  `DAFT_NO_LIVE=1` for prune/sync scenarios so golden outputs stay stable. (Or
+  set per-scenario in YAML headers.)
+
+**No new files.**
+
+---
+
+## Task 1: Add `spawn_post_fetch_refresh` helper to sync.rs
+
+**Files:**
+
+- Modify: `src/commands/sync.rs`
+
+Sibling of the existing `spawn_post_task_refresh`. Spawns the collector with
+`FieldSet::REMOTE_DERIVED` and `PatchSource::PostFetch` for every branch in the
+`worktree_map` after the Fetch phase completes. Used by both `daft sync` and
+`daft prune` (extracted to a shared module if convenient — but starting in
+sync.rs is fine; move later if both need it).
+
+- [ ] **Step 1: Implement the helper**
+
+In `src/commands/sync.rs`, near `spawn_post_task_refresh`:
+
+```rust
+/// After the Fetch phase completes, re-run the streaming collector
+/// against `REMOTE_DERIVED` fields for every worktree branch. Patches
+/// arrive as `PatchSource::PostFetch` so `LiveTable` can suppress any
+/// stale `Collector` patches on the same fields. Blocks on join() so
+/// patches land before the orchestrator dispatches per-branch tasks.
+fn spawn_post_fetch_refresh(
+    worktree_map: &HashMap<String, (PathBuf, bool)>,
+    settings: &Arc<DaftSettings>,
+    base_branch: &str,
+    user_email: Option<&str>,
+    stat: Stat,
+    tx: &mpsc::Sender<DagEvent>,
+) {
+    let targets: Vec<list_stream::CollectorTarget> = worktree_map.iter()
+        .map(|(branch_name, (path, _is_main))| list_stream::CollectorTarget {
+            branch_name: branch_name.clone(),
+            path: Some(path.clone()),
+            kind: EntryKind::Worktree,
+            is_detached: false,
+        })
+        .collect();
+    if targets.is_empty() { return; }
+    let ctx = Arc::new(list_stream::CollectorContext {
+        use_gitoxide: settings.use_gitoxide,
+        base_branch: base_branch.to_string(),
+        remote_name: settings.remote.clone(),
+        ownership_strategy: settings.ownership_strategy,
+        user_email: user_email.map(|s| s.to_string()),
+    });
+    let handle = list_stream::spawn(
+        list_stream::CollectorRequest {
+            targets,
+            fields: FieldSet::REMOTE_DERIVED,
+            stat,
+            source: PatchSource::PostFetch,
+            ctx,
+        },
+        tx.clone(),
+    );
+    handle.join();
+}
+```
+
+- [ ] **Step 2: Call it from sync's orchestrator thread after Fetch succeeds**
+
+In `src/commands/sync.rs::run_tui`'s orchestrator-thread closure, find where
+`Fetch` task completes successfully. Add the call there. (Look for the pattern
+that today's code uses to detect Fetch completion — likely via
+`match task.id { TaskId::Fetch => ... }` after `execute_fetch_task` returns
+`TaskStatus::Succeeded`.)
+
+- [ ] **Step 3: Verify build + unit tests**
+
+Run: `cargo build --lib && cargo test --lib` Expected: clean build, all tests
+pass (no behavior change yet — helper exists but until Phase 3 Task 3 lands the
+streaming collector seed, the `LiveTable` doesn't show changes).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/commands/sync.rs
+git commit -m "feat(sync): add spawn_post_fetch_refresh for live remote-tracking refresh (#402)"
+```
+
+---
+
+## Task 2: Replace sync's blocking pre-seed with streaming collector
+
+**Files:**
+
+- Modify: `src/commands/sync.rs`
+
+Drop the `needs_spinner` blocking block (lines ~417-440). Replace with cheap
+porcelain seed + spawn the streaming collector concurrently with the
+orchestrator. The collector emits patches that `LiveTable` consumes via the
+existing channel.
+
+- [ ] **Step 1: Remove the spinner block**
+
+In `src/commands/sync.rs::run_tui`, delete lines ~417-440 (the
+`let needs_spinner = ...; let worktree_infos = if needs_spinner { ... } else { ... };`
+block).
+
+Replace with:
+
+```rust
+// Cheap porcelain seed — branches + paths + is_default known instantly.
+let worktree_entries = prune::parse_worktree_list(&git)?;
+let worktree_infos: Vec<WorktreeInfo> = worktree_entries.iter()
+    .filter(|e| !e.is_bare)
+    .map(|e| {
+        let mut info = WorktreeInfo::empty(e.branch.as_deref().unwrap_or(""));
+        info.path = Some(e.path.clone());
+        info.is_default_branch = e.branch.as_deref() == Some(base_branch.as_str());
+        info.is_current = current_path.as_deref() == Some(e.path.as_path());
+        info
+    })
+    .collect();
+```
+
+(The `worktree_map` building below already uses `worktree_entries` — no
+duplication.)
+
+- [ ] **Step 2: Spawn the streaming collector after the orchestrator starts**
+
+After `let (tx, rx) = mpsc::channel();` and the
+`orchestrator_handle = thread::spawn(...)` line, add:
+
+```rust
+// Streaming collector: cells fill in concurrently with orchestrator.
+let collector_targets: Vec<list_stream::CollectorTarget> = worktree_infos.iter()
+    .map(|i| list_stream::CollectorTarget {
+        branch_name: i.name.clone(),
+        path: i.path.clone(),
+        kind: EntryKind::Worktree,
+        is_detached: false,
+    })
+    .collect();
+let collector_ctx = Arc::new(list_stream::CollectorContext {
+    use_gitoxide: settings.use_gitoxide,
+    base_branch: base_branch.clone(),
+    remote_name: settings.remote.clone(),
+    ownership_strategy: settings.ownership_strategy,
+    user_email: user_email.clone(),
+});
+let collector_handle = list_stream::spawn(
+    list_stream::CollectorRequest {
+        targets: collector_targets,
+        fields: FieldSet::ALL,
+        stat,
+        source: PatchSource::Collector,
+        ctx: collector_ctx,
+    },
+    tx.clone(),
+);
+```
+
+After `renderer.run()?` returns and before exiting, drain the collector:
+
+```rust
+collector_handle.join();
+```
+
+- [ ] **Step 3: Verify build + tests with DAFT_NO_LIVE=1**
+
+Run:
+
+```bash
+cargo build --bin daft
+DAFT_NO_LIVE=1 cargo test --lib
+DAFT_NO_LIVE=1 mise run test:integration -- --filter sync
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Manual smoke test**
+
+Run `daft sync` against a real repo. Observe: spinner is gone, table appears
+instantly, cells fill in as fetch + per-branch tasks complete.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/commands/sync.rs
+git commit -m "feat(sync): replace blocking pre-seed with streaming collector (#402)"
+```
+
+---
+
+## Task 3: Wire post-fetch refresh into sync's task closure
+
+**Files:**
+
+- Modify: `src/commands/sync.rs`
+
+In sync's orchestrator-thread closure, after the `Fetch` task succeeds, call
+`spawn_post_fetch_refresh(...)` so `REMOTE_DERIVED` cells reflect post-fetch
+reality.
+
+- [ ] **Step 1: Add the call**
+
+Find the `match &task.id { TaskId::Fetch => ... }` arm (or wherever the fetch
+completion handler runs). After the existing fetch logic and before the
+`(status, message, outcomes)` return, add:
+
+```rust
+if status == TaskStatus::Succeeded {
+    spawn_post_fetch_refresh(
+        &shared_worktree_map,
+        &orch_settings,
+        &orch_base_branch,
+        orch_user_email.as_deref(),
+        orch_stat,
+        &tx_for_tasks,
+    );
+}
+```
+
+(Use the existing `Arc`-cloned variables that the closure captures —
+`shared_worktree_map`, `orch_settings`, etc.)
+
+- [ ] **Step 2: Verify**
+
+Run: `cargo test --lib` Expected: all tests pass.
+
+Run: `DAFT_NO_LIVE=1 mise run test:integration -- --filter sync` Expected: all
+tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/commands/sync.rs
+git commit -m "feat(sync): refresh remote-derived cells after fetch (#402)"
+```
+
+---
+
+## Task 4: Replace prune's blocking pre-seed with streaming collector
+
+**Files:**
+
+- Modify: `src/commands/prune.rs`
+
+Same migration as sync (Task 2 of this phase) but for `prune.rs::run_tui`.
+
+- [ ] **Step 1: Remove the spinner block**
+
+In `src/commands/prune.rs::run_tui`, delete lines ~220-254 (the `needs_spinner`
+block).
+
+Replace with the same cheap porcelain seed pattern from sync's Task 2.
+
+- [ ] **Step 2: Spawn the streaming collector after orchestrator starts**
+
+Add the same collector spawn pattern after the orchestrator thread is created.
+
+- [ ] **Step 3: Verify build**
+
+Run: `cargo build --bin daft` Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/commands/prune.rs
+git commit -m "feat(prune): replace blocking pre-seed with streaming collector (#402)"
+```
+
+---
+
+## Task 5: Wire post-fetch refresh into prune's task closure
+
+**Files:**
+
+- Modify: `src/commands/prune.rs`
+
+Same as sync's Task 3.
+
+- [ ] **Step 1: Make `spawn_post_fetch_refresh` callable from prune.rs**
+
+Either: (a) Move `spawn_post_fetch_refresh` from sync.rs to a new shared
+location like `src/commands/sync_shared.rs` (and import from both). (b)
+Duplicate it inside prune.rs.
+
+Pick (a) — it's a clear shared helper and `sync_shared.rs` already exists.
+
+- [ ] **Step 2: Add the call after Fetch in prune's orchestrator**
+
+In `src/commands/prune.rs::run_tui`'s orchestrator thread, find where `Fetch`
+succeeds and add the same call as sync's Task 3.
+
+- [ ] **Step 3: Verify**
+
+Run: `cargo test --lib` Run:
+`DAFT_NO_LIVE=1 mise run test:integration -- --filter prune` Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/commands/prune.rs src/commands/sync.rs src/commands/sync_shared.rs
+git commit -m "feat(prune): refresh remote-derived cells after fetch (#402)"
+```
+
+---
+
+## Task 6: Set `DAFT_NO_LIVE=1` for integration tests
+
+**Files:**
+
+- Modify: `tests/integration/run.sh` (or similar test driver)
+- Possibly: `tests/manual/scenarios/**/*.yml` — per-scenario env var if a global
+  setting doesn't fit
+
+Integration tests rely on stable golden output. The new live UX introduces
+tick-based updates and timing variance that can break golden assertions. Setting
+`DAFT_NO_LIVE=1` in the test environment forces the existing one-shot path.
+
+- [ ] **Step 1: Identify the test driver**
+
+Read `tests/integration/run.sh` (or the equivalent driver). Find where the
+`daft` binary is invoked.
+
+- [ ] **Step 2: Set the env var**
+
+Either prepend `DAFT_NO_LIVE=1` to each `daft` invocation, or set it once at the
+top of the driver (`export DAFT_NO_LIVE=1`).
+
+For the YAML manual scenarios, check if they support per-scenario env vars. If
+yes, add `env: DAFT_NO_LIVE=1` to each list/prune/sync scenario header. If no,
+set it globally.
+
+- [ ] **Step 3: Run the full integration suite**
+
+Run: `mise run test:integration` Expected: all tests pass (with `DAFT_NO_LIVE=1`
+set in the environment).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/integration/ tests/manual/scenarios/
+git commit -m "test(integration): set DAFT_NO_LIVE=1 for stable golden output (#402)"
+```
+
+---
+
+## Task 7: Final verification + push
+
+- [ ] **Step 1: Full CI matrix**
+
+Run: `mise run ci` Expected: zero warnings, all unit + integration tests pass.
+
+- [ ] **Step 2: Manual smoke test of all three commands**
+
+```bash
+daft list                # rows appear instantly, cells fill live
+daft prune               # no spinner, table appears instantly
+daft sync                # no spinner, table fills live as phases progress
+DAFT_NO_LIVE=1 daft list # one-shot rendering as before
+```
+
+- [ ] **Step 3: Push**
+
+```bash
+git push origin HEAD
+```
+
+- [ ] **Step 4: Update PR description**
+
+Use `gh pr edit 410 --body "$(cat <<'EOF' ...)"` to add Phase 2 + 3 sections to
+the PR body.
+
+---
+
+## Self-Review Notes
+
+Performed inline before save:
+
+- **Spec coverage**: Phase 3 deliverables map to tasks: streaming seed for prune
+  (T4) and sync (T2), post-fetch refresh (T3, T5), `DAFT_NO_LIVE=1` opt-out for
+  tests (T6), spinner removal (T2, T4 — removing `needs_spinner` blocks).
+- **Placeholders**: none.
+- **Type consistency**: `spawn_post_fetch_refresh`, `collector_handle`,
+  `collector_targets` — used consistently.
+- **Scope**: Phase 3 only.
+- **Ambiguity**: Task 5's location of `spawn_post_fetch_refresh` (sync.rs vs
+  sync_shared.rs) is decided in step 1 (move to sync_shared.rs).

--- a/docs/superpowers/plans/2026-04-27-graceful-cancellation.md
+++ b/docs/superpowers/plans/2026-04-27-graceful-cancellation.md
@@ -1,0 +1,1251 @@
+# Graceful Ctrl-C Cancellation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `daft list` Ctrl-C exit cleanly and mark cells that didn't finish
+loading with a distinct "didn't load" indicator instead of a frozen skeleton
+bar.
+
+**Architecture:** Add a `cancelled: bool` flag on `LiveTable` (set via
+`mark_cancelled()` which also flips `collection_complete = true`); render path
+consults a sibling `is_cell_unloaded(row, field)` predicate to swap the loading
+shimmer for a dim em-dash; driver Ctrl-C arm calls `mark_cancelled()` before the
+final draw and writes a trailing `\n` to stderr after viewport teardown so the
+shell prompt lands on its own line.
+
+**Tech Stack:** Rust 2021, ratatui 0.30, crossterm 0.29, std::io::Write,
+std::sync::atomic.
+
+**Spec:** `docs/superpowers/specs/2026-04-27-graceful-cancellation-design.md`
+(commit `4ca43230`).
+
+---
+
+## File Structure
+
+| File                           | Changes                                                                                                                                                                                |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/output/tui/live_table.rs` | Add `cancelled: bool` field, `mark_cancelled()` method, `is_cell_unloaded()` method, tests.                                                                                            |
+| `src/output/tui/render.rs`     | Add `not_loaded_cell()` helper, second closure parameter on `render_cell`, per-column branch updates, both `render_table` call sites updated, `render_footer` cancelled suffix, tests. |
+| `src/output/tui/driver.rs`     | Add `use std::io::Write;`, call `state.live.mark_cancelled()` in Ctrl-C arm, write `\n` to stderr after `drop(terminal)` when cancelled, test.                                         |
+
+Sequencing rationale: `live_table.rs` first (data model). Then `render.rs`
+(consumer of the data model). Then `driver.rs` (producer of the cancellation
+event). Each task is self-contained and leaves the build green.
+
+---
+
+## Task 1: Add `cancelled` field + `mark_cancelled()` to `LiveTable`
+
+**Files:**
+
+- Modify: `src/output/tui/live_table.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the `mod tests` block at the end of `src/output/tui/live_table.rs`
+(after the existing tests, before the closing `}`):
+
+```rust
+    #[test]
+    fn mark_cancelled_sets_cancelled_and_collection_complete() {
+        let mut t = LiveTable::new(vec![info("a")], cfg());
+        assert!(!t.cancelled);
+        assert!(!t.collection_complete);
+        t.mark_cancelled();
+        assert!(t.cancelled);
+        assert!(t.collection_complete);
+        assert!(t.pending_resort);
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cargo test --lib --quiet output::tui::live_table::tests::mark_cancelled_sets_cancelled_and_collection_complete 2>&1 | tail -20
+```
+
+Expected: compile error — `LiveTable` has no field named `cancelled` and no
+method named `mark_cancelled`.
+
+- [ ] **Step 3: Add the `cancelled` field to `LiveTable`**
+
+In `src/output/tui/live_table.rs`, modify the `LiveTable` struct definition:
+
+```rust
+pub struct LiveTable {
+    pub rows: Vec<WorktreeRow>,
+    pub cfg: LiveTableConfig,
+    pub pending_resort: bool,
+    pub collection_complete: bool,
+    /// Set when the user cancels (Ctrl-C). Cells that haven't received their
+    /// patch should render a "data didn't load" marker rather than the
+    /// loading shimmer. `mark_cancelled` also sets `collection_complete = true`
+    /// so `is_cell_loading` naturally returns false post-cancel.
+    pub cancelled: bool,
+    pub source_log: PatchSourceLog,
+    /// Per-row bitmask of "patches received".
+    pub received_patches: Vec<FieldSet>,
+    /// Index of the first row in the unowned section, or `None` if no
+    /// partition. Recomputed when `partition_by_owner` is true.
+    pub unowned_start_index: Option<usize>,
+}
+```
+
+In `LiveTable::new`, initialize the field. Modify the existing
+`let mut t = Self { ... };` block to add `cancelled: false,`:
+
+```rust
+        let mut t = Self {
+            rows,
+            cfg,
+            pending_resort: true,
+            collection_complete: false,
+            cancelled: false,
+            source_log: PatchSourceLog::default(),
+            received_patches,
+            unowned_start_index: None,
+        };
+```
+
+- [ ] **Step 4: Add the `mark_cancelled` method**
+
+In `src/output/tui/live_table.rs`, add this method inside the
+`impl LiveTable { ... }` block (place it after the existing `apply_event` method
+for visibility, but anywhere inside the impl is fine):
+
+```rust
+    /// Mark the live table as cancelled by user (Ctrl-C). Sets
+    /// `collection_complete = true` so the loading shimmer stops and
+    /// `pending_resort = true` so the next tick re-runs the sort/partition.
+    /// Cells that haven't received their patch will render via
+    /// `is_cell_unloaded` rather than the loading shimmer.
+    pub fn mark_cancelled(&mut self) {
+        self.cancelled = true;
+        self.collection_complete = true;
+        self.pending_resort = true;
+    }
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+```bash
+cargo test --lib --quiet output::tui::live_table::tests::mark_cancelled_sets_cancelled_and_collection_complete 2>&1 | tail -10
+```
+
+Expected: PASS (1 passed; 0 failed).
+
+- [ ] **Step 6: Run full test suite to confirm no regressions**
+
+```bash
+mise run test:unit 2>&1 | tail -15
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Lint and format**
+
+```bash
+mise run fmt && mise run clippy 2>&1 | tail -10
+```
+
+Expected: clippy emits no warnings; fmt completes without diffs needing fixup.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/output/tui/live_table.rs
+git commit -m "$(cat <<'EOF'
+feat(tui): add cancelled flag and mark_cancelled to LiveTable (#402)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Add `is_cell_unloaded()` predicate to `LiveTable`
+
+**Files:**
+
+- Modify: `src/output/tui/live_table.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append these tests inside the `mod tests` block in
+`src/output/tui/live_table.rs`:
+
+```rust
+    #[test]
+    fn is_cell_unloaded_false_before_cancel() {
+        let t = LiveTable::new(vec![info("a")], cfg());
+        assert!(!t.is_cell_unloaded(0, FieldSet::SIZE));
+    }
+
+    #[test]
+    fn is_cell_unloaded_true_when_cancelled_and_not_received() {
+        let mut t = LiveTable::new(vec![info("a")], cfg());
+        t.mark_cancelled();
+        assert!(t.is_cell_unloaded(0, FieldSet::SIZE));
+    }
+
+    #[test]
+    fn is_cell_unloaded_false_when_received_even_after_cancel() {
+        let mut t = LiveTable::new(vec![info("a")], cfg());
+        t.apply_event(&DagEvent::WorktreeInfoUpdated {
+            branch_name: "a".into(),
+            patch: WorktreeInfoPatch::Size(Some(123)),
+            source: PatchSource::Collector,
+        });
+        t.mark_cancelled();
+        assert!(!t.is_cell_unloaded(0, FieldSet::SIZE));
+    }
+
+    #[test]
+    fn is_cell_loading_returns_false_after_mark_cancelled() {
+        // Regression guard: mark_cancelled sets collection_complete = true,
+        // which makes is_cell_loading naturally return false. We rely on this
+        // so the render path doesn't need a second "and not cancelled" check
+        // in the loading branch.
+        let mut t = LiveTable::new(vec![info("a")], cfg());
+        assert!(t.is_cell_loading(0, FieldSet::SIZE));
+        t.mark_cancelled();
+        assert!(!t.is_cell_loading(0, FieldSet::SIZE));
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cargo test --lib --quiet output::tui::live_table::tests::is_cell_unloaded 2>&1 | tail -10
+```
+
+Expected: compile error — `is_cell_unloaded` does not exist.
+
+- [ ] **Step 3: Add the `is_cell_unloaded` method**
+
+In `src/output/tui/live_table.rs`, add this method to the
+`impl LiveTable { ... }` block, right next to (immediately after) the existing
+`is_cell_loading` method:
+
+```rust
+    /// True when the cell for `field` on `row_idx` should render the
+    /// "data didn't load" marker because the user cancelled before the
+    /// patch arrived. Mutually exclusive with `is_cell_loading` after
+    /// `mark_cancelled()` runs (which sets `collection_complete = true`).
+    pub fn is_cell_unloaded(&self, row_idx: usize, field: FieldSet) -> bool {
+        self.cancelled && !self.received_patches[row_idx].contains(field)
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cargo test --lib --quiet output::tui::live_table::tests::is_cell 2>&1 | tail -15
+```
+
+Expected: 5 passed (4 new + 1 pre-existing `is_cell_loading_*` and
+`patch_applied_marks_received_for_loading_glyph`). Match by `is_cell` prefix.
+
+- [ ] **Step 5: Run full test suite to confirm no regressions**
+
+```bash
+mise run test:unit 2>&1 | tail -10
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Lint**
+
+```bash
+mise run clippy 2>&1 | tail -10
+```
+
+Expected: zero warnings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/output/tui/live_table.rs
+git commit -m "$(cat <<'EOF'
+feat(tui): add is_cell_unloaded predicate to LiveTable (#402)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Add `not_loaded_cell()` helper in `render.rs`
+
+**Files:**
+
+- Modify: `src/output/tui/render.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append this test inside the `mod tests` block at the bottom of
+`src/output/tui/render.rs` (after
+`render_footer_shows_inflight_and_elapsed_when_verbose`, before the closing
+`}`):
+
+```rust
+    #[test]
+    fn not_loaded_cell_renders_dim_em_dash() {
+        // The "didn't load" cell should be a single em-dash (U+2014) styled
+        // dim + DarkGray, distinct from the breathing skeleton bar (which
+        // fills the column with U+25AC).
+        let backend = TestBackend::new(5, 1);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                let cell = not_loaded_cell();
+                let table = Table::new(vec![Row::new(vec![cell])], &[Constraint::Length(5)]);
+                frame.render_widget(table, frame.area());
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+        assert_eq!(buffer[(0, 0)].symbol(), "\u{2014}");
+        assert_eq!(buffer[(0, 0)].fg, ratatui::style::Color::DarkGray);
+        assert!(
+            buffer[(0, 0)]
+                .modifier
+                .contains(ratatui::style::Modifier::DIM),
+            "not_loaded_cell should be DIM"
+        );
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cargo test --lib --quiet output::tui::render::tests::not_loaded_cell_renders_dim_em_dash 2>&1 | tail -10
+```
+
+Expected: compile error — `not_loaded_cell` is not defined.
+
+- [ ] **Step 3: Add the `not_loaded_cell` helper**
+
+In `src/output/tui/render.rs`, add this function immediately after the
+`loading_shimmer_cell` definition (currently around line 633–643). Place it
+right after `skeleton_pulse_color` so the loading-glyph helpers stay grouped:
+
+```rust
+/// Render a "data didn't load" placeholder for a cell whose patch was not
+/// received before the user cancelled (Ctrl-C). Single em-dash (U+2014),
+/// dim + DarkGray. Distinct from the loading shimmer (which is a full-width
+/// bar of U+25AC) and from a legitimately-empty cell (a blank).
+fn not_loaded_cell() -> Cell<'static> {
+    Cell::from(Span::styled(
+        "\u{2014}",
+        Style::default()
+            .fg(Color::DarkGray)
+            .add_modifier(Modifier::DIM),
+    ))
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cargo test --lib --quiet output::tui::render::tests::not_loaded_cell_renders_dim_em_dash 2>&1 | tail -10
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run full test suite**
+
+```bash
+mise run test:unit 2>&1 | tail -10
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Lint**
+
+```bash
+mise run clippy 2>&1 | tail -10
+```
+
+Expected: clippy may emit `dead_code` warning for `not_loaded_cell` since no
+caller exists yet — acceptable, will be wired in Task 4. If it fires, add
+`#[allow(dead_code)]` directly above the function and remove the attribute in
+Task 4. Confirm with:
+
+```bash
+mise run clippy 2>&1 | grep -E "warning|error" | head -5
+```
+
+If only `dead_code: function .* is never used` appears for `not_loaded_cell`,
+add the attribute. Otherwise proceed.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/output/tui/render.rs
+git commit -m "$(cat <<'EOF'
+feat(tui): add not_loaded_cell helper for cancelled-state placeholder (#402)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Wire `is_cell_unloaded` through `render_cell` and both `render_table` call sites
+
+This task ships together because changing `render_cell`'s signature breaks both
+`render_table` call sites; partial commits don't compile.
+
+**Files:**
+
+- Modify: `src/output/tui/render.rs`
+
+- [ ] **Step 1: Write the failing test for `render_cell`**
+
+Append this test inside the `mod tests` block at the bottom of
+`src/output/tui/render.rs`:
+
+```rust
+    #[test]
+    fn render_cell_uses_not_loaded_when_cancelled_and_unfilled() {
+        // For each loadable column, with is_cell_unloaded returning true,
+        // the cell should render the dim em-dash, not the shimmer bar and
+        // not an empty cell.
+        use crate::core::worktree::info_field::FieldSet;
+        use crate::output::format::compute_column_values;
+        use crate::output::tui::columns::ColumnContext;
+        use crate::output::tui::state::WorktreeRow;
+
+        let info = WorktreeInfo::empty("a");
+        let wt = WorktreeRow::idle(info.clone());
+        let ctx = ColumnContext {
+            project_root: &PathBuf::from("/tmp"),
+            cwd: &PathBuf::from("/tmp"),
+            now: 0,
+            stat: Stat::Lines,
+        };
+        let vals = compute_column_values(&info, &ctx);
+
+        let columns = [
+            (Column::Size, FieldSet::SIZE),
+            (Column::Base, FieldSet::BASE_AHEAD_BEHIND),
+            (Column::Changes, FieldSet::CHANGES),
+            (Column::Remote, FieldSet::REMOTE_AHEAD_BEHIND),
+            (Column::Age, FieldSet::BRANCH_AGE),
+            (Column::Owner, FieldSet::OWNER),
+            (Column::Hash, FieldSet::LAST_COMMIT),
+            (Column::LastCommit, FieldSet::LAST_COMMIT),
+        ];
+
+        for (col, _field) in columns {
+            let backend = TestBackend::new(10, 1);
+            let mut terminal = Terminal::new(backend).unwrap();
+            terminal
+                .draw(|frame| {
+                    let cell = render_cell(
+                        &col,
+                        &wt,
+                        &vals,
+                        0,
+                        Stat::Lines,
+                        10,
+                        |_fs| false,         // not loading (cancelled implies collection_complete)
+                        |_fs| true,          // is_cell_unloaded → true
+                    );
+                    let table =
+                        Table::new(vec![Row::new(vec![cell])], &[Constraint::Length(10)]);
+                    frame.render_widget(table, frame.area());
+                })
+                .unwrap();
+            let buffer = terminal.backend().buffer();
+            assert_eq!(
+                buffer[(0, 0)].symbol(),
+                "\u{2014}",
+                "column {col:?} should render em-dash when cancelled and unfilled"
+            );
+        }
+    }
+
+    #[test]
+    fn render_cell_uses_value_when_received_even_if_cancelled() {
+        // If the cell value is non-empty (received), is_cell_unloaded should
+        // be false and the value should render. Guards against rendering
+        // "—" over real data.
+        use crate::output::format::compute_column_values;
+        use crate::output::tui::columns::ColumnContext;
+        use crate::output::tui::state::WorktreeRow;
+
+        let mut info = WorktreeInfo::empty("a");
+        info.size_bytes = Some(1024);
+        let wt = WorktreeRow::idle(info.clone());
+        let ctx = ColumnContext {
+            project_root: &PathBuf::from("/tmp"),
+            cwd: &PathBuf::from("/tmp"),
+            now: 0,
+            stat: Stat::Lines,
+        };
+        let vals = compute_column_values(&info, &ctx);
+
+        let backend = TestBackend::new(10, 1);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                let cell = render_cell(
+                    &Column::Size,
+                    &wt,
+                    &vals,
+                    0,
+                    Stat::Lines,
+                    10,
+                    |_fs| false,         // not loading
+                    |_fs| false,         // not unloaded — received
+                );
+                let table = Table::new(vec![Row::new(vec![cell])], &[Constraint::Length(10)]);
+                frame.render_widget(table, frame.area());
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+        let row: String = (0..10).map(|x| buffer[(x, 0)].symbol().to_string()).collect();
+        assert!(
+            !row.contains("\u{2014}"),
+            "received cell should render value, not em-dash; got {row:?}"
+        );
+        assert!(
+            row.trim_end().chars().any(|c| c.is_ascii_digit() || c == 'B' || c == 'K'),
+            "received Size cell should render numeric/unit value; got {row:?}"
+        );
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cargo test --lib --quiet output::tui::render::tests::render_cell_uses 2>&1 | tail -15
+```
+
+Expected: compile error — `render_cell` takes 7 args, not 8.
+
+- [ ] **Step 3: Update `render_cell` signature**
+
+In `src/output/tui/render.rs`, modify the `render_cell` function signature
+(currently around lines 665–673):
+
+```rust
+/// Render a single cell for the given column and worktree row.
+///
+/// `width` is the column's assigned width — used to size shimmer bars when
+/// the cell is in a loading state.
+/// `is_cell_unloaded` returns true when the user cancelled before the cell's
+/// patch arrived; takes precedence over `is_cell_loading`.
+fn render_cell(
+    col: &Column,
+    wt: &super::state::WorktreeRow,
+    vals: &ColumnValues,
+    tick: usize,
+    stat: Stat,
+    width: u16,
+    is_cell_loading: impl Fn(FieldSet) -> bool,
+    is_cell_unloaded: impl Fn(FieldSet) -> bool,
+) -> Cell<'static> {
+```
+
+- [ ] **Step 4: Update each loadable column branch in `render_cell`**
+
+Replace the bodies of the loadable column match arms inside `render_cell`. Each
+follows the same pattern: `is_cell_unloaded` check first, then existing
+`is_cell_loading` check, then value render.
+
+Replace `Column::Size` arm with:
+
+```rust
+        Column::Size => {
+            if vals.size.is_empty() {
+                if is_cell_unloaded(FieldSet::SIZE) {
+                    not_loaded_cell()
+                } else if is_cell_loading(FieldSet::SIZE) {
+                    loading_shimmer_cell(width, tick)
+                } else {
+                    Cell::from(vals.size.clone())
+                }
+            } else {
+                Cell::from(vals.size.clone())
+            }
+        }
+```
+
+Replace `Column::Base` arm with:
+
+```rust
+        Column::Base => {
+            let unfilled = wt.info.ahead.is_none() && wt.info.behind.is_none();
+            if unfilled && is_cell_unloaded(FieldSet::BASE_AHEAD_BEHIND) {
+                not_loaded_cell()
+            } else if unfilled && is_cell_loading(FieldSet::BASE_AHEAD_BEHIND) {
+                loading_shimmer_cell(width, tick)
+            } else {
+                render_base_cell(&wt.info, stat)
+            }
+        }
+```
+
+Replace `Column::Changes` arm with:
+
+```rust
+        Column::Changes => {
+            let unfilled = wt.info.staged + wt.info.unstaged + wt.info.untracked == 0;
+            if unfilled && is_cell_unloaded(FieldSet::CHANGES) {
+                not_loaded_cell()
+            } else if unfilled && is_cell_loading(FieldSet::CHANGES) {
+                loading_shimmer_cell(width, tick)
+            } else {
+                render_changes_cell(&wt.info, stat)
+            }
+        }
+```
+
+Replace `Column::Remote` arm with:
+
+```rust
+        Column::Remote => {
+            let unfilled = wt.info.remote_ahead.is_none() && wt.info.remote_behind.is_none();
+            if unfilled && is_cell_unloaded(FieldSet::REMOTE_AHEAD_BEHIND) {
+                not_loaded_cell()
+            } else if unfilled && is_cell_loading(FieldSet::REMOTE_AHEAD_BEHIND) {
+                loading_shimmer_cell(width, tick)
+            } else {
+                render_remote_cell(&wt.info, stat)
+            }
+        }
+```
+
+Replace `Column::Age` arm with:
+
+```rust
+        Column::Age => {
+            if vals.branch_age.is_empty() {
+                if is_cell_unloaded(FieldSet::BRANCH_AGE) {
+                    not_loaded_cell()
+                } else if is_cell_loading(FieldSet::BRANCH_AGE) {
+                    loading_shimmer_cell(width, tick)
+                } else {
+                    Cell::from(vals.branch_age.clone())
+                }
+            } else {
+                let cell = Cell::from(vals.branch_age.clone());
+                if vals.is_old_branch {
+                    cell.style(Style::default().add_modifier(Modifier::DIM))
+                } else {
+                    cell
+                }
+            }
+        }
+```
+
+Replace `Column::Owner` arm with:
+
+```rust
+        Column::Owner => {
+            if vals.owner.is_empty() {
+                if is_cell_unloaded(FieldSet::OWNER) {
+                    not_loaded_cell()
+                } else if is_cell_loading(FieldSet::OWNER) {
+                    loading_shimmer_cell(width, tick)
+                } else {
+                    Cell::from(vals.owner.clone())
+                }
+            } else {
+                Cell::from(vals.owner.clone())
+            }
+        }
+```
+
+Replace `Column::Hash` arm with:
+
+```rust
+        Column::Hash => {
+            if vals.hash.is_empty() {
+                if is_cell_unloaded(FieldSet::LAST_COMMIT) {
+                    not_loaded_cell()
+                } else if is_cell_loading(FieldSet::LAST_COMMIT) {
+                    loading_shimmer_cell(width, tick)
+                } else {
+                    Cell::from(vals.hash.clone())
+                }
+            } else {
+                Cell::from(vals.hash.clone())
+            }
+        }
+```
+
+Replace `Column::LastCommit` arm with:
+
+```rust
+        Column::LastCommit => {
+            if vals.last_commit_age.is_empty() && vals.last_commit_subject.is_empty() {
+                if is_cell_unloaded(FieldSet::LAST_COMMIT) {
+                    not_loaded_cell()
+                } else if is_cell_loading(FieldSet::LAST_COMMIT) {
+                    loading_shimmer_cell(width, tick)
+                } else {
+                    Cell::from("")
+                }
+            } else if vals.last_commit_age.is_empty() {
+                Cell::from(vals.last_commit_subject.clone())
+            } else if vals.last_commit_subject.is_empty() {
+                let cell = Cell::from(vals.last_commit_age.clone());
+                if vals.is_old_commit {
+                    cell.style(Style::default().add_modifier(Modifier::DIM))
+                } else {
+                    cell
+                }
+            } else {
+                let age_style = if vals.is_old_commit {
+                    Style::default().add_modifier(Modifier::DIM)
+                } else {
+                    Style::default()
+                };
+                Cell::from(Line::from(vec![
+                    Span::styled(vals.last_commit_age.clone(), age_style),
+                    Span::raw(format!(" {}", vals.last_commit_subject)),
+                ]))
+            }
+        }
+```
+
+- [ ] **Step 5: Update both `render_table` call sites**
+
+In `src/output/tui/render.rs`, the function `render_table` calls `render_cell`
+in two places (currently around lines 344 and 363). Update both to pass the new
+closure.
+
+First call site (the pruned-row branch, currently around line 344):
+
+```rust
+                    if matches!(col, Column::Status | Column::Annotation) {
+                        render_cell(
+                            col,
+                            wt,
+                            vals,
+                            state.tick,
+                            state.live.cfg.stat,
+                            assigned_widths[i],
+                            |fs| state.live.is_cell_loading(row_idx, fs),
+                            |fs| state.live.is_cell_unloaded(row_idx, fs),
+                        )
+                    } else {
+                        Cell::from("")
+                    }
+```
+
+Second call site (the normal-row branch, currently around line 363):
+
+```rust
+                .map(|(i, col)| {
+                    render_cell(
+                        col,
+                        wt,
+                        vals,
+                        state.tick,
+                        state.live.cfg.stat,
+                        assigned_widths[i],
+                        |fs| state.live.is_cell_loading(row_idx, fs),
+                        |fs| state.live.is_cell_unloaded(row_idx, fs),
+                    )
+                })
+```
+
+- [ ] **Step 6: If Task 3 added `#[allow(dead_code)]` to `not_loaded_cell`,
+      remove it now**
+
+The function now has callers (every loadable column branch). Search:
+
+```bash
+grep -n "allow(dead_code)" src/output/tui/render.rs
+```
+
+If a `#[allow(dead_code)]` line precedes `fn not_loaded_cell`, delete that line.
+
+- [ ] **Step 7: Run new tests to verify they pass**
+
+```bash
+cargo test --lib --quiet output::tui::render::tests::render_cell_uses 2>&1 | tail -15
+```
+
+Expected: 2 passed (`render_cell_uses_not_loaded_when_cancelled_and_unfilled` +
+`render_cell_uses_value_when_received_even_if_cancelled`).
+
+- [ ] **Step 8: Run full test suite to confirm no regressions**
+
+```bash
+mise run test:unit 2>&1 | tail -10
+```
+
+Expected: all tests pass. Watch for any `output::tui::render::tests::*` test
+that was using a state with `cancelled = false` — it should still pass because
+`is_cell_unloaded` returns false in that state.
+
+- [ ] **Step 9: Lint and format**
+
+```bash
+mise run fmt && mise run clippy 2>&1 | tail -10
+```
+
+Expected: zero clippy warnings.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/output/tui/render.rs
+git commit -m "$(cat <<'EOF'
+feat(tui): wire is_cell_unloaded through render_cell for cancelled cells (#402)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Append "cancelled" suffix to the verbose footer
+
+**Files:**
+
+- Modify: `src/output/tui/render.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append these tests inside the `mod tests` block of `src/output/tui/render.rs`:
+
+```rust
+    #[test]
+    fn render_footer_appends_cancelled_when_live_cancelled() {
+        let mut state = make_test_state(1);
+        state.render_start_elapsed = std::time::Duration::from_millis(1234);
+        state.live.mark_cancelled();
+        let backend = TestBackend::new(80, 1);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render_footer(&state, frame, frame.area());
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+        let row: String = (0..buffer.area.width)
+            .map(|x| buffer[(x, 0)].symbol().to_string())
+            .collect();
+        assert!(row.contains("cancelled"), "row was: {row:?}");
+        assert!(row.contains("inflight:"), "row was: {row:?}");
+    }
+
+    #[test]
+    fn render_footer_no_cancelled_suffix_when_not_cancelled() {
+        let mut state = make_test_state(1);
+        state.render_start_elapsed = std::time::Duration::from_millis(1234);
+        // NOT calling mark_cancelled.
+        let backend = TestBackend::new(80, 1);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render_footer(&state, frame, frame.area());
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+        let row: String = (0..buffer.area.width)
+            .map(|x| buffer[(x, 0)].symbol().to_string())
+            .collect();
+        assert!(!row.contains("cancelled"), "row was: {row:?}");
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cargo test --lib --quiet output::tui::render::tests::render_footer_ 2>&1 | tail -15
+```
+
+Expected: `render_footer_appends_cancelled_when_live_cancelled` fails (no
+"cancelled" in output). `render_footer_no_cancelled_suffix_when_not_cancelled`
+passes (already true).
+
+- [ ] **Step 3: Update `render_footer` to append the suffix**
+
+In `src/output/tui/render.rs`, modify `render_footer` (currently around lines
+91–108). Replace the body with:
+
+```rust
+pub fn render_footer(state: &TuiState, frame: &mut Frame, area: Rect) {
+    if !state.show_hook_sub_rows {
+        return;
+    }
+    let inflight: usize = state
+        .live
+        .received_patches
+        .iter()
+        .filter(|fs| !fs.contains(crate::core::worktree::info_field::FieldSet::ALL))
+        .count();
+    let elapsed_secs = state.render_start_elapsed.as_secs_f32();
+    let mut text = format!(" inflight: {inflight} \u{00B7} elapsed: {elapsed_secs:.1}s");
+    if state.live.cancelled {
+        text.push_str(" \u{00B7} cancelled");
+    }
+    let line = Line::from(Span::styled(
+        text,
+        Style::default().add_modifier(Modifier::DIM),
+    ));
+    frame.render_widget(Paragraph::new(line), area);
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cargo test --lib --quiet output::tui::render::tests::render_footer_ 2>&1 | tail -10
+```
+
+Expected: 4 passed (2 new + 2 existing — `render_footer_no_op_when_not_verbose`,
+`render_footer_shows_inflight_and_elapsed_when_verbose`).
+
+- [ ] **Step 5: Run full test suite**
+
+```bash
+mise run test:unit 2>&1 | tail -10
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Lint and format**
+
+```bash
+mise run fmt && mise run clippy 2>&1 | tail -10
+```
+
+Expected: zero warnings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/output/tui/render.rs
+git commit -m "$(cat <<'EOF'
+feat(tui): append cancelled suffix to verbose footer (#402)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Driver Ctrl-C arm calls `mark_cancelled`
+
+**Files:**
+
+- Modify: `src/output/tui/driver.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append this test inside the `mod tests` block at the bottom of
+`src/output/tui/driver.rs`. It mirrors the existing
+`cancel_signal_can_be_set_externally` test (which sets the signal and reads it
+back). The new test additionally asserts that calling `mark_cancelled` on the
+state's live table gives us the expected post-cancel state.
+
+```rust
+    #[test]
+    fn mark_cancelled_via_state_flips_live_cancelled() {
+        // Direct unit test for the post-Ctrl-C state mutation that the
+        // driver's Ctrl-C arm performs. We can't easily synthesize a
+        // crossterm Event in a unit test, so we exercise the same
+        // mutation path the arm performs.
+        let phases = Vec::<crate::core::worktree::sync_dag::OperationPhase>::new();
+        let infos = vec![crate::core::worktree::list::WorktreeInfo::empty("a")];
+        let mut state = TuiState::new(
+            phases,
+            infos,
+            std::path::PathBuf::from("/tmp"),
+            std::path::PathBuf::from("/tmp"),
+            crate::core::worktree::list::Stat::Summary,
+            0,
+            None,
+            false,
+            None,
+            None,
+            true,
+            false,
+        );
+        assert!(!state.live.cancelled);
+        assert!(!state.live.collection_complete);
+
+        state.live.mark_cancelled();
+        state.done = true;
+
+        assert!(state.live.cancelled);
+        assert!(state.live.collection_complete);
+        assert!(state.done);
+    }
+```
+
+- [ ] **Step 2: Run test to verify it passes (the methods already exist from
+      Tasks 1–2)**
+
+```bash
+cargo test --lib --quiet output::tui::driver::tests::mark_cancelled_via_state_flips_live_cancelled 2>&1 | tail -10
+```
+
+Expected: PASS. (This is a regression-style guard test for the post-cancel state
+combination — it should already work because Tasks 1–2 wired `mark_cancelled`.
+Confirms the driver-side wiring path is exercising the right API.)
+
+- [ ] **Step 3: Wire `mark_cancelled` into the Ctrl-C arm**
+
+In `src/output/tui/driver.rs`, the Ctrl-C handling block sits inside the main
+`run` loop, currently around lines 251–263. Modify it to add the
+`mark_cancelled` call before `state.done = true`:
+
+```rust
+            // Poll for keyboard events (Ctrl-C). Non-blocking. If a Ctrl-C
+            // is observed, flip the optional cancel signal so the producer
+            // exits cooperatively, mark state done and live as cancelled,
+            // and emit a final draw.
+            if event::poll(Duration::from_millis(0)).unwrap_or(false) {
+                if let Ok(Event::Key(key)) = event::read() {
+                    if key.code == KeyCode::Char('c')
+                        && key.modifiers.contains(KeyModifiers::CONTROL)
+                    {
+                        if let Some(sig) = &self.cancel_signal {
+                            sig.store(true, Ordering::Relaxed);
+                        }
+                        self.state.live.mark_cancelled();
+                        self.state.done = true;
+                        final_draw_and_return!();
+                    }
+                }
+            }
+```
+
+- [ ] **Step 4: Run full test suite to confirm no regressions**
+
+```bash
+mise run test:unit 2>&1 | tail -10
+```
+
+Expected: all tests pass, including the new
+`mark_cancelled_via_state_flips_live_cancelled`.
+
+- [ ] **Step 5: Lint and format**
+
+```bash
+mise run fmt && mise run clippy 2>&1 | tail -10
+```
+
+Expected: zero warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/output/tui/driver.rs
+git commit -m "$(cat <<'EOF'
+feat(tui): mark live table cancelled in driver Ctrl-C handler (#402)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Write trailing newline to stderr after cancelled teardown
+
+This task adds a single `\n` write to stderr after `drop(terminal)` so the shell
+prompt lands on its own line. Best-effort, ignored failure. Only runs when
+`state.live.cancelled` is true to avoid adding a blank line on normal
+completion.
+
+**Files:**
+
+- Modify: `src/output/tui/driver.rs`
+
+- [ ] **Step 1: Add `std::io::Write` import**
+
+In `src/output/tui/driver.rs`, the existing imports near the top of the file
+(currently lines 1–13) do not include `std::io::Write`. Add it. Insert this line
+after the existing `std::sync::Arc;` import (alphabetical-ish ordering,
+alongside other `std::` imports):
+
+```rust
+use std::io::Write;
+```
+
+- [ ] **Step 2: Update the `final_draw_and_return!` macro**
+
+In `src/output/tui/driver.rs`, modify the `final_draw_and_return!` macro
+(currently around lines 178–205). Add a single conditional write to stderr after
+`drop(terminal)`. Replace the macro body with:
+
+```rust
+        macro_rules! final_draw_and_return {
+            () => {{
+                let total_rows = self.total_rendered_rows();
+                terminal.draw(|frame| {
+                    let area = frame.area();
+                    let chunks = Layout::vertical([
+                        Constraint::Length(header_height),
+                        Constraint::Fill(1),
+                        Constraint::Length(footer_height),
+                    ])
+                    .split(area);
+                    render::render_header(&self.state, frame, chunks[0]);
+                    render::render_table(&self.state, frame, chunks[1]);
+                    render::render_footer(&self.state, frame, chunks[2]);
+
+                    // sort summary rows (when present) + table header (1 row)
+                    // + data rows (including hook sub-rows / size summary).
+                    let content_bottom =
+                        area.y + header_height + sort_rows + 1 + total_rows + footer_height;
+                    frame.set_cursor_position(Position {
+                        x: 0,
+                        y: content_bottom,
+                    });
+                })?;
+                drop(terminal);
+                if self.state.live.cancelled {
+                    // After a cancelled run the cursor can land inside the
+                    // last table row (terminal-height clamping of the inline
+                    // viewport). Emit a newline so the shell prompt starts on
+                    // a fresh line. Best-effort.
+                    let _ = std::io::stderr().write_all(b"\n");
+                }
+                return Ok(self.state);
+            }};
+        }
+```
+
+- [ ] **Step 3: Build to confirm compilation**
+
+```bash
+cargo build --quiet 2>&1 | tail -10
+```
+
+Expected: clean build, no warnings.
+
+- [ ] **Step 4: Run full test suite**
+
+```bash
+mise run test:unit 2>&1 | tail -10
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Lint and format**
+
+```bash
+mise run fmt && mise run clippy 2>&1 | tail -10
+```
+
+Expected: zero warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/output/tui/driver.rs
+git commit -m "$(cat <<'EOF'
+feat(tui): write trailing newline after cancelled viewport teardown (#402)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Manual smoke verification
+
+This is a non-TDD verification task. Test in a sandbox repo with multiple
+worktrees so the live UX has cells in flight when Ctrl-C lands.
+
+**Files:** none modified.
+
+- [ ] **Step 1: Open the existing daft sandbox in a fresh terminal**
+
+Use the project's sandbox at `/Users/avihu/Projects/daft/.git/.daft-sandbox`
+(created by `daft sandbox init`). If a sandbox is not already initialized for
+this branch, create one:
+
+```bash
+cd /Users/avihu/Projects/daft/daft-402/feat/live-list-population
+mise run dev
+# In a new shell:
+DAFT_CONFIG_DIR=/Users/avihu/Projects/daft/.git/.daft-sandbox daft list --columns=-path,+size --sort activity --stat lines
+```
+
+Hit Ctrl-C while the `▬` skeleton bars are still pulsing (within the first
+second).
+
+Expected:
+
+- All cells whose patches hadn't arrived render as a dim em-dash `—`, NOT as
+  frozen `▬▬▬▬`.
+- Already-loaded cells (Branch, Annotation, Status, plus any cell that finished
+  before cancel) show their real values.
+- The shell prompt returns on its own line — no `^C%` overlap with the master
+  row's content.
+
+- [ ] **Step 2: Verify the cancelled-suffix behavior in verbose mode**
+
+Run with verbose flag:
+
+```bash
+DAFT_CONFIG_DIR=/Users/avihu/Projects/daft/.git/.daft-sandbox daft list -v --columns=-path,+size --sort activity --stat lines
+```
+
+Hit Ctrl-C. Expected: footer shows ` · cancelled` appended after
+`inflight: N · elapsed: T.Xs`.
+
+- [ ] **Step 3: Verify normal completion is unchanged**
+
+Let `daft list` run to completion (do not hit Ctrl-C). Expected:
+
+- All cells render their real values; no `—` markers anywhere.
+- Footer (in verbose mode) does NOT contain "cancelled".
+- Shell prompt returns on its own line as before.
+
+- [ ] **Step 4: Run the full integration suite as a regression guard**
+
+```bash
+mise run test:integration 2>&1 | tail -20
+```
+
+Expected: all integration tests pass. (Long-running; ~20 min.)
+
+- [ ] **Step 5: If everything passes, no commit needed for this task**
+
+This is verification only.
+
+---
+
+## Spec Coverage Self-Review
+
+| Spec section / requirement                                                              | Implemented in           |
+| --------------------------------------------------------------------------------------- | ------------------------ |
+| `LiveTable.cancelled` field, default false                                              | Task 1                   |
+| `mark_cancelled()` sets `cancelled`, `collection_complete`, `pending_resort`            | Task 1                   |
+| `is_cell_unloaded(row, field)` predicate                                                | Task 2                   |
+| `is_cell_loading` returns false post-cancel via `collection_complete`                   | Task 2 (regression test) |
+| `not_loaded_cell()` helper renders dim em-dash                                          | Task 3                   |
+| `render_cell` accepts `is_cell_unloaded` closure parameter                              | Task 4                   |
+| Each loadable column branch checks `is_cell_unloaded` before `is_cell_loading`          | Task 4 (8 column arms)   |
+| Both `render_table` call sites pass the new closure                                     | Task 4                   |
+| `render_footer` appends ` · cancelled` when `live.cancelled`                            | Task 5                   |
+| Driver Ctrl-C arm calls `state.live.mark_cancelled()`                                   | Task 6                   |
+| Driver writes `\n` to stderr after `drop(terminal)` when cancelled                      | Task 7                   |
+| Manual smoke test (clean prompt, em-dashes, footer suffix, normal completion unchanged) | Task 8                   |
+
+No gaps. Out-of-scope items from the spec (prune/sync polish, killing in-flight
+git children, cursor-positioning rework) are deliberately not present in any
+task.

--- a/docs/superpowers/specs/2026-04-25-live-list-population-design.md
+++ b/docs/superpowers/specs/2026-04-25-live-list-population-design.md
@@ -1,0 +1,458 @@
+# Live List Population — Design
+
+## Goal
+
+Replace the spinner-then-snapshot rendering used by `daft list`, `daft prune`,
+and `daft sync` with a live UX in which rows appear immediately from cheap
+porcelain data and individual cells fill in as their underlying git/FS calls
+return. The list becomes interactive almost instantly; slow cells (size, line
+counts, ahead/behind) settle progressively without blocking the rest of the
+table.
+
+For `daft list`, this also closes the gap between commands that already render
+live (prune/sync, via `OperationTable` over a DAG-event channel) and the one
+read-only command that still blocks behind a spinner. The new shared
+infrastructure reuses the existing `DagEvent` channel and ratatui inline
+viewport, extracted into a `LiveTable` widget that all three commands share.
+
+## Motivation
+
+Today every "list-using" command pays the full cost of `collect_worktree_info`
+before showing anything:
+
+- `daft list` (`src/commands/list.rs:209`) shows a spinner when `Stat::Lines`,
+  `--branches`, `--remotes`, or the size column is requested. The user waits
+  several seconds for cells they never asked to wait for (branch name and path
+  are known instantly from `git worktree list --porcelain`).
+- `daft prune` (`src/commands/prune.rs:221`) and `daft sync`
+  (`src/commands/sync.rs:418`) already drive a live ratatui renderer for the
+  _task execution_ phase, but they still block on a synchronous
+  `collect_worktree_info` call before the TUI can launch. The same spinner
+  problem, just inside an otherwise-live command.
+
+Per-entry data collection is independent across worktrees and trivially
+parallelizable; the bottleneck is purely that the existing collector is
+sequential and that consumers wait for it to finish.
+
+## Non-Goals
+
+- **Restructuring the column model.** `ColumnSelection`, `ListColumn`, `Stat`,
+  `SortSpec` stay as they are. The new code consumes them.
+- **Streaming structured output.** `--format json|csv|ndjson|...` keeps today's
+  one-shot semantics. A partial JSON document mid-stream is a footgun.
+- **Streaming non-TTY plain output.** Piping `daft list` to `less` or a file
+  also keeps today's one-shot output. "Live" is a TTY-only affordance.
+- **Per-cell error indicators.** Today errors are silently swallowed (cells
+  return `None`). That stays. Adding error UX is out of scope.
+- **Killing in-flight git subprocesses on Ctrl-C.** Cancellation is cooperative
+  between cluster calls. Worst case the user waits one git call.
+- **Changing `daft list`'s output for non-TTY callers.** Scripts piping
+  `daft list` see the exact same output as today.
+
+## Locked Design Decisions
+
+These were decided during brainstorming and are load-bearing for the rest of the
+spec:
+
+| #   | Decision                                                                                                                                                                                    |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | This spec covers all three commands. Implementation ships in three phases (shared infra → `daft list` → migrate prune/sync), each in its own PR.                                            |
+| 2   | The streaming collector is a **re-runnable subset engine**: it takes a `FieldSet` + a list of branches and emits patches. It knows nothing about phases. Orchestrators trigger re-runs.     |
+| 3   | Non-TTY (pipe stdout, redirect to file) and `--format` structured output for `daft list` fall back to today's one-shot blocking path. The new code path is gated on TTY detection.          |
+| 4   | Sort tie-break diverges between commands by config: `pin_default_branch=false` for `daft list` (pure `--sort`), `pin_default_branch=true` for prune/sync (anchor on the operation's trunk). |
+| 5   | Owner-driven partitioning in prune/sync shuffles live as owners arrive — the partition divider moves mid-render. Same principle as live re-sorting.                                         |
+| 6   | The row-rendering core is extracted as `LiveTable`; `OperationTable` becomes a wrapper that adds phase banners + hook sub-rows around `LiveTable`.                                          |
+
+Auto-baked smaller defaults (overridable but assumed throughout):
+
+- **Cancellation in `daft list`**: Ctrl-C cleanly exits, returns whatever cells
+  have arrived, exit code 0.
+- **Verbose `-v`**: footer shows inflight cell count and total elapsed.
+- **Loading glyph**: dim middle-dot `·` for unfilled cells.
+- **Per-cell errors**: keep today's silent-fail (None → blank).
+- **`--branches`/`--remotes` enumeration**: synchronous porcelain + branch enum
+  before the TUI launches; viewport sized once.
+- **Collector parallelism**: per-row workers (one thread per worktree, cells
+  sequential within), reusing the `thread::scope` pattern from
+  `src/core/worktree/exec/progress_renderer.rs:171`.
+- **`--no-live` opt-out**: env var `DAFT_NO_LIVE=1` forces the one-shot path.
+  Used by integration tests for golden-output stability.
+
+## Architecture
+
+Three layers, one producer, three consumers:
+
+```
+┌───────────────────────────────────────────────────────────────────┐
+│  Streaming collector (subset engine)                              │
+│  - Input: { branches[], FieldSubset, Stat, OwnershipStrategy }    │
+│  - Workers: one thread per branch (thread::scope)                 │
+│  - Output: WorktreeInfoUpdated { branch, patch, source } events   │
+│            + WorktreeInfoCollectionDone for source=Collector      │
+└────────────────────────────┬──────────────────────────────────────┘
+                             │ mpsc::Sender<DagEvent>
+        ┌────────────────────┼────────────────────────┐
+        │                    │                        │
+        ▼                    ▼                        ▼
+   daft list             daft prune                daft sync
+   (LiveTable)           (OperationTable           (OperationTable
+                          → LiveTable)              → LiveTable)
+```
+
+Properties:
+
+- The collector knows nothing about phases. Same code serves the initial run,
+  post-fetch refresh, and post-task refresh — only the input `FieldSet`, branch
+  list, and `PatchSource` tag differ.
+- `LiveTable` owns row rendering, sort, partition, patch application, columns,
+  and loading glyphs. `OperationTable` owns phase banners and hook sub-rows.
+- The orchestrator in prune/sync drives subset re-runs by calling
+  `collector::spawn` again with a narrower `FieldSet` and `source=PostFetch` or
+  `source=PostTask(phase)`.
+- `daft list` skips the orchestrator entirely: spawn the collector once, consume
+  events into `LiveTable`, exit on `WorktreeInfoCollectionDone` or Ctrl-C.
+
+## Core Types
+
+### `FieldSet` — the shared vocabulary
+
+The single bridge between collector subsets, sort keys, and patches.
+
+```rust
+// src/core/worktree/info_field.rs (new)
+
+bitflags! {
+    pub struct FieldSet: u32 {
+        const BASE_AHEAD_BEHIND   = 1 << 0;
+        const REMOTE_AHEAD_BEHIND = 1 << 1;
+        const CHANGES             = 1 << 2;
+        const LAST_COMMIT         = 1 << 3;
+        const BRANCH_AGE          = 1 << 4;
+        const OWNER               = 1 << 5;
+        const BASE_LINES          = 1 << 6;
+        const CHANGES_LINES       = 1 << 7;
+        const REMOTE_LINES        = 1 << 8;
+        const SIZE                = 1 << 9;
+        const MTIME               = 1 << 10;
+
+        // Convenience subsets for orchestrator re-runs:
+        const REMOTE_DERIVED = Self::REMOTE_AHEAD_BEHIND.bits | Self::REMOTE_LINES.bits;
+        const VOLATILE       = Self::BASE_AHEAD_BEHIND.bits | Self::REMOTE_AHEAD_BEHIND.bits
+                             | Self::CHANGES.bits           | Self::LAST_COMMIT.bits
+                             | Self::BASE_LINES.bits        | Self::CHANGES_LINES.bits
+                             | Self::REMOTE_LINES.bits;
+        const ALL = !0;
+    }
+}
+```
+
+`FieldSet` is used in three places:
+
+- The collector takes one as input to scope its work.
+- `WorktreeInfo::apply_patch` returns one to indicate which fields changed.
+- `SortSpec::required_fields()` returns one to indicate sort dependencies.
+
+Re-sort triggers when `touched.intersects(required)`.
+
+### `WorktreeInfoPatch` — typed cell clusters
+
+One variant per underlying git/FS call cluster. Granularity matches
+`collect_worktree_info`'s existing call boundaries (see
+`src/core/worktree/list.rs:746–928`).
+
+```rust
+// src/core/worktree/sync_dag.rs (DagEvent module)
+
+#[derive(Debug, Clone)]
+pub enum WorktreeInfoPatch {
+    BaseAheadBehind(Option<(usize, usize)>),
+    RemoteAheadBehind(Option<(usize, usize)>),
+    Changes { staged: usize, unstaged: usize, untracked: usize },
+    LastCommit { timestamp: Option<i64>, hash: Option<String>, subject: String },
+    BranchAge(Option<i64>),
+    Owner(Option<BranchOwner>),
+    BaseLines(Option<(usize, usize)>),
+    ChangesLines { staged: (usize, usize), unstaged: (usize, usize) },
+    RemoteLines(Option<(usize, usize)>),
+    Size(Option<u64>),
+    Mtime(Option<i64>),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PatchSource {
+    Collector,                  // initial streaming run
+    PostFetch,                  // orchestrator re-run after Fetch
+    PostTask(OperationPhase),   // orchestrator re-run after a per-branch task
+}
+```
+
+`PatchSource` is load-bearing for staleness suppression: a `Collector` patch
+that lands after a `PostFetch` patch covering the same field on the same branch
+is dropped. Priority order in `LiveTable`: `PostTask > PostFetch > Collector`.
+
+### `DagEvent` extensions
+
+```rust
+pub enum DagEvent {
+    // ... existing variants ...
+    WorktreeInfoUpdated {
+        branch_name: String,
+        patch: WorktreeInfoPatch,
+        source: PatchSource,
+    },
+    WorktreeInfoCollectionDone,  // emitted only by source=Collector run
+}
+```
+
+`TaskCompleted::updated_info: Option<Box<WorktreeInfo>>` is **removed**. The
+orchestrator emits `WorktreeInfoUpdated { source: PostTask(phase) }` patches for
+whichever fields the task touched. Net effect on rendered output is identical;
+the wire format becomes typed and bandwidth-efficient.
+
+### `WorktreeInfo::apply_patch`
+
+```rust
+impl WorktreeInfo {
+    /// Returns the FieldSet of fields whose value changed.
+    pub fn apply_patch(&mut self, patch: &WorktreeInfoPatch) -> FieldSet { /* one arm per variant */ }
+}
+```
+
+### `LiveTable` widget
+
+Extracted from `OperationTable`. Generic over the consumer (no DAG awareness).
+
+```rust
+// src/output/tui/live_table.rs (new)
+
+pub struct LiveTableConfig {
+    pub stat: Stat,
+    pub columns: Option<Vec<Column>>,
+    pub columns_explicit: bool,
+    pub sort_spec: Option<SortSpec>,
+    pub pin_default_branch: bool,   // list=false, prune/sync=true
+    pub partition_by_owner: bool,   // list=false, prune/sync=true
+    pub project_root: PathBuf,
+    pub cwd: PathBuf,
+}
+
+pub struct LiveTable {
+    rows: Vec<WorktreeRow>,
+    cfg: LiveTableConfig,
+    pending_resort: bool,
+    collection_complete: bool,
+    // received_patches per row, partition state, source-priority log
+}
+
+impl LiveTable {
+    pub fn new(seed: Vec<WorktreeInfo>, cfg: LiveTableConfig) -> Self;
+    pub fn apply_event(&mut self, event: &DagEvent);   // handles WorktreeInfoUpdated, WorktreeInfoCollectionDone
+    pub fn tick(&mut self);                            // drains pending_resort, re-partitions
+    pub fn render(&self, frame: &mut Frame, area: Rect);
+    pub fn into_completed_view(self) -> CompletedTableView;
+}
+```
+
+`OperationTable::new` keeps its existing signature; internally it constructs a
+`LiveTable` and forwards row events while handling phase + hook events itself.
+
+## Streaming Collector Contract
+
+```rust
+// src/core/worktree/list_stream.rs (new — sibling of list.rs)
+
+pub struct CollectorRequest {
+    pub targets: Vec<CollectorTarget>,
+    pub fields: FieldSet,
+    pub stat: Stat,
+    pub source: PatchSource,
+    pub ctx: Arc<CollectorContext>,
+}
+
+pub struct CollectorTarget {
+    pub branch_name: String,            // "" for detached (sandbox)
+    pub path: Option<PathBuf>,
+    pub kind: EntryKind,
+    pub is_detached: bool,
+}
+
+pub struct CollectorContext {
+    pub git: GitCommand,
+    pub base_branch: String,
+    pub remote_name: String,
+    pub ownership_strategy: OwnershipStrategy,
+    pub user_email: Option<String>,
+}
+
+/// Spawns workers and streams patches into `tx`. Returns a handle the caller
+/// can drop to request cooperative cancellation.
+///
+/// Emits `WorktreeInfoCollectionDone` once on completion **only when**
+/// `source == PatchSource::Collector`. Subset re-runs do not emit it.
+pub fn spawn(req: CollectorRequest, tx: mpsc::Sender<DagEvent>) -> CollectorHandle;
+
+pub struct CollectorHandle { /* cancel flag + join handles */ }
+impl CollectorHandle {
+    pub fn cancel(&self);
+    pub fn join(self);
+}
+```
+
+### Per-worker loop
+
+One thread per `CollectorTarget`. Cluster calls execute in a fixed cheap-first
+order. Cancellation is checked between every emit:
+
+```rust
+// Order: BASE_AHEAD_BEHIND → CHANGES → LAST_COMMIT → BRANCH_AGE → OWNER
+//        → REMOTE_AHEAD_BEHIND
+//        → BASE_LINES → CHANGES_LINES → REMOTE_LINES   (Stat::Lines only)
+//        → SIZE → MTIME                                (slowest last)
+```
+
+Rationale: the user sees identity (already from porcelain), then ahead/behind,
+then change counts, then commit info — all within milliseconds. Sort keys land
+predictably, so re-sorts cluster early instead of dribbling in. Slow cells
+(`SIZE`, `MTIME`, `*_LINES`) are last, so they're the only cells still showing
+the loading glyph in the final seconds — exactly the cells where the user's
+intuition expects a small wait.
+
+### Cancellation
+
+`CollectorHandle::cancel` flips an `AtomicBool` checked between cluster calls.
+No mid-call interruption. Workers exit cleanly the next time they're between
+emits.
+
+### Re-runs
+
+The orchestrator calls `spawn` again with a narrower `fields` and a different
+`source` tag. The same channel carries patches from concurrent runs; `LiveTable`
+distinguishes them by `PatchSource` and applies the priority ordering rule
+above.
+
+## Per-Command Event Flow
+
+### `daft list` (TTY + non-structured only)
+
+```
+parse porcelain (sync)              → seed LiveTable rows (identity columns)
+parse --branches/--remotes (sync)   → extend rows, lock viewport size
+collector::spawn(ALL, Collector)    → stream patches into LiveTable
+on WorktreeInfoCollectionDone       → drop loading glyphs, final resort, exit ratatui
+on Ctrl-C                           → handle.cancel(); render whatever landed; exit 0
+```
+
+Non-TTY / `--format` / `DAFT_NO_LIVE=1` path: skip everything above, fall
+through to today's blocking `collect_worktree_info` + one-shot render
+(`print_table` / `build_emit_table` unchanged).
+
+### `daft prune`
+
+```
+parse porcelain (sync)              → seed OperationTable's inner LiveTable
+                                      (identity + is_default_branch only)
+collector::spawn(ALL, Collector)    → stream patches concurrently with orchestrator
+spawn orchestrator thread:
+  Fetch phase                       → on completion: collector::spawn(REMOTE_DERIVED,
+                                                                      PostFetch)
+  identify gone branches
+  for each gone branch:
+    Prune task                      → row removed; no patch
+on AllDone                          → exit ratatui, print CompletedTableView
+```
+
+### `daft sync`
+
+Same shape as prune, with additional post-task subset re-runs after each
+per-branch task:
+
+| Task     | Fields re-emitted as `PostTask`                           |
+| -------- | --------------------------------------------------------- |
+| `Update` | `BASE_AHEAD_BEHIND`, `LAST_COMMIT`, `CHANGES`             |
+| `Rebase` | `BASE_AHEAD_BEHIND`, `LAST_COMMIT`, `REMOTE_AHEAD_BEHIND` |
+| `Push`   | `REMOTE_AHEAD_BEHIND`                                     |
+| `Prune`  | (row removed; no patch)                                   |
+
+## Phasing
+
+### Phase 1 — Shared infrastructure (one PR)
+
+No user-visible behavior change. Lands:
+
+- `FieldSet`, `WorktreeInfoPatch`, `PatchSource`
+- `DagEvent::WorktreeInfoUpdated`, `DagEvent::WorktreeInfoCollectionDone`
+- `WorktreeInfo::apply_patch`, `SortSpec::required_fields`
+- `src/core/worktree/list_stream.rs` (the streaming collector)
+- `LiveTable` extracted from `OperationTable`; `OperationTable` refactored to
+  wrap it
+- Removal of `TaskCompleted::updated_info`; orchestrator emits `PostTask`
+  patches with the same end-state information
+
+Verifiable by existing prune/sync integration tests passing unchanged.
+
+### Phase 2 — `daft list` live UX (one PR)
+
+- `daft list` TTY path: cheap porcelain seed → `LiveTable::new` →
+  `collector::spawn(ALL, Collector)` → render loop
+- Cancellation, loading glyphs, verbose footer
+- New PTY-driven YAML scenarios under `tests/manual/scenarios/list/live/`
+- Non-TTY / `--format` / `DAFT_NO_LIVE=1` paths unchanged
+
+### Phase 3 — Migrate prune/sync to streaming seed (one PR)
+
+- Replace blocking `collect_worktree_info` pre-seed with cheap porcelain seed
+  - `collector::spawn(ALL, Collector)` running concurrently with the
+    orchestrator
+- Add `collector::spawn(REMOTE_DERIVED, PostFetch)` after Fetch phase
+- Add per-task `collector::spawn(subset, PostTask(phase), targets=[branch])`
+  calls
+- Remove the `needs_spinner` branches and the spinner output in both commands
+- Integration tests run with `DAFT_NO_LIVE=1` for golden-output stability
+
+## Testing Strategy
+
+- **Unit**: `apply_patch` truth table per variant; `SortSpec::required_fields`
+  per sort key; `LiveTable::apply_event` with constructed patch sequences (sort
+  re-eval, partition shuffle, stale-source suppression).
+- **Channel-based**: extend the existing
+  `let events: Vec<DagEvent> = rx.iter().collect()` pattern from
+  `src/core/worktree/sync_dag.rs:776` to the collector. New test: spawn
+  collector against a fixture repo, assert the multiset of patches produced for
+  a given `FieldSet`.
+- **Integration (Phases 1 & 3)**: existing prune/sync YAML scenarios pass
+  unchanged in Phase 1; in Phase 3 they run with `DAFT_NO_LIVE=1`.
+- **Integration (Phase 2)**: new PTY-driven scenarios under
+  `tests/manual/scenarios/list/live/` assert "rows visible before any cell-fill
+  events" and "all cells filled before completion sentinel".
+
+## Invariants and Constraints
+
+These are pinned design properties to refer back to during implementation and
+review:
+
+1. **Inline viewport height is fixed at creation** in ratatui inline mode. For
+   prune/sync this means the row count must be known before the TUI launches —
+   already true today since porcelain + branch enum are synchronous. Phase 3
+   keeps that property: only slow _cells_ stream.
+2. **Opt-out env var**: `DAFT_NO_LIVE=1`. Forces the one-shot path. Tests depend
+   on it; do not rename without updating fixtures.
+3. **`PatchSource` priority ordering**: `PostTask > PostFetch > Collector`. A
+   lower-priority patch arriving for a field already written by a
+   higher-priority patch is dropped on the floor in `LiveTable`.
+4. **Post-task patch emission lives in the orchestrator**, not the collector.
+   The collector is phase-agnostic; the orchestrator owns the
+   "what-fields-did-this-task-touch" mapping.
+5. **`WorktreeInfoCollectionDone` is emitted only by the initial
+   `source=Collector` run.** Subset re-runs (`PostFetch`, `PostTask`) finish
+   silently — orchestrator-driven completion is signalled via the existing
+   `AllDone` event.
+
+## Related
+
+- `2026-04-21-worktree-exec-design.md` — established the orchestrator-emits-
+  events-into-mpsc-channel pattern adopted here.
+- `2026-04-22-worktree-exec-ui-revision-design.md` — established the inline
+  ratatui viewport pattern that prune/sync already use and that `LiveTable`
+  factors out.
+- `2026-03-16-list-column-selection-design.md` — defined `ColumnSelection` /
+  `ListColumn` / `Stat` consumed unchanged by this design.

--- a/docs/superpowers/specs/2026-04-27-graceful-cancellation-design.md
+++ b/docs/superpowers/specs/2026-04-27-graceful-cancellation-design.md
@@ -1,0 +1,255 @@
+# Graceful Ctrl-C Cancellation for `daft list` Live UX
+
+**Status:** Approved **Scope:** `daft list` only (prune/sync deferred)
+**Author:** Avihu Turzion (drafted via Claude) **Date:** 2026-04-27
+
+## Problem
+
+When the user hits Ctrl-C during `daft list`'s live cell population, the inline
+viewport leaves an ungraceful final frame:
+
+1. Cells that hadn't received their patch keep showing the breathing `▬▬▬▬`
+   skeleton bar — frozen mid-animation, indistinguishable from "still loading."
+2. The shell's `^C` echo lands inside the table content (next to a skeleton bar)
+   instead of on its own line. Captured terminal output ended with `▬▬▬▬^C%` —
+   the trailing `%` is zsh's "previous output didn't end with a newline" marker.
+3. There is no visible signal that the operation was cancelled — the user has to
+   infer it from the missing data and the skeleton bars.
+
+Captured symptom (from sandbox at
+`/Users/avihu/Projects/daft/.git/.daft-sandbox`):
+
+```
+     daft-345/fix/shift-tab-exits-manage-shared-editor  ▬▬▬▬               +233 -14          1d   Avihu Turzion  47m fix(exec): resolve user shell aliases and functio...
+  ✦  master                                             ▬▬▬▬^C%
+```
+
+## Goal
+
+After Ctrl-C in `daft list`:
+
+- Cells that haven't received their patch render a clear "didn't load" marker
+  that is visually distinct from both the loading shimmer and a legitimately
+  empty cell.
+- The terminal exits cleanly: shell prompt returns on its own line, no half-row
+  overlap.
+- Verbose mode shows a `cancelled` indicator in the footer.
+
+Out of scope:
+
+- `daft prune` / `daft sync` cancellation polish (different cancellation
+  semantics, per-row Status column already carries the signal).
+- Killing in-flight git child processes (workers exit cooperatively between
+  cluster calls; current `join_thread.join()` waits for the slowest in-flight
+  child to settle).
+- Reworking the existing `set_cursor_position` calculation in the final-draw
+  macro (only adding a trailing newline; not modifying the cursor math).
+
+## Architecture
+
+A new `cancelled: bool` flag on `LiveTable` is the single source of truth for
+"user aborted." It's set by a new `mark_cancelled()` method, which also sets
+`collection_complete = true`. This means the existing `is_cell_loading`
+predicate (`!collection_complete && !received`) naturally returns `false`
+post-cancel — no two-flag bookkeeping in the loading-state predicate.
+
+The render path consults a sibling predicate
+`is_cell_unloaded(row, field) → bool` that returns `cancelled && !received`.
+When this predicate is true and the cell value is empty, the renderer emits a
+"didn't load" cell instead of the loading shimmer.
+
+The Ctrl-C arm in `TuiRenderer::run` calls `state.live.mark_cancelled()` before
+the existing `final_draw_and_return!()` macro so the macro's last
+`terminal.draw(...)` paints with the new state. After viewport teardown, the
+cancelled path writes a single `\n` to stderr to guarantee the shell prompt
+lands on its own row.
+
+`prune`/`sync` are unaffected: they share `LiveTable` and `TuiRenderer`, but
+their `cancelled` flag stays `false` — they don't go through the same list-only
+Ctrl-C arm, and even if they did, marking unfilled cells as "didn't load" would
+be additive, not regressive.
+
+## Components
+
+### `src/output/tui/live_table.rs`
+
+Additions only. No removals, no signature changes to existing methods.
+
+- New field: `pub cancelled: bool` on `LiveTable`. Initialized to `false` in
+  `LiveTable::new`.
+- New method: `pub fn mark_cancelled(&mut self)`. Sets:
+  - `self.cancelled = true`
+  - `self.collection_complete = true`
+  - `self.pending_resort = true`
+- New method:
+  `pub fn is_cell_unloaded(&self, row_idx: usize, field: FieldSet) -> bool`.
+  Returns `self.cancelled && !self.received_patches[row_idx].contains(field)`.
+- Existing `is_cell_loading` is unchanged in source. Its return value naturally
+  flips to `false` post-cancel because `collection_complete` is set by
+  `mark_cancelled`.
+
+### `src/output/tui/render.rs`
+
+Three additions plus signature change to `render_cell`.
+
+- New helper: `fn not_loaded_cell() -> Cell<'static>`. Returns
+  `Cell::from(Span::styled("\u{2014}", Style::default().fg(Color::DarkGray).add_modifier(Modifier::DIM)))`.
+  Single em-dash, no width parameter, default left-aligned in cell.
+- `render_cell` signature gains a second closure parameter
+  `is_cell_unloaded: impl Fn(FieldSet) -> bool`. Position: directly after the
+  existing `is_cell_loading` parameter.
+- For each loadable column branch (`Size`, `Base`, `Changes`, `Remote`, `Age`,
+  `Owner`, `Hash`, `LastCommit`), check `is_cell_unloaded(field)` BEFORE the
+  existing `is_cell_loading(field)` check. The "is this empty?" gate (e.g.,
+  `vals.size.is_empty()`, `wt.info.ahead.is_none() && wt.info.behind.is_none()`,
+  etc.) is unchanged. Pattern:
+
+  ```rust
+  Column::Size => {
+      if vals.size.is_empty() {
+          if is_cell_unloaded(FieldSet::SIZE) {
+              not_loaded_cell()
+          } else if is_cell_loading(FieldSet::SIZE) {
+              loading_shimmer_cell(width, tick)
+          } else {
+              Cell::from("")
+          }
+      } else {
+          Cell::from(vals.size.clone())
+      }
+  }
+  ```
+
+- Both call sites in `render_table` (currently around lines 344 and 363) pass
+  `|fs| state.live.is_cell_unloaded(row_idx, fs)` as the new closure alongside
+  the existing loading closure.
+- `render_footer`: when `state.live.cancelled` is true, append
+  ` \u{00B7} cancelled` to the footer string (after the existing
+  `inflight: N · elapsed: T.Xs` content). Same dim styling.
+
+### `src/output/tui/driver.rs`
+
+Two surgical changes to the Ctrl-C arm + teardown.
+
+- In the Ctrl-C branch (currently around lines 252–261), call
+  `self.state.live.mark_cancelled()` before the existing
+  `self.state.done = true; final_draw_and_return!()` lines.
+- After `drop(terminal)` in `final_draw_and_return!()`, write `b"\n"` to stderr
+  when `self.state.live.cancelled` is true. Single line:
+  `if self.state.live.cancelled { let _ = std::io::stderr().write_all(b"\n"); }`.
+  Best-effort, ignored failure.
+
+## Data flow
+
+```
+User Ctrl-C
+  ↓
+crossterm Event::Key (driver.rs poll, ~line 251)
+  ↓
+cancel_signal.store(true)              ← collector workers exit between clusters
+state.live.mark_cancelled()            ← cancelled = true, collection_complete = true
+state.done = true
+  ↓
+final_draw_and_return!()
+  └─ terminal.draw(|frame| {
+       render_header / render_table / render_footer
+         └─ render_cell(...) for each loadable column:
+              if value missing && is_cell_unloaded(field) → not_loaded_cell()  // NEW
+              else if value missing && is_cell_loading(field) → shimmer (now never true after cancel)
+              else → render value
+         render_footer appends " · cancelled" when state.live.cancelled
+     })
+  └─ drop(terminal)                    ← inline viewport torn down
+  └─ stderr.write_all(b"\n") if cancelled
+  └─ return Ok(state)
+  ↓
+list_live::run
+  └─ join_thread.join()                ← waits for workers (out of scope: not changed)
+  ↓
+process exits cleanly → shell prompt on fresh line
+```
+
+## Testing
+
+### Unit tests — `live_table.rs`
+
+- `mark_cancelled_sets_cancelled_and_collection_complete` — both flags flip,
+  `pending_resort` is set.
+- `is_cell_unloaded_true_when_cancelled_and_not_received` — basic positive.
+- `is_cell_unloaded_false_when_received_even_after_cancel` — received cells are
+  not marked unloaded.
+- `is_cell_unloaded_false_before_cancel` — predicate is gated on cancellation.
+- `is_cell_loading_returns_false_after_mark_cancelled` — confirms the
+  `collection_complete` side effect (regression guard for the "two predicates"
+  simplification).
+
+### Unit tests — `render.rs`
+
+- `not_loaded_cell_renders_dim_em_dash` — `TestBackend`, single column, assert
+  buffer cell contains `"—"` and the styled span carries `Color::DarkGray` +
+  `Modifier::DIM`.
+- `render_cell_uses_not_loaded_when_cancelled_and_unfilled` — for each of `Size`
+  / `Base` / `Changes` / `Remote` / `Age` / `Owner` / `Hash` / `LastCommit`:
+  with `is_cell_unloaded` returning true and the value-empty gate satisfied,
+  assert `"—"` is rendered.
+- `render_cell_uses_value_when_received_even_if_cancelled` — guard against
+  rendering `"—"` over a real value (e.g., `Size = "1.2 MB"` should still render
+  as the value when `is_cell_unloaded` returns false because `received` is
+  true).
+- `render_footer_appends_cancelled_when_live_cancelled` — verbose mode,
+  `live.cancelled = true` → footer string contains ` · cancelled` after the
+  elapsed-time segment.
+- `render_footer_no_cancelled_suffix_when_not_cancelled` — guard against false
+  positive when `live.cancelled` is false.
+
+### Unit test — `driver.rs`
+
+- `ctrl_c_sets_cancelled_on_state` — synthesize `Event::Key(Ctrl-C)`, drive one
+  loop turn, assert `state.live.cancelled` is true, `state.done` is true,
+  `cancel_signal` is true. Existing `cancel_signal_can_be_set_externally` is the
+  template.
+
+### Manual smoke
+
+In a sandbox repo with multiple worktrees:
+
+```
+daft list --columns=-path,+size --sort activity --stat lines
+```
+
+Hit Ctrl-C while the `▬` skeletons are still pulsing. Confirm:
+
+- All unfilled cells show dim `—` rather than frozen `▬▬▬▬`.
+- Shell prompt returns on a fresh line — no `^C%` adjacent to any table row.
+- Verbose mode (`-v` flag, if applicable) shows `· cancelled` appended to the
+  footer.
+- Already-loaded cells still render their real values.
+
+## Trade-offs and rationale
+
+**Why a single dim `—` rather than a row of `—`s sized to column width?** The
+single character is the universal table convention for "no value" (Wikipedia
+tables, financial reports, CSVs rendered as ASCII). A row of em-dashes would
+visually mimic the skeleton bar's footprint, weakening the "this is different"
+signal. The single em-dash is small enough to read as "absence" and large enough
+to be obvious.
+
+**Why mark `collection_complete = true` inside `mark_cancelled`?** It avoids
+splitting "is this cell loading?" across two flags. The semantic reading of
+`collection_complete` becomes "the streaming work is over, whether by completion
+or by cancellation." Render-path predicates stay simple. The advisor flagged
+this simplification explicitly.
+
+**Why a single `\n` after teardown rather than reworking cursor placement?** The
+existing cursor calculation in `final_draw_and_return!()` works correctly for
+normal completion. The Ctrl-C symptom (cursor inside table content) appears to
+stem from the inline viewport's last-row interaction with terminal height
+clamping — fixing the calculation risks breaking the normal path. A trailing
+newline is a robust, low-risk guarantee that the shell prompt lands on a fresh
+line regardless of where the cursor ended up.
+
+**Why not kill in-flight git children?** Workers respond to `cancel_signal`
+between cluster calls. The window where a child is still mid-execution is small.
+Killing children mid-stream risks leaving the worktree in an inconsistent state
+and adds platform-specific process-group complexity. Defer until evidence of
+user-visible delay warrants it.

--- a/src/commands/clone.rs
+++ b/src/commands/clone.rs
@@ -1104,6 +1104,8 @@ fn create_satellite_worktrees_tui(
             sort_spec: None,
             extra_rows: 5 + (satellite_count as u16) * 8,
             verbosity,
+            pin_default_branch: true,
+            partition_by_owner: false, // Clone does not partition by owner.
         },
         None,
     );

--- a/src/commands/clone.rs
+++ b/src/commands/clone.rs
@@ -898,6 +898,7 @@ fn create_satellite_worktrees_tui(
                     &shared_remote_name,
                     shared_ownership_strategy,
                     None,
+                    &shared_git_dir,
                     &tx,
                 );
             }
@@ -1065,6 +1066,7 @@ fn create_satellite_worktrees_tui(
                         &shared_remote_name,
                         shared_ownership_strategy,
                         None,
+                        &shared_git_dir,
                         &tx,
                     );
 
@@ -1362,6 +1364,7 @@ fn spawn_post_clone_refresh(
     remote_name: &str,
     ownership_strategy: OwnershipStrategy,
     user_email: Option<&str>,
+    git_common_dir: &std::path::Path,
     tx: &std::sync::mpsc::Sender<DagEvent>,
 ) {
     let target = list_stream::CollectorTarget {
@@ -1376,6 +1379,7 @@ fn spawn_post_clone_refresh(
         remote_name: remote_name.to_string(),
         ownership_strategy,
         user_email: user_email.map(|s| s.to_string()),
+        git_common_dir: git_common_dir.to_path_buf(),
     });
     let handle = list_stream::spawn(
         list_stream::CollectorRequest {

--- a/src/commands/clone.rs
+++ b/src/commands/clone.rs
@@ -827,7 +827,6 @@ fn create_satellite_worktrees_tui(
             branch_name: String::new(),
             status: TaskStatus::Succeeded,
             message: TaskMessage::Ok("cloned".into()),
-            updated_info: None,
         });
 
         // Mark the base worktree as started, run post-create hook, then complete.
@@ -883,25 +882,11 @@ fn create_satellite_worktrees_tui(
                 }
             }
 
-            // Populate commit metadata for the base worktree
-            let base_updated = shared_base_path.as_ref().map(|bp| {
-                let mut info = WorktreeInfo::empty(base);
-                info.path = Some(bp.clone());
-                if let Ok((ts, hash, subj)) = crate::git::oxide::get_commit_metadata_for_head(bp) {
-                    info.last_commit_timestamp = Some(ts);
-                    info.last_commit_hash = Some(hash);
-                    info.last_commit_subject = subj;
-                }
-                info.branch_creation_timestamp = info.last_commit_timestamp;
-                Box::new(info)
-            });
-
             let _ = tx.send(DagEvent::TaskCompleted {
                 phase: OperationPhase::Setup,
                 branch_name: base.clone(),
                 status: TaskStatus::Succeeded,
                 message: TaskMessage::BaseCreated,
-                updated_info: base_updated,
             });
         }
 
@@ -932,7 +917,6 @@ fn create_satellite_worktrees_tui(
                             message: TaskMessage::Failed(format!(
                                 "failed to initialize hook executor: {e}"
                             )),
-                            updated_info: None,
                         });
                         continue;
                     }
@@ -978,7 +962,6 @@ fn create_satellite_worktrees_tui(
                     branch_name: branch.clone(),
                     status: TaskStatus::Failed,
                     message: TaskMessage::Failed("pre-create hook failed".into()),
-                    updated_info: None,
                 });
                 continue;
             }
@@ -1009,7 +992,6 @@ fn create_satellite_worktrees_tui(
                                     message: TaskMessage::Failed(format!(
                                         "failed to initialize hook executor for post-create: {e}"
                                     )),
-                                    updated_info: None,
                                 });
                             }
                             Ok(mut executor) => {
@@ -1053,24 +1035,11 @@ fn create_satellite_worktrees_tui(
                         }
                     }
 
-                    // Populate commit metadata for the newly created worktree
-                    let mut updated = WorktreeInfo::empty(branch);
-                    updated.path = Some(worktree_path.clone());
-                    if let Ok((ts, hash, subj)) =
-                        crate::git::oxide::get_commit_metadata_for_head(worktree_path)
-                    {
-                        updated.last_commit_timestamp = Some(ts);
-                        updated.last_commit_hash = Some(hash);
-                        updated.last_commit_subject = subj;
-                    }
-                    updated.branch_creation_timestamp = updated.last_commit_timestamp;
-
                     let _ = tx.send(DagEvent::TaskCompleted {
                         phase: OperationPhase::Setup,
                         branch_name: branch.clone(),
                         status: TaskStatus::Succeeded,
                         message: TaskMessage::Created,
-                        updated_info: Some(Box::new(updated)),
                     });
                 }
                 Err(e) => {
@@ -1079,7 +1048,6 @@ fn create_satellite_worktrees_tui(
                         branch_name: branch.clone(),
                         status: TaskStatus::Failed,
                         message: TaskMessage::Failed(format!("{e}")),
-                        updated_info: None,
                     });
                 }
             }

--- a/src/commands/clone.rs
+++ b/src/commands/clone.rs
@@ -6,11 +6,14 @@ use crate::{
             resolver::{resolve_layout, LayoutResolutionContext},
             Layout, TemplateContext,
         },
+        ownership::OwnershipStrategy,
         worktree::{
             branch_source::{BranchPlan, BranchSource},
             clone,
-            list::WorktreeInfo,
-            sync_dag::{DagEvent, OperationPhase, TaskMessage, TaskStatus},
+            info_field::FieldSet,
+            list::{EntryKind, Stat, WorktreeInfo},
+            list_stream,
+            sync_dag::{DagEvent, OperationPhase, PatchSource, TaskMessage, TaskStatus},
         },
         HookRunner, NullSink, OutputSink, TuiBridge,
     },
@@ -807,6 +810,8 @@ fn create_satellite_worktrees_tui(
     let shared_remote_name = Arc::new(bare_params.remote_name.clone());
     let shared_checkout_upstream = settings.checkout_upstream;
     let shared_use_gitoxide = settings.use_gitoxide;
+    let shared_ownership_strategy = settings.ownership_strategy;
+    let shared_default_branch = Arc::new(base_result.default_branch.clone());
     let shared_satellite_paths = Arc::new(satellite_paths);
     let shared_git_dir = Arc::new(base_result.git_dir.clone());
     let shared_parent_dir = Arc::new(base_result.parent_dir.clone());
@@ -880,6 +885,21 @@ fn create_satellite_worktrees_tui(
 
                     let _ = bridge.run_hook(&ctx);
                 }
+            }
+
+            // Refresh last_commit + branch_age cells via PostTask patches so
+            // the post-clone TUI rows show real values (not empty cells).
+            if let Some(ref bp) = shared_base_path {
+                spawn_post_clone_refresh(
+                    base,
+                    bp,
+                    shared_use_gitoxide,
+                    &shared_default_branch,
+                    &shared_remote_name,
+                    shared_ownership_strategy,
+                    None,
+                    &tx,
+                );
             }
 
             let _ = tx.send(DagEvent::TaskCompleted {
@@ -1034,6 +1054,19 @@ fn create_satellite_worktrees_tui(
                             }
                         }
                     }
+
+                    // Refresh last_commit + branch_age cells via PostTask patches so
+                    // the post-clone TUI rows show real values (not empty cells).
+                    spawn_post_clone_refresh(
+                        branch,
+                        worktree_path,
+                        shared_use_gitoxide,
+                        &shared_default_branch,
+                        &shared_remote_name,
+                        shared_ownership_strategy,
+                        None,
+                        &tx,
+                    );
 
                     let _ = tx.send(DagEvent::TaskCompleted {
                         phase: OperationPhase::Setup,
@@ -1309,4 +1342,50 @@ fn run_post_create_hook(
     executor.execute(&ctx, output, presenter)?;
 
     Ok(())
+}
+
+/// Spawn a streaming-collector run that re-emits `LAST_COMMIT | BRANCH_AGE`
+/// for the freshly-created worktree as `PatchSource::PostTask(Setup)`
+/// patches. Blocks briefly so the patches land before the accompanying
+/// `TaskCompleted` event, keeping the renderer state consistent (no empty
+/// "Age"/"Commit" cells in the post-clone TUI).
+///
+/// Mirrors `sync.rs::spawn_post_task_refresh` but tailored to clone: the
+/// only refreshed cells are commit metadata for the just-created worktree,
+/// and the operation phase is always `Setup`.
+#[allow(clippy::too_many_arguments)]
+fn spawn_post_clone_refresh(
+    branch_name: &str,
+    path: &std::path::Path,
+    use_gitoxide: bool,
+    base_branch: &str,
+    remote_name: &str,
+    ownership_strategy: OwnershipStrategy,
+    user_email: Option<&str>,
+    tx: &std::sync::mpsc::Sender<DagEvent>,
+) {
+    let target = list_stream::CollectorTarget {
+        branch_name: branch_name.to_string(),
+        path: Some(path.to_path_buf()),
+        kind: EntryKind::Worktree,
+        is_detached: false,
+    };
+    let ctx = Arc::new(list_stream::CollectorContext {
+        use_gitoxide,
+        base_branch: base_branch.to_string(),
+        remote_name: remote_name.to_string(),
+        ownership_strategy,
+        user_email: user_email.map(|s| s.to_string()),
+    });
+    let handle = list_stream::spawn(
+        list_stream::CollectorRequest {
+            targets: vec![target],
+            fields: FieldSet::LAST_COMMIT | FieldSet::BRANCH_AGE,
+            stat: Stat::Summary,
+            source: PatchSource::PostTask(OperationPhase::Setup),
+            ctx,
+        },
+        tx.clone(),
+    );
+    handle.join();
 }

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1120,3 +1120,42 @@ mod tests {
         assert_eq!(total_row[size_bytes_idx], Cell::Int(1024));
     }
 }
+
+#[cfg(test)]
+mod dispatch_tests {
+    use super::*;
+
+    fn make_args(structured: bool) -> Args {
+        // Construct an Args via clap's parser so the EmitArgs flatten resolves
+        // correctly without us having to know its internal field shape.
+        let mut argv = vec!["git-worktree-list"];
+        if structured {
+            argv.push("--format");
+            argv.push("json");
+        }
+        Args::parse_from(argv)
+    }
+
+    #[test]
+    fn should_use_live_returns_false_for_structured_output() {
+        let args = make_args(true);
+        // Even if other conditions are favorable, structured output forces
+        // blocking. Whatever the TTY/env give us, the result must be false.
+        assert!(!should_use_live(&args));
+    }
+
+    #[test]
+    fn should_use_live_respects_daft_no_live_env_var() {
+        // Note: setting env vars in tests is process-global; tests in the same
+        // binary may run in parallel. We save/restore to avoid leaking state to
+        // other tests that read DAFT_NO_LIVE.
+        let prev = std::env::var_os("DAFT_NO_LIVE");
+        std::env::set_var("DAFT_NO_LIVE", "1");
+        let args = make_args(false);
+        assert!(!should_use_live(&args));
+        match prev {
+            Some(v) => std::env::set_var("DAFT_NO_LIVE", v),
+            None => std::env::remove_var("DAFT_NO_LIVE"),
+        }
+    }
+}

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -91,50 +91,50 @@ with daft.list.sort.
 "#)]
 pub struct Args {
     #[command(flatten)]
-    emit: EmitArgs,
+    pub(crate) emit: EmitArgs,
 
     #[arg(short, long, help = "Be verbose; show detailed progress")]
-    verbose: bool,
+    pub(crate) verbose: bool,
 
     #[arg(
         short = 'b',
         long = "branches",
         help = "Also show local branches without a worktree"
     )]
-    branches: bool,
+    pub(crate) branches: bool,
 
     #[arg(
         short = 'r',
         long = "remotes",
         help = "Also show remote tracking branches"
     )]
-    remotes: bool,
+    pub(crate) remotes: bool,
 
     #[arg(
         short = 'a',
         long = "all",
         help = "Show all branches (equivalent to -b -r)"
     )]
-    all: bool,
+    pub(crate) all: bool,
 
     #[arg(
         long,
         value_enum,
         help = "Statistics mode: summary or lines (default: from git config daft.list.stat, or summary)"
     )]
-    stat: Option<Stat>,
+    pub(crate) stat: Option<Stat>,
 
     #[arg(
         long,
         help = "Columns to display (comma-separated). Replace: branch,path,age. Modify defaults: +col,-col. Available: branch, path, size, base, changes, remote, age, annotation, owner, hash, last-commit"
     )]
-    columns: Option<String>,
+    pub(crate) columns: Option<String>,
 
     #[arg(
         long,
         help = "Sort order (comma-separated). +col ascending, -col descending. Columns: branch, path, size, base, changes, remote, age, owner, hash, activity, commit"
     )]
-    sort: Option<String>,
+    pub(crate) sort: Option<String>,
 }
 
 /// A row in the worktree list table.
@@ -173,6 +173,22 @@ pub fn run() -> Result<()> {
     }
 
     let settings = DaftSettings::load()?;
+
+    if should_use_live(&args) {
+        crate::commands::list_live::run_live(args, settings)
+    } else {
+        run_blocking(args, settings)
+    }
+}
+
+fn should_use_live(args: &Args) -> bool {
+    use std::io::IsTerminal;
+    !args.emit.is_structured()
+        && std::env::var_os("DAFT_NO_LIVE").is_none()
+        && std::io::stdout().is_terminal()
+}
+
+fn run_blocking(args: Args, settings: DaftSettings) -> Result<()> {
     let stat = args.stat.unwrap_or(settings.list_stat);
     let columns_input = args.columns.or(settings.list_columns);
     let resolved = match columns_input {

--- a/src/commands/list_live.rs
+++ b/src/commands/list_live.rs
@@ -231,7 +231,10 @@ pub fn run_live(args: Args, settings: DaftSettings) -> Result<()> {
         false, // partition_by_owner
     );
 
-    let renderer = TuiRenderer::new(state, rx);
+    // Single source of truth for cancellation: the renderer's Ctrl-C handler
+    // flips the same flag the collector workers observe between cluster calls.
+    let cancel = collector_handle.cancel_flag();
+    let renderer = TuiRenderer::new(state, rx).with_cancel_signal(cancel);
     let _final_state = renderer.run()?;
 
     collector_handle.join();

--- a/src/commands/list_live.rs
+++ b/src/commands/list_live.rs
@@ -255,11 +255,39 @@ pub fn run_live(args: Args, settings: DaftSettings) -> Result<()> {
         collector_handle.join();
     });
 
-    let renderer = TuiRenderer::new(state, rx).with_cancel_signal(cancel);
-    let _final_state = renderer.run()?;
+    // Enable raw mode so crossterm's event loop receives Ctrl-C as a key event
+    // (ISIG off) and the terminal driver doesn't echo `^C` mid-render. The
+    // SIGINT handler above stays installed as a fallback in case raw mode fails
+    // to enable. RAII guard restores cooked mode on every exit path.
+    let _raw_guard = enable_raw_mode_guard();
 
-    // Workers have finished by the time the sentinel arrived; this should
-    // return promptly. Cancel first in case Ctrl-C broke us out early.
-    let _ = join_thread.join();
+    let renderer = TuiRenderer::new(state, rx).with_cancel_signal(cancel);
+    let final_state = renderer.run()?;
+
+    // On normal completion, workers have already finished and `join()` returns
+    // immediately. On cancellation, workers may still be mid-`git` invocation
+    // (the cancel flag is checked between clusters, not mid-command). Skip the
+    // join so the user gets an instant prompt back; the OS reaps any in-flight
+    // git children when the process exits — they're read-only and safe to abort.
+    if !final_state.live.cancelled {
+        let _ = join_thread.join();
+    }
     Ok(())
+}
+
+/// RAII guard that enables crossterm raw mode now and restores cooked mode on
+/// drop. Best-effort: if `enable_raw_mode` fails (e.g. stdin isn't a terminal),
+/// the guard is still returned so its `Drop` is safe to run. Disabling raw
+/// mode on a terminal that wasn't in raw mode is a no-op.
+fn enable_raw_mode_guard() -> RawModeGuard {
+    let _ = crossterm::terminal::enable_raw_mode();
+    RawModeGuard
+}
+
+struct RawModeGuard;
+
+impl Drop for RawModeGuard {
+    fn drop(&mut self) {
+        let _ = crossterm::terminal::disable_raw_mode();
+    }
 }

--- a/src/commands/list_live.rs
+++ b/src/commands/list_live.rs
@@ -204,6 +204,7 @@ pub fn run_live(args: Args, settings: DaftSettings) -> Result<()> {
         remote_name: settings.remote.clone(),
         ownership_strategy: settings.ownership_strategy,
         user_email: user_email.clone(),
+        git_common_dir: git_common_dir.clone(),
     });
     let collector_handle = list_stream::spawn(
         list_stream::CollectorRequest {

--- a/src/commands/list_live.rs
+++ b/src/commands/list_live.rs
@@ -236,6 +236,18 @@ pub fn run_live(args: Args, settings: DaftSettings) -> Result<()> {
     // flips the same flag the collector workers observe between cluster calls.
     let cancel = collector_handle.cancel_flag();
 
+    // The inline viewport doesn't enable raw mode, so crossterm's keyboard
+    // event loop never receives Ctrl-C — the OS sends SIGINT first and the
+    // process terminates before our handler can run. Install a SIGINT handler
+    // that flips the same cancel flag, so the renderer's cancel-signal poll
+    // path picks it up and runs the graceful exit.
+    // `ctrlc::set_handler` is process-global and can only be installed once;
+    // swallow the error so nested invocations and tests don't panic.
+    let signal_cancel = std::sync::Arc::clone(&cancel);
+    let _ = ctrlc::set_handler(move || {
+        signal_cancel.store(true, std::sync::atomic::Ordering::Relaxed);
+    });
+
     // The renderer waits for `WorktreeInfoCollectionDone`, which the collector
     // handle emits on `join()`. Joining must happen on a separate thread so the
     // sentinel fires while the renderer is still listening on the channel.

--- a/src/commands/list_live.rs
+++ b/src/commands/list_live.rs
@@ -234,9 +234,19 @@ pub fn run_live(args: Args, settings: DaftSettings) -> Result<()> {
     // Single source of truth for cancellation: the renderer's Ctrl-C handler
     // flips the same flag the collector workers observe between cluster calls.
     let cancel = collector_handle.cancel_flag();
+
+    // The renderer waits for `WorktreeInfoCollectionDone`, which the collector
+    // handle emits on `join()`. Joining must happen on a separate thread so the
+    // sentinel fires while the renderer is still listening on the channel.
+    let join_thread = std::thread::spawn(move || {
+        collector_handle.join();
+    });
+
     let renderer = TuiRenderer::new(state, rx).with_cancel_signal(cancel);
     let _final_state = renderer.run()?;
 
-    collector_handle.join();
+    // Workers have finished by the time the sentinel arrived; this should
+    // return promptly. Cancel first in case Ctrl-C broke us out early.
+    let _ = join_thread.join();
     Ok(())
 }

--- a/src/commands/list_live.rs
+++ b/src/commands/list_live.rs
@@ -1,0 +1,239 @@
+//! Live cell-by-cell rendering for `daft list`.
+//!
+//! Used when stdout is a TTY, the user did not request structured output
+//! (`--format`), and `DAFT_NO_LIVE` is not set. Otherwise the dispatcher
+//! in `list::run` falls back to `list::run_blocking` (today's behavior).
+
+use crate::{
+    commands::list::Args,
+    core::{
+        columns::{ColumnSelection, CommandKind, ListColumn, ResolvedColumns},
+        repo::{get_current_worktree_path, get_git_common_dir, get_project_root},
+        sort::SortSpec,
+        worktree::{
+            info_field::FieldSet,
+            list::{collect_branch_info, EntryKind, WorktreeInfo},
+            list_stream,
+            sync_dag::{DagEvent, PatchSource},
+        },
+    },
+    git::GitCommand,
+    output::tui::{Column, TuiRenderer, TuiState},
+    remote::get_default_branch_local,
+    settings::DaftSettings,
+};
+use anyhow::Result;
+use std::{
+    collections::HashSet,
+    path::PathBuf,
+    sync::{mpsc, Arc},
+};
+
+/// Inline porcelain parsing — `core::worktree::list::parse_porcelain` is
+/// private and its enclosing file is outside this task's allowed scope.
+struct PorcelainEntry {
+    path: PathBuf,
+    branch: Option<String>,
+    is_bare: bool,
+    is_detached: bool,
+}
+
+fn parse_porcelain(output: &str) -> Vec<PorcelainEntry> {
+    let mut entries = Vec::new();
+    let mut current_path: Option<PathBuf> = None;
+    let mut current_branch: Option<String> = None;
+    let mut is_bare = false;
+    let mut is_detached = false;
+
+    for line in output.lines() {
+        if let Some(path_str) = line.strip_prefix("worktree ") {
+            if let Some(path) = current_path.take() {
+                entries.push(PorcelainEntry {
+                    path,
+                    branch: current_branch.take(),
+                    is_bare,
+                    is_detached,
+                });
+            }
+            current_path = Some(PathBuf::from(path_str));
+            current_branch = None;
+            is_bare = false;
+            is_detached = false;
+        } else if let Some(branch_ref) = line.strip_prefix("branch ") {
+            current_branch = branch_ref.strip_prefix("refs/heads/").map(String::from);
+        } else if line == "bare" {
+            is_bare = true;
+        } else if line == "detached" {
+            is_detached = true;
+        }
+    }
+    if let Some(path) = current_path.take() {
+        entries.push(PorcelainEntry {
+            path,
+            branch: current_branch.take(),
+            is_bare,
+            is_detached,
+        });
+    }
+
+    entries
+}
+
+pub fn run_live(args: Args, settings: DaftSettings) -> Result<()> {
+    let git = GitCommand::new(false).with_gitoxide(settings.use_gitoxide);
+    let user_email: Option<String> = git.config_get("user.email").ok().flatten();
+    let git_common_dir = get_git_common_dir()?;
+    let base_branch =
+        get_default_branch_local(&git_common_dir, &settings.remote, settings.use_gitoxide)
+            .unwrap_or_else(|_| "master".to_string());
+    let current_path = get_current_worktree_path()
+        .ok()
+        .and_then(|p| p.canonicalize().ok());
+    let project_root = get_project_root()?;
+    let cwd = std::env::current_dir().unwrap_or_else(|_| project_root.clone());
+
+    let stat = args.stat.unwrap_or(settings.list_stat);
+
+    // Resolve columns + sort spec (same logic as run_blocking).
+    let columns_input = args.columns.clone().or(settings.list_columns.clone());
+    let resolved = match columns_input {
+        Some(ref input) => {
+            ColumnSelection::parse(input, CommandKind::List).map_err(|e| anyhow::anyhow!("{e}"))?
+        }
+        None => ResolvedColumns::defaults(ListColumn::list_defaults()),
+    };
+    let selected_columns = resolved.columns.clone();
+    let columns_explicit = resolved.explicit;
+    let sort_input = args.sort.clone().or(settings.list_sort.clone());
+    let sort_spec = match sort_input {
+        Some(ref input) => Some(
+            SortSpec::parse(input)
+                .map_err(|e| anyhow::anyhow!("{e}"))?
+                .with_stat(stat),
+        ),
+        None => None,
+    };
+
+    let show_local = args.branches || args.all;
+    let show_remote = args.remotes || args.all;
+
+    // Cheap porcelain seed: branches, paths, is_default, is_current.
+    let porcelain = git
+        .worktree_list_porcelain()
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    let entries = parse_porcelain(&porcelain);
+    let mut worktree_infos: Vec<WorktreeInfo> = Vec::new();
+    let mut targets: Vec<list_stream::CollectorTarget> = Vec::new();
+    let mut worktree_branches: HashSet<String> = HashSet::new();
+
+    for entry in entries {
+        if entry.is_bare {
+            continue;
+        }
+        let branch_display = if entry.is_detached {
+            "(detached)".to_string()
+        } else {
+            entry.branch.clone().unwrap_or_default()
+        };
+        let canonical = entry
+            .path
+            .canonicalize()
+            .unwrap_or_else(|_| entry.path.clone());
+        let is_current = current_path.as_deref() == Some(canonical.as_path());
+        let is_default_branch = entry.branch.as_deref() == Some(base_branch.as_str());
+
+        let mut info = WorktreeInfo::empty(&branch_display);
+        info.path = Some(entry.path.clone());
+        info.is_current = is_current;
+        info.is_default_branch = is_default_branch;
+        info.is_sandbox = entry.is_detached;
+        info.kind = EntryKind::Worktree;
+        worktree_infos.push(info);
+
+        targets.push(list_stream::CollectorTarget {
+            branch_name: branch_display.clone(),
+            path: Some(entry.path.clone()),
+            kind: EntryKind::Worktree,
+            is_detached: entry.is_detached,
+        });
+
+        if !branch_display.is_empty() && !entry.is_detached {
+            worktree_branches.insert(branch_display);
+        }
+    }
+
+    // Optionally enumerate non-worktree branches (sync — cheap git for-each-ref).
+    if show_local || show_remote {
+        let branch_infos = collect_branch_info(
+            &git,
+            &base_branch,
+            stat,
+            show_local,
+            show_remote,
+            &worktree_branches,
+            &project_root,
+            settings.ownership_strategy,
+            user_email.as_deref(),
+            &settings.remote,
+        )?;
+        for info in branch_infos {
+            targets.push(list_stream::CollectorTarget {
+                branch_name: info.name.clone(),
+                path: info.path.clone(),
+                kind: info.kind,
+                is_detached: false,
+            });
+            worktree_infos.push(info);
+        }
+    }
+
+    // Build TUI state — pin_default_branch=false, partition_by_owner=false
+    // for `daft list` (per spec).
+    let tui_columns: Vec<Column> = selected_columns
+        .iter()
+        .map(|c| Column::from_list_column(*c))
+        .collect();
+
+    let (tx, rx) = mpsc::channel::<DagEvent>();
+
+    // Spawn the streaming collector. Cells stream into LiveTable as they
+    // arrive.
+    let collector_ctx = Arc::new(list_stream::CollectorContext {
+        use_gitoxide: settings.use_gitoxide,
+        base_branch: base_branch.clone(),
+        remote_name: settings.remote.clone(),
+        ownership_strategy: settings.ownership_strategy,
+        user_email: user_email.clone(),
+    });
+    let collector_handle = list_stream::spawn(
+        list_stream::CollectorRequest {
+            targets,
+            fields: FieldSet::ALL,
+            stat,
+            source: PatchSource::Collector,
+            ctx: collector_ctx,
+        },
+        tx,
+    );
+
+    let state = TuiState::new(
+        Vec::new(), // no phases
+        worktree_infos,
+        project_root.clone(),
+        cwd,
+        stat,
+        u8::from(args.verbose),
+        Some(tui_columns),
+        columns_explicit,
+        None, // unowned_start_index — list does not partition
+        sort_spec,
+        false, // pin_default_branch
+        false, // partition_by_owner
+    );
+
+    let renderer = TuiRenderer::new(state, rx);
+    let _final_state = renderer.run()?;
+
+    collector_handle.join();
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -19,6 +19,7 @@ pub mod hooks;
 pub mod init;
 pub mod layout;
 pub mod list;
+pub mod list_live;
 pub mod multi_remote;
 pub mod prune;
 pub mod release_notes;

--- a/src/commands/prune.rs
+++ b/src/commands/prune.rs
@@ -3,12 +3,13 @@ use crate::{
     core::{
         sort::SortSpec,
         worktree::{
+            info_field::FieldSet,
             list,
             list::Stat,
-            prune,
+            list_stream, prune,
             sync_dag::{
-                DagEvent, DagExecutor, OperationPhase, SyncDag, SyncTask, TaskId, TaskMessage,
-                TaskStatus,
+                DagEvent, DagExecutor, OperationPhase, PatchSource, SyncDag, SyncTask, TaskId,
+                TaskMessage, TaskStatus,
             },
         },
         CommandBridge, NullBridge,
@@ -217,41 +218,21 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
         from_columns || sort_spec.as_ref().is_some_and(|s| s.needs_size())
     };
     let compute_mtime = sort_spec.as_ref().is_some_and(|s| s.needs_mtime());
-    let needs_spinner = stat == Stat::Lines || has_size;
-    let mut worktree_infos = if needs_spinner {
-        let mut output = CliOutput::new(OutputConfig::new(false, false));
-        let msg = if stat == Stat::Lines {
-            "Computing line statistics..."
-        } else {
-            "Computing worktree sizes..."
-        };
-        output.start_spinner(msg);
-        let result = list::collect_worktree_info(
-            &git,
-            &base_branch,
-            current_path.as_deref(),
-            stat,
-            has_size,
-            compute_mtime,
-            settings.ownership_strategy,
-            user_email.as_deref(),
-            &settings.remote,
-        )?;
-        output.finish_spinner();
-        result
-    } else {
-        list::collect_worktree_info(
-            &git,
-            &base_branch,
-            current_path.as_deref(),
-            stat,
-            has_size,
-            compute_mtime,
-            settings.ownership_strategy,
-            user_email.as_deref(),
-            &settings.remote,
-        )?
-    };
+
+    // Synchronous seed: compute everything EXCEPT the heavy cells (size,
+    // mtime, line stats). Those will stream in via the collector below.
+    // shared_owner_lookup (built later) depends on this call's output.
+    let mut worktree_infos = list::collect_worktree_info(
+        &git,
+        &base_branch,
+        current_path.as_deref(),
+        Stat::Summary, // Force Summary; line stats stream below.
+        false,         // has_size = false: stream the size cluster instead
+        false,         // compute_mtime = false: stream the mtime cluster
+        settings.ownership_strategy,
+        user_email.as_deref(),
+        &settings.remote,
+    )?;
 
     // Parse worktree list for prune context
     let worktree_entries = prune::parse_worktree_list(&git)?;
@@ -262,6 +243,20 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
         if let Some(ref branch) = entry.branch {
             worktree_map.insert(branch.clone(), (entry.path.clone(), i == 0));
         }
+    }
+
+    // Heavy cells the user requested but the seed deliberately skipped.
+    // These will arrive via the streaming collector concurrent with the
+    // orchestrator below.
+    let mut streaming_fields = FieldSet::EMPTY;
+    if has_size {
+        streaming_fields |= FieldSet::SIZE;
+    }
+    if compute_mtime {
+        streaming_fields |= FieldSet::MTIME;
+    }
+    if stat == Stat::Lines {
+        streaming_fields |= FieldSet::BASE_LINES | FieldSet::CHANGES_LINES | FieldSet::REMOTE_LINES;
     }
 
     // ── Seed local-only gone branches (pre-fetch best-effort) ──────────
@@ -330,6 +325,9 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
 
     // ── Create channel and spawn orchestrator ──────────────────────────
     let (tx, rx) = std::sync::mpsc::channel();
+    // Clone for the streaming collector below, since `tx` is moved into the
+    // orchestrator closure.
+    let tx_for_collector = tx.clone();
 
     let shared_settings = Arc::new(settings.clone());
     let shared_project_root = Arc::new(project_root.clone());
@@ -352,11 +350,26 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
     let orch_settings = Arc::clone(&shared_settings);
     let shared_hooks_config = Arc::new(hooks_config.clone());
 
+    // Captures for the post-fetch refresh inside the orchestrator thread.
+    let orch_base_branch = Arc::new(base_branch.clone());
+    let orch_user_email: Arc<Option<String>> = Arc::new(user_email.clone());
+    let orch_stat = stat;
+
     let orchestrator_handle = std::thread::spawn(move || {
         // ── Phase 1: Fetch ─────────────────────────────────────────────
         if !sync_shared::run_fetch_phase(&tx, orch_settings.use_gitoxide, &orch_settings.remote) {
             return;
         }
+
+        // ── Refresh remote-derived cells now that fetch updated remote refs ──
+        sync_shared::spawn_post_fetch_refresh(
+            &shared_worktree_map,
+            &orch_settings,
+            &orch_base_branch,
+            orch_user_email.as_deref(),
+            orch_stat,
+            &tx,
+        );
 
         // ── Phase 2: Identify gone branches + build DAG ────────────────
         let gone_branches = {
@@ -431,6 +444,40 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
         );
     });
 
+    // Streaming collector for heavy cells (concurrent with orchestrator).
+    let collector_handle = if !streaming_fields.is_empty() {
+        let targets: Vec<list_stream::CollectorTarget> = worktree_map
+            .iter()
+            .map(
+                |(branch_name, (path, _is_main))| list_stream::CollectorTarget {
+                    branch_name: branch_name.clone(),
+                    path: Some(path.clone()),
+                    kind: list::EntryKind::Worktree,
+                    is_detached: false,
+                },
+            )
+            .collect();
+        let ctx = Arc::new(list_stream::CollectorContext {
+            use_gitoxide: settings.use_gitoxide,
+            base_branch: base_branch.clone(),
+            remote_name: settings.remote.clone(),
+            ownership_strategy: settings.ownership_strategy,
+            user_email: user_email.clone(),
+        });
+        Some(list_stream::spawn(
+            list_stream::CollectorRequest {
+                targets,
+                fields: streaming_fields,
+                stat,
+                source: PatchSource::Collector,
+                ctx,
+            },
+            tx_for_collector,
+        ))
+    } else {
+        None
+    };
+
     // ── Run TUI via OperationTable on main thread ──────────────────────
     // Budget hook + job sub-rows per worktree (2 hooks × ~3 jobs each).
     // Not all worktrees will have hooks, but the ratatui inline viewport
@@ -459,6 +506,11 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
         None,
     );
     let completed = table.run()?;
+
+    if let Some(handle) = collector_handle {
+        handle.cancel(); // Renderer is gone, don't keep workers running.
+        handle.join();
+    }
 
     // Wait for orchestrator thread to finish
     orchestrator_handle

--- a/src/commands/prune.rs
+++ b/src/commands/prune.rs
@@ -368,6 +368,7 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
             &orch_base_branch,
             orch_user_email.as_deref(),
             orch_stat,
+            &shared_git_dir,
             &tx,
         );
 
@@ -463,6 +464,7 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
             remote_name: settings.remote.clone(),
             ownership_strategy: settings.ownership_strategy,
             user_email: user_email.clone(),
+            git_common_dir: git_dir.clone(),
         });
         Some(list_stream::spawn(
             list_stream::CollectorRequest {

--- a/src/commands/prune.rs
+++ b/src/commands/prune.rs
@@ -456,6 +456,8 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
             sort_spec,
             extra_rows: 5 + hook_extra_rows,
             verbosity: args.verbose,
+            pin_default_branch: true,
+            partition_by_owner: false, // External unowned_start_index drives the partition.
         },
         None,
     );

--- a/src/commands/prune.rs
+++ b/src/commands/prune.rs
@@ -392,14 +392,12 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
                 TaskStatus,
                 TaskMessage,
                 std::collections::HashSet<crate::core::worktree::sync_dag::TaskOutcome>,
-                Option<Box<list::WorktreeInfo>>,
             ) {
                 match &task.id {
                     TaskId::Fetch => (
                         TaskStatus::Succeeded,
                         TaskMessage::Ok("fetched".into()),
                         outcomes.clone(),
-                        None,
                     ),
                     TaskId::Prune(branch_name) => {
                         let (status, message) = sync_shared::execute_prune_task(
@@ -420,13 +418,12 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
                         if matches!(message, TaskMessage::Deferred) {
                             *deferred_branch_writer.lock().unwrap() = Some(branch_name.clone());
                         }
-                        (status, message, outcomes.clone(), None)
+                        (status, message, outcomes.clone())
                     }
                     TaskId::Update(_) | TaskId::Rebase(_) | TaskId::Push(_) => (
                         TaskStatus::Skipped,
                         TaskMessage::Ok("not applicable".into()),
                         outcomes.clone(),
-                        None,
                     ),
                     TaskId::Setup(_) => unreachable!("Setup is only used by clone"),
                 }

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -833,6 +833,8 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
             sort_spec,
             extra_rows: 5 + hook_extra_rows,
             verbosity: args.verbose,
+            pin_default_branch: true,
+            partition_by_owner: false, // External unowned_start_index drives the partition.
         },
         unowned_start_index,
     );

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -636,6 +636,16 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
             return;
         }
 
+        // ── Refresh remote-derived cells now that fetch updated remote refs ──
+        spawn_post_fetch_refresh(
+            &shared_worktree_map,
+            &orch_settings,
+            &orch_base_branch,
+            orch_user_email.as_deref(),
+            orch_stat,
+            &tx,
+        );
+
         // ── Phase 2: Identify gone branches + build DAG ────────────────
         let gone_branches = {
             let git = GitCommand::new(false).with_gitoxide(orch_settings.use_gitoxide);
@@ -977,7 +987,6 @@ fn spawn_post_task_refresh(
 /// arrive as `PatchSource::PostFetch` so `LiveTable` can suppress any
 /// stale `Collector` patches on the same fields. Blocks on join() so
 /// patches land before the orchestrator dispatches per-branch tasks.
-#[allow(dead_code)]
 fn spawn_post_fetch_refresh(
     worktree_map: &HashMap<String, (PathBuf, bool)>,
     settings: &Arc<DaftSettings>,

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -637,7 +637,7 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
         }
 
         // ── Refresh remote-derived cells now that fetch updated remote refs ──
-        spawn_post_fetch_refresh(
+        sync_shared::spawn_post_fetch_refresh(
             &shared_worktree_map,
             &orch_settings,
             &orch_base_branch,
@@ -975,53 +975,6 @@ fn spawn_post_task_refresh(
             fields,
             stat,
             source: PatchSource::PostTask(phase),
-            ctx,
-        },
-        tx.clone(),
-    );
-    handle.join();
-}
-
-/// After the Fetch phase completes, re-run the streaming collector
-/// against `REMOTE_DERIVED` fields for every worktree branch. Patches
-/// arrive as `PatchSource::PostFetch` so `LiveTable` can suppress any
-/// stale `Collector` patches on the same fields. Blocks on join() so
-/// patches land before the orchestrator dispatches per-branch tasks.
-fn spawn_post_fetch_refresh(
-    worktree_map: &HashMap<String, (PathBuf, bool)>,
-    settings: &Arc<DaftSettings>,
-    base_branch: &str,
-    user_email: Option<&str>,
-    stat: Stat,
-    tx: &mpsc::Sender<sync_dag::DagEvent>,
-) {
-    let targets: Vec<list_stream::CollectorTarget> = worktree_map
-        .iter()
-        .map(
-            |(branch_name, (path, _is_main))| list_stream::CollectorTarget {
-                branch_name: branch_name.clone(),
-                path: Some(path.clone()),
-                kind: EntryKind::Worktree,
-                is_detached: false,
-            },
-        )
-        .collect();
-    if targets.is_empty() {
-        return;
-    }
-    let ctx = Arc::new(list_stream::CollectorContext {
-        use_gitoxide: settings.use_gitoxide,
-        base_branch: base_branch.to_string(),
-        remote_name: settings.remote.clone(),
-        ownership_strategy: settings.ownership_strategy,
-        user_email: user_email.map(|s| s.to_string()),
-    });
-    let handle = list_stream::spawn(
-        list_stream::CollectorRequest {
-            targets,
-            fields: FieldSet::REMOTE_DERIVED,
-            stat,
-            source: PatchSource::PostFetch,
             ctx,
         },
         tx.clone(),

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -643,6 +643,7 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
             &orch_base_branch,
             orch_user_email.as_deref(),
             orch_stat,
+            &shared_git_dir,
             &tx,
         );
 
@@ -755,6 +756,7 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
                                 &orch_base_branch,
                                 orch_user_email.as_deref(),
                                 orch_stat,
+                                &shared_git_dir,
                                 &tx_for_tasks,
                             );
                         }
@@ -786,6 +788,7 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
                                 &orch_base_branch,
                                 orch_user_email.as_deref(),
                                 orch_stat,
+                                &shared_git_dir,
                                 &tx_for_tasks,
                             );
                         }
@@ -810,6 +813,7 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
                                 &orch_base_branch,
                                 orch_user_email.as_deref(),
                                 orch_stat,
+                                &shared_git_dir,
                                 &tx_for_tasks,
                             );
                         }
@@ -841,6 +845,7 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
             remote_name: settings.remote.clone(),
             ownership_strategy: settings.ownership_strategy,
             user_email: user_email.clone(),
+            git_common_dir: git_dir.clone(),
         });
         Some(list_stream::spawn(
             list_stream::CollectorRequest {
@@ -951,6 +956,7 @@ fn spawn_post_task_refresh(
     base_branch: &str,
     user_email: Option<&str>,
     stat: Stat,
+    git_common_dir: &std::path::Path,
     tx: &mpsc::Sender<sync_dag::DagEvent>,
 ) {
     let Some((path, _is_main)) = worktree_map.get(branch_name) else {
@@ -968,6 +974,7 @@ fn spawn_post_task_refresh(
         remote_name: settings.remote.clone(),
         ownership_strategy: settings.ownership_strategy,
         user_email: user_email.map(|s| s.to_string()),
+        git_common_dir: git_common_dir.to_path_buf(),
     });
     let handle = list_stream::spawn(
         list_stream::CollectorRequest {

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -417,41 +417,20 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
     };
     let compute_mtime = sort_spec.as_ref().is_some_and(|s| s.needs_mtime());
     let user_email: Option<String> = git.config_get("user.email").ok().flatten();
-    let needs_spinner = stat == Stat::Lines || has_size;
-    let worktree_infos = if needs_spinner {
-        let mut output = CliOutput::new(OutputConfig::new(false, false));
-        let msg = if stat == Stat::Lines {
-            "Computing line statistics..."
-        } else {
-            "Computing worktree sizes..."
-        };
-        output.start_spinner(msg);
-        let result = list::collect_worktree_info(
-            &git,
-            &base_branch,
-            current_path.as_deref(),
-            stat,
-            has_size,
-            compute_mtime,
-            settings.ownership_strategy,
-            user_email.as_deref(),
-            &settings.remote,
-        )?;
-        output.finish_spinner();
-        result
-    } else {
-        list::collect_worktree_info(
-            &git,
-            &base_branch,
-            current_path.as_deref(),
-            stat,
-            has_size,
-            compute_mtime,
-            settings.ownership_strategy,
-            user_email.as_deref(),
-            &settings.remote,
-        )?
-    };
+    // Synchronous seed: compute everything EXCEPT the heavy cells (size,
+    // mtime, line stats). Those will stream in via the collector below.
+    // shared_owner_lookup depends on this call's output.
+    let worktree_infos = list::collect_worktree_info(
+        &git,
+        &base_branch,
+        current_path.as_deref(),
+        Stat::Summary, // Force Summary for the seed; line stats stream below.
+        false,         // has_size = false: stream the size cluster instead
+        false,         // compute_mtime = false: stream the mtime cluster
+        settings.ownership_strategy,
+        user_email.as_deref(),
+        &settings.remote,
+    )?;
 
     // Get worktree list for DAG (branch name + path pairs)
     let all_worktrees = fetch::get_all_worktrees_with_branches(&git)?;
@@ -465,6 +444,20 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
         if let Some(ref branch) = entry.branch {
             worktree_map.insert(branch.clone(), (entry.path.clone(), i == 0));
         }
+    }
+
+    // Heavy cells that the user requested but the seed deliberately skipped.
+    // These will arrive via the streaming collector in parallel with the
+    // orchestrator.
+    let mut streaming_fields = FieldSet::EMPTY;
+    if has_size {
+        streaming_fields |= FieldSet::SIZE;
+    }
+    if compute_mtime {
+        streaming_fields |= FieldSet::MTIME;
+    }
+    if stat == Stat::Lines {
+        streaming_fields |= FieldSet::BASE_LINES | FieldSet::CHANGES_LINES | FieldSet::REMOTE_LINES;
     }
 
     // ── Create TUI state with known phases and worktrees ───────────────
@@ -579,6 +572,9 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
 
     // ── Create channel and spawn orchestrator ──────────────────────────
     let (tx, rx) = std::sync::mpsc::channel();
+    // Clone for the streaming collector below, since `tx` is moved into the
+    // orchestrator closure.
+    let tx_for_collector = tx.clone();
 
     // Shared context for workers
     let shared_settings = Arc::new(settings.clone());
@@ -815,6 +811,41 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
         );
     });
 
+    // Spawn the streaming collector for heavy cells (concurrent with
+    // orchestrator). No-op if streaming_fields is empty.
+    let collector_handle = if !streaming_fields.is_empty() {
+        let targets: Vec<list_stream::CollectorTarget> = worktree_map
+            .iter()
+            .map(
+                |(branch_name, (path, _is_main))| list_stream::CollectorTarget {
+                    branch_name: branch_name.clone(),
+                    path: Some(path.clone()),
+                    kind: list::EntryKind::Worktree,
+                    is_detached: false,
+                },
+            )
+            .collect();
+        let ctx = Arc::new(list_stream::CollectorContext {
+            use_gitoxide: settings.use_gitoxide,
+            base_branch: base_branch.clone(),
+            remote_name: settings.remote.clone(),
+            ownership_strategy: settings.ownership_strategy,
+            user_email: user_email.clone(),
+        });
+        Some(list_stream::spawn(
+            list_stream::CollectorRequest {
+                targets,
+                fields: streaming_fields,
+                stat,
+                source: PatchSource::Collector,
+                ctx,
+            },
+            tx_for_collector,
+        ))
+    } else {
+        None
+    };
+
     // ── Run TUI via OperationTable on main thread ──────────────────────
     let table = OperationTable::new(
         phases,
@@ -835,6 +866,11 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
         unowned_start_index,
     );
     let completed = table.run()?;
+
+    if let Some(handle) = collector_handle {
+        handle.cancel(); // Renderer is gone, don't keep workers running.
+        handle.join();
+    }
 
     // Wait for orchestrator thread to finish
     orchestrator_handle

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -12,11 +12,14 @@ use crate::{
     core::{
         sort::SortSpec,
         worktree::{
-            fetch, list,
-            list::Stat,
-            prune, push, rebase,
+            fetch,
+            info_field::FieldSet,
+            list,
+            list::{EntryKind, Stat},
+            list_stream, prune, push, rebase,
             sync_dag::{
-                self, DagExecutor, SyncDag, SyncTask, TaskId, TaskMessage, TaskOutcome, TaskStatus,
+                self, DagExecutor, OperationPhase, PatchSource, SyncDag, SyncTask, TaskId,
+                TaskMessage, TaskOutcome, TaskStatus,
             },
             temp_worktree,
         },
@@ -39,7 +42,7 @@ use anyhow::Result;
 use clap::Parser;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{mpsc, Arc};
 
 /// Parsed `--include` value.
 enum IncludeFilter {
@@ -541,13 +544,6 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
     };
 
     // ── Build shared maps from worktree_infos before they move into OperationTable ──
-    // Shared worktree info map for live refresh after tasks complete
-    let shared_info_map: Arc<HashMap<String, list::WorktreeInfo>> = Arc::new(
-        worktree_infos
-            .iter()
-            .map(|info| (info.name.clone(), info.clone()))
-            .collect(),
-    );
     // Build worktree list including local-only branches (with None paths).
     let worktree_branch_set: HashSet<String> =
         all_worktrees.iter().map(|(_, b)| b.clone()).collect();
@@ -626,11 +622,14 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
 
     let shared_base_branch = Arc::new(base_branch.clone());
 
-    // Clone values needed by orchestrator
+    // Clone values needed by orchestrator. Whole-WorktreeInfo snapshots are no
+    // longer threaded through TaskCompleted — instead, each task spawns a
+    // streaming-collector run with `PatchSource::PostTask(phase)` to refresh
+    // just the fields it touched.
     let orch_settings = Arc::clone(&shared_settings);
-    let orch_info_map = Arc::clone(&shared_info_map);
     let orch_base_branch = Arc::clone(&shared_base_branch);
     let orch_stat = stat;
+    let orch_user_email: Arc<Option<String>> = Arc::new(user_email.clone());
 
     // Ownership filtering for the orchestrator
     let shared_include: Arc<Vec<String>> = Arc::new(args.include.clone());
@@ -697,7 +696,6 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
                 TaskStatus,
                 TaskMessage,
                 std::collections::HashSet<crate::core::worktree::sync_dag::TaskOutcome>,
-                Option<Box<list::WorktreeInfo>>,
             ) {
                 match &task.id {
                     TaskId::Fetch => {
@@ -706,7 +704,6 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
                             TaskStatus::Succeeded,
                             TaskMessage::Ok("fetched".into()),
                             outcomes.clone(),
-                            None,
                         )
                     }
                     TaskId::Prune(branch_name) => {
@@ -728,7 +725,8 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
                         if matches!(message, TaskMessage::Deferred) {
                             *deferred_branch_writer.lock().unwrap() = Some(branch_name.clone());
                         }
-                        (status, message, outcomes.clone(), None)
+                        // Prune removes the row entirely; no patch to emit.
+                        (status, message, outcomes.clone())
                     }
                     TaskId::Update(branch_name) => {
                         let (status, message) = execute_update_task(
@@ -739,22 +737,22 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
                             &shared_pull_args,
                             shared_force,
                         );
-                        let updated = if status == TaskStatus::Succeeded {
-                            orch_info_map.get(branch_name.as_str()).map(|info| {
-                                let mut refreshed = info.clone();
-                                let git = GitCommand::new(false)
-                                    .with_gitoxide(orch_settings.use_gitoxide);
-                                refreshed.refresh_dynamic_fields(
-                                    &orch_base_branch,
-                                    orch_stat,
-                                    &git,
-                                );
-                                Box::new(refreshed)
-                            })
-                        } else {
-                            None
-                        };
-                        (status, message, outcomes.clone(), updated)
+                        if status == TaskStatus::Succeeded {
+                            spawn_post_task_refresh(
+                                branch_name,
+                                OperationPhase::Update,
+                                FieldSet::BASE_AHEAD_BEHIND
+                                    | FieldSet::LAST_COMMIT
+                                    | FieldSet::CHANGES,
+                                &shared_worktree_map,
+                                &orch_settings,
+                                &orch_base_branch,
+                                orch_user_email.as_deref(),
+                                orch_stat,
+                                &tx_for_tasks,
+                            );
+                        }
+                        (status, message, outcomes.clone())
                     }
                     TaskId::Rebase(branch_name) => {
                         let base = shared_rebase_branch.as_deref().unwrap_or("master");
@@ -768,24 +766,24 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
                             shared_autostash,
                             outcomes,
                         );
-                        let updated = if status == TaskStatus::Succeeded
+                        if status == TaskStatus::Succeeded
                             && !matches!(message, TaskMessage::Conflict)
                         {
-                            orch_info_map.get(branch_name.as_str()).map(|info| {
-                                let mut refreshed = info.clone();
-                                let git = GitCommand::new(false)
-                                    .with_gitoxide(orch_settings.use_gitoxide);
-                                refreshed.refresh_dynamic_fields(
-                                    &orch_base_branch,
-                                    orch_stat,
-                                    &git,
-                                );
-                                Box::new(refreshed)
-                            })
-                        } else {
-                            None
-                        };
-                        (status, message, new_outcomes, updated)
+                            spawn_post_task_refresh(
+                                branch_name,
+                                OperationPhase::Rebase(base.to_string()),
+                                FieldSet::BASE_AHEAD_BEHIND
+                                    | FieldSet::LAST_COMMIT
+                                    | FieldSet::REMOTE_AHEAD_BEHIND,
+                                &shared_worktree_map,
+                                &orch_settings,
+                                &orch_base_branch,
+                                orch_user_email.as_deref(),
+                                orch_stat,
+                                &tx_for_tasks,
+                            );
+                        }
+                        (status, message, new_outcomes)
                     }
                     TaskId::Push(branch_name) => {
                         let (status, message, new_outcomes) = execute_push_task(
@@ -796,22 +794,20 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
                             shared_force_with_lease,
                             outcomes,
                         );
-                        let updated = if status == TaskStatus::Succeeded {
-                            orch_info_map.get(branch_name.as_str()).map(|info| {
-                                let mut refreshed = info.clone();
-                                let git = GitCommand::new(false)
-                                    .with_gitoxide(orch_settings.use_gitoxide);
-                                refreshed.refresh_dynamic_fields(
-                                    &orch_base_branch,
-                                    orch_stat,
-                                    &git,
-                                );
-                                Box::new(refreshed)
-                            })
-                        } else {
-                            None
-                        };
-                        (status, message, new_outcomes, updated)
+                        if status == TaskStatus::Succeeded {
+                            spawn_post_task_refresh(
+                                branch_name,
+                                OperationPhase::Push,
+                                FieldSet::REMOTE_AHEAD_BEHIND,
+                                &shared_worktree_map,
+                                &orch_settings,
+                                &orch_base_branch,
+                                orch_user_email.as_deref(),
+                                orch_stat,
+                                &tx_for_tasks,
+                            );
+                        }
+                        (status, message, new_outcomes)
                     }
                     TaskId::Setup(_) => unreachable!("Setup is only used by clone"),
                 }
@@ -893,6 +889,52 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
 }
 
 // ── DAG task execution functions ───────────────────────────────────────────
+
+/// Spawn a streaming-collector run that re-emits the given `fields` for
+/// `branch_name` as `PatchSource::PostTask(phase)` patches. Blocks until the
+/// workers finish so that patches land before the next dependent task starts;
+/// otherwise the renderer can briefly show stale values during a Push that
+/// follows a Rebase, etc.
+#[allow(clippy::too_many_arguments)]
+fn spawn_post_task_refresh(
+    branch_name: &str,
+    phase: OperationPhase,
+    fields: FieldSet,
+    worktree_map: &HashMap<String, (PathBuf, bool)>,
+    settings: &Arc<DaftSettings>,
+    base_branch: &str,
+    user_email: Option<&str>,
+    stat: Stat,
+    tx: &mpsc::Sender<sync_dag::DagEvent>,
+) {
+    let Some((path, _is_main)) = worktree_map.get(branch_name) else {
+        return;
+    };
+    let target = list_stream::CollectorTarget {
+        branch_name: branch_name.to_string(),
+        path: Some(path.clone()),
+        kind: EntryKind::Worktree,
+        is_detached: false,
+    };
+    let ctx = Arc::new(list_stream::CollectorContext {
+        use_gitoxide: settings.use_gitoxide,
+        base_branch: base_branch.to_string(),
+        remote_name: settings.remote.clone(),
+        ownership_strategy: settings.ownership_strategy,
+        user_email: user_email.map(|s| s.to_string()),
+    });
+    let handle = list_stream::spawn(
+        list_stream::CollectorRequest {
+            targets: vec![target],
+            fields,
+            stat,
+            source: PatchSource::PostTask(phase),
+            ctx,
+        },
+        tx.clone(),
+    );
+    handle.join();
+}
 
 /// Execute a single update task for a DAG worker.
 fn execute_update_task(

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -936,6 +936,54 @@ fn spawn_post_task_refresh(
     handle.join();
 }
 
+/// After the Fetch phase completes, re-run the streaming collector
+/// against `REMOTE_DERIVED` fields for every worktree branch. Patches
+/// arrive as `PatchSource::PostFetch` so `LiveTable` can suppress any
+/// stale `Collector` patches on the same fields. Blocks on join() so
+/// patches land before the orchestrator dispatches per-branch tasks.
+#[allow(dead_code)]
+fn spawn_post_fetch_refresh(
+    worktree_map: &HashMap<String, (PathBuf, bool)>,
+    settings: &Arc<DaftSettings>,
+    base_branch: &str,
+    user_email: Option<&str>,
+    stat: Stat,
+    tx: &mpsc::Sender<sync_dag::DagEvent>,
+) {
+    let targets: Vec<list_stream::CollectorTarget> = worktree_map
+        .iter()
+        .map(
+            |(branch_name, (path, _is_main))| list_stream::CollectorTarget {
+                branch_name: branch_name.clone(),
+                path: Some(path.clone()),
+                kind: EntryKind::Worktree,
+                is_detached: false,
+            },
+        )
+        .collect();
+    if targets.is_empty() {
+        return;
+    }
+    let ctx = Arc::new(list_stream::CollectorContext {
+        use_gitoxide: settings.use_gitoxide,
+        base_branch: base_branch.to_string(),
+        remote_name: settings.remote.clone(),
+        ownership_strategy: settings.ownership_strategy,
+        user_email: user_email.map(|s| s.to_string()),
+    });
+    let handle = list_stream::spawn(
+        list_stream::CollectorRequest {
+            targets,
+            fields: FieldSet::REMOTE_DERIVED,
+            stat,
+            source: PatchSource::PostFetch,
+            ctx,
+        },
+        tx.clone(),
+    );
+    handle.join();
+}
+
 /// Execute a single update task for a DAG worker.
 fn execute_update_task(
     branch_name: &str,

--- a/src/commands/sync_shared.rs
+++ b/src/commands/sync_shared.rs
@@ -256,6 +256,7 @@ pub fn spawn_post_fetch_refresh(
     base_branch: &str,
     user_email: Option<&str>,
     stat: Stat,
+    git_common_dir: &std::path::Path,
     tx: &mpsc::Sender<DagEvent>,
 ) {
     let targets: Vec<list_stream::CollectorTarget> = worktree_map
@@ -278,6 +279,7 @@ pub fn spawn_post_fetch_refresh(
         remote_name: settings.remote.clone(),
         ownership_strategy: settings.ownership_strategy,
         user_email: user_email.map(|s| s.to_string()),
+        git_common_dir: git_common_dir.to_path_buf(),
     });
     let handle = list_stream::spawn(
         list_stream::CollectorRequest {

--- a/src/commands/sync_shared.rs
+++ b/src/commands/sync_shared.rs
@@ -5,8 +5,10 @@
 use crate::{
     core::{
         worktree::{
-            prune,
-            sync_dag::{DagEvent, OperationPhase, TaskMessage, TaskStatus},
+            info_field::FieldSet,
+            list::{EntryKind, Stat},
+            list_stream, prune,
+            sync_dag::{DagEvent, OperationPhase, PatchSource, TaskMessage, TaskStatus},
         },
         CommandBridge, TuiBridge,
     },
@@ -21,6 +23,7 @@ use crate::{
 };
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::{mpsc, Arc};
 
 /// Execute a single prune task for a DAG worker.
 #[allow(clippy::too_many_arguments)]
@@ -240,6 +243,53 @@ pub fn run_fetch_phase(
     });
 
     true
+}
+
+/// After the Fetch phase completes, re-run the streaming collector
+/// against `REMOTE_DERIVED` fields for every worktree branch. Patches
+/// arrive as `PatchSource::PostFetch` so `LiveTable` can suppress any
+/// stale `Collector` patches on the same fields. Blocks on join() so
+/// patches land before the orchestrator dispatches per-branch tasks.
+pub fn spawn_post_fetch_refresh(
+    worktree_map: &HashMap<String, (PathBuf, bool)>,
+    settings: &Arc<DaftSettings>,
+    base_branch: &str,
+    user_email: Option<&str>,
+    stat: Stat,
+    tx: &mpsc::Sender<DagEvent>,
+) {
+    let targets: Vec<list_stream::CollectorTarget> = worktree_map
+        .iter()
+        .map(
+            |(branch_name, (path, _is_main))| list_stream::CollectorTarget {
+                branch_name: branch_name.clone(),
+                path: Some(path.clone()),
+                kind: EntryKind::Worktree,
+                is_detached: false,
+            },
+        )
+        .collect();
+    if targets.is_empty() {
+        return;
+    }
+    let ctx = Arc::new(list_stream::CollectorContext {
+        use_gitoxide: settings.use_gitoxide,
+        base_branch: base_branch.to_string(),
+        remote_name: settings.remote.clone(),
+        ownership_strategy: settings.ownership_strategy,
+        user_email: user_email.map(|s| s.to_string()),
+    });
+    let handle = list_stream::spawn(
+        list_stream::CollectorRequest {
+            targets,
+            fields: FieldSet::REMOTE_DERIVED,
+            stat,
+            source: PatchSource::PostFetch,
+            ctx,
+        },
+        tx.clone(),
+    );
+    handle.join();
 }
 
 /// Render the result of a sequential prune operation (header, details, summary).

--- a/src/commands/sync_shared.rs
+++ b/src/commands/sync_shared.rs
@@ -227,7 +227,6 @@ pub fn run_fetch_phase(
             branch_name: String::new(),
             status: TaskStatus::Failed,
             message: TaskMessage::Failed(format!("fetch failed: {e}")),
-            updated_info: None,
         });
         let _ = tx.send(DagEvent::AllDone);
         return false;
@@ -238,7 +237,6 @@ pub fn run_fetch_phase(
         branch_name: String::new(),
         status: TaskStatus::Succeeded,
         message: TaskMessage::Ok("fetched".into()),
-        updated_info: None,
     });
 
     true

--- a/src/core/cache.rs
+++ b/src/core/cache.rs
@@ -1,0 +1,155 @@
+//! On-disk JSON cache primitives shared by per-cell cache wrappers.
+//!
+//! Lives under `<git-common-dir>/.daft/cache/<kind>/`. Each kind owns its
+//! filename scheme (typically `{sha1}-{sha2}.json` for content-addressed pair
+//! caches) and its struct shape. This module owns only the filesystem
+//! mechanics so torn-write semantics and the silent-failure write policy
+//! live in one place.
+//!
+//! # Torn-write semantics
+//!
+//! Writes use `fs::write` directly, not temp-file-plus-rename. A crash mid-
+//! write produces a truncated file at the expected path, which `read_json`
+//! rejects as corrupt JSON — indistinguishable from a cache miss.
+//!
+//! # Error policy
+//!
+//! - `read_json` returns `None` on any failure (missing file, I/O error,
+//!   corrupt JSON).
+//! - `write_json` degrades silently — a failed write means the next read
+//!   recomputes.
+//! - `clear_kind` propagates I/O errors so a future `daft cache clear`
+//!   command could report failures.
+
+use serde::{de::DeserializeOwned, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// The directory for a named cache kind under the given git common dir.
+pub fn cache_dir_for(git_common_dir: &Path, kind: &str) -> PathBuf {
+    git_common_dir.join(".daft").join("cache").join(kind)
+}
+
+/// Read and deserialize a JSON cache entry. Returns `None` on any failure.
+pub fn read_json<T: DeserializeOwned>(path: &Path) -> Option<T> {
+    let json = fs::read_to_string(path).ok()?;
+    serde_json::from_str::<T>(&json).ok()
+}
+
+/// Serialize and write a JSON cache entry, creating parent dirs as needed.
+/// Degrades silently on any failure.
+pub fn write_json<T: Serialize>(path: &Path, value: &T) {
+    if let Some(parent) = path.parent() {
+        if fs::create_dir_all(parent).is_err() {
+            return;
+        }
+    }
+    let Ok(json) = serde_json::to_string(value) else {
+        return;
+    };
+    let _ = fs::write(path, json);
+}
+
+/// Delete every regular file in the cache kind's directory. Errors propagate
+/// so callers can report partial failures. Missing directories are a no-op.
+pub fn clear_kind(git_common_dir: &Path, kind: &str) -> std::io::Result<()> {
+    let dir = cache_dir_for(git_common_dir, kind);
+    let read = match fs::read_dir(&dir) {
+        Ok(r) => r,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(e),
+    };
+    for entry in read {
+        let entry = entry?;
+        if entry.file_type()?.is_file() {
+            fs::remove_file(entry.path())?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+    use tempfile::TempDir;
+
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    struct Foo {
+        n: u32,
+        s: String,
+    }
+
+    #[test]
+    fn read_returns_none_for_missing_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("missing.json");
+        let read: Option<Foo> = read_json(&path);
+        assert!(read.is_none());
+    }
+
+    #[test]
+    fn write_then_read_round_trips() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("nested").join("entry.json");
+        let v = Foo {
+            n: 7,
+            s: "hello".into(),
+        };
+        write_json(&path, &v);
+        let got: Option<Foo> = read_json(&path);
+        assert_eq!(got, Some(v));
+    }
+
+    #[test]
+    fn read_returns_none_for_corrupt_json() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("bad.json");
+        std::fs::write(&path, b"{not-json").unwrap();
+        let got: Option<Foo> = read_json(&path);
+        assert!(got.is_none());
+    }
+
+    #[test]
+    fn write_creates_missing_parent_dirs() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("a").join("b").join("c").join("e.json");
+        write_json(
+            &path,
+            &Foo {
+                n: 1,
+                s: "x".into(),
+            },
+        );
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn cache_dir_uses_kind_under_git_common() {
+        let dir = TempDir::new().unwrap();
+        let p = cache_dir_for(dir.path(), "ahead-behind");
+        assert_eq!(
+            p,
+            dir.path().join(".daft").join("cache").join("ahead-behind")
+        );
+    }
+
+    #[test]
+    fn clear_kind_removes_directory_contents() {
+        let dir = TempDir::new().unwrap();
+        let kind_dir = cache_dir_for(dir.path(), "k");
+        std::fs::create_dir_all(&kind_dir).unwrap();
+        std::fs::write(kind_dir.join("a.json"), "{}").unwrap();
+        std::fs::write(kind_dir.join("b.json"), "{}").unwrap();
+        clear_kind(dir.path(), "k").unwrap();
+        let entries: Vec<_> = std::fs::read_dir(&kind_dir).unwrap().collect();
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn clear_kind_is_noop_when_dir_missing() {
+        let dir = TempDir::new().unwrap();
+        // Don't create the kind dir at all.
+        assert!(clear_kind(dir.path(), "nonexistent").is_ok());
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -4,6 +4,7 @@
 //! report progress and trigger hooks without depending on specific UI
 //! implementations (CLI, TUI, tests, etc.).
 
+pub mod cache;
 pub mod columns;
 pub mod config;
 pub mod global_config;

--- a/src/core/sort.rs
+++ b/src/core/sort.rs
@@ -433,6 +433,30 @@ impl SortSpec {
         }
         Ordering::Equal
     }
+
+    /// Returns the set of `WorktreeInfo` fields needed to evaluate this sort
+    /// spec. Used by `LiveTable` to skip re-sorts when a patch lands on a
+    /// cell unrelated to the current sort order.
+    pub fn required_fields(&self) -> crate::core::worktree::info_field::FieldSet {
+        use crate::core::worktree::info_field::FieldSet;
+        let mut acc = FieldSet::EMPTY;
+        for key in &self.keys {
+            acc |= match key.column {
+                SortColumn::Branch => FieldSet::EMPTY,
+                SortColumn::Path => FieldSet::EMPTY,
+                SortColumn::Size => FieldSet::SIZE,
+                SortColumn::Age => FieldSet::BRANCH_AGE,
+                SortColumn::Owner => FieldSet::OWNER,
+                SortColumn::Hash => FieldSet::LAST_COMMIT,
+                SortColumn::Activity => FieldSet::LAST_COMMIT | FieldSet::MTIME,
+                SortColumn::LastCommit => FieldSet::LAST_COMMIT,
+                SortColumn::Base => FieldSet::BASE_AHEAD_BEHIND,
+                SortColumn::Changes => FieldSet::CHANGES,
+                SortColumn::Remote => FieldSet::REMOTE_AHEAD_BEHIND,
+            };
+        }
+        acc
+    }
 }
 
 #[cfg(test)]
@@ -912,5 +936,66 @@ mod tests {
         assert_eq!(spec.compare(&a, &b), Ordering::Greater);
         assert_eq!(spec.compare(&b, &a), Ordering::Less);
         assert_eq!(spec.compare(&a, &a), Ordering::Equal);
+    }
+}
+
+#[cfg(test)]
+mod required_fields_tests {
+    use super::*;
+    use crate::core::worktree::info_field::FieldSet;
+
+    fn fields_for(input: &str) -> FieldSet {
+        SortSpec::parse(input).unwrap().required_fields()
+    }
+
+    #[test]
+    fn branch_path_hash_require_no_dynamic_fields() {
+        // These sort by data already present from porcelain.
+        assert_eq!(fields_for("branch"), FieldSet::EMPTY);
+        assert_eq!(fields_for("path"), FieldSet::EMPTY);
+        assert_eq!(fields_for("hash"), FieldSet::LAST_COMMIT);
+    }
+
+    #[test]
+    fn size_requires_size() {
+        assert_eq!(fields_for("size"), FieldSet::SIZE);
+    }
+
+    #[test]
+    fn age_requires_branch_age() {
+        assert_eq!(fields_for("age"), FieldSet::BRANCH_AGE);
+    }
+
+    #[test]
+    fn owner_requires_owner() {
+        assert_eq!(fields_for("owner"), FieldSet::OWNER);
+    }
+
+    #[test]
+    fn last_commit_requires_last_commit() {
+        assert_eq!(fields_for("commit"), FieldSet::LAST_COMMIT);
+    }
+
+    #[test]
+    fn activity_requires_last_commit_and_mtime() {
+        assert_eq!(
+            fields_for("activity"),
+            FieldSet::LAST_COMMIT | FieldSet::MTIME,
+        );
+    }
+
+    #[test]
+    fn base_changes_remote_each_require_their_cluster() {
+        assert_eq!(fields_for("base"), FieldSet::BASE_AHEAD_BEHIND);
+        assert_eq!(fields_for("changes"), FieldSet::CHANGES);
+        assert_eq!(fields_for("remote"), FieldSet::REMOTE_AHEAD_BEHIND);
+    }
+
+    #[test]
+    fn multi_key_unions_required_fields() {
+        // +owner,-size: requires both OWNER and SIZE.
+        let f = fields_for("+owner,-size");
+        assert!(f.contains(FieldSet::OWNER));
+        assert!(f.contains(FieldSet::SIZE));
     }
 }

--- a/src/core/worktree/cell_cache.rs
+++ b/src/core/worktree/cell_cache.rs
@@ -1,0 +1,85 @@
+//! Cache wrappers for the slow `daft list` cells.
+//!
+//! Each public `cached_*` function (added in subsequent tasks):
+//!   1. Resolves the SHAs that fully define the cell's inputs.
+//!   2. Reads the cache entry keyed by those SHAs.
+//!   3. On hit, returns the cached value.
+//!   4. On miss, calls the underlying compute fn, writes the result, returns
+//!      it.
+//!
+//! Cells covered (all are pure functions of their key SHAs):
+//!   - `cached_base_ahead_behind`   key: `(base_sha, head_sha)`
+//!   - `cached_remote_ahead_behind` key: `(head_sha, upstream_sha)`
+//!   - `cached_last_commit`         key: `head_sha`
+//!   - `cached_base_lines`          key: `(base_sha, head_sha)`
+//!   - `cached_remote_lines`        key: `(head_sha, upstream_sha)`
+//!
+//! Cells deliberately not cached (working-tree-dependent, would risk staleness):
+//!   - Changes (staged/unstaged/untracked counts)
+//!   - Size (filesystem walk)
+//!   - Branch age, owner (cheap enough already)
+
+// Helpers below are scaffolding for the `cached_*` wrappers added in
+// subsequent batches. Suppress dead_code until then.
+#![allow(dead_code)]
+
+use crate::core::cache;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Resolve a ref to its 40-char SHA via `git rev-parse`. Returns `None` on
+/// any failure (unknown ref, git missing, non-utf8 output, malformed SHA).
+pub(super) fn resolve_ref_sha(worktree_path: &Path, refname: &str) -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--verify", "--quiet", refname])
+        .current_dir(worktree_path)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let s = String::from_utf8(output.stdout).ok()?.trim().to_string();
+    if s.len() == 40 && s.chars().all(|c| c.is_ascii_hexdigit()) {
+        Some(s)
+    } else {
+        None
+    }
+}
+
+/// Path for a SHA-pair cache entry: `<git-common>/.daft/cache/<kind>/<a>-<b>.json`.
+/// Caller decides ordering (typically the natural input order, not sorted).
+pub(super) fn pair_key_path(git_common_dir: &Path, kind: &str, a: &str, b: &str) -> PathBuf {
+    cache::cache_dir_for(git_common_dir, kind).join(format!("{a}-{b}.json"))
+}
+
+/// Path for a single-SHA cache entry: `<git-common>/.daft/cache/<kind>/<sha>.json`.
+pub(super) fn single_key_path(git_common_dir: &Path, kind: &str, sha: &str) -> PathBuf {
+    cache::cache_dir_for(git_common_dir, kind).join(format!("{sha}.json"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pair_key_path_uses_dash_separator() {
+        let p = pair_key_path(Path::new("/tmp/x"), "kind", "aaa", "bbb");
+        assert!(p.ends_with("aaa-bbb.json"));
+    }
+
+    #[test]
+    fn single_key_path_uses_sha_filename() {
+        let p = single_key_path(Path::new("/tmp/x"), "kind", "abc");
+        assert!(p.ends_with("abc.json"));
+    }
+
+    #[test]
+    fn resolve_ref_sha_returns_none_for_nonrepo_dir() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let sha = resolve_ref_sha(dir.path(), "HEAD");
+        assert!(
+            sha.is_none(),
+            "non-repo dir should return None, got {sha:?}"
+        );
+    }
+}

--- a/src/core/worktree/cell_cache.rs
+++ b/src/core/worktree/cell_cache.rs
@@ -57,6 +57,30 @@ pub(super) fn single_key_path(git_common_dir: &Path, kind: &str, sha: &str) -> P
     cache::cache_dir_for(git_common_dir, kind).join(format!("{sha}.json"))
 }
 
+/// Cached wrapper for `(base..head)` ahead/behind counts.
+///
+/// Cache key: `(base_sha, head_sha)`. The result is a pure function of these
+/// two SHAs, so a hit is provably correct — no TTL or invalidation needed.
+/// `None` results are NOT cached (the underlying git command may have failed
+/// transiently; we want the next run to retry).
+pub(crate) fn cached_base_ahead_behind<F>(
+    git_common_dir: &Path,
+    base_sha: &str,
+    head_sha: &str,
+    compute: F,
+) -> Option<(usize, usize)>
+where
+    F: FnOnce() -> Option<(usize, usize)>,
+{
+    let path = pair_key_path(git_common_dir, "base-ahead-behind", base_sha, head_sha);
+    if let Some(v) = cache::read_json::<(usize, usize)>(&path) {
+        return Some(v);
+    }
+    let computed = compute()?;
+    cache::write_json(&path, &computed);
+    Some(computed)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -81,5 +105,42 @@ mod tests {
             sha.is_none(),
             "non-repo dir should return None, got {sha:?}"
         );
+    }
+
+    #[test]
+    fn cached_base_ahead_behind_writes_and_reads_back() {
+        use tempfile::TempDir;
+
+        let common = TempDir::new().unwrap();
+        let common_dir = common.path();
+
+        let out = cached_base_ahead_behind(common_dir, "abc1234", "def5678", || Some((3, 1)));
+        assert_eq!(out, Some((3, 1)));
+
+        let path = pair_key_path(common_dir, "base-ahead-behind", "abc1234", "def5678");
+        assert!(
+            path.exists(),
+            "cache file at {} not written",
+            path.display()
+        );
+
+        let out2 = cached_base_ahead_behind(common_dir, "abc1234", "def5678", || {
+            panic!("compute called on cache hit")
+        });
+        assert_eq!(out2, Some((3, 1)));
+    }
+
+    #[test]
+    fn cached_base_ahead_behind_does_not_cache_none() {
+        use tempfile::TempDir;
+
+        let common = TempDir::new().unwrap();
+        let common_dir = common.path();
+
+        let out = cached_base_ahead_behind(common_dir, "abc1234", "def5678", || None);
+        assert_eq!(out, None);
+
+        let path = pair_key_path(common_dir, "base-ahead-behind", "abc1234", "def5678");
+        assert!(!path.exists(), "None should not be cached");
     }
 }

--- a/src/core/worktree/cell_cache.rs
+++ b/src/core/worktree/cell_cache.rs
@@ -108,6 +108,30 @@ where
     Some(computed)
 }
 
+/// Cached wrapper for `(timestamp, hash, subject)` of the commit at `head_sha`.
+///
+/// Cache key: `head_sha`. The cached `hash` field always equals the key, but
+/// we store it for shape-compatibility with `get_commit_metadata`'s return
+/// type. Empty / `None` timestamp results are not cached (treated as failures).
+pub(crate) fn cached_last_commit<F>(
+    git_common_dir: &Path,
+    head_sha: &str,
+    compute: F,
+) -> (Option<i64>, Option<String>, String)
+where
+    F: FnOnce() -> (Option<i64>, Option<String>, String),
+{
+    let path = single_key_path(git_common_dir, "last-commit", head_sha);
+    if let Some(v) = cache::read_json::<(Option<i64>, Option<String>, String)>(&path) {
+        return v;
+    }
+    let computed = compute();
+    if computed.0.is_some() {
+        cache::write_json(&path, &computed);
+    }
+    computed
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -188,5 +212,43 @@ mod tests {
             panic!("compute called on cache hit")
         });
         assert_eq!(out2, Some((2, 4)));
+    }
+
+    #[test]
+    fn cached_last_commit_writes_and_reads_back() {
+        use tempfile::TempDir;
+
+        let common = TempDir::new().unwrap();
+        let common_dir = common.path();
+
+        let computed = (
+            Some(1700000000_i64),
+            Some("abc1234".to_string()),
+            "first commit".to_string(),
+        );
+
+        let out = cached_last_commit(common_dir, "abc1234", || computed.clone());
+        assert_eq!(out, computed);
+
+        let path = single_key_path(common_dir, "last-commit", "abc1234");
+        assert!(path.exists());
+
+        let out2 = cached_last_commit(common_dir, "abc1234", || panic!("hit"));
+        assert_eq!(out2, computed);
+    }
+
+    #[test]
+    fn cached_last_commit_does_not_cache_when_timestamp_missing() {
+        use tempfile::TempDir;
+
+        let common = TempDir::new().unwrap();
+        let common_dir = common.path();
+        let bad = (None, None, String::new());
+
+        let out = cached_last_commit(common_dir, "abc1234", || bad.clone());
+        assert_eq!(out, bad);
+
+        let path = single_key_path(common_dir, "last-commit", "abc1234");
+        assert!(!path.exists());
     }
 }

--- a/src/core/worktree/cell_cache.rs
+++ b/src/core/worktree/cell_cache.rs
@@ -156,6 +156,27 @@ where
     computed
 }
 
+/// Cached wrapper for upstream line counts. Cache key: `(head_sha, upstream_sha)`.
+pub(crate) fn cached_remote_lines<F>(
+    git_common_dir: &Path,
+    head_sha: &str,
+    upstream_sha: &str,
+    compute: F,
+) -> (Option<usize>, Option<usize>)
+where
+    F: FnOnce() -> (Option<usize>, Option<usize>),
+{
+    let path = pair_key_path(git_common_dir, "remote-lines", head_sha, upstream_sha);
+    if let Some(v) = cache::read_json::<(Option<usize>, Option<usize>)>(&path) {
+        return v;
+    }
+    let computed = compute();
+    if computed.0.is_some() || computed.1.is_some() {
+        cache::write_json(&path, &computed);
+    }
+    computed
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -291,6 +312,24 @@ mod tests {
         assert!(path.exists());
 
         let out2 = cached_base_lines(common_dir, "base", "head", || panic!("hit"));
+        assert_eq!(out2, computed);
+    }
+
+    #[test]
+    fn cached_remote_lines_writes_and_reads_back() {
+        use tempfile::TempDir;
+
+        let common = TempDir::new().unwrap();
+        let common_dir = common.path();
+
+        let computed = (Some(7_usize), Some(2_usize));
+        let out = cached_remote_lines(common_dir, "head", "upstream", || computed);
+        assert_eq!(out, computed);
+
+        let path = pair_key_path(common_dir, "remote-lines", "head", "upstream");
+        assert!(path.exists());
+
+        let out2 = cached_remote_lines(common_dir, "head", "upstream", || panic!("hit"));
         assert_eq!(out2, computed);
     }
 }

--- a/src/core/worktree/cell_cache.rs
+++ b/src/core/worktree/cell_cache.rs
@@ -81,6 +81,33 @@ where
     Some(computed)
 }
 
+/// Cached wrapper for upstream ahead/behind counts.
+///
+/// Cache key: `(head_sha, upstream_sha)`. Pure function — hit is provably
+/// correct. `None` results are not cached.
+pub(crate) fn cached_remote_ahead_behind<F>(
+    git_common_dir: &Path,
+    head_sha: &str,
+    upstream_sha: &str,
+    compute: F,
+) -> Option<(usize, usize)>
+where
+    F: FnOnce() -> Option<(usize, usize)>,
+{
+    let path = pair_key_path(
+        git_common_dir,
+        "remote-ahead-behind",
+        head_sha,
+        upstream_sha,
+    );
+    if let Some(v) = cache::read_json::<(usize, usize)>(&path) {
+        return Some(v);
+    }
+    let computed = compute()?;
+    cache::write_json(&path, &computed);
+    Some(computed)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -142,5 +169,24 @@ mod tests {
 
         let path = pair_key_path(common_dir, "base-ahead-behind", "abc1234", "def5678");
         assert!(!path.exists(), "None should not be cached");
+    }
+
+    #[test]
+    fn cached_remote_ahead_behind_writes_and_reads_back() {
+        use tempfile::TempDir;
+
+        let common = TempDir::new().unwrap();
+        let common_dir = common.path();
+
+        let out = cached_remote_ahead_behind(common_dir, "head1234", "upst5678", || Some((2, 4)));
+        assert_eq!(out, Some((2, 4)));
+
+        let path = pair_key_path(common_dir, "remote-ahead-behind", "head1234", "upst5678");
+        assert!(path.exists());
+
+        let out2 = cached_remote_ahead_behind(common_dir, "head1234", "upst5678", || {
+            panic!("compute called on cache hit")
+        });
+        assert_eq!(out2, Some((2, 4)));
     }
 }

--- a/src/core/worktree/cell_cache.rs
+++ b/src/core/worktree/cell_cache.rs
@@ -19,10 +19,6 @@
 //!   - Size (filesystem walk)
 //!   - Branch age, owner (cheap enough already)
 
-// Helpers below are scaffolding for the `cached_*` wrappers added in
-// subsequent batches. Suppress dead_code until then.
-#![allow(dead_code)]
-
 use crate::core::cache;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -134,47 +130,45 @@ where
 
 /// Cached wrapper for `(inserted, deleted)` line counts in `base..head`.
 ///
-/// Cache key: `(base_sha, head_sha)`. Only writes the cache when at least
-/// one of the two values is `Some` (treats fully-`None` as failure).
+/// Cache key: `(base_sha, head_sha)`. The result is a pure function of the
+/// two SHAs. `None` results are not cached (treated as transient compute
+/// failures — next run retries).
 pub(crate) fn cached_base_lines<F>(
     git_common_dir: &Path,
     base_sha: &str,
     head_sha: &str,
     compute: F,
-) -> (Option<usize>, Option<usize>)
+) -> Option<(usize, usize)>
 where
-    F: FnOnce() -> (Option<usize>, Option<usize>),
+    F: FnOnce() -> Option<(usize, usize)>,
 {
     let path = pair_key_path(git_common_dir, "base-lines", base_sha, head_sha);
-    if let Some(v) = cache::read_json::<(Option<usize>, Option<usize>)>(&path) {
-        return v;
+    if let Some(v) = cache::read_json::<(usize, usize)>(&path) {
+        return Some(v);
     }
-    let computed = compute();
-    if computed.0.is_some() || computed.1.is_some() {
-        cache::write_json(&path, &computed);
-    }
-    computed
+    let computed = compute()?;
+    cache::write_json(&path, &computed);
+    Some(computed)
 }
 
 /// Cached wrapper for upstream line counts. Cache key: `(head_sha, upstream_sha)`.
+/// `None` results are not cached.
 pub(crate) fn cached_remote_lines<F>(
     git_common_dir: &Path,
     head_sha: &str,
     upstream_sha: &str,
     compute: F,
-) -> (Option<usize>, Option<usize>)
+) -> Option<(usize, usize)>
 where
-    F: FnOnce() -> (Option<usize>, Option<usize>),
+    F: FnOnce() -> Option<(usize, usize)>,
 {
     let path = pair_key_path(git_common_dir, "remote-lines", head_sha, upstream_sha);
-    if let Some(v) = cache::read_json::<(Option<usize>, Option<usize>)>(&path) {
-        return v;
+    if let Some(v) = cache::read_json::<(usize, usize)>(&path) {
+        return Some(v);
     }
-    let computed = compute();
-    if computed.0.is_some() || computed.1.is_some() {
-        cache::write_json(&path, &computed);
-    }
-    computed
+    let computed = compute()?;
+    cache::write_json(&path, &computed);
+    Some(computed)
 }
 
 #[cfg(test)]
@@ -304,7 +298,7 @@ mod tests {
         let common = TempDir::new().unwrap();
         let common_dir = common.path();
 
-        let computed = (Some(120_usize), Some(45_usize));
+        let computed = Some((120_usize, 45_usize));
         let out = cached_base_lines(common_dir, "base", "head", || computed);
         assert_eq!(out, computed);
 
@@ -316,13 +310,27 @@ mod tests {
     }
 
     #[test]
+    fn cached_base_lines_does_not_cache_none() {
+        use tempfile::TempDir;
+
+        let common = TempDir::new().unwrap();
+        let common_dir = common.path();
+
+        let out = cached_base_lines(common_dir, "base", "head", || None);
+        assert_eq!(out, None);
+
+        let path = pair_key_path(common_dir, "base-lines", "base", "head");
+        assert!(!path.exists(), "None should not be cached");
+    }
+
+    #[test]
     fn cached_remote_lines_writes_and_reads_back() {
         use tempfile::TempDir;
 
         let common = TempDir::new().unwrap();
         let common_dir = common.path();
 
-        let computed = (Some(7_usize), Some(2_usize));
+        let computed = Some((7_usize, 2_usize));
         let out = cached_remote_lines(common_dir, "head", "upstream", || computed);
         assert_eq!(out, computed);
 

--- a/src/core/worktree/cell_cache.rs
+++ b/src/core/worktree/cell_cache.rs
@@ -132,6 +132,30 @@ where
     computed
 }
 
+/// Cached wrapper for `(inserted, deleted)` line counts in `base..head`.
+///
+/// Cache key: `(base_sha, head_sha)`. Only writes the cache when at least
+/// one of the two values is `Some` (treats fully-`None` as failure).
+pub(crate) fn cached_base_lines<F>(
+    git_common_dir: &Path,
+    base_sha: &str,
+    head_sha: &str,
+    compute: F,
+) -> (Option<usize>, Option<usize>)
+where
+    F: FnOnce() -> (Option<usize>, Option<usize>),
+{
+    let path = pair_key_path(git_common_dir, "base-lines", base_sha, head_sha);
+    if let Some(v) = cache::read_json::<(Option<usize>, Option<usize>)>(&path) {
+        return v;
+    }
+    let computed = compute();
+    if computed.0.is_some() || computed.1.is_some() {
+        cache::write_json(&path, &computed);
+    }
+    computed
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -250,5 +274,23 @@ mod tests {
 
         let path = single_key_path(common_dir, "last-commit", "abc1234");
         assert!(!path.exists());
+    }
+
+    #[test]
+    fn cached_base_lines_writes_and_reads_back() {
+        use tempfile::TempDir;
+
+        let common = TempDir::new().unwrap();
+        let common_dir = common.path();
+
+        let computed = (Some(120_usize), Some(45_usize));
+        let out = cached_base_lines(common_dir, "base", "head", || computed);
+        assert_eq!(out, computed);
+
+        let path = pair_key_path(common_dir, "base-lines", "base", "head");
+        assert!(path.exists());
+
+        let out2 = cached_base_lines(common_dir, "base", "head", || panic!("hit"));
+        assert_eq!(out2, computed);
     }
 }

--- a/src/core/worktree/info_field.rs
+++ b/src/core/worktree/info_field.rs
@@ -1,0 +1,152 @@
+//! Bitmask identifying fields of `WorktreeInfo` for the live-population
+//! pipeline. Used in three places: (1) the streaming collector takes one as
+//! input to scope its work, (2) `WorktreeInfo::apply_patch` returns one to
+//! signal which fields changed, (3) `SortSpec::required_fields` returns one
+//! to declare its sort dependencies.
+
+use std::ops::{BitAnd, BitOr, BitOrAssign, Not};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FieldSet(u32);
+
+impl FieldSet {
+    pub const EMPTY: Self = Self(0);
+
+    pub const BASE_AHEAD_BEHIND: Self = Self(1 << 0);
+    pub const REMOTE_AHEAD_BEHIND: Self = Self(1 << 1);
+    pub const CHANGES: Self = Self(1 << 2);
+    pub const LAST_COMMIT: Self = Self(1 << 3);
+    pub const BRANCH_AGE: Self = Self(1 << 4);
+    pub const OWNER: Self = Self(1 << 5);
+    pub const BASE_LINES: Self = Self(1 << 6);
+    pub const CHANGES_LINES: Self = Self(1 << 7);
+    pub const REMOTE_LINES: Self = Self(1 << 8);
+    pub const SIZE: Self = Self(1 << 9);
+    pub const MTIME: Self = Self(1 << 10);
+
+    /// Fields whose values can change after a `git fetch`.
+    pub const REMOTE_DERIVED: Self = Self(Self::REMOTE_AHEAD_BEHIND.0 | Self::REMOTE_LINES.0);
+
+    /// Fields whose values can change after any per-branch task
+    /// (Update / Rebase / Push). Used by the orchestrator for post-task
+    /// re-runs.
+    pub const VOLATILE: Self = Self(
+        Self::BASE_AHEAD_BEHIND.0
+            | Self::REMOTE_AHEAD_BEHIND.0
+            | Self::CHANGES.0
+            | Self::LAST_COMMIT.0
+            | Self::BASE_LINES.0
+            | Self::CHANGES_LINES.0
+            | Self::REMOTE_LINES.0,
+    );
+
+    /// All fields. Used by the initial Collector run.
+    pub const ALL: Self = Self(u32::MAX);
+
+    pub const fn contains(self, other: Self) -> bool {
+        (self.0 & other.0) == other.0
+    }
+
+    pub const fn intersects(self, other: Self) -> bool {
+        (self.0 & other.0) != 0
+    }
+
+    pub const fn is_empty(self) -> bool {
+        self.0 == 0
+    }
+}
+
+impl BitOr for FieldSet {
+    type Output = Self;
+    fn bitor(self, rhs: Self) -> Self {
+        Self(self.0 | rhs.0)
+    }
+}
+
+impl BitOrAssign for FieldSet {
+    fn bitor_assign(&mut self, rhs: Self) {
+        self.0 |= rhs.0;
+    }
+}
+
+impl BitAnd for FieldSet {
+    type Output = Self;
+    fn bitand(self, rhs: Self) -> Self {
+        Self(self.0 & rhs.0)
+    }
+}
+
+impl Not for FieldSet {
+    type Output = Self;
+    fn not(self) -> Self {
+        Self(!self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_contains_nothing_and_intersects_nothing() {
+        assert!(FieldSet::EMPTY.is_empty());
+        assert!(!FieldSet::EMPTY.contains(FieldSet::SIZE));
+        assert!(!FieldSet::EMPTY.intersects(FieldSet::SIZE));
+    }
+
+    #[test]
+    fn or_combines_members() {
+        let s = FieldSet::SIZE | FieldSet::OWNER;
+        assert!(s.contains(FieldSet::SIZE));
+        assert!(s.contains(FieldSet::OWNER));
+        assert!(!s.contains(FieldSet::CHANGES));
+    }
+
+    #[test]
+    fn intersects_returns_true_for_any_overlap() {
+        let a = FieldSet::SIZE | FieldSet::OWNER;
+        let b = FieldSet::OWNER | FieldSet::CHANGES;
+        assert!(a.intersects(b));
+    }
+
+    #[test]
+    fn intersects_returns_false_for_disjoint_sets() {
+        let a = FieldSet::SIZE;
+        let b = FieldSet::OWNER;
+        assert!(!a.intersects(b));
+    }
+
+    #[test]
+    fn remote_derived_subset_contains_only_remote_fields() {
+        assert!(FieldSet::REMOTE_DERIVED.contains(FieldSet::REMOTE_AHEAD_BEHIND));
+        assert!(FieldSet::REMOTE_DERIVED.contains(FieldSet::REMOTE_LINES));
+        assert!(!FieldSet::REMOTE_DERIVED.contains(FieldSet::SIZE));
+        assert!(!FieldSet::REMOTE_DERIVED.contains(FieldSet::CHANGES));
+    }
+
+    #[test]
+    fn volatile_subset_excludes_size_and_owner_and_age() {
+        assert!(!FieldSet::VOLATILE.contains(FieldSet::SIZE));
+        assert!(!FieldSet::VOLATILE.contains(FieldSet::OWNER));
+        assert!(!FieldSet::VOLATILE.contains(FieldSet::BRANCH_AGE));
+    }
+
+    #[test]
+    fn all_contains_every_known_member() {
+        for member in [
+            FieldSet::BASE_AHEAD_BEHIND,
+            FieldSet::REMOTE_AHEAD_BEHIND,
+            FieldSet::CHANGES,
+            FieldSet::LAST_COMMIT,
+            FieldSet::BRANCH_AGE,
+            FieldSet::OWNER,
+            FieldSet::BASE_LINES,
+            FieldSet::CHANGES_LINES,
+            FieldSet::REMOTE_LINES,
+            FieldSet::SIZE,
+            FieldSet::MTIME,
+        ] {
+            assert!(FieldSet::ALL.contains(member));
+        }
+    }
+}

--- a/src/core/worktree/list.rs
+++ b/src/core/worktree/list.rs
@@ -230,6 +230,91 @@ impl WorktreeInfo {
             self.size_bytes = compute_directory_size(path);
         }
     }
+
+    /// Apply a typed patch in place. Returns the `FieldSet` of fields whose
+    /// value changed (the caller — typically `LiveTable` — uses this to
+    /// decide whether to re-sort).
+    pub fn apply_patch(
+        &mut self,
+        patch: &crate::core::worktree::sync_dag::WorktreeInfoPatch,
+    ) -> crate::core::worktree::info_field::FieldSet {
+        use crate::core::worktree::info_field::FieldSet;
+        use crate::core::worktree::sync_dag::WorktreeInfoPatch as P;
+
+        match patch {
+            P::BaseAheadBehind(v) => {
+                (self.ahead, self.behind) = match v {
+                    Some((a, b)) => (Some(*a), Some(*b)),
+                    None => (None, None),
+                };
+                FieldSet::BASE_AHEAD_BEHIND
+            }
+            P::RemoteAheadBehind(v) => {
+                (self.remote_ahead, self.remote_behind) = match v {
+                    Some((a, b)) => (Some(*a), Some(*b)),
+                    None => (None, None),
+                };
+                FieldSet::REMOTE_AHEAD_BEHIND
+            }
+            P::Changes {
+                staged,
+                unstaged,
+                untracked,
+            } => {
+                self.staged = *staged;
+                self.unstaged = *unstaged;
+                self.untracked = *untracked;
+                FieldSet::CHANGES
+            }
+            P::LastCommit {
+                timestamp,
+                hash,
+                subject,
+            } => {
+                self.last_commit_timestamp = *timestamp;
+                self.last_commit_hash = hash.clone();
+                self.last_commit_subject = subject.clone();
+                FieldSet::LAST_COMMIT
+            }
+            P::BranchAge(v) => {
+                self.branch_creation_timestamp = *v;
+                FieldSet::BRANCH_AGE
+            }
+            P::Owner(v) => {
+                self.owner = v.clone();
+                FieldSet::OWNER
+            }
+            P::BaseLines(v) => {
+                (self.base_lines_inserted, self.base_lines_deleted) = match v {
+                    Some((i, d)) => (Some(*i), Some(*d)),
+                    None => (None, None),
+                };
+                FieldSet::BASE_LINES
+            }
+            P::ChangesLines { staged, unstaged } => {
+                self.staged_lines_inserted = Some(staged.0);
+                self.staged_lines_deleted = Some(staged.1);
+                self.unstaged_lines_inserted = Some(unstaged.0);
+                self.unstaged_lines_deleted = Some(unstaged.1);
+                FieldSet::CHANGES_LINES
+            }
+            P::RemoteLines(v) => {
+                (self.remote_lines_inserted, self.remote_lines_deleted) = match v {
+                    Some((i, d)) => (Some(*i), Some(*d)),
+                    None => (None, None),
+                };
+                FieldSet::REMOTE_LINES
+            }
+            P::Size(v) => {
+                self.size_bytes = *v;
+                FieldSet::SIZE
+            }
+            P::Mtime(v) => {
+                self.working_tree_mtime = *v;
+                FieldSet::MTIME
+            }
+        }
+    }
 }
 
 /// Raw entry parsed from `git worktree list --porcelain`.
@@ -1251,5 +1336,84 @@ branch refs/heads/feature/cool
         assert!(entries[2].is_detached);
         assert!(!entries[3].is_bare);
         assert_eq!(entries[3].branch.as_deref(), Some("feature/cool"));
+    }
+}
+
+#[cfg(test)]
+mod apply_patch_tests {
+    use super::*;
+    use crate::core::worktree::info_field::FieldSet;
+    use crate::core::worktree::sync_dag::WorktreeInfoPatch;
+
+    fn empty_info() -> WorktreeInfo {
+        WorktreeInfo::empty("test")
+    }
+
+    #[test]
+    fn base_ahead_behind_some_fills_both_and_returns_the_field() {
+        let mut info = empty_info();
+        let touched = info.apply_patch(&WorktreeInfoPatch::BaseAheadBehind(Some((3, 1))));
+        assert_eq!(info.ahead, Some(3));
+        assert_eq!(info.behind, Some(1));
+        assert_eq!(touched, FieldSet::BASE_AHEAD_BEHIND);
+    }
+
+    #[test]
+    fn base_ahead_behind_none_clears_both() {
+        let mut info = empty_info();
+        info.ahead = Some(5);
+        info.behind = Some(2);
+        let touched = info.apply_patch(&WorktreeInfoPatch::BaseAheadBehind(None));
+        assert_eq!(info.ahead, None);
+        assert_eq!(info.behind, None);
+        assert_eq!(touched, FieldSet::BASE_AHEAD_BEHIND);
+    }
+
+    #[test]
+    fn changes_fills_three_fields() {
+        let mut info = empty_info();
+        let touched = info.apply_patch(&WorktreeInfoPatch::Changes {
+            staged: 2,
+            unstaged: 1,
+            untracked: 4,
+        });
+        assert_eq!((info.staged, info.unstaged, info.untracked), (2, 1, 4));
+        assert_eq!(touched, FieldSet::CHANGES);
+    }
+
+    #[test]
+    fn last_commit_fills_three_fields() {
+        let mut info = empty_info();
+        let touched = info.apply_patch(&WorktreeInfoPatch::LastCommit {
+            timestamp: Some(1700000000),
+            hash: Some("abc1234".into()),
+            subject: "fix bug".into(),
+        });
+        assert_eq!(info.last_commit_timestamp, Some(1700000000));
+        assert_eq!(info.last_commit_hash, Some("abc1234".into()));
+        assert_eq!(info.last_commit_subject, "fix bug");
+        assert_eq!(touched, FieldSet::LAST_COMMIT);
+    }
+
+    #[test]
+    fn size_fills_size_bytes() {
+        let mut info = empty_info();
+        let touched = info.apply_patch(&WorktreeInfoPatch::Size(Some(2048)));
+        assert_eq!(info.size_bytes, Some(2048));
+        assert_eq!(touched, FieldSet::SIZE);
+    }
+
+    #[test]
+    fn changes_lines_fills_four_fields() {
+        let mut info = empty_info();
+        let touched = info.apply_patch(&WorktreeInfoPatch::ChangesLines {
+            staged: (10, 2),
+            unstaged: (5, 1),
+        });
+        assert_eq!(info.staged_lines_inserted, Some(10));
+        assert_eq!(info.staged_lines_deleted, Some(2));
+        assert_eq!(info.unstaged_lines_inserted, Some(5));
+        assert_eq!(info.unstaged_lines_deleted, Some(1));
+        assert_eq!(touched, FieldSet::CHANGES_LINES);
     }
 }

--- a/src/core/worktree/list.rs
+++ b/src/core/worktree/list.rs
@@ -385,7 +385,7 @@ fn parse_porcelain(output: &str) -> Vec<PorcelainEntry> {
 /// Runs `git rev-list --left-right --count base...branch` in the given
 /// worktree directory. Returns `(ahead, behind)` or `None` if the comparison
 /// is not possible (e.g. unrelated histories, missing refs).
-fn get_ahead_behind(
+pub(crate) fn get_ahead_behind(
     base_branch: &str,
     branch: &str,
     worktree_path: &Path,
@@ -414,7 +414,7 @@ fn get_ahead_behind(
 
 /// Dispatch commit metadata retrieval for a worktree HEAD, using gitoxide when
 /// enabled with a fallback to the git subprocess.
-fn get_commit_metadata(
+pub(crate) fn get_commit_metadata(
     worktree_path: &Path,
     git: &GitCommand,
 ) -> (Option<i64>, Option<String>, String) {
@@ -529,7 +529,7 @@ fn get_last_commit_info_for_ref(
 /// Primary: oldest reflog entry for the branch.
 /// Fallback: timestamp of the first commit on the branch.
 /// Returns `None` for detached HEAD or if both methods fail.
-fn get_branch_creation_timestamp(branch: &str, worktree_path: &Path) -> Option<i64> {
+pub(crate) fn get_branch_creation_timestamp(branch: &str, worktree_path: &Path) -> Option<i64> {
     // Primary: oldest reflog entry
     let reflog_output = Command::new("git")
         .args(["reflog", "show", branch, "--format=%ct"])
@@ -567,16 +567,16 @@ fn get_branch_creation_timestamp(branch: &str, worktree_path: &Path) -> Option<i
 }
 
 /// Result of counting changed files in a worktree.
-struct ChangedFiles {
-    staged: usize,
-    unstaged: usize,
-    untracked: usize,
+pub(crate) struct ChangedFiles {
+    pub(crate) staged: usize,
+    pub(crate) unstaged: usize,
+    pub(crate) untracked: usize,
     /// Relative paths of all changed/untracked files (for mtime computation).
-    paths: Vec<String>,
+    pub(crate) paths: Vec<String>,
 }
 
 /// Count staged, unstaged, and untracked files in a worktree.
-fn count_changed_files(worktree_path: &Path) -> ChangedFiles {
+pub(crate) fn count_changed_files(worktree_path: &Path) -> ChangedFiles {
     let output = Command::new("git")
         .args(["status", "--porcelain"])
         .current_dir(worktree_path)
@@ -631,7 +631,10 @@ fn count_changed_files(worktree_path: &Path) -> ChangedFiles {
 }
 
 /// Get ahead/behind counts for a branch relative to its remote tracking branch.
-fn get_upstream_ahead_behind(branch: &str, worktree_path: &Path) -> Option<(usize, usize)> {
+pub(crate) fn get_upstream_ahead_behind(
+    branch: &str,
+    worktree_path: &Path,
+) -> Option<(usize, usize)> {
     let range = format!("{branch}@{{upstream}}...{branch}");
     let output = Command::new("git")
         .args(["rev-list", "--left-right", "--count", &range])
@@ -674,7 +677,7 @@ fn parse_numstat(output: &str) -> (usize, usize) {
 /// Count lines inserted/deleted for staged and unstaged changes in a worktree.
 ///
 /// Returns `((staged_ins, staged_del), (unstaged_ins, unstaged_del))`.
-fn count_changed_lines(worktree_path: &Path) -> ((usize, usize), (usize, usize)) {
+pub(crate) fn count_changed_lines(worktree_path: &Path) -> ((usize, usize), (usize, usize)) {
     let staged = Command::new("git")
         .args(["diff", "--cached", "--numstat"])
         .current_dir(worktree_path)
@@ -700,7 +703,7 @@ fn count_changed_lines(worktree_path: &Path) -> ((usize, usize), (usize, usize))
 ///
 /// Runs `git diff --numstat base...branch`.
 /// Returns `(insertions, deletions)` or `None` if not computable.
-fn get_base_line_counts(
+pub(crate) fn get_base_line_counts(
     base_branch: &str,
     branch: &str,
     worktree_path: &Path,
@@ -723,7 +726,7 @@ fn get_base_line_counts(
 ///
 /// Runs `git diff --numstat branch@{upstream}...branch`.
 /// Returns `(insertions, deletions)` or `None` if no upstream.
-fn get_remote_line_counts(branch: &str, worktree_path: &Path) -> Option<(usize, usize)> {
+pub(crate) fn get_remote_line_counts(branch: &str, worktree_path: &Path) -> Option<(usize, usize)> {
     let range = format!("{branch}@{{upstream}}...{branch}");
     let output = Command::new("git")
         .args(["diff", "--numstat", &range])
@@ -744,7 +747,7 @@ fn get_remote_line_counts(branch: &str, worktree_path: &Path) -> Option<(usize, 
 /// so a worktree with a few permission-denied entries still reports the sum of
 /// all readable files. Tracks seen inodes to count hard-linked files only once
 /// (matching `du` behavior). Does not follow symlinks.
-fn compute_directory_size(path: &Path) -> Option<u64> {
+pub(crate) fn compute_directory_size(path: &Path) -> Option<u64> {
     #[cfg(unix)]
     {
         use std::collections::HashSet;
@@ -807,7 +810,7 @@ fn compute_directory_size(path: &Path) -> Option<u64> {
 /// `worktree_path` is the root of the worktree; `relative_paths` are the
 /// paths reported by `git status --porcelain` (relative to the worktree root).
 /// Returns `None` if the list is empty or no file could be stat-ed.
-fn max_mtime_of_files(worktree_path: &Path, relative_paths: &[String]) -> Option<i64> {
+pub(crate) fn max_mtime_of_files(worktree_path: &Path, relative_paths: &[String]) -> Option<i64> {
     let mut max_mtime: Option<i64> = None;
     for rel in relative_paths {
         let full = worktree_path.join(rel);

--- a/src/core/worktree/list.rs
+++ b/src/core/worktree/list.rs
@@ -231,9 +231,11 @@ impl WorktreeInfo {
         }
     }
 
-    /// Apply a typed patch in place. Returns the `FieldSet` of fields whose
-    /// value changed (the caller — typically `LiveTable` — uses this to
-    /// decide whether to re-sort).
+    /// Apply a typed patch in place. Returns the `FieldSet` of fields the
+    /// patch addressed (the caller — typically `LiveTable` — uses this to
+    /// decide whether to re-sort). The returned set reflects which cluster
+    /// the patch belongs to, not whether values actually differ from prior
+    /// state; idempotent re-sort is acceptable per spec.
     pub fn apply_patch(
         &mut self,
         patch: &crate::core::worktree::sync_dag::WorktreeInfoPatch,

--- a/src/core/worktree/list_stream.rs
+++ b/src/core/worktree/list_stream.rs
@@ -45,6 +45,9 @@ pub struct CollectorContext {
     pub remote_name: String,
     pub ownership_strategy: OwnershipStrategy,
     pub user_email: Option<String>,
+    /// Resolved `git --git-common-dir`. Used as the root for the on-disk
+    /// SHA-keyed cache that backs the slow `cached_*` cluster wrappers.
+    pub git_common_dir: PathBuf,
 }
 
 pub struct CollectorRequest {
@@ -161,10 +164,22 @@ fn run_worker(
 
     let path = target.path.as_deref();
 
-    // 1. BASE_AHEAD_BEHIND (skip detached)
+    // 1. BASE_AHEAD_BEHIND (skip detached) — content-addressed cache by
+    //    (base_sha, head_sha). Falls through to compute on key-resolution
+    //    failure; the wrapper itself skips writing on a None compute result.
     if fields.contains(FieldSet::BASE_AHEAD_BEHIND) && !target.is_detached {
         if let Some(p) = path {
-            let v = get_ahead_behind(&ctx.base_branch, &target.branch_name, p);
+            let base_sha = crate::core::worktree::cell_cache::resolve_ref_sha(p, &ctx.base_branch);
+            let head_sha = crate::core::worktree::cell_cache::resolve_ref_sha(p, "HEAD");
+            let v = match (base_sha, head_sha) {
+                (Some(b), Some(h)) => crate::core::worktree::cell_cache::cached_base_ahead_behind(
+                    &ctx.git_common_dir,
+                    &b,
+                    &h,
+                    || get_ahead_behind(&ctx.base_branch, &target.branch_name, p),
+                ),
+                _ => get_ahead_behind(&ctx.base_branch, &target.branch_name, p),
+            };
             emit!(P::BaseAheadBehind(v));
         }
     }
@@ -181,10 +196,18 @@ fn run_worker(
         }
     }
 
-    // 3. LAST_COMMIT
+    // 3. LAST_COMMIT — content-addressed cache by HEAD sha.
     if fields.contains(FieldSet::LAST_COMMIT) {
         if let Some(p) = path {
-            let (timestamp, hash, subject) = get_commit_metadata(p, &git);
+            let head_sha = crate::core::worktree::cell_cache::resolve_ref_sha(p, "HEAD");
+            let (timestamp, hash, subject) = match head_sha {
+                Some(h) => crate::core::worktree::cell_cache::cached_last_commit(
+                    &ctx.git_common_dir,
+                    &h,
+                    || get_commit_metadata(p, &git),
+                ),
+                None => get_commit_metadata(p, &git),
+            };
             emit!(P::LastCommit {
                 timestamp,
                 hash,
@@ -216,19 +239,48 @@ fn run_worker(
         }
     }
 
-    // 6. REMOTE_AHEAD_BEHIND (skip detached)
+    // 6. REMOTE_AHEAD_BEHIND (skip detached) — content-addressed cache by
+    //    (head_sha, upstream_sha). The upstream refspec uses the
+    //    `<branch>@{upstream}` form so git resolves the configured upstream.
     if fields.contains(FieldSet::REMOTE_AHEAD_BEHIND) && !target.is_detached {
         if let Some(p) = path {
-            let v = get_upstream_ahead_behind(&target.branch_name, p);
+            let head_sha = crate::core::worktree::cell_cache::resolve_ref_sha(p, "HEAD");
+            let upstream_sha = crate::core::worktree::cell_cache::resolve_ref_sha(
+                p,
+                &format!("{}@{{upstream}}", target.branch_name),
+            );
+            let v = match (head_sha, upstream_sha) {
+                (Some(h), Some(u)) => {
+                    crate::core::worktree::cell_cache::cached_remote_ahead_behind(
+                        &ctx.git_common_dir,
+                        &h,
+                        &u,
+                        || get_upstream_ahead_behind(&target.branch_name, p),
+                    )
+                }
+                _ => get_upstream_ahead_behind(&target.branch_name, p),
+            };
             emit!(P::RemoteAheadBehind(v));
         }
     }
 
     // 7. Stat::Lines clusters
     if matches!(stat, Stat::Lines) {
+        // BASE_LINES — content-addressed cache by (base_sha, head_sha).
         if fields.contains(FieldSet::BASE_LINES) && !target.is_detached {
             if let Some(p) = path {
-                let v = get_base_line_counts(&ctx.base_branch, &target.branch_name, p);
+                let base_sha =
+                    crate::core::worktree::cell_cache::resolve_ref_sha(p, &ctx.base_branch);
+                let head_sha = crate::core::worktree::cell_cache::resolve_ref_sha(p, "HEAD");
+                let v = match (base_sha, head_sha) {
+                    (Some(b), Some(h)) => crate::core::worktree::cell_cache::cached_base_lines(
+                        &ctx.git_common_dir,
+                        &b,
+                        &h,
+                        || get_base_line_counts(&ctx.base_branch, &target.branch_name, p),
+                    ),
+                    _ => get_base_line_counts(&ctx.base_branch, &target.branch_name, p),
+                };
                 emit!(P::BaseLines(v));
             }
         }
@@ -241,9 +293,23 @@ fn run_worker(
                 });
             }
         }
+        // REMOTE_LINES — content-addressed cache by (head_sha, upstream_sha).
         if fields.contains(FieldSet::REMOTE_LINES) && !target.is_detached {
             if let Some(p) = path {
-                let v = get_remote_line_counts(&target.branch_name, p);
+                let head_sha = crate::core::worktree::cell_cache::resolve_ref_sha(p, "HEAD");
+                let upstream_sha = crate::core::worktree::cell_cache::resolve_ref_sha(
+                    p,
+                    &format!("{}@{{upstream}}", target.branch_name),
+                );
+                let v = match (head_sha, upstream_sha) {
+                    (Some(h), Some(u)) => crate::core::worktree::cell_cache::cached_remote_lines(
+                        &ctx.git_common_dir,
+                        &h,
+                        &u,
+                        || get_remote_line_counts(&target.branch_name, p),
+                    ),
+                    _ => get_remote_line_counts(&target.branch_name, p),
+                };
                 emit!(P::RemoteLines(v));
             }
         }
@@ -283,6 +349,7 @@ mod tests {
             remote_name: "origin".into(),
             ownership_strategy: OwnershipStrategy::RecencyPlurality,
             user_email: None,
+            git_common_dir: PathBuf::new(),
         });
         let handle = spawn(
             CollectorRequest {
@@ -310,6 +377,7 @@ mod tests {
             remote_name: "origin".into(),
             ownership_strategy: OwnershipStrategy::RecencyPlurality,
             user_email: None,
+            git_common_dir: PathBuf::new(),
         });
         let handle = spawn(
             CollectorRequest {
@@ -383,6 +451,7 @@ mod fixture_tests {
             remote_name: "origin".into(),
             ownership_strategy: OwnershipStrategy::RecencyPlurality,
             user_email: Some("test@test.com".into()),
+            git_common_dir: dir.path().join(".git"),
         });
         let target = CollectorTarget {
             branch_name: "master".into(),
@@ -429,5 +498,20 @@ mod fixture_tests {
             events.last(),
             Some(DagEvent::WorktreeInfoCollectionDone)
         ));
+
+        // The LAST_COMMIT cluster runs through the cached_last_commit
+        // wrapper, which should have written one entry under the cache
+        // root we passed (`<git_common_dir>/.daft/cache/last-commit/`).
+        let cache_dir = dir.path().join(".git").join(".daft").join("cache");
+        let last_commit_dir = cache_dir.join("last-commit");
+        let entries: Vec<_> = std::fs::read_dir(&last_commit_dir)
+            .unwrap_or_else(|e| panic!("cache dir {} should exist: {e}", last_commit_dir.display()))
+            .filter_map(|e| e.ok())
+            .collect();
+        assert!(
+            !entries.is_empty(),
+            "expected cached last-commit entry under {}",
+            last_commit_dir.display()
+        );
     }
 }

--- a/src/core/worktree/list_stream.rs
+++ b/src/core/worktree/list_stream.rs
@@ -1,0 +1,188 @@
+//! Streaming collector for `WorktreeInfo` cells.
+//!
+//! Spawns one worker thread per branch, each running cluster calls in a
+//! fixed cheap-first order and emitting `DagEvent::WorktreeInfoUpdated`
+//! patches into a shared channel. Cancellation is cooperative between
+//! cluster calls. Re-runnable: callers invoke `spawn` again with a
+//! narrower `FieldSet` and a different `PatchSource` to drive post-fetch
+//! and post-task refreshes.
+
+use crate::core::{
+    ownership::OwnershipStrategy,
+    worktree::{
+        info_field::FieldSet,
+        list::EntryKind,
+        sync_dag::{DagEvent, PatchSource},
+    },
+};
+use std::{
+    path::PathBuf,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        mpsc, Arc,
+    },
+    thread::{self, JoinHandle},
+};
+
+use super::list::Stat;
+
+#[derive(Debug, Clone)]
+pub struct CollectorTarget {
+    /// Branch name. `""` for detached (sandbox) entries.
+    pub branch_name: String,
+    pub path: Option<PathBuf>,
+    pub kind: EntryKind,
+    pub is_detached: bool,
+}
+
+pub struct CollectorContext {
+    /// Whether worker threads should construct their `GitCommand` with
+    /// gitoxide enabled. `GitCommand` itself is not `Sync` (it holds a
+    /// `OnceLock<gix::ThreadSafeRepository>` whose internals contain
+    /// non-thread-safe `Rc`s), so each worker constructs its own.
+    pub use_gitoxide: bool,
+    pub base_branch: String,
+    pub remote_name: String,
+    pub ownership_strategy: OwnershipStrategy,
+    pub user_email: Option<String>,
+}
+
+pub struct CollectorRequest {
+    pub targets: Vec<CollectorTarget>,
+    pub fields: FieldSet,
+    pub stat: Stat,
+    pub source: PatchSource,
+    pub ctx: Arc<CollectorContext>,
+}
+
+pub struct CollectorHandle {
+    cancel: Arc<AtomicBool>,
+    handles: Vec<JoinHandle<()>>,
+    /// Collector-only sentinel sender (kept alive by handle so the
+    /// completion event fires only after all workers have observably
+    /// joined or cancelled).
+    sentinel: Option<(mpsc::Sender<DagEvent>, PatchSource)>,
+}
+
+impl CollectorHandle {
+    /// Request cooperative cancellation. Workers exit between cluster calls.
+    pub fn cancel(&self) {
+        self.cancel.store(true, Ordering::Relaxed);
+    }
+
+    /// Wait for all workers to finish. Emits
+    /// `DagEvent::WorktreeInfoCollectionDone` if and only if the spawning
+    /// run was `source=Collector`.
+    pub fn join(mut self) {
+        for h in self.handles.drain(..) {
+            let _ = h.join();
+        }
+        if let Some((tx, source)) = self.sentinel.take() {
+            if matches!(source, PatchSource::Collector) {
+                let _ = tx.send(DagEvent::WorktreeInfoCollectionDone);
+            }
+        }
+    }
+}
+
+/// Spawn workers for the request. Workers stream patches into `tx`.
+/// The caller MUST call `CollectorHandle::join` (or drop the handle, which
+/// silently joins) for the completion sentinel to fire.
+pub fn spawn(req: CollectorRequest, tx: mpsc::Sender<DagEvent>) -> CollectorHandle {
+    let cancel = Arc::new(AtomicBool::new(false));
+    let CollectorRequest {
+        targets,
+        fields,
+        stat,
+        source,
+        ctx,
+    } = req;
+
+    let mut handles = Vec::with_capacity(targets.len());
+    for target in targets {
+        let tx = tx.clone();
+        let ctx = Arc::clone(&ctx);
+        let cancel = Arc::clone(&cancel);
+        let source = source.clone();
+        handles.push(thread::spawn(move || {
+            run_worker(target, fields, stat, source, ctx, cancel, tx);
+        }));
+    }
+
+    CollectorHandle {
+        cancel,
+        handles,
+        sentinel: Some((tx, source)),
+    }
+}
+
+fn run_worker(
+    target: CollectorTarget,
+    _fields: FieldSet,
+    _stat: Stat,
+    _source: PatchSource,
+    _ctx: Arc<CollectorContext>,
+    _cancel: Arc<AtomicBool>,
+    _tx: mpsc::Sender<DagEvent>,
+) {
+    // Cluster calls land in Task 7. For now: no-op.
+    let _ = target;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_request_emits_only_completion_sentinel() {
+        let (tx, rx) = mpsc::channel();
+        let ctx = Arc::new(CollectorContext {
+            use_gitoxide: false,
+            base_branch: "master".into(),
+            remote_name: "origin".into(),
+            ownership_strategy: OwnershipStrategy::RecencyPlurality,
+            user_email: None,
+        });
+        let handle = spawn(
+            CollectorRequest {
+                targets: vec![],
+                fields: FieldSet::ALL,
+                stat: Stat::Summary,
+                source: PatchSource::Collector,
+                ctx,
+            },
+            tx,
+        );
+        handle.join();
+
+        let events: Vec<DagEvent> = rx.iter().collect();
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], DagEvent::WorktreeInfoCollectionDone));
+    }
+
+    #[test]
+    fn post_fetch_run_does_not_emit_completion_sentinel() {
+        let (tx, rx) = mpsc::channel();
+        let ctx = Arc::new(CollectorContext {
+            use_gitoxide: false,
+            base_branch: "master".into(),
+            remote_name: "origin".into(),
+            ownership_strategy: OwnershipStrategy::RecencyPlurality,
+            user_email: None,
+        });
+        let handle = spawn(
+            CollectorRequest {
+                targets: vec![],
+                fields: FieldSet::REMOTE_DERIVED,
+                stat: Stat::Summary,
+                source: PatchSource::PostFetch,
+                ctx,
+            },
+            tx,
+        );
+        handle.join();
+
+        let events: Vec<DagEvent> = rx.iter().collect();
+        assert_eq!(events.len(), 0);
+    }
+}

--- a/src/core/worktree/list_stream.rs
+++ b/src/core/worktree/list_stream.rs
@@ -118,15 +118,149 @@ pub fn spawn(req: CollectorRequest, tx: mpsc::Sender<DagEvent>) -> CollectorHand
 
 fn run_worker(
     target: CollectorTarget,
-    _fields: FieldSet,
-    _stat: Stat,
-    _source: PatchSource,
-    _ctx: Arc<CollectorContext>,
-    _cancel: Arc<AtomicBool>,
-    _tx: mpsc::Sender<DagEvent>,
+    fields: FieldSet,
+    stat: Stat,
+    source: PatchSource,
+    ctx: Arc<CollectorContext>,
+    cancel: Arc<AtomicBool>,
+    tx: mpsc::Sender<DagEvent>,
 ) {
-    // Cluster calls land in Task 7. For now: no-op.
-    let _ = target;
+    use crate::core::ownership;
+    use crate::core::worktree::list::{
+        compute_directory_size, count_changed_files, count_changed_lines, get_ahead_behind,
+        get_base_line_counts, get_branch_creation_timestamp, get_commit_metadata,
+        get_remote_line_counts, get_upstream_ahead_behind, max_mtime_of_files,
+    };
+    use crate::core::worktree::sync_dag::WorktreeInfoPatch as P;
+    use crate::git::GitCommand;
+
+    // Workers construct their own GitCommand: gix::ThreadSafeRepository is
+    // !Sync, so wrapping GitCommand in Arc<CollectorContext> would block the
+    // closure's Send bound. ctx.use_gitoxide carries the choice through.
+    let git = GitCommand::new(true).with_gitoxide(ctx.use_gitoxide);
+
+    macro_rules! emit {
+        ($patch:expr) => {{
+            if cancel.load(Ordering::Relaxed) {
+                return;
+            }
+            let _ = tx.send(DagEvent::WorktreeInfoUpdated {
+                branch_name: target.branch_name.clone(),
+                patch: $patch,
+                source: source.clone(), // PatchSource is Clone, not Copy.
+            });
+        }};
+    }
+
+    let path = target.path.as_deref();
+
+    // 1. BASE_AHEAD_BEHIND (skip detached)
+    if fields.contains(FieldSet::BASE_AHEAD_BEHIND) && !target.is_detached {
+        if let Some(p) = path {
+            let v = get_ahead_behind(&ctx.base_branch, &target.branch_name, p);
+            emit!(P::BaseAheadBehind(v));
+        }
+    }
+
+    // 2. CHANGES
+    if fields.contains(FieldSet::CHANGES) {
+        if let Some(p) = path {
+            let c = count_changed_files(p);
+            emit!(P::Changes {
+                staged: c.staged,
+                unstaged: c.unstaged,
+                untracked: c.untracked
+            });
+        }
+    }
+
+    // 3. LAST_COMMIT
+    if fields.contains(FieldSet::LAST_COMMIT) {
+        if let Some(p) = path {
+            let (timestamp, hash, subject) = get_commit_metadata(p, &git);
+            emit!(P::LastCommit {
+                timestamp,
+                hash,
+                subject
+            });
+        }
+    }
+
+    // 4. BRANCH_AGE (skip detached)
+    if fields.contains(FieldSet::BRANCH_AGE) && !target.is_detached {
+        if let Some(p) = path {
+            let v = get_branch_creation_timestamp(&target.branch_name, p);
+            emit!(P::BranchAge(v));
+        }
+    }
+
+    // 5. OWNER (skip detached)
+    if fields.contains(FieldSet::OWNER) && !target.is_detached {
+        if let Some(p) = path {
+            let owner = ownership::resolve_owner_with_fallbacks(
+                &ctx.base_branch,
+                &target.branch_name,
+                p,
+                ctx.ownership_strategy,
+                ctx.user_email.as_deref(),
+                Some(&ctx.remote_name),
+            );
+            emit!(P::Owner(owner));
+        }
+    }
+
+    // 6. REMOTE_AHEAD_BEHIND (skip detached)
+    if fields.contains(FieldSet::REMOTE_AHEAD_BEHIND) && !target.is_detached {
+        if let Some(p) = path {
+            let v = get_upstream_ahead_behind(&target.branch_name, p);
+            emit!(P::RemoteAheadBehind(v));
+        }
+    }
+
+    // 7. Stat::Lines clusters
+    if matches!(stat, Stat::Lines) {
+        if fields.contains(FieldSet::BASE_LINES) && !target.is_detached {
+            if let Some(p) = path {
+                let v = get_base_line_counts(&ctx.base_branch, &target.branch_name, p);
+                emit!(P::BaseLines(v));
+            }
+        }
+        if fields.contains(FieldSet::CHANGES_LINES) {
+            if let Some(p) = path {
+                let (s, u) = count_changed_lines(p);
+                emit!(P::ChangesLines {
+                    staged: s,
+                    unstaged: u
+                });
+            }
+        }
+        if fields.contains(FieldSet::REMOTE_LINES) && !target.is_detached {
+            if let Some(p) = path {
+                let v = get_remote_line_counts(&target.branch_name, p);
+                emit!(P::RemoteLines(v));
+            }
+        }
+    }
+
+    // 8. SIZE (slowest cluster)
+    if fields.contains(FieldSet::SIZE) {
+        if let Some(p) = path {
+            emit!(P::Size(compute_directory_size(p)));
+        }
+    }
+
+    // 9. MTIME
+    if fields.contains(FieldSet::MTIME) {
+        if let Some(p) = path {
+            // Re-count just to get the path list — cheap relative to mtime walk.
+            let c = count_changed_files(p);
+            if !c.paths.is_empty() {
+                emit!(P::Mtime(max_mtime_of_files(p, &c.paths)));
+            } else {
+                emit!(P::Mtime(None));
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -184,5 +318,109 @@ mod tests {
 
         let events: Vec<DagEvent> = rx.iter().collect();
         assert_eq!(events.len(), 0);
+    }
+}
+
+#[cfg(test)]
+mod fixture_tests {
+    use super::*;
+    use std::process::Command;
+    use tempfile::TempDir;
+
+    fn init_temp_repo() -> TempDir {
+        let dir = TempDir::new().unwrap();
+        let p = dir.path();
+        Command::new("git")
+            .arg("init")
+            .arg("-q")
+            .current_dir(p)
+            .status()
+            .unwrap();
+        // LOCAL config only — never use --global per CLAUDE.md.
+        Command::new("git")
+            .args(["config", "user.email", "test@test.com"])
+            .current_dir(p)
+            .status()
+            .unwrap();
+        Command::new("git")
+            .args(["config", "user.name", "test"])
+            .current_dir(p)
+            .status()
+            .unwrap();
+        std::fs::write(p.join("README"), "hello").unwrap();
+        Command::new("git")
+            .args(["add", "."])
+            .current_dir(p)
+            .status()
+            .unwrap();
+        Command::new("git")
+            .args(["commit", "-q", "-m", "init"])
+            .current_dir(p)
+            .status()
+            .unwrap();
+        Command::new("git")
+            .args(["branch", "-M", "master"])
+            .current_dir(p)
+            .status()
+            .unwrap();
+        dir
+    }
+
+    #[test]
+    fn collector_emits_changes_and_last_commit_for_a_real_repo() {
+        let dir = init_temp_repo();
+        let (tx, rx) = mpsc::channel();
+        let ctx = Arc::new(CollectorContext {
+            use_gitoxide: false,
+            base_branch: "master".into(),
+            remote_name: "origin".into(),
+            ownership_strategy: OwnershipStrategy::RecencyPlurality,
+            user_email: Some("test@test.com".into()),
+        });
+        let target = CollectorTarget {
+            branch_name: "master".into(),
+            path: Some(dir.path().to_path_buf()),
+            kind: EntryKind::Worktree,
+            is_detached: false,
+        };
+        let fields = FieldSet::CHANGES | FieldSet::LAST_COMMIT;
+        let handle = spawn(
+            CollectorRequest {
+                targets: vec![target],
+                fields,
+                stat: Stat::Summary,
+                source: PatchSource::Collector,
+                ctx,
+            },
+            tx,
+        );
+        handle.join();
+
+        let events: Vec<DagEvent> = rx.iter().collect();
+        let patches: Vec<_> = events
+            .iter()
+            .filter_map(|e| match e {
+                DagEvent::WorktreeInfoUpdated { patch, .. } => Some(patch),
+                _ => None,
+            })
+            .collect();
+
+        assert!(patches.iter().any(|p| matches!(
+            p,
+            crate::core::worktree::sync_dag::WorktreeInfoPatch::Changes { .. }
+        )));
+        assert!(patches.iter().any(|p| matches!(
+            p,
+            crate::core::worktree::sync_dag::WorktreeInfoPatch::LastCommit { .. }
+        )));
+        // Did NOT request SIZE — must not appear.
+        assert!(!patches.iter().any(|p| matches!(
+            p,
+            crate::core::worktree::sync_dag::WorktreeInfoPatch::Size(_)
+        )));
+        assert!(matches!(
+            events.last(),
+            Some(DagEvent::WorktreeInfoCollectionDone)
+        ));
     }
 }

--- a/src/core/worktree/list_stream.rs
+++ b/src/core/worktree/list_stream.rs
@@ -70,6 +70,13 @@ impl CollectorHandle {
         self.cancel.store(true, Ordering::Relaxed);
     }
 
+    /// Returns a clone of the cancel flag so external code (e.g. the
+    /// renderer's Ctrl-C handler) can flip it. The collector workers
+    /// observe the flag between cluster calls.
+    pub fn cancel_flag(&self) -> Arc<AtomicBool> {
+        Arc::clone(&self.cancel)
+    }
+
     /// Wait for all workers to finish. Emits
     /// `DagEvent::WorktreeInfoCollectionDone` if and only if the spawning
     /// run was `source=Collector`.

--- a/src/core/worktree/mod.rs
+++ b/src/core/worktree/mod.rs
@@ -19,6 +19,7 @@ pub mod exec;
 pub mod fetch;
 pub mod flow_adopt;
 pub mod flow_eject;
+pub mod info_field;
 pub mod init;
 pub mod list;
 pub mod previous;

--- a/src/core/worktree/mod.rs
+++ b/src/core/worktree/mod.rs
@@ -12,6 +12,7 @@
 pub mod branch_delete;
 pub mod branch_source;
 pub mod carry;
+pub(crate) mod cell_cache;
 pub mod checkout;
 pub mod checkout_branch;
 pub mod clone;

--- a/src/core/worktree/mod.rs
+++ b/src/core/worktree/mod.rs
@@ -22,6 +22,7 @@ pub mod flow_eject;
 pub mod info_field;
 pub mod init;
 pub mod list;
+pub mod list_stream;
 pub mod previous;
 pub mod prune;
 pub mod push;

--- a/src/core/worktree/sync_dag.rs
+++ b/src/core/worktree/sync_dag.rs
@@ -468,6 +468,18 @@ pub enum DagEvent {
         duration: Duration,
         skip_reason: Option<String>,
     },
+
+    /// A patch landed for `branch_name` from `source`. Carries one cluster
+    /// of cells produced by a single underlying git/FS call.
+    WorktreeInfoUpdated {
+        branch_name: String,
+        patch: WorktreeInfoPatch,
+        source: PatchSource,
+    },
+
+    /// The initial `source=Collector` run completed. Subset re-runs
+    /// (`PostFetch`, `PostTask`) do not emit this — they end silently.
+    WorktreeInfoCollectionDone,
 }
 
 /// Terminal status for a job within a hook.

--- a/src/core/worktree/sync_dag.rs
+++ b/src/core/worktree/sync_dag.rs
@@ -4,6 +4,7 @@
 //! the sync and prune TUI renderers.
 
 use super::list::WorktreeInfo;
+use crate::core::ownership::BranchOwner;
 use crate::hooks::HookType;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
@@ -364,6 +365,56 @@ impl SyncDag {
     }
 }
 
+/// A typed delta over `WorktreeInfo`. Each variant maps 1:1 to one
+/// underlying git/FS call cluster in the streaming collector.
+#[derive(Debug, Clone)]
+pub enum WorktreeInfoPatch {
+    BaseAheadBehind(Option<(usize, usize)>),
+    RemoteAheadBehind(Option<(usize, usize)>),
+    Changes {
+        staged: usize,
+        unstaged: usize,
+        untracked: usize,
+    },
+    LastCommit {
+        timestamp: Option<i64>,
+        hash: Option<String>,
+        subject: String,
+    },
+    BranchAge(Option<i64>),
+    Owner(Option<BranchOwner>),
+    BaseLines(Option<(usize, usize)>),
+    ChangesLines {
+        staged: (usize, usize),
+        unstaged: (usize, usize),
+    },
+    RemoteLines(Option<(usize, usize)>),
+    Size(Option<u64>),
+    Mtime(Option<i64>),
+}
+
+/// Why a patch was emitted. `LiveTable` uses this to suppress stale
+/// patches: a `Collector` patch arriving after a `PostFetch` patch covering
+/// the same field on the same branch is dropped. Priority order:
+/// `PostTask > PostFetch > Collector`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PatchSource {
+    Collector,
+    PostFetch,
+    PostTask(OperationPhase),
+}
+
+impl PatchSource {
+    /// Higher = more authoritative. Used for staleness suppression.
+    pub fn priority(&self) -> u8 {
+        match self {
+            Self::Collector => 0,
+            Self::PostFetch => 1,
+            Self::PostTask(_) => 2,
+        }
+    }
+}
+
 /// Message sent from worker threads to the renderer.
 #[derive(Debug, Clone)]
 pub enum DagEvent {
@@ -652,6 +703,15 @@ impl DagExecutor {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn patch_source_priority_ordering() {
+        assert!(
+            PatchSource::PostTask(OperationPhase::Push).priority()
+                > PatchSource::PostFetch.priority()
+        );
+        assert!(PatchSource::PostFetch.priority() > PatchSource::Collector.priority());
+    }
 
     #[test]
     fn task_id_display() {

--- a/src/core/worktree/sync_dag.rs
+++ b/src/core/worktree/sync_dag.rs
@@ -5,6 +5,7 @@
 
 use super::list::WorktreeInfo;
 use crate::core::ownership::BranchOwner;
+use crate::core::worktree::info_field::FieldSet;
 use crate::hooks::HookType;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
@@ -1167,5 +1168,69 @@ mod tests {
             !push_b.1.contains(&TaskOutcome::Conflict),
             "feat/b's push should not see feat/a's Conflict outcome"
         );
+    }
+}
+
+/// Tracks which `PatchSource` last wrote each (branch, field) pair.
+/// Used by `LiveTable` to suppress patches arriving from a lower-priority
+/// source after a higher-priority source has already filled a field.
+#[derive(Debug, Default)]
+pub struct PatchSourceLog {
+    last_writer: HashMap<String, Vec<(FieldSet, PatchSource)>>,
+}
+
+impl PatchSourceLog {
+    /// Returns `true` if `source` is allowed to write `fields` for `branch`.
+    /// Updates internal state to record the new write.
+    pub fn try_admit(&mut self, branch: &str, fields: FieldSet, source: PatchSource) -> bool {
+        let entries = self.last_writer.entry(branch.to_string()).or_default();
+        // If any existing entry overlaps with `fields` and has a strictly
+        // higher priority, reject.
+        for (existing_fields, existing_source) in entries.iter() {
+            if existing_fields.intersects(fields) && existing_source.priority() > source.priority()
+            {
+                return false;
+            }
+        }
+        // Admit. Record (fields, source); we don't bother garbage-collecting
+        // overlapping entries — `intersects` checks above are O(entries) and
+        // the entry count per branch is bounded by the number of patch
+        // clusters (~11).
+        entries.push((fields, source));
+        true
+    }
+}
+
+#[cfg(test)]
+mod patch_source_log_tests {
+    use super::*;
+
+    #[test]
+    fn collector_then_post_fetch_admits_post_fetch() {
+        let mut log = PatchSourceLog::default();
+        assert!(log.try_admit("a", FieldSet::REMOTE_AHEAD_BEHIND, PatchSource::Collector));
+        assert!(log.try_admit("a", FieldSet::REMOTE_AHEAD_BEHIND, PatchSource::PostFetch));
+    }
+
+    #[test]
+    fn post_fetch_then_collector_rejects_collector() {
+        let mut log = PatchSourceLog::default();
+        assert!(log.try_admit("a", FieldSet::REMOTE_AHEAD_BEHIND, PatchSource::PostFetch));
+        assert!(!log.try_admit("a", FieldSet::REMOTE_AHEAD_BEHIND, PatchSource::Collector));
+    }
+
+    #[test]
+    fn disjoint_field_sets_do_not_block_each_other() {
+        let mut log = PatchSourceLog::default();
+        assert!(log.try_admit("a", FieldSet::SIZE, PatchSource::PostFetch));
+        // Different field — Collector still allowed.
+        assert!(log.try_admit("a", FieldSet::CHANGES, PatchSource::Collector));
+    }
+
+    #[test]
+    fn different_branches_are_independent() {
+        let mut log = PatchSourceLog::default();
+        assert!(log.try_admit("a", FieldSet::SIZE, PatchSource::PostFetch));
+        assert!(log.try_admit("b", FieldSet::SIZE, PatchSource::Collector));
     }
 }

--- a/src/core/worktree/sync_dag.rs
+++ b/src/core/worktree/sync_dag.rs
@@ -3,7 +3,6 @@
 //! Defines task types, status tracking, and operation phases used by
 //! the sync and prune TUI renderers.
 
-use super::list::WorktreeInfo;
 use crate::core::ownership::BranchOwner;
 use crate::core::worktree::info_field::FieldSet;
 use crate::hooks::HookType;
@@ -431,8 +430,6 @@ pub enum DagEvent {
         status: TaskStatus,
         /// Typed result message.
         message: TaskMessage,
-        /// Refreshed worktree info after the operation (if applicable).
-        updated_info: Option<Box<WorktreeInfo>>,
     },
     /// All tasks are done.
     AllDone,
@@ -519,23 +516,19 @@ impl DagExecutor {
     /// Tasks are executed in parallel (respecting dependencies) using a thread pool.
     /// The closure receives a reference to the `SyncTask` and the current set of
     /// outcome tags for that branch, and must return a
-    /// `(TaskStatus, TaskMessage, HashSet<TaskOutcome>, Option<Box<WorktreeInfo>>)`
-    /// tuple indicating the result status, a typed message, updated outcome tags,
-    /// and optionally refreshed worktree info.
+    /// `(TaskStatus, TaskMessage, HashSet<TaskOutcome>)` tuple indicating the
+    /// result status, a typed message, and updated outcome tags.
+    ///
+    /// Refreshed worktree info is now propagated out-of-band as
+    /// `WorktreeInfoUpdated` patches with `PatchSource::PostTask(phase)`.
+    /// Callers wire this up via `list_stream::spawn` in their task closures.
     ///
     /// Consumes `self` so that the sender is dropped after `AllDone` is sent,
     /// allowing the receiver to detect channel closure.
     pub fn run<F>(self, task_fn: F)
     where
-        F: Fn(
-                &SyncTask,
-                &HashSet<TaskOutcome>,
-            ) -> (
-                TaskStatus,
-                TaskMessage,
-                HashSet<TaskOutcome>,
-                Option<Box<WorktreeInfo>>,
-            ) + Send
+        F: Fn(&SyncTask, &HashSet<TaskOutcome>) -> (TaskStatus, TaskMessage, HashSet<TaskOutcome>)
+            + Send
             + Sync,
     {
         let n = self.dag.tasks.len();
@@ -623,7 +616,7 @@ impl DagExecutor {
 
                         // Execute the task outside the lock.
                         let task = &dag.tasks[task_idx];
-                        let (result_status, message, returned_outcomes, updated_info) =
+                        let (result_status, message, returned_outcomes) =
                             task_fn(task, &branch_outcomes);
 
                         // Update DAG state.
@@ -672,7 +665,6 @@ impl DagExecutor {
                                 branch_name: dag.tasks[task_idx].branch_name.clone(),
                                 status: result_status,
                                 message: message.clone(),
-                                updated_info,
                             });
 
                             // Also send TaskCompleted for any dep-failed dependents.
@@ -692,7 +684,6 @@ impl DagExecutor {
                                                     "dependency {:?} failed",
                                                     dag.tasks[task_idx].id
                                                 )),
-                                                updated_info: None,
                                             });
                                             stack.push(dep_idx);
                                         }
@@ -842,7 +833,6 @@ mod tests {
                 TaskStatus::Succeeded,
                 TaskMessage::Ok("ok".into()),
                 outcomes.clone(),
-                None,
             )
         });
 
@@ -883,7 +873,6 @@ mod tests {
                 TaskStatus::Succeeded,
                 TaskMessage::Ok("ok".into()),
                 outcomes.clone(),
-                None,
             )
         });
 
@@ -1013,13 +1002,11 @@ mod tests {
                 TaskStatus::Failed,
                 TaskMessage::Failed("pull failed".into()),
                 outcomes.clone(),
-                None,
             ),
             _ => (
                 TaskStatus::Succeeded,
                 TaskMessage::Ok("ok".into()),
                 outcomes.clone(),
-                None,
             ),
         });
 
@@ -1066,7 +1053,7 @@ mod tests {
                 TaskId::Rebase(name) if name == "feat/a" => {
                     let mut out = outcomes.clone();
                     out.insert(TaskOutcome::Conflict);
-                    (TaskStatus::Succeeded, TaskMessage::Conflict, out, None)
+                    (TaskStatus::Succeeded, TaskMessage::Conflict, out)
                 }
                 TaskId::Push(name) if name == "feat/a" => {
                     if outcomes.contains(&TaskOutcome::Conflict) {
@@ -1074,22 +1061,15 @@ mod tests {
                             TaskStatus::PreconditionFailed,
                             TaskMessage::Failed("rebase conflict".into()),
                             outcomes.clone(),
-                            None,
                         )
                     } else {
-                        (
-                            TaskStatus::Succeeded,
-                            TaskMessage::Pushed,
-                            outcomes.clone(),
-                            None,
-                        )
+                        (TaskStatus::Succeeded, TaskMessage::Pushed, outcomes.clone())
                     }
                 }
                 _ => (
                     TaskStatus::Succeeded,
                     TaskMessage::Ok("ok".into()),
                     outcomes.clone(),
-                    None,
                 ),
             }
         });
@@ -1134,19 +1114,17 @@ mod tests {
                 TaskId::Rebase(name) if name == "feat/a" => {
                     let mut out = outcomes.clone();
                     out.insert(TaskOutcome::Conflict);
-                    (TaskStatus::Succeeded, TaskMessage::Conflict, out, None)
+                    (TaskStatus::Succeeded, TaskMessage::Conflict, out)
                 }
                 TaskId::Rebase(name) if name == "feat/b" => (
                     TaskStatus::Succeeded,
                     TaskMessage::Ok("rebased".into()),
                     outcomes.clone(),
-                    None,
                 ),
                 _ => (
                     TaskStatus::Succeeded,
                     TaskMessage::Ok("ok".into()),
                     outcomes.clone(),
-                    None,
                 ),
             }
         });

--- a/src/output/tui/columns.rs
+++ b/src/output/tui/columns.rs
@@ -133,8 +133,8 @@ pub(super) const ALL_COLUMNS: &[Column] = &[
 /// Used to prevent layout jumps as statuses change during the TUI loop.
 pub(super) const STATUS_MAX_WIDTH: u16 = 13;
 
-/// Minimum width reserved for the LastCommit column before it switches to Fill.
-pub(super) const LAST_COMMIT_MIN: u16 = 10;
+/// Minimum width LastCommit can be shrunk to before we accept overflow.
+pub(super) const LAST_COMMIT_MIN: u16 = 16;
 
 /// Compute the visible display width of a status cell.
 pub(super) fn status_display_width(status: &WorktreeStatus) -> u16 {
@@ -194,7 +194,20 @@ pub(super) fn column_content_width(
             Column::Age => v.branch_age.len() as u16,
             Column::Owner => v.owner.len() as u16,
             Column::Hash => 7,
-            Column::LastCommit => LAST_COMMIT_MIN,
+            // Use the actual rendered width — "<age> <subject>" — so the
+            // fit-to-width algorithm has a real natural width to shrink from.
+            // Falls back to LAST_COMMIT_MIN when both are empty so the column
+            // doesn't disappear during early streaming.
+            Column::LastCommit => {
+                let age_len = v.last_commit_age.chars().count() as u16;
+                let subj_len = v.last_commit_subject.chars().count() as u16;
+                let combined = if age_len == 0 || subj_len == 0 {
+                    age_len + subj_len
+                } else {
+                    age_len + 1 + subj_len // " " between age and subject
+                };
+                combined.max(LAST_COMMIT_MIN)
+            }
         })
         .max()
         .unwrap_or(0);
@@ -238,20 +251,15 @@ pub fn select_columns(
 const BRANCH_MIN_WIDTH: u16 = 12;
 const PATH_MIN_WIDTH: u16 = 8;
 
-/// Reserved width for `LastCommit` when it's present, so Branch/Path can't
-/// squeeze it to zero via `Constraint::Fill(1)`.
-const LAST_COMMIT_RESERVED: u16 = 24;
-
 /// Inter-column spacing in the TUI table (must match `Table::column_spacing`).
 const COLUMN_SPACING: u16 = 2;
 
 /// Adjust per-column natural widths so the table fits in `available` width.
 ///
-/// Shrinks `Branch` and `Path` (in that order, widest first) down to their
-/// minimum widths. Reserves a baseline width for `LastCommit` because it's
-/// rendered with `Constraint::Fill(1)` and would otherwise be starved by
-/// over-eager Length constraints. Returns the natural widths unchanged when
-/// they already fit.
+/// Shrinks the widest of {Branch, Path, LastCommit} down to per-column
+/// minimums until the table fits, mirroring `tabled::Width::truncate(...)
+/// .priority(Priority::max(true))` from the blocking renderer. Returns the
+/// natural widths unchanged when they already fit.
 pub(super) fn fit_widths_to_available(
     columns: &[Column],
     natural_widths: &[u16],
@@ -263,19 +271,7 @@ pub(super) fn fit_widths_to_available(
     }
 
     let spacing = (columns.len().saturating_sub(1)) as u16 * COLUMN_SPACING;
-    let lastcommit_idx = columns.iter().position(|c| matches!(c, Column::LastCommit));
-
-    // If LastCommit is present, treat it as occupying at least
-    // LAST_COMMIT_RESERVED chars during fit calculations, even though the real
-    // constraint is Fill(1). This forces Branch/Path to share the remaining
-    // budget with the commit column rather than starving it.
-    let lastcommit_reserved = lastcommit_idx
-        .map(|i| LAST_COMMIT_RESERVED.max(widths[i]).min(available / 3))
-        .unwrap_or(0);
-
-    let total_natural: u32 = widths.iter().map(|w| *w as u32).sum::<u32>() + spacing as u32
-        - lastcommit_idx.map(|i| widths[i] as u32).unwrap_or(0)
-        + lastcommit_reserved as u32;
+    let total_natural: u32 = widths.iter().map(|w| *w as u32).sum::<u32>() + spacing as u32;
     if total_natural <= available as u32 {
         return widths;
     }
@@ -284,6 +280,7 @@ pub(super) fn fit_widths_to_available(
         match c {
             Column::Branch => Some(BRANCH_MIN_WIDTH),
             Column::Path => Some(PATH_MIN_WIDTH),
+            Column::LastCommit => Some(LAST_COMMIT_MIN),
             _ => None,
         }
     };
@@ -382,23 +379,36 @@ mod tests {
     }
 
     #[test]
-    fn fit_widths_reserves_space_for_lastcommit() {
-        // Branch=200, Path=200, LastCommit=10. Without reserving for
-        // LastCommit, Branch+Path would consume nearly all available width.
+    fn fit_widths_shrinks_lastcommit_too() {
+        // LastCommit is the widest, so it should be shrunk first when the
+        // table doesn't fit.
         let cols = vec![Column::Branch, Column::Path, Column::LastCommit];
-        let natural = vec![200, 200, 10];
-        let out = fit_widths_to_available(&cols, &natural, 120);
-        // Branch + Path + spacing should leave at least LAST_COMMIT_RESERVED
-        // (or close to it; we cap reserve at available/3 to avoid pathological
-        // narrow terminals).
-        let nonlast: u16 = out[0] + out[1] + 4; // 2 gaps = 4
-        let lastcommit_room = 120u16.saturating_sub(nonlast);
+        let natural = vec![20, 20, 200];
+        let out = fit_widths_to_available(&cols, &natural, 100);
+        let total: u16 = out.iter().sum::<u16>() + 4; // 2 gaps = 4
+        assert!(total <= 100, "fit widths exceed available: {out:?}");
+        // Branch and Path should still be at natural since LastCommit had room
+        // to spare on its own.
+        assert_eq!(out[0], 20);
+        assert_eq!(out[1], 20);
+        assert!(out[2] >= LAST_COMMIT_MIN);
+    }
+
+    #[test]
+    fn fit_widths_lastcommit_keeps_room_when_branch_path_huge() {
+        // Branch=200, Path=200, LastCommit=80. Total way over. The widest-first
+        // policy should shrink Branch and Path before touching LastCommit.
+        let cols = vec![Column::Branch, Column::Path, Column::LastCommit];
+        let natural = vec![200, 200, 80];
+        let out = fit_widths_to_available(&cols, &natural, 160);
+        let total: u16 = out.iter().sum::<u16>() + 4;
+        assert!(total <= 160, "fit widths exceed available: {out:?}");
         assert!(
-            lastcommit_room >= 10,
-            "LastCommit should have headroom: branch={}, path={}, lastcommit_room={}",
+            out[2] >= 40,
+            "LastCommit kept most of its width: branch={}, path={}, lc={}",
             out[0],
             out[1],
-            lastcommit_room
+            out[2]
         );
     }
 

--- a/src/output/tui/columns.rs
+++ b/src/output/tui/columns.rs
@@ -233,6 +233,98 @@ pub fn select_columns(
     cols
 }
 
+/// Minimum widths for shrinkable columns. Below these the column would lose
+/// most of its meaning, so we stop shrinking and accept overflow instead.
+const BRANCH_MIN_WIDTH: u16 = 12;
+const PATH_MIN_WIDTH: u16 = 8;
+
+/// Reserved width for `LastCommit` when it's present, so Branch/Path can't
+/// squeeze it to zero via `Constraint::Fill(1)`.
+const LAST_COMMIT_RESERVED: u16 = 24;
+
+/// Inter-column spacing in the TUI table (must match `Table::column_spacing`).
+const COLUMN_SPACING: u16 = 2;
+
+/// Adjust per-column natural widths so the table fits in `available` width.
+///
+/// Shrinks `Branch` and `Path` (in that order, widest first) down to their
+/// minimum widths. Reserves a baseline width for `LastCommit` because it's
+/// rendered with `Constraint::Fill(1)` and would otherwise be starved by
+/// over-eager Length constraints. Returns the natural widths unchanged when
+/// they already fit.
+pub(super) fn fit_widths_to_available(
+    columns: &[Column],
+    natural_widths: &[u16],
+    available: u16,
+) -> Vec<u16> {
+    let mut widths = natural_widths.to_vec();
+    if columns.is_empty() {
+        return widths;
+    }
+
+    let spacing = (columns.len().saturating_sub(1)) as u16 * COLUMN_SPACING;
+    let lastcommit_idx = columns.iter().position(|c| matches!(c, Column::LastCommit));
+
+    // If LastCommit is present, treat it as occupying at least
+    // LAST_COMMIT_RESERVED chars during fit calculations, even though the real
+    // constraint is Fill(1). This forces Branch/Path to share the remaining
+    // budget with the commit column rather than starving it.
+    let lastcommit_reserved = lastcommit_idx
+        .map(|i| LAST_COMMIT_RESERVED.max(widths[i]).min(available / 3))
+        .unwrap_or(0);
+
+    let total_natural: u32 = widths.iter().map(|w| *w as u32).sum::<u32>() + spacing as u32
+        - lastcommit_idx.map(|i| widths[i] as u32).unwrap_or(0)
+        + lastcommit_reserved as u32;
+    if total_natural <= available as u32 {
+        return widths;
+    }
+
+    let shrink_min = |c: Column| -> Option<u16> {
+        match c {
+            Column::Branch => Some(BRANCH_MIN_WIDTH),
+            Column::Path => Some(PATH_MIN_WIDTH),
+            _ => None,
+        }
+    };
+
+    let mut current = total_natural;
+    while current > available as u32 {
+        let candidate = columns
+            .iter()
+            .enumerate()
+            .filter_map(|(i, c)| {
+                let min = shrink_min(*c)?;
+                (widths[i] > min).then_some((i, widths[i]))
+            })
+            .max_by_key(|(_, w)| *w);
+        match candidate {
+            Some((i, _)) => {
+                widths[i] -= 1;
+                current -= 1;
+            }
+            None => break,
+        }
+    }
+
+    widths
+}
+
+/// Truncate `s` to fit `width` columns, appending an ellipsis when shortened.
+/// Falls back to a hard cut for very small widths where an ellipsis wouldn't
+/// leave room for any content.
+pub(super) fn truncate_with_ellipsis(s: &str, width: u16) -> String {
+    let w = width as usize;
+    if s.chars().count() <= w {
+        return s.to_string();
+    }
+    if w < 4 {
+        return s.chars().take(w).collect();
+    }
+    let prefix: String = s.chars().take(w - 3).collect();
+    format!("{prefix}...")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -265,5 +357,81 @@ mod tests {
             !cols.iter().any(|c| matches!(c, Column::Size)),
             "Size should not appear in responsive defaults even on a wide terminal"
         );
+    }
+
+    #[test]
+    fn fit_widths_passthrough_when_total_fits() {
+        let cols = vec![Column::Branch, Column::Path, Column::Age];
+        let natural = vec![20, 30, 4];
+        let out = fit_widths_to_available(&cols, &natural, 200);
+        assert_eq!(out, natural);
+    }
+
+    #[test]
+    fn fit_widths_shrinks_widest_first() {
+        // Branch=80, Path=60, total+spacing = 142. Available = 100.
+        // Path is wider, should be shrunk first; Branch shrinks once Path
+        // catches it.
+        let cols = vec![Column::Branch, Column::Path];
+        let natural = vec![80, 60];
+        let out = fit_widths_to_available(&cols, &natural, 100);
+        let total: u16 = out.iter().sum::<u16>() + 2;
+        assert!(total <= 100, "fit widths exceed available: {out:?}");
+        assert!(out[0] >= BRANCH_MIN_WIDTH);
+        assert!(out[1] >= PATH_MIN_WIDTH);
+    }
+
+    #[test]
+    fn fit_widths_reserves_space_for_lastcommit() {
+        // Branch=200, Path=200, LastCommit=10. Without reserving for
+        // LastCommit, Branch+Path would consume nearly all available width.
+        let cols = vec![Column::Branch, Column::Path, Column::LastCommit];
+        let natural = vec![200, 200, 10];
+        let out = fit_widths_to_available(&cols, &natural, 120);
+        // Branch + Path + spacing should leave at least LAST_COMMIT_RESERVED
+        // (or close to it; we cap reserve at available/3 to avoid pathological
+        // narrow terminals).
+        let nonlast: u16 = out[0] + out[1] + 4; // 2 gaps = 4
+        let lastcommit_room = 120u16.saturating_sub(nonlast);
+        assert!(
+            lastcommit_room >= 10,
+            "LastCommit should have headroom: branch={}, path={}, lastcommit_room={}",
+            out[0],
+            out[1],
+            lastcommit_room
+        );
+    }
+
+    #[test]
+    fn fit_widths_stops_at_minimums() {
+        // Even an absurdly narrow terminal shouldn't shrink Branch/Path below
+        // their minimum widths.
+        let cols = vec![Column::Branch, Column::Path];
+        let natural = vec![100, 100];
+        let out = fit_widths_to_available(&cols, &natural, 10);
+        assert_eq!(out[0], BRANCH_MIN_WIDTH);
+        assert_eq!(out[1], PATH_MIN_WIDTH);
+    }
+
+    #[test]
+    fn truncate_with_ellipsis_shorter_than_width() {
+        assert_eq!(truncate_with_ellipsis("hello", 10), "hello");
+    }
+
+    #[test]
+    fn truncate_with_ellipsis_appends_dots() {
+        assert_eq!(truncate_with_ellipsis("hello world", 8), "hello...");
+    }
+
+    #[test]
+    fn truncate_with_ellipsis_hard_cut_when_no_room_for_dots() {
+        assert_eq!(truncate_with_ellipsis("hello", 3), "hel");
+    }
+
+    #[test]
+    fn truncate_with_ellipsis_handles_unicode() {
+        // Each emoji is 1 char (not 1 byte), so truncating to 5 keeps 5 emoji.
+        let s = "🦀🦀🦀🦀🦀🦀🦀";
+        assert_eq!(truncate_with_ellipsis(s, 5).chars().count(), 5);
     }
 }

--- a/src/output/tui/driver.rs
+++ b/src/output/tui/driver.rs
@@ -247,7 +247,8 @@ impl TuiRenderer {
 
             // Poll for keyboard events (Ctrl-C). Non-blocking. If a Ctrl-C
             // is observed, flip the optional cancel signal so the producer
-            // exits cooperatively, mark state done, and emit a final draw.
+            // exits cooperatively, mark state done and live as cancelled,
+            // and emit a final draw.
             if event::poll(Duration::from_millis(0)).unwrap_or(false) {
                 if let Ok(Event::Key(key)) = event::read() {
                     if key.code == KeyCode::Char('c')
@@ -256,6 +257,7 @@ impl TuiRenderer {
                         if let Some(sig) = &self.cancel_signal {
                             sig.store(true, Ordering::Relaxed);
                         }
+                        self.state.live.mark_cancelled();
                         self.state.done = true;
                         final_draw_and_return!();
                     }
@@ -334,5 +336,38 @@ mod tests {
         let (_tx, rx) = mpsc::channel();
         let renderer = TuiRenderer::new(state, rx);
         assert!(renderer.cancel_signal.is_none());
+    }
+
+    #[test]
+    fn mark_cancelled_via_state_flips_live_cancelled() {
+        // Direct unit test for the post-Ctrl-C state mutation that the
+        // driver's Ctrl-C arm performs. We can't easily synthesize a
+        // crossterm Event in a unit test, so we exercise the same
+        // mutation path the arm performs.
+        let phases = Vec::<crate::core::worktree::sync_dag::OperationPhase>::new();
+        let infos = vec![crate::core::worktree::list::WorktreeInfo::empty("a")];
+        let mut state = TuiState::new(
+            phases,
+            infos,
+            std::path::PathBuf::from("/tmp"),
+            std::path::PathBuf::from("/tmp"),
+            crate::core::worktree::list::Stat::Summary,
+            0,
+            None,
+            false,
+            None,
+            None,
+            true,
+            false,
+        );
+        assert!(!state.live.cancelled);
+        assert!(!state.live.collection_complete);
+
+        state.live.mark_cancelled();
+        state.done = true;
+
+        assert!(state.live.cancelled);
+        assert!(state.live.collection_complete);
+        assert!(state.done);
     }
 }

--- a/src/output/tui/driver.rs
+++ b/src/output/tui/driver.rs
@@ -51,10 +51,31 @@ impl TuiRenderer {
         self
     }
 
-    /// Compute total rendered worktree rows including hook sub-rows and divider.
-    ///
-    /// When `show_hook_sub_rows` is true (verbose >= 1), each hook sub-row and
-    /// its nested job sub-rows add extra rendered rows beneath the parent worktree row.
+    /// Whether `render_table` will emit a "Sorted by …" summary line above the
+    /// table (true sort spec set AND its keys aren't all already shown as
+    /// column-header arrows). Always 2 rows when present: summary + spacer.
+    fn sort_summary_rows(&self) -> u16 {
+        let Some(spec) = self.state.live.cfg.sort_spec.as_ref() else {
+            return 0;
+        };
+        let displayed: Vec<crate::core::columns::ListColumn> = self
+            .state
+            .live
+            .cfg
+            .columns
+            .as_ref()
+            .map(|cols| cols.iter().filter_map(|c| c.to_list_column()).collect())
+            .unwrap_or_else(|| crate::core::columns::ListColumn::list_defaults().to_vec());
+        if spec.needs_summary_line(&displayed) {
+            2
+        } else {
+            0
+        }
+    }
+
+    /// Total rendered rows beneath the table header — data rows, divider,
+    /// optional Size summary footer, and any hook/job sub-rows expanded in
+    /// verbose mode. Used for cursor positioning after the final draw.
     fn total_rendered_rows(&self) -> u16 {
         let base = self.state.live.rows.len() as u16;
         let divider = if self.state.live.unowned_start_index.is_some() {
@@ -114,7 +135,29 @@ impl TuiRenderer {
         } else {
             0
         };
-        let table_height = self.state.live.rows.len() as u16 + 2 + self.extra_rows + divider_row;
+        // Size summary footer: 2 rows (blank separator + total) when present.
+        let size_summary_rows: u16 = if self
+            .state
+            .live
+            .cfg
+            .columns
+            .as_ref()
+            .is_some_and(|cols| cols.contains(&Column::Size))
+        {
+            2
+        } else {
+            0
+        };
+        // table_height = sort summary (rendered inside chunks[1] when present)
+        // + table header row + 1 trailing row for cursor parking + data rows
+        // + extra room for late-arriving rows + divider + size summary footer.
+        let sort_rows = self.sort_summary_rows();
+        let table_height = sort_rows
+            + self.state.live.rows.len() as u16
+            + 2
+            + self.extra_rows
+            + divider_row
+            + size_summary_rows;
         let footer_height: u16 = if self.state.show_hook_sub_rows { 1 } else { 0 };
         let viewport_height = header_height + table_height + footer_height;
 
@@ -147,8 +190,10 @@ impl TuiRenderer {
                     render::render_table(&self.state, frame, chunks[1]);
                     render::render_footer(&self.state, frame, chunks[2]);
 
-                    // table header (1 row) + data rows (including hook sub-rows)
-                    let content_bottom = area.y + header_height + 1 + total_rows + footer_height;
+                    // sort summary rows (when present) + table header (1 row)
+                    // + data rows (including hook sub-rows / size summary).
+                    let content_bottom =
+                        area.y + header_height + sort_rows + 1 + total_rows + footer_height;
                     frame.set_cursor_position(Position {
                         x: 0,
                         y: content_bottom,

--- a/src/output/tui/driver.rs
+++ b/src/output/tui/driver.rs
@@ -214,9 +214,11 @@ impl TuiRenderer {
 
         loop {
             // Honor an externally-set cancel signal (e.g. flipped by a sibling
-            // thread) before we draw, so we exit promptly.
+            // thread or a SIGINT handler) before we draw, so we exit promptly
+            // and the final draw renders the cancelled-state UI.
             if let Some(sig) = &self.cancel_signal {
                 if sig.load(Ordering::Relaxed) {
+                    self.state.live.mark_cancelled();
                     self.state.done = true;
                     final_draw_and_return!();
                 }

--- a/src/output/tui/driver.rs
+++ b/src/output/tui/driver.rs
@@ -2,21 +2,28 @@ use super::columns::Column;
 use super::render;
 use super::state::TuiState;
 use crate::core::worktree::sync_dag::DagEvent;
+use crossterm::event::{self, Event, KeyCode, KeyModifiers};
 use ratatui::{
     layout::{Constraint, Layout, Position},
     Terminal, TerminalOptions, Viewport,
 };
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 /// Drives the inline TUI render loop, consuming `DagEvent`s and updating the
 /// ratatui terminal until all tasks complete.
 pub struct TuiRenderer {
-    state: TuiState,
+    pub(crate) state: TuiState,
     receiver: mpsc::Receiver<DagEvent>,
     /// Extra rows to reserve in the viewport for dynamically discovered branches
     /// (e.g., gone branches found after fetch).
     extra_rows: u16,
+    /// Optional cooperative-cancellation flag. When set externally OR by a
+    /// Ctrl-C key event observed during the render loop, the renderer flips
+    /// the signal and exits cleanly after one final draw.
+    pub(crate) cancel_signal: Option<Arc<AtomicBool>>,
 }
 
 impl TuiRenderer {
@@ -25,6 +32,7 @@ impl TuiRenderer {
             state,
             receiver,
             extra_rows: 0,
+            cancel_signal: None,
         }
     }
 
@@ -32,6 +40,14 @@ impl TuiRenderer {
     /// after the TUI starts (e.g., gone branches found after fetch completes).
     pub fn with_extra_rows(mut self, rows: u16) -> Self {
         self.extra_rows = rows;
+        self
+    }
+
+    /// Attach a cancel signal shared with an upstream producer (typically the
+    /// streaming collector). Ctrl-C in the render loop flips this flag; the
+    /// producer observes it between cluster calls and exits cooperatively.
+    pub fn with_cancel_signal(mut self, cancel: Arc<AtomicBool>) -> Self {
+        self.cancel_signal = Some(cancel);
         self
     }
 
@@ -113,7 +129,46 @@ impl TuiRenderer {
         let tick_rate = Duration::from_millis(80);
         let mut last_tick = Instant::now();
 
+        // Helper: emit one last draw with the cursor placed past the table so
+        // the shell prompt does not overwrite content. Used by all exit paths
+        // (completion, channel disconnect, Ctrl-C).
+        macro_rules! final_draw_and_return {
+            () => {{
+                let total_rows = self.total_rendered_rows();
+                terminal.draw(|frame| {
+                    let area = frame.area();
+                    let chunks = Layout::vertical([
+                        Constraint::Length(header_height),
+                        Constraint::Fill(1),
+                        Constraint::Length(footer_height),
+                    ])
+                    .split(area);
+                    render::render_header(&self.state, frame, chunks[0]);
+                    render::render_table(&self.state, frame, chunks[1]);
+                    render::render_footer(&self.state, frame, chunks[2]);
+
+                    // table header (1 row) + data rows (including hook sub-rows)
+                    let content_bottom = area.y + header_height + 1 + total_rows + footer_height;
+                    frame.set_cursor_position(Position {
+                        x: 0,
+                        y: content_bottom,
+                    });
+                })?;
+                drop(terminal);
+                return Ok(self.state);
+            }};
+        }
+
         loop {
+            // Honor an externally-set cancel signal (e.g. flipped by a sibling
+            // thread) before we draw, so we exit promptly.
+            if let Some(sig) = &self.cancel_signal {
+                if sig.load(Ordering::Relaxed) {
+                    self.state.done = true;
+                    final_draw_and_return!();
+                }
+            }
+
             // Render current state.
             terminal.draw(|frame| {
                 let area = frame.area();
@@ -135,59 +190,29 @@ impl TuiRenderer {
                     Ok(event) => {
                         self.state.apply_event(&event);
                         if self.state.is_complete() {
-                            // Final render — position cursor past all content so
-                            // the shell prompt won't overwrite the table.
-                            let total_rows = self.total_rendered_rows();
-                            terminal.draw(|frame| {
-                                let area = frame.area();
-                                let chunks = Layout::vertical([
-                                    Constraint::Length(header_height),
-                                    Constraint::Fill(1),
-                                    Constraint::Length(footer_height),
-                                ])
-                                .split(area);
-                                render::render_header(&self.state, frame, chunks[0]);
-                                render::render_table(&self.state, frame, chunks[1]);
-                                render::render_footer(&self.state, frame, chunks[2]);
-
-                                // table header (1 row) + data rows (including hook sub-rows)
-                                let content_bottom =
-                                    area.y + header_height + 1 + total_rows + footer_height;
-                                frame.set_cursor_position(Position {
-                                    x: 0,
-                                    y: content_bottom,
-                                });
-                            })?;
-
-                            drop(terminal);
-                            return Ok(self.state);
+                            final_draw_and_return!();
                         }
                     }
                     Err(mpsc::TryRecvError::Empty) => break,
                     Err(mpsc::TryRecvError::Disconnected) => {
-                        let total_rows = self.total_rendered_rows();
-                        terminal.draw(|frame| {
-                            let area = frame.area();
-                            let chunks = Layout::vertical([
-                                Constraint::Length(header_height),
-                                Constraint::Fill(1),
-                                Constraint::Length(footer_height),
-                            ])
-                            .split(area);
-                            render::render_header(&self.state, frame, chunks[0]);
-                            render::render_table(&self.state, frame, chunks[1]);
-                            render::render_footer(&self.state, frame, chunks[2]);
+                        final_draw_and_return!();
+                    }
+                }
+            }
 
-                            // table header (1 row) + data rows (including hook sub-rows)
-                            let content_bottom =
-                                area.y + header_height + 1 + total_rows + footer_height;
-                            frame.set_cursor_position(Position {
-                                x: 0,
-                                y: content_bottom,
-                            });
-                        })?;
-                        drop(terminal);
-                        return Ok(self.state);
+            // Poll for keyboard events (Ctrl-C). Non-blocking. If a Ctrl-C
+            // is observed, flip the optional cancel signal so the producer
+            // exits cooperatively, mark state done, and emit a final draw.
+            if event::poll(Duration::from_millis(0)).unwrap_or(false) {
+                if let Ok(Event::Key(key)) = event::read() {
+                    if key.code == KeyCode::Char('c')
+                        && key.modifiers.contains(KeyModifiers::CONTROL)
+                    {
+                        if let Some(sig) = &self.cancel_signal {
+                            sig.store(true, Ordering::Relaxed);
+                        }
+                        self.state.done = true;
+                        final_draw_and_return!();
                     }
                 }
             }
@@ -201,5 +226,68 @@ impl TuiRenderer {
 
             std::thread::sleep(Duration::from_millis(16));
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::worktree::list::Stat;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    #[test]
+    fn cancel_signal_can_be_set_externally() {
+        let signal = Arc::new(AtomicBool::new(false));
+        let state = TuiState::new(
+            Vec::new(),
+            Vec::new(),
+            PathBuf::from("/tmp"),
+            PathBuf::from("/tmp"),
+            Stat::Summary,
+            0,
+            None,
+            false,
+            None,
+            None,
+            false,
+            false,
+        );
+        let (_tx, rx) = mpsc::channel();
+        let renderer = TuiRenderer::new(state, rx).with_cancel_signal(Arc::clone(&signal));
+
+        // Renderer should be holding the signal.
+        assert!(renderer.cancel_signal.is_some());
+
+        // Flipping the external clone is observable through the renderer's
+        // own clone (single source of truth).
+        signal.store(true, Ordering::Relaxed);
+        assert!(renderer
+            .cancel_signal
+            .as_ref()
+            .unwrap()
+            .load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn renderer_without_cancel_signal_defaults_to_none() {
+        let state = TuiState::new(
+            Vec::new(),
+            Vec::new(),
+            PathBuf::from("/tmp"),
+            PathBuf::from("/tmp"),
+            Stat::Summary,
+            0,
+            None,
+            false,
+            None,
+            None,
+            false,
+            false,
+        );
+        let (_tx, rx) = mpsc::channel();
+        let renderer = TuiRenderer::new(state, rx);
+        assert!(renderer.cancel_signal.is_none());
     }
 }

--- a/src/output/tui/driver.rs
+++ b/src/output/tui/driver.rs
@@ -40,8 +40,8 @@ impl TuiRenderer {
     /// When `show_hook_sub_rows` is true (verbose >= 1), each hook sub-row and
     /// its nested job sub-rows add extra rendered rows beneath the parent worktree row.
     fn total_rendered_rows(&self) -> u16 {
-        let base = self.state.worktrees.len() as u16;
-        let divider = if self.state.unowned_start_index.is_some() {
+        let base = self.state.live.rows.len() as u16;
+        let divider = if self.state.live.unowned_start_index.is_some() {
             1
         } else {
             0
@@ -49,6 +49,8 @@ impl TuiRenderer {
         // Summary footer: 2 rows (separator + total) when Size column is present
         let summary = if self
             .state
+            .live
+            .cfg
             .columns
             .as_ref()
             .is_some_and(|cols| cols.contains(&Column::Size))
@@ -62,7 +64,8 @@ impl TuiRenderer {
                 + summary
                 + self
                     .state
-                    .worktrees
+                    .live
+                    .rows
                     .iter()
                     .map(|wt| {
                         let hooks = wt.hook_sub_rows.len() as u16;
@@ -83,12 +86,12 @@ impl TuiRenderer {
     /// Returns the final `TuiState` for post-render summary.
     pub fn run(mut self) -> anyhow::Result<TuiState> {
         let header_height = self.state.phases.len() as u16 + 1;
-        let divider_row = if self.state.unowned_start_index.is_some() {
+        let divider_row = if self.state.live.unowned_start_index.is_some() {
             1
         } else {
             0
         };
-        let table_height = self.state.worktrees.len() as u16 + 2 + self.extra_rows + divider_row;
+        let table_height = self.state.live.rows.len() as u16 + 2 + self.extra_rows + divider_row;
         let viewport_height = header_height + table_height;
 
         let backend = ratatui::backend::CrosstermBackend::new(std::io::stderr());

--- a/src/output/tui/driver.rs
+++ b/src/output/tui/driver.rs
@@ -7,6 +7,7 @@ use ratatui::{
     layout::{Constraint, Layout, Position},
     Terminal, TerminalOptions, Viewport,
 };
+use std::io::Write;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
 use std::sync::Arc;
@@ -200,6 +201,13 @@ impl TuiRenderer {
                     });
                 })?;
                 drop(terminal);
+                if self.state.live.cancelled {
+                    // After a cancelled run the cursor can land inside the
+                    // last table row (terminal-height clamping of the inline
+                    // viewport). Emit a newline so the shell prompt starts on
+                    // a fresh line. Best-effort.
+                    let _ = std::io::stderr().write_all(b"\n");
+                }
                 return Ok(self.state);
             }};
         }

--- a/src/output/tui/driver.rs
+++ b/src/output/tui/driver.rs
@@ -85,7 +85,13 @@ impl TuiRenderer {
     /// Run the render loop until all tasks complete.
     /// Returns the final `TuiState` for post-render summary.
     pub fn run(mut self) -> anyhow::Result<TuiState> {
-        let header_height = self.state.phases.len() as u16 + 1;
+        // `+1` is the phase header label row when phases exist; zero phases =
+        // no header at all (daft list).
+        let header_height = if self.state.phases.is_empty() {
+            0
+        } else {
+            self.state.phases.len() as u16 + 1
+        };
         let divider_row = if self.state.live.unowned_start_index.is_some() {
             1
         } else {
@@ -121,9 +127,8 @@ impl TuiRenderer {
             loop {
                 match self.receiver.try_recv() {
                     Ok(event) => {
-                        let is_done = matches!(event, DagEvent::AllDone);
                         self.state.apply_event(&event);
-                        if is_done {
+                        if self.state.is_complete() {
                             // Final render — position cursor past all content so
                             // the shell prompt won't overwrite the table.
                             let total_rows = self.total_rendered_rows();

--- a/src/output/tui/driver.rs
+++ b/src/output/tui/driver.rs
@@ -85,6 +85,7 @@ impl TuiRenderer {
     /// Run the render loop until all tasks complete.
     /// Returns the final `TuiState` for post-render summary.
     pub fn run(mut self) -> anyhow::Result<TuiState> {
+        let render_start = Instant::now();
         // `+1` is the phase header label row when phases exist; zero phases =
         // no header at all (daft list).
         let header_height = if self.state.phases.is_empty() {
@@ -98,7 +99,8 @@ impl TuiRenderer {
             0
         };
         let table_height = self.state.live.rows.len() as u16 + 2 + self.extra_rows + divider_row;
-        let viewport_height = header_height + table_height;
+        let footer_height: u16 = if self.state.show_hook_sub_rows { 1 } else { 0 };
+        let viewport_height = header_height + table_height + footer_height;
 
         let backend = ratatui::backend::CrosstermBackend::new(std::io::stderr());
         let mut terminal = Terminal::with_options(
@@ -115,12 +117,16 @@ impl TuiRenderer {
             // Render current state.
             terminal.draw(|frame| {
                 let area = frame.area();
-                let chunks =
-                    Layout::vertical([Constraint::Length(header_height), Constraint::Fill(1)])
-                        .split(area);
+                let chunks = Layout::vertical([
+                    Constraint::Length(header_height),
+                    Constraint::Fill(1),
+                    Constraint::Length(footer_height),
+                ])
+                .split(area);
 
                 render::render_header(&self.state, frame, chunks[0]);
                 render::render_table(&self.state, frame, chunks[1]);
+                render::render_footer(&self.state, frame, chunks[2]);
             })?;
 
             // Process all pending events.
@@ -137,13 +143,16 @@ impl TuiRenderer {
                                 let chunks = Layout::vertical([
                                     Constraint::Length(header_height),
                                     Constraint::Fill(1),
+                                    Constraint::Length(footer_height),
                                 ])
                                 .split(area);
                                 render::render_header(&self.state, frame, chunks[0]);
                                 render::render_table(&self.state, frame, chunks[1]);
+                                render::render_footer(&self.state, frame, chunks[2]);
 
                                 // table header (1 row) + data rows (including hook sub-rows)
-                                let content_bottom = area.y + header_height + 1 + total_rows;
+                                let content_bottom =
+                                    area.y + header_height + 1 + total_rows + footer_height;
                                 frame.set_cursor_position(Position {
                                     x: 0,
                                     y: content_bottom,
@@ -162,13 +171,16 @@ impl TuiRenderer {
                             let chunks = Layout::vertical([
                                 Constraint::Length(header_height),
                                 Constraint::Fill(1),
+                                Constraint::Length(footer_height),
                             ])
                             .split(area);
                             render::render_header(&self.state, frame, chunks[0]);
                             render::render_table(&self.state, frame, chunks[1]);
+                            render::render_footer(&self.state, frame, chunks[2]);
 
                             // table header (1 row) + data rows (including hook sub-rows)
-                            let content_bottom = area.y + header_height + 1 + total_rows;
+                            let content_bottom =
+                                area.y + header_height + 1 + total_rows + footer_height;
                             frame.set_cursor_position(Position {
                                 x: 0,
                                 y: content_bottom,
@@ -182,6 +194,7 @@ impl TuiRenderer {
 
             // Tick spinner animation.
             if last_tick.elapsed() >= tick_rate {
+                self.state.render_start_elapsed = render_start.elapsed();
                 self.state.tick();
                 last_tick = Instant::now();
             }

--- a/src/output/tui/live_table.rs
+++ b/src/output/tui/live_table.rs
@@ -191,6 +191,14 @@ impl LiveTable {
         !self.collection_complete && !self.received_patches[row_idx].contains(field)
     }
 
+    /// True when the cell for `field` on `row_idx` should render the
+    /// "data didn't load" marker because the user cancelled before the
+    /// patch arrived. Mutually exclusive with `is_cell_loading` after
+    /// `mark_cancelled()` runs (which sets `collection_complete = true`).
+    pub fn is_cell_unloaded(&self, row_idx: usize, field: FieldSet) -> bool {
+        self.cancelled && !self.received_patches[row_idx].contains(field)
+    }
+
     /// Append a new row, keeping `received_patches` in lockstep so
     /// `is_cell_loading` cannot index out of bounds. Used when a
     /// dynamically-discovered branch (e.g. a gone branch surfaced after
@@ -298,5 +306,42 @@ mod tests {
         assert!(t.cancelled);
         assert!(t.collection_complete);
         assert!(t.pending_resort);
+    }
+
+    #[test]
+    fn is_cell_unloaded_false_before_cancel() {
+        let t = LiveTable::new(vec![info("a")], cfg());
+        assert!(!t.is_cell_unloaded(0, FieldSet::SIZE));
+    }
+
+    #[test]
+    fn is_cell_unloaded_true_when_cancelled_and_not_received() {
+        let mut t = LiveTable::new(vec![info("a")], cfg());
+        t.mark_cancelled();
+        assert!(t.is_cell_unloaded(0, FieldSet::SIZE));
+    }
+
+    #[test]
+    fn is_cell_unloaded_false_when_received_even_after_cancel() {
+        let mut t = LiveTable::new(vec![info("a")], cfg());
+        t.apply_event(&DagEvent::WorktreeInfoUpdated {
+            branch_name: "a".into(),
+            patch: WorktreeInfoPatch::Size(Some(123)),
+            source: PatchSource::Collector,
+        });
+        t.mark_cancelled();
+        assert!(!t.is_cell_unloaded(0, FieldSet::SIZE));
+    }
+
+    #[test]
+    fn is_cell_loading_returns_false_after_mark_cancelled() {
+        // Regression guard: mark_cancelled sets collection_complete = true,
+        // which makes is_cell_loading naturally return false. We rely on this
+        // so the render path doesn't need a second "and not cancelled" check
+        // in the loading branch.
+        let mut t = LiveTable::new(vec![info("a")], cfg());
+        assert!(t.is_cell_loading(0, FieldSet::SIZE));
+        t.mark_cancelled();
+        assert!(!t.is_cell_loading(0, FieldSet::SIZE));
     }
 }

--- a/src/output/tui/live_table.rs
+++ b/src/output/tui/live_table.rs
@@ -173,6 +173,15 @@ impl LiveTable {
     pub fn is_cell_loading(&self, row_idx: usize, field: FieldSet) -> bool {
         !self.collection_complete && !self.received_patches[row_idx].contains(field)
     }
+
+    /// Append a new row, keeping `received_patches` in lockstep so
+    /// `is_cell_loading` cannot index out of bounds. Used when a
+    /// dynamically-discovered branch (e.g. a gone branch surfaced after
+    /// fetch) gets a row.
+    pub fn push_row(&mut self, info: WorktreeInfo) {
+        self.rows.push(WorktreeRow::idle(info));
+        self.received_patches.push(FieldSet::EMPTY);
+    }
 }
 
 fn patch_field_claim(patch: &crate::core::worktree::sync_dag::WorktreeInfoPatch) -> FieldSet {

--- a/src/output/tui/live_table.rs
+++ b/src/output/tui/live_table.rs
@@ -1,0 +1,265 @@
+//! Worktree-rows widget shared by `daft list`, `daft prune`, and `daft sync`.
+//!
+//! Owns: row collection, sort, owner-partition, column selection, patch
+//! application, loading-glyph state. Knows nothing about phases or hook
+//! sub-rows — those live in the wrapping `OperationTable` / `TuiState`.
+
+use crate::{
+    core::{
+        sort::SortSpec,
+        worktree::{
+            info_field::FieldSet,
+            list::{EntryKind, Stat, WorktreeInfo},
+            sync_dag::{DagEvent, PatchSourceLog},
+        },
+    },
+    output::tui::columns::Column,
+};
+use std::path::PathBuf;
+
+use super::state::WorktreeRow;
+
+#[derive(Clone)]
+pub struct LiveTableConfig {
+    pub stat: Stat,
+    pub columns: Option<Vec<Column>>,
+    pub columns_explicit: bool,
+    pub sort_spec: Option<SortSpec>,
+    /// `true` for prune/sync, `false` for `daft list`.
+    pub pin_default_branch: bool,
+    /// `true` for prune/sync, `false` for `daft list`.
+    pub partition_by_owner: bool,
+    pub project_root: PathBuf,
+    pub cwd: PathBuf,
+}
+
+pub struct LiveTable {
+    pub rows: Vec<WorktreeRow>,
+    pub cfg: LiveTableConfig,
+    pub pending_resort: bool,
+    pub collection_complete: bool,
+    pub source_log: PatchSourceLog,
+    /// Per-row bitmask of "patches received".
+    pub received_patches: Vec<FieldSet>,
+    /// Index of the first row in the unowned section, or `None` if no
+    /// partition. Recomputed when `partition_by_owner` is true.
+    pub unowned_start_index: Option<usize>,
+}
+
+impl LiveTable {
+    pub fn new(seed: Vec<WorktreeInfo>, cfg: LiveTableConfig) -> Self {
+        let received_patches = vec![FieldSet::EMPTY; seed.len()];
+        let rows: Vec<WorktreeRow> = seed.into_iter().map(WorktreeRow::idle).collect();
+        let mut t = Self {
+            rows,
+            cfg,
+            pending_resort: true,
+            collection_complete: false,
+            source_log: PatchSourceLog::default(),
+            received_patches,
+            unowned_start_index: None,
+        };
+        t.resort_and_repartition();
+        t
+    }
+
+    pub fn apply_event(&mut self, event: &DagEvent) {
+        match event {
+            DagEvent::WorktreeInfoUpdated {
+                branch_name,
+                patch,
+                source,
+            } => {
+                let touched = match self.find_row_idx(branch_name) {
+                    Some(idx) => {
+                        let claim = patch_field_claim(patch);
+                        // PatchSource is Clone (not Copy) because it carries
+                        // OperationPhase which contains a String-bearing variant.
+                        if !self
+                            .source_log
+                            .try_admit(branch_name, claim, source.clone())
+                        {
+                            return;
+                        }
+                        let touched = self.rows[idx].info.apply_patch(patch);
+                        self.received_patches[idx] |= touched;
+                        touched
+                    }
+                    None => return,
+                };
+                if let Some(spec) = &self.cfg.sort_spec {
+                    if touched.intersects(spec.required_fields()) {
+                        self.pending_resort = true;
+                    }
+                }
+                if self.cfg.partition_by_owner && touched.contains(FieldSet::OWNER) {
+                    self.pending_resort = true;
+                }
+            }
+            DagEvent::WorktreeInfoCollectionDone => {
+                self.collection_complete = true;
+                self.pending_resort = true;
+            }
+            _ => { /* phase/hook events handled by wrapper */ }
+        }
+    }
+
+    pub fn tick(&mut self) {
+        if self.pending_resort {
+            self.resort_and_repartition();
+            self.pending_resort = false;
+        }
+    }
+
+    fn find_row_idx(&self, branch: &str) -> Option<usize> {
+        self.rows.iter().position(|r| r.info.name == branch)
+    }
+
+    fn resort_and_repartition(&mut self) {
+        let pin = self.cfg.pin_default_branch;
+        let sort_spec = self.cfg.sort_spec.clone();
+        let mut indexed: Vec<usize> = (0..self.rows.len()).collect();
+        indexed.sort_by(|&a, &b| {
+            let ra = &self.rows[a];
+            let rb = &self.rows[b];
+            if pin {
+                let da = u8::from(!ra.info.is_default_branch);
+                let db = u8::from(!rb.info.is_default_branch);
+                let c = da.cmp(&db);
+                if c != std::cmp::Ordering::Equal {
+                    return c;
+                }
+            }
+            let kind = |k: &EntryKind| match k {
+                EntryKind::Worktree => 0,
+                EntryKind::LocalBranch => 1,
+                EntryKind::RemoteBranch => 2,
+            };
+            let c = kind(&ra.info.kind).cmp(&kind(&rb.info.kind));
+            if c != std::cmp::Ordering::Equal {
+                return c;
+            }
+            match &sort_spec {
+                Some(spec) => spec.compare(&ra.info, &rb.info),
+                None => ra
+                    .info
+                    .name
+                    .to_lowercase()
+                    .cmp(&rb.info.name.to_lowercase()),
+            }
+        });
+
+        let mut new_rows: Vec<WorktreeRow> = Vec::with_capacity(self.rows.len());
+        let mut new_recv: Vec<FieldSet> = Vec::with_capacity(self.received_patches.len());
+        for &i in &indexed {
+            new_rows.push(std::mem::replace(
+                &mut self.rows[i],
+                WorktreeRow::placeholder(),
+            ));
+            new_recv.push(self.received_patches[i]);
+        }
+        self.rows = new_rows;
+        self.received_patches = new_recv;
+
+        self.unowned_start_index = if self.cfg.partition_by_owner {
+            self.rows.iter().position(|r| r.info.owner.is_none())
+        } else {
+            None
+        };
+    }
+
+    /// True when the cell for `field` on `row_idx` should render the
+    /// loading glyph. Only meaningful while !collection_complete.
+    pub fn is_cell_loading(&self, row_idx: usize, field: FieldSet) -> bool {
+        !self.collection_complete && !self.received_patches[row_idx].contains(field)
+    }
+}
+
+fn patch_field_claim(patch: &crate::core::worktree::sync_dag::WorktreeInfoPatch) -> FieldSet {
+    use crate::core::worktree::sync_dag::WorktreeInfoPatch as P;
+    match patch {
+        P::BaseAheadBehind(_) => FieldSet::BASE_AHEAD_BEHIND,
+        P::RemoteAheadBehind(_) => FieldSet::REMOTE_AHEAD_BEHIND,
+        P::Changes { .. } => FieldSet::CHANGES,
+        P::LastCommit { .. } => FieldSet::LAST_COMMIT,
+        P::BranchAge(_) => FieldSet::BRANCH_AGE,
+        P::Owner(_) => FieldSet::OWNER,
+        P::BaseLines(_) => FieldSet::BASE_LINES,
+        P::ChangesLines { .. } => FieldSet::CHANGES_LINES,
+        P::RemoteLines(_) => FieldSet::REMOTE_LINES,
+        P::Size(_) => FieldSet::SIZE,
+        P::Mtime(_) => FieldSet::MTIME,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::worktree::sync_dag::{PatchSource, WorktreeInfoPatch};
+
+    fn cfg() -> LiveTableConfig {
+        LiveTableConfig {
+            stat: Stat::Summary,
+            columns: None,
+            columns_explicit: false,
+            sort_spec: None,
+            pin_default_branch: true,
+            partition_by_owner: false,
+            project_root: PathBuf::from("/tmp"),
+            cwd: PathBuf::from("/tmp"),
+        }
+    }
+
+    fn info(name: &str) -> WorktreeInfo {
+        WorktreeInfo::empty(name)
+    }
+
+    #[test]
+    fn collection_done_sets_collection_complete() {
+        let mut t = LiveTable::new(vec![info("a")], cfg());
+        assert!(!t.collection_complete);
+        t.apply_event(&DagEvent::WorktreeInfoCollectionDone);
+        assert!(t.collection_complete);
+    }
+
+    #[test]
+    fn updated_event_for_unknown_branch_is_ignored() {
+        let mut t = LiveTable::new(vec![info("a")], cfg());
+        t.apply_event(&DagEvent::WorktreeInfoUpdated {
+            branch_name: "b".into(),
+            patch: WorktreeInfoPatch::Size(Some(123)),
+            source: PatchSource::Collector,
+        });
+        assert_eq!(t.rows[0].info.size_bytes, None);
+    }
+
+    #[test]
+    fn patch_applied_marks_received_for_loading_glyph() {
+        let mut t = LiveTable::new(vec![info("a")], cfg());
+        assert!(t.is_cell_loading(0, FieldSet::SIZE));
+        t.apply_event(&DagEvent::WorktreeInfoUpdated {
+            branch_name: "a".into(),
+            patch: WorktreeInfoPatch::Size(Some(123)),
+            source: PatchSource::Collector,
+        });
+        assert!(!t.is_cell_loading(0, FieldSet::SIZE));
+        assert_eq!(t.rows[0].info.size_bytes, Some(123));
+    }
+
+    #[test]
+    fn collector_patch_is_dropped_after_post_fetch_for_same_field() {
+        let mut t = LiveTable::new(vec![info("a")], cfg());
+        t.apply_event(&DagEvent::WorktreeInfoUpdated {
+            branch_name: "a".into(),
+            patch: WorktreeInfoPatch::RemoteAheadBehind(Some((5, 0))),
+            source: PatchSource::PostFetch,
+        });
+        t.apply_event(&DagEvent::WorktreeInfoUpdated {
+            branch_name: "a".into(),
+            patch: WorktreeInfoPatch::RemoteAheadBehind(Some((1, 1))),
+            source: PatchSource::Collector,
+        });
+        assert_eq!(t.rows[0].info.remote_ahead, Some(5));
+        assert_eq!(t.rows[0].info.remote_behind, Some(0));
+    }
+}

--- a/src/output/tui/live_table.rs
+++ b/src/output/tui/live_table.rs
@@ -38,6 +38,11 @@ pub struct LiveTable {
     pub cfg: LiveTableConfig,
     pub pending_resort: bool,
     pub collection_complete: bool,
+    /// Set when the user cancels (Ctrl-C). Cells that haven't received their
+    /// patch should render a "data didn't load" marker rather than the
+    /// loading shimmer. `mark_cancelled` also sets `collection_complete = true`
+    /// so `is_cell_loading` naturally returns false post-cancel.
+    pub cancelled: bool,
     pub source_log: PatchSourceLog,
     /// Per-row bitmask of "patches received".
     pub received_patches: Vec<FieldSet>,
@@ -55,6 +60,7 @@ impl LiveTable {
             cfg,
             pending_resort: true,
             collection_complete: false,
+            cancelled: false,
             source_log: PatchSourceLog::default(),
             received_patches,
             unowned_start_index: None,
@@ -102,6 +108,17 @@ impl LiveTable {
             }
             _ => { /* phase/hook events handled by wrapper */ }
         }
+    }
+
+    /// Mark the live table as cancelled by user (Ctrl-C). Sets
+    /// `collection_complete = true` so the loading shimmer stops and
+    /// `pending_resort = true` so the next tick re-runs the sort/partition.
+    /// Cells that haven't received their patch will render via
+    /// `is_cell_unloaded` rather than the loading shimmer.
+    pub fn mark_cancelled(&mut self) {
+        self.cancelled = true;
+        self.collection_complete = true;
+        self.pending_resort = true;
     }
 
     pub fn tick(&mut self) {
@@ -270,5 +287,16 @@ mod tests {
         });
         assert_eq!(t.rows[0].info.remote_ahead, Some(5));
         assert_eq!(t.rows[0].info.remote_behind, Some(0));
+    }
+
+    #[test]
+    fn mark_cancelled_sets_cancelled_and_collection_complete() {
+        let mut t = LiveTable::new(vec![info("a")], cfg());
+        assert!(!t.cancelled);
+        assert!(!t.collection_complete);
+        t.mark_cancelled();
+        assert!(t.cancelled);
+        assert!(t.collection_complete);
+        assert!(t.pending_resort);
     }
 }

--- a/src/output/tui/mod.rs
+++ b/src/output/tui/mod.rs
@@ -5,6 +5,7 @@
 
 mod columns;
 mod driver;
+pub mod live_table;
 pub mod operation_table;
 mod presenter;
 mod render;
@@ -13,6 +14,7 @@ mod state;
 
 pub use columns::{select_columns, Column};
 pub use driver::TuiRenderer;
+pub use live_table::{LiveTable, LiveTableConfig};
 pub use operation_table::{CompletedTable, OperationTable, TableConfig};
 pub use presenter::TuiPresenter;
 pub use state::{FinalStatus, PhaseState, PhaseStatus, TuiState, WorktreeRow, WorktreeStatus};

--- a/src/output/tui/operation_table.rs
+++ b/src/output/tui/operation_table.rs
@@ -31,6 +31,17 @@ pub struct TableConfig {
     pub extra_rows: u16,
     /// Verbosity level.  `>= 1` enables hook sub-rows in the TUI.
     pub verbosity: u8,
+    /// Pin the default branch to the first row regardless of `--sort`.
+    /// Defaults to `true` (prune/sync behavior). `daft list` will set
+    /// `false` in Phase 2.
+    pub pin_default_branch: bool,
+    /// Split rows into "owned" and "unowned" sections by `info.owner`.
+    /// Defaults to `true` for daft list (Phase 2). PRUNE/SYNC set this to
+    /// `false` because they compute `unowned_start_index` externally using
+    /// a richer predicate (`is_branch_included` with include_filters); the
+    /// external value is injected into `live.unowned_start_index` after
+    /// `TuiState::new` returns, and we must not let LiveTable overwrite it.
+    pub partition_by_owner: bool,
 }
 
 /// Result returned after the TUI completes.
@@ -107,6 +118,8 @@ impl OperationTable {
             self.config.columns_explicit,
             self.unowned_start_index,
             self.config.sort_spec,
+            self.config.pin_default_branch,
+            self.config.partition_by_owner,
         );
 
         let renderer =
@@ -136,6 +149,8 @@ mod tests {
             sort_spec: None,
             extra_rows: 0,
             verbosity: 0,
+            pin_default_branch: true,
+            partition_by_owner: true,
         };
         assert_eq!(cfg_silent.verbosity, 0);
 
@@ -145,6 +160,8 @@ mod tests {
             sort_spec: None,
             extra_rows: 0,
             verbosity: 1,
+            pin_default_branch: true,
+            partition_by_owner: true,
         };
         assert!(cfg_verbose.verbosity >= 1);
     }

--- a/src/output/tui/operation_table.rs
+++ b/src/output/tui/operation_table.rs
@@ -115,7 +115,7 @@ impl OperationTable {
         let final_state = renderer.run()?;
 
         Ok(CompletedTable {
-            rows: final_state.worktrees,
+            rows: final_state.live.rows,
             hook_summaries: final_state.hook_summaries,
         })
     }

--- a/src/output/tui/render.rs
+++ b/src/output/tui/render.rs
@@ -83,26 +83,29 @@ fn render_sort_summary_spans(spec: &SortSpec) -> Vec<Span<'static>> {
 pub fn render_table(state: &TuiState, frame: &mut Frame, area: Rect) {
     let now = chrono::Utc::now().timestamp();
     let ctx = ColumnContext {
-        project_root: &state.project_root,
-        cwd: &state.cwd,
+        project_root: &state.live.cfg.project_root,
+        cwd: &state.live.cfg.cwd,
         now,
-        stat: state.stat,
+        stat: state.live.cfg.stat,
     };
 
     // Pre-compute all column values for sizing and reuse.
     let row_vals: Vec<ColumnValues> = state
-        .worktrees
+        .live
+        .rows
         .iter()
         .map(|wt| format::compute_column_values(&wt.info, &ctx))
         .collect();
 
     // Select columns and compute dynamic constraints from content widths.
-    let sort_ref = state.sort_spec.as_ref();
+    let sort_ref = state.live.cfg.sort_spec.as_ref();
 
     // Render "Sorted by" summary line if column headers can't convey the sort.
     let table_area = if let Some(spec) = sort_ref {
         // Collect displayed ListColumns (excluding Status which is TUI-only).
         let displayed: Vec<crate::core::columns::ListColumn> = state
+            .live
+            .cfg
             .columns
             .as_deref()
             .map(|cols| cols.iter().filter_map(|c| c.to_list_column()).collect())
@@ -129,7 +132,7 @@ pub fn render_table(state: &TuiState, frame: &mut Frame, area: Rect) {
     } else {
         area
     };
-    let columns = match (&state.columns, state.columns_explicit) {
+    let columns = match (&state.live.cfg.columns, state.live.cfg.columns_explicit) {
         // Replace mode: user explicitly chose columns, don't responsively drop.
         (Some(user_cols), true) => user_cols.clone(),
         // Modifier mode: user tweaked defaults, responsive dropping still applies.
@@ -137,7 +140,7 @@ pub fn render_table(state: &TuiState, frame: &mut Frame, area: Rect) {
         // added are always included — they bypass responsive dropping.
         (Some(user_cols), false) => {
             let responsive =
-                select_columns(table_area.width, &state.worktrees, &row_vals, sort_ref);
+                select_columns(table_area.width, &state.live.rows, &row_vals, sort_ref);
             let mut cols: Vec<Column> = responsive
                 .into_iter()
                 .filter(|c| matches!(c, Column::Status) || user_cols.contains(c))
@@ -150,7 +153,7 @@ pub fn render_table(state: &TuiState, frame: &mut Frame, area: Rect) {
             cols
         }
         // No column selection: fully responsive.
-        (None, _) => select_columns(table_area.width, &state.worktrees, &row_vals, sort_ref),
+        (None, _) => select_columns(table_area.width, &state.live.rows, &row_vals, sort_ref),
     };
     // Status is always prepended for TUI commands.
     let columns = if !columns.contains(&Column::Status) {
@@ -169,7 +172,7 @@ pub fn render_table(state: &TuiState, frame: &mut Frame, area: Rect) {
             } else {
                 Constraint::Length(column_content_width(
                     *col,
-                    &state.worktrees,
+                    &state.live.rows,
                     &row_vals,
                     sort_ref,
                 ))
@@ -197,6 +200,8 @@ pub fn render_table(state: &TuiState, frame: &mut Frame, area: Rect) {
                 .add_modifier(Modifier::UNDERLINED);
             let indicator = col.to_list_column().and_then(|lc| {
                 state
+                    .live
+                    .cfg
                     .sort_spec
                     .as_ref()
                     .and_then(|s| s.direction_indicator(lc))
@@ -229,10 +234,10 @@ pub fn render_table(state: &TuiState, frame: &mut Frame, area: Rect) {
     let mut row_count: u16 = 0;
     let num_columns = columns.len();
 
-    for (wt_idx, (wt, vals)) in state.worktrees.iter().zip(row_vals.iter()).enumerate() {
+    for (wt_idx, (wt, vals)) in state.live.rows.iter().zip(row_vals.iter()).enumerate() {
         // Insert a placeholder row for the section divider between owned and
         // unowned worktrees.  The actual divider content is overlaid later.
-        if state.unowned_start_index == Some(wt_idx) {
+        if state.live.unowned_start_index == Some(wt_idx) {
             let empty_cells: Vec<Cell> = (0..num_columns).map(|_| Cell::from("")).collect();
             all_rows.push(Row::new(empty_cells));
             divider_row_offset = Some(row_count);
@@ -248,7 +253,7 @@ pub fn render_table(state: &TuiState, frame: &mut Frame, area: Rect) {
                 .iter()
                 .map(|col| {
                     if matches!(col, Column::Status | Column::Annotation) {
-                        render_cell(col, wt, vals, state.tick, state.stat)
+                        render_cell(col, wt, vals, state.tick, state.live.cfg.stat)
                     } else {
                         Cell::from("")
                     }
@@ -257,7 +262,7 @@ pub fn render_table(state: &TuiState, frame: &mut Frame, area: Rect) {
         } else {
             columns
                 .iter()
-                .map(|col| render_cell(col, wt, vals, state.tick, state.stat))
+                .map(|col| render_cell(col, wt, vals, state.tick, state.live.cfg.stat))
                 .collect()
         };
         all_rows.push(Row::new(main_cells));
@@ -306,7 +311,8 @@ pub fn render_table(state: &TuiState, frame: &mut Frame, area: Rect) {
 
         // Summary row with total size (excludes pruned worktrees)
         let total_bytes: u64 = state
-            .worktrees
+            .live
+            .rows
             .iter()
             .filter(|wt| wt.info.kind == EntryKind::Worktree)
             .filter(|wt| !matches!(wt.status, WorktreeStatus::Done(FinalStatus::Pruned)))

--- a/src/output/tui/render.rs
+++ b/src/output/tui/render.rs
@@ -609,19 +609,6 @@ fn render_remote_cell(info: &WorktreeInfo, stat: Stat) -> Cell<'static> {
     }
 }
 
-/// Render a dim middle-dot for an unfilled cell while the table is still
-/// streaming. Used as a fallback when the column is too narrow for a shimmer
-/// bar to read clearly.
-fn loading_glyph_cell() -> Cell<'static> {
-    Cell::from(Span::styled(
-        "\u{00B7}",
-        Style::default().add_modifier(Modifier::DIM),
-    ))
-}
-
-/// Width below which the skeleton bar collapses to a single dim glyph.
-const SKELETON_MIN_WIDTH: u16 = 3;
-
 /// Frames in one full breath (dim → bright → dim). At the driver's 80ms tick
 /// rate, 16 frames = ~1.3s full cycle. Halve for a snappier pulse, double
 /// for a slower one.
@@ -633,19 +620,17 @@ const SKELETON_BREATH_FRAMES: usize = 16;
 const SKELETON_GRAY_DARKEST: u8 = 234;
 const SKELETON_GRAY_BRIGHTEST: u8 = 253;
 
-/// Render a "skeleton bar" placeholder for an unfilled cell — a row of solid
-/// `█` block characters sized to the column's assigned width, breathing
-/// uniformly along the xterm 256-color grayscale ramp via a triangle wave.
-/// When the column is too narrow for the bar to read (< 3 chars), falls back
-/// to the dim middle-dot.
+/// Render a skeleton placeholder for an unfilled cell — a row of `▬`
+/// (BLACK RECTANGLE U+25AC) characters sized to the column's assigned
+/// width, breathing uniformly along the xterm 256-color grayscale ramp
+/// via a triangle wave. The rectangle char is centered vertically in the
+/// cell and shorter than `█`, giving the bar a soft low-profile feel
+/// without any height-mismatch caps.
 fn loading_shimmer_cell(width: u16, tick: usize) -> Cell<'static> {
     if width == 0 {
         return Cell::from("");
     }
-    if width < SKELETON_MIN_WIDTH {
-        return loading_glyph_cell();
-    }
-    const BAR_CHAR: &str = "\u{2588}"; // █
+    const BAR_CHAR: &str = "\u{25AC}"; // ▬
     let bar: String = BAR_CHAR.repeat(width as usize);
     Cell::from(Span::styled(
         bar,
@@ -1104,26 +1089,25 @@ mod tests {
     }
 
     #[test]
-    fn loading_glyph_cell_renders_dim_middle_dot() {
-        let cell = loading_glyph_cell();
-        // Cell is opaque; the test just confirms it constructs without panic.
-        // Detailed visual verification belongs in the PTY scenario tests.
-        let _ = cell;
+    fn loading_shimmer_cell_zero_width_returns_empty() {
+        // Width-0 columns shouldn't paint anything.
+        let backend = TestBackend::new(1, 1);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                let cell = loading_shimmer_cell(0, 0);
+                let table = Table::new(vec![Row::new(vec![cell])], &[Constraint::Length(0)]);
+                frame.render_widget(table, frame.area());
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+        assert_eq!(buffer[(0, 0)].symbol(), " ");
     }
 
     #[test]
-    fn loading_shimmer_cell_collapses_to_glyph_when_too_narrow() {
-        // Width below SHIMMER_MIN_WIDTH (3) should fall back to the dim dot —
-        // a single ▒ wouldn't read as "loading" without movement.
-        let _ = loading_shimmer_cell(0, 0);
-        let _ = loading_shimmer_cell(1, 0);
-        let _ = loading_shimmer_cell(2, 0);
-    }
-
-    #[test]
-    fn loading_shimmer_cell_fills_column_with_block_chars() {
-        // Render a shimmer cell into a 1-row buffer and confirm the bar
-        // characters appear across the assigned width.
+    fn loading_shimmer_cell_fills_column_with_rectangle_chars() {
+        // Render a skeleton cell and confirm every cell in the bar is the
+        // BLACK RECTANGLE U+25AC glyph across the full assigned width.
         let backend = TestBackend::new(10, 1);
         let mut terminal = Terminal::new(backend).unwrap();
         terminal
@@ -1138,8 +1122,8 @@ mod tests {
             .map(|x| buffer[(x, 0)].symbol().to_string())
             .collect();
         assert!(
-            row.chars().all(|c| c == '\u{2588}'),
-            "skeleton bar should be all █, got {row:?}"
+            row.chars().all(|c| c == '\u{25AC}'),
+            "skeleton bar should be all ▬, got {row:?}"
         );
     }
 

--- a/src/output/tui/render.rs
+++ b/src/output/tui/render.rs
@@ -1,4 +1,7 @@
-use super::columns::{column_content_width, select_columns, Column, ALL_COLUMNS};
+use super::columns::{
+    column_content_width, fit_widths_to_available, select_columns, truncate_with_ellipsis, Column,
+    ALL_COLUMNS,
+};
 use super::state::{FinalStatus, PhaseStatus, TuiState, WorktreeStatus};
 use crate::core::sort::SortSpec;
 use crate::core::worktree::info_field::FieldSet;
@@ -115,7 +118,7 @@ pub fn render_table(state: &TuiState, frame: &mut Frame, area: Rect) {
     };
 
     // Pre-compute all column values for sizing and reuse.
-    let row_vals: Vec<ColumnValues> = state
+    let mut row_vals: Vec<ColumnValues> = state
         .live
         .rows
         .iter()
@@ -203,18 +206,46 @@ pub fn render_table(state: &TuiState, frame: &mut Frame, area: Rect) {
         }
     };
 
+    // Compute natural column widths, then shrink Branch/Path so the table fits
+    // in the available area. Without this step a single long path or branch
+    // name in `live.rows` (often off-screen) blows out those columns and
+    // squeezes `LastCommit` (Fill(1)) down to nearly zero width.
+    let natural_widths: Vec<u16> = columns
+        .iter()
+        .map(|col| column_content_width(*col, &state.live.rows, &row_vals, sort_ref))
+        .collect();
+    let assigned_widths = fit_widths_to_available(&columns, &natural_widths, table_area.width);
+
+    // When Branch or Path was shrunk below its natural width, pre-truncate the
+    // displayed text so the renderer shows "..." rather than ratatui's silent
+    // hard cut. Other columns are short by construction and don't need this.
+    for (i, col) in columns.iter().enumerate() {
+        if assigned_widths[i] >= natural_widths[i] {
+            continue;
+        }
+        match col {
+            Column::Branch => {
+                for vals in &mut row_vals {
+                    vals.branch = truncate_with_ellipsis(&vals.branch, assigned_widths[i]);
+                }
+            }
+            Column::Path => {
+                for vals in &mut row_vals {
+                    vals.path = truncate_with_ellipsis(&vals.path, assigned_widths[i]);
+                }
+            }
+            _ => {}
+        }
+    }
+
     let constraints: Vec<Constraint> = columns
         .iter()
-        .map(|col| {
+        .enumerate()
+        .map(|(i, col)| {
             if matches!(col, Column::LastCommit) {
                 Constraint::Fill(1)
             } else {
-                Constraint::Length(column_content_width(
-                    *col,
-                    &state.live.rows,
-                    &row_vals,
-                    sort_ref,
-                ))
+                Constraint::Length(assigned_widths[i])
             }
         })
         .collect();

--- a/src/output/tui/render.rs
+++ b/src/output/tui/render.rs
@@ -622,14 +622,20 @@ fn loading_glyph_cell() -> Cell<'static> {
 /// Width below which the skeleton bar collapses to a single dim glyph.
 const SKELETON_MIN_WIDTH: u16 = 3;
 
-/// Frames each phase of the breathing pulse holds. With the driver's 80ms
-/// tick rate, 10 frames ≈ 800ms per phase → ~3.2s full cycle through the
-/// four phases (dim → mid → bright → mid).
-const SKELETON_PULSE_PHASE_FRAMES: usize = 10;
+/// Frames in one full breath (dim → bright → dim). At the driver's 80ms tick
+/// rate, 16 frames = ~1.3s full cycle. Halve for a snappier pulse, double
+/// for a slower one.
+const SKELETON_BREATH_FRAMES: usize = 16;
 
-/// Render a "skeleton bar" placeholder for an unfilled cell — a row of dim
-/// `▒` block characters sized to the column's assigned width, breathing
-/// uniformly through DarkGray → Gray → White → Gray on the renderer tick.
+/// xterm 256-color grayscale ramp endpoints. Indices 232 (near-black) through
+/// 255 (white) form a 24-step ramp — supported by every terminal that does
+/// 256 colors (effectively all modern terminals).
+const SKELETON_GRAY_DARKEST: u8 = 234;
+const SKELETON_GRAY_BRIGHTEST: u8 = 253;
+
+/// Render a "skeleton bar" placeholder for an unfilled cell — a row of solid
+/// `█` block characters sized to the column's assigned width, breathing
+/// uniformly along the xterm 256-color grayscale ramp via a triangle wave.
 /// When the column is too narrow for the bar to read (< 3 chars), falls back
 /// to the dim middle-dot.
 fn loading_shimmer_cell(width: u16, tick: usize) -> Cell<'static> {
@@ -640,15 +646,27 @@ fn loading_shimmer_cell(width: u16, tick: usize) -> Cell<'static> {
         return loading_glyph_cell();
     }
     const BAR_CHAR: &str = "\u{2588}"; // █
-    let phase = (tick / SKELETON_PULSE_PHASE_FRAMES) % 4;
-    let color = match phase {
-        0 => Color::DarkGray,
-        1 => Color::Gray,
-        2 => Color::White,
-        _ => Color::Gray,
-    };
     let bar: String = BAR_CHAR.repeat(width as usize);
-    Cell::from(Span::styled(bar, Style::default().fg(color)))
+    Cell::from(Span::styled(
+        bar,
+        Style::default().fg(Color::Indexed(skeleton_pulse_color(tick))),
+    ))
+}
+
+/// Triangle-wave brightness selector. Returns a 256-color palette index that
+/// ramps from `SKELETON_GRAY_DARKEST` up to `SKELETON_GRAY_BRIGHTEST` and
+/// back, completing one full breath every `SKELETON_BREATH_FRAMES` ticks.
+fn skeleton_pulse_color(tick: usize) -> u8 {
+    let half = SKELETON_BREATH_FRAMES / 2;
+    let phase = tick % SKELETON_BREATH_FRAMES;
+    let t = if phase < half {
+        phase
+    } else {
+        SKELETON_BREATH_FRAMES - phase
+    };
+    let span = (SKELETON_GRAY_BRIGHTEST - SKELETON_GRAY_DARKEST) as usize;
+    let offset = (t * span) / half;
+    SKELETON_GRAY_DARKEST + offset as u8
 }
 
 /// Render a single cell for the given column and worktree row.
@@ -1152,13 +1170,36 @@ mod tests {
             first_fg
         };
 
-        // Phase 0 (DarkGray) vs phase 2 (White) — different ticks, different
-        // colors.
-        let phase0 = render_at(0);
-        let phase2 = render_at(SKELETON_PULSE_PHASE_FRAMES * 2);
+        // Tick 0 (darkest) vs tick at the bright peak — different colors.
+        let dark = render_at(0);
+        let bright = render_at(SKELETON_BREATH_FRAMES / 2);
         assert_ne!(
-            phase0, phase2,
-            "skeleton bar should pulse across phases (phase0={phase0:?}, phase2={phase2:?})"
+            dark, bright,
+            "skeleton bar should pulse across the breath (dark={dark:?}, bright={bright:?})"
+        );
+    }
+
+    #[test]
+    fn skeleton_pulse_color_traces_a_triangle_wave() {
+        // At tick 0 we're at the darkest stop.
+        assert_eq!(skeleton_pulse_color(0), SKELETON_GRAY_DARKEST);
+        // At the half-cycle we're at the brightest stop.
+        assert_eq!(
+            skeleton_pulse_color(SKELETON_BREATH_FRAMES / 2),
+            SKELETON_GRAY_BRIGHTEST
+        );
+        // At the end of the cycle we're back at darkest (modular).
+        assert_eq!(
+            skeleton_pulse_color(SKELETON_BREATH_FRAMES),
+            SKELETON_GRAY_DARKEST
+        );
+        // Symmetry: ascending and descending halves visit the same brightness.
+        let quarter = SKELETON_BREATH_FRAMES / 4;
+        let three_quarter = SKELETON_BREATH_FRAMES * 3 / 4;
+        assert_eq!(
+            skeleton_pulse_color(quarter),
+            skeleton_pulse_color(three_quarter),
+            "triangle wave should be symmetric around the peak"
         );
     }
 

--- a/src/output/tui/render.rs
+++ b/src/output/tui/render.rs
@@ -372,7 +372,11 @@ pub fn render_table(state: &TuiState, frame: &mut Frame, area: Rect) {
                 })
                 .collect()
         };
-        all_rows.push(Row::new(main_cells));
+        let mut row = Row::new(main_cells);
+        if wt.info.is_current {
+            row = row.style(Style::default().bg(Color::Indexed(235)));
+        }
+        all_rows.push(row);
         if is_pruned {
             pruned_overlays.push((
                 row_count,

--- a/src/output/tui/render.rs
+++ b/src/output/tui/render.rs
@@ -619,35 +619,36 @@ fn loading_glyph_cell() -> Cell<'static> {
     ))
 }
 
-/// Width below which the shimmer bar collapses to a single dim glyph.
-const SHIMMER_MIN_WIDTH: u16 = 3;
+/// Width below which the skeleton bar collapses to a single dim glyph.
+const SKELETON_MIN_WIDTH: u16 = 3;
 
-/// Width of the bright "highlight" band that sweeps across the shimmer bar.
-const SHIMMER_HIGHLIGHT_WIDTH: u16 = 3;
+/// Frames each phase of the breathing pulse holds. With the driver's 80ms
+/// tick rate, 10 frames ≈ 800ms per phase → ~3.2s full cycle through the
+/// four phases (dim → mid → bright → mid).
+const SKELETON_PULSE_PHASE_FRAMES: usize = 10;
 
-/// Render a sweeping shimmer placeholder for an unfilled cell. The bar fills
-/// the column's assigned width with a dim block character; a brighter band
-/// sweeps left-to-right driven by the renderer tick. When the column is too
-/// narrow for the sweep to read (< 3 chars), falls back to the dim middle-dot.
+/// Render a "skeleton bar" placeholder for an unfilled cell — a row of dim
+/// `▒` block characters sized to the column's assigned width, breathing
+/// uniformly through DarkGray → Gray → White → Gray on the renderer tick.
+/// When the column is too narrow for the bar to read (< 3 chars), falls back
+/// to the dim middle-dot.
 fn loading_shimmer_cell(width: u16, tick: usize) -> Cell<'static> {
     if width == 0 {
         return Cell::from("");
     }
-    if width < SHIMMER_MIN_WIDTH {
+    if width < SKELETON_MIN_WIDTH {
         return loading_glyph_cell();
     }
     const BAR_CHAR: &str = "\u{2592}"; // ▒
-    let cycle = width + SHIMMER_HIGHLIGHT_WIDTH;
-    let pos = (tick as u16) % cycle;
-    let dim = Style::default().fg(Color::DarkGray);
-    let bright = Style::default().fg(Color::Gray);
-    let mut spans: Vec<Span<'static>> = Vec::with_capacity(width as usize);
-    for i in 0..width {
-        let in_highlight = pos >= i && pos - i < SHIMMER_HIGHLIGHT_WIDTH;
-        let style = if in_highlight { bright } else { dim };
-        spans.push(Span::styled(BAR_CHAR, style));
-    }
-    Cell::from(Line::from(spans))
+    let phase = (tick / SKELETON_PULSE_PHASE_FRAMES) % 4;
+    let color = match phase {
+        0 => Color::DarkGray,
+        1 => Color::Gray,
+        2 => Color::White,
+        _ => Color::Gray,
+    };
+    let bar: String = BAR_CHAR.repeat(width as usize);
+    Cell::from(Span::styled(bar, Style::default().fg(color)))
 }
 
 /// Render a single cell for the given column and worktree row.
@@ -1125,41 +1126,40 @@ mod tests {
     }
 
     #[test]
-    fn loading_shimmer_cell_highlight_position_advances_with_tick() {
-        // Render two snapshots at different ticks and confirm the bright
-        // highlight is at different positions. We can't easily inspect the fg
-        // color of cells directly, but we can confirm the renders differ when
-        // the highlight band moves enough to land on different cells.
-        let backend1 = TestBackend::new(20, 1);
-        let mut t1 = Terminal::new(backend1).unwrap();
-        t1.draw(|frame| {
-            let cell = loading_shimmer_cell(20, 0);
-            let table = Table::new(vec![Row::new(vec![cell])], &[Constraint::Length(20)]);
-            frame.render_widget(table, frame.area());
-        })
-        .unwrap();
-        let buf1 = t1.backend().buffer().clone();
-
-        let backend2 = TestBackend::new(20, 1);
-        let mut t2 = Terminal::new(backend2).unwrap();
-        t2.draw(|frame| {
-            let cell = loading_shimmer_cell(20, 10);
-            let table = Table::new(vec![Row::new(vec![cell])], &[Constraint::Length(20)]);
-            frame.render_widget(table, frame.area());
-        })
-        .unwrap();
-        let buf2 = t2.backend().buffer().clone();
-
-        // Compare foreground colors at each x — they should differ for at
-        // least one cell because the highlight has moved.
-        let mut differs = false;
-        for x in 0..20 {
-            if buf1[(x, 0)].fg != buf2[(x, 0)].fg {
-                differs = true;
-                break;
+    fn loading_shimmer_cell_pulses_uniformly_across_phases() {
+        // The whole bar should share one foreground color at any given tick,
+        // and that color should differ across pulse phases.
+        let render_at = |tick: usize| -> ratatui::style::Color {
+            let backend = TestBackend::new(20, 1);
+            let mut terminal = Terminal::new(backend).unwrap();
+            terminal
+                .draw(|frame| {
+                    let cell = loading_shimmer_cell(20, tick);
+                    let table = Table::new(vec![Row::new(vec![cell])], &[Constraint::Length(20)]);
+                    frame.render_widget(table, frame.area());
+                })
+                .unwrap();
+            let buffer = terminal.backend().buffer().clone();
+            // Confirm uniform fg across the bar.
+            let first_fg = buffer[(0, 0)].fg;
+            for x in 1..20 {
+                assert_eq!(
+                    buffer[(x, 0)].fg,
+                    first_fg,
+                    "skeleton bar should be uniform in color at x={x} (tick={tick})"
+                );
             }
-        }
-        assert!(differs, "highlight should move between tick 0 and tick 10");
+            first_fg
+        };
+
+        // Phase 0 (DarkGray) vs phase 2 (White) — different ticks, different
+        // colors.
+        let phase0 = render_at(0);
+        let phase2 = render_at(SKELETON_PULSE_PHASE_FRAMES * 2);
+        assert_ne!(
+            phase0, phase2,
+            "skeleton bar should pulse across phases (phase0={phase0:?}, phase2={phase2:?})"
+        );
     }
 
     #[test]

--- a/src/output/tui/render.rs
+++ b/src/output/tui/render.rs
@@ -83,6 +83,27 @@ fn render_sort_summary_spans(spec: &SortSpec) -> Vec<Span<'static>> {
     spans
 }
 
+/// Render a verbose-mode footer below the table showing inflight cell
+/// count and elapsed time. No-op when not in verbose mode.
+pub fn render_footer(state: &TuiState, frame: &mut Frame, area: Rect) {
+    if !state.show_hook_sub_rows {
+        return;
+    }
+    let inflight: usize = state
+        .live
+        .received_patches
+        .iter()
+        .filter(|fs| !fs.contains(crate::core::worktree::info_field::FieldSet::ALL))
+        .count();
+    let elapsed_secs = state.render_start_elapsed.as_secs_f32();
+    let text = format!(" inflight: {inflight} \u{00B7} elapsed: {elapsed_secs:.1}s");
+    let line = Line::from(Span::styled(
+        text,
+        Style::default().add_modifier(Modifier::DIM),
+    ));
+    frame.render_widget(Paragraph::new(line), area);
+}
+
 /// Render the worktree status table.
 pub fn render_table(state: &TuiState, frame: &mut Frame, area: Rect) {
     let now = chrono::Utc::now().timestamp();
@@ -927,6 +948,29 @@ fn render_annotation_cell(info: &WorktreeInfo) -> Cell<'static> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::sort::SortSpec;
+    use crate::core::worktree::list::{Stat, WorktreeInfo};
+    use crate::core::worktree::sync_dag::OperationPhase;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+    use std::path::PathBuf;
+
+    fn make_test_state(verbose: u8) -> TuiState {
+        TuiState::new(
+            Vec::<OperationPhase>::new(),
+            vec![WorktreeInfo::empty("master")],
+            PathBuf::from("/tmp/test"),
+            PathBuf::from("/tmp/test"),
+            Stat::Summary,
+            verbose,
+            None,
+            false,
+            None,
+            None::<SortSpec>,
+            true,
+            false,
+        )
+    }
 
     #[test]
     fn loading_glyph_cell_renders_dim_middle_dot() {
@@ -934,5 +978,43 @@ mod tests {
         // Cell is opaque; the test just confirms it constructs without panic.
         // Detailed visual verification belongs in the PTY scenario tests.
         let _ = cell;
+    }
+
+    #[test]
+    fn render_footer_no_op_when_not_verbose() {
+        let state = make_test_state(0);
+        assert!(!state.show_hook_sub_rows);
+        let backend = TestBackend::new(40, 1);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render_footer(&state, frame, frame.area());
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+        // All cells should be empty (default).
+        for cell in buffer.content().iter() {
+            assert_eq!(cell.symbol(), " ");
+        }
+    }
+
+    #[test]
+    fn render_footer_shows_inflight_and_elapsed_when_verbose() {
+        let mut state = make_test_state(1);
+        state.render_start_elapsed = std::time::Duration::from_millis(1234);
+        let backend = TestBackend::new(60, 1);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render_footer(&state, frame, frame.area());
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+        let row: String = (0..buffer.area.width)
+            .map(|x| buffer[(x, 0)].symbol().to_string())
+            .collect();
+        assert!(row.contains("inflight:"), "row was: {row:?}");
+        assert!(row.contains("elapsed:"), "row was: {row:?}");
+        assert!(row.contains("1.2s"), "row was: {row:?}");
     }
 }

--- a/src/output/tui/render.rs
+++ b/src/output/tui/render.rs
@@ -23,6 +23,9 @@ const DASH: &str = "\u{2014}";
 
 /// Render the operation header showing phase progress.
 pub fn render_header(state: &TuiState, frame: &mut Frame, area: Rect) {
+    if state.phases.is_empty() {
+        return;
+    }
     let lines: Vec<Line> = state
         .phases
         .iter()

--- a/src/output/tui/render.rs
+++ b/src/output/tui/render.rs
@@ -658,6 +658,20 @@ fn skeleton_pulse_color(tick: usize) -> u8 {
     SKELETON_GRAY_DARKEST + offset as u8
 }
 
+/// Render a "data didn't load" placeholder for a cell whose patch was not
+/// received before the user cancelled (Ctrl-C). Single em-dash (U+2014),
+/// dim + DarkGray. Distinct from the loading shimmer (which is a full-width
+/// bar of U+25AC) and from a legitimately-empty cell (a blank).
+#[allow(dead_code)]
+fn not_loaded_cell() -> Cell<'static> {
+    Cell::from(Span::styled(
+        "\u{2014}",
+        Style::default()
+            .fg(Color::DarkGray)
+            .add_modifier(Modifier::DIM),
+    ))
+}
+
 /// Render a single cell for the given column and worktree row.
 ///
 /// `width` is the column's assigned width — used to size shimmer bars when
@@ -1227,5 +1241,30 @@ mod tests {
         assert!(row.contains("inflight:"), "row was: {row:?}");
         assert!(row.contains("elapsed:"), "row was: {row:?}");
         assert!(row.contains("1.2s"), "row was: {row:?}");
+    }
+
+    #[test]
+    fn not_loaded_cell_renders_dim_em_dash() {
+        // The "didn't load" cell should be a single em-dash (U+2014) styled
+        // dim + DarkGray, distinct from the breathing skeleton bar (which
+        // fills the column with U+25AC).
+        let backend = TestBackend::new(5, 1);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                let cell = not_loaded_cell();
+                let table = Table::new(vec![Row::new(vec![cell])], &[Constraint::Length(5)]);
+                frame.render_widget(table, frame.area());
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+        assert_eq!(buffer[(0, 0)].symbol(), "\u{2014}");
+        assert_eq!(buffer[(0, 0)].fg, ratatui::style::Color::DarkGray);
+        assert!(
+            buffer[(0, 0)]
+                .modifier
+                .contains(ratatui::style::Modifier::DIM),
+            "not_loaded_cell should be DIM"
+        );
     }
 }

--- a/src/output/tui/render.rs
+++ b/src/output/tui/render.rs
@@ -99,7 +99,10 @@ pub fn render_footer(state: &TuiState, frame: &mut Frame, area: Rect) {
         .filter(|fs| !fs.contains(crate::core::worktree::info_field::FieldSet::ALL))
         .count();
     let elapsed_secs = state.render_start_elapsed.as_secs_f32();
-    let text = format!(" inflight: {inflight} \u{00B7} elapsed: {elapsed_secs:.1}s");
+    let mut text = format!(" inflight: {inflight} \u{00B7} elapsed: {elapsed_secs:.1}s");
+    if state.live.cancelled {
+        text.push_str(" \u{00B7} cancelled");
+    }
     let line = Line::from(Span::styled(
         text,
         Style::default().add_modifier(Modifier::DIM),
@@ -1410,5 +1413,44 @@ mod tests {
                 .any(|c| c.is_ascii_digit() || c == 'B' || c == 'K'),
             "received Size cell should render numeric/unit value; got {row:?}"
         );
+    }
+
+    #[test]
+    fn render_footer_appends_cancelled_when_live_cancelled() {
+        let mut state = make_test_state(1);
+        state.render_start_elapsed = std::time::Duration::from_millis(1234);
+        state.live.mark_cancelled();
+        let backend = TestBackend::new(80, 1);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render_footer(&state, frame, frame.area());
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+        let row: String = (0..buffer.area.width)
+            .map(|x| buffer[(x, 0)].symbol().to_string())
+            .collect();
+        assert!(row.contains("cancelled"), "row was: {row:?}");
+        assert!(row.contains("inflight:"), "row was: {row:?}");
+    }
+
+    #[test]
+    fn render_footer_no_cancelled_suffix_when_not_cancelled() {
+        let mut state = make_test_state(1);
+        state.render_start_elapsed = std::time::Duration::from_millis(1234);
+        // NOT calling mark_cancelled.
+        let backend = TestBackend::new(80, 1);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render_footer(&state, frame, frame.area());
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+        let row: String = (0..buffer.area.width)
+            .map(|x| buffer[(x, 0)].symbol().to_string())
+            .collect();
+        assert!(!row.contains("cancelled"), "row was: {row:?}");
     }
 }

--- a/src/output/tui/render.rs
+++ b/src/output/tui/render.rs
@@ -349,6 +349,7 @@ pub fn render_table(state: &TuiState, frame: &mut Frame, area: Rect) {
                             state.live.cfg.stat,
                             assigned_widths[i],
                             |fs| state.live.is_cell_loading(row_idx, fs),
+                            |fs| state.live.is_cell_unloaded(row_idx, fs),
                         )
                     } else {
                         Cell::from("")
@@ -368,6 +369,7 @@ pub fn render_table(state: &TuiState, frame: &mut Frame, area: Rect) {
                         state.live.cfg.stat,
                         assigned_widths[i],
                         |fs| state.live.is_cell_loading(row_idx, fs),
+                        |fs| state.live.is_cell_unloaded(row_idx, fs),
                     )
                 })
                 .collect()
@@ -662,7 +664,6 @@ fn skeleton_pulse_color(tick: usize) -> u8 {
 /// received before the user cancelled (Ctrl-C). Single em-dash (U+2014),
 /// dim + DarkGray. Distinct from the loading shimmer (which is a full-width
 /// bar of U+25AC) and from a legitimately-empty cell (a blank).
-#[allow(dead_code)]
 fn not_loaded_cell() -> Cell<'static> {
     Cell::from(Span::styled(
         "\u{2014}",
@@ -676,6 +677,9 @@ fn not_loaded_cell() -> Cell<'static> {
 ///
 /// `width` is the column's assigned width — used to size shimmer bars when
 /// the cell is in a loading state.
+/// `is_cell_unloaded` returns true when the user cancelled before the cell's
+/// patch arrived; takes precedence over `is_cell_loading`.
+#[allow(clippy::too_many_arguments)]
 fn render_cell(
     col: &Column,
     wt: &super::state::WorktreeRow,
@@ -684,6 +688,7 @@ fn render_cell(
     stat: Stat,
     width: u16,
     is_cell_loading: impl Fn(FieldSet) -> bool,
+    is_cell_unloaded: impl Fn(FieldSet) -> bool,
 ) -> Cell<'static> {
     match col {
         Column::Status => render_status_cell(wt, tick),
@@ -691,44 +696,57 @@ fn render_cell(
         Column::Branch => Cell::from(vals.branch.clone()),
         Column::Path => Cell::from(vals.path.clone()),
         Column::Size => {
-            if vals.size.is_empty() && is_cell_loading(FieldSet::SIZE) {
-                loading_shimmer_cell(width, tick)
+            if vals.size.is_empty() {
+                if is_cell_unloaded(FieldSet::SIZE) {
+                    not_loaded_cell()
+                } else if is_cell_loading(FieldSet::SIZE) {
+                    loading_shimmer_cell(width, tick)
+                } else {
+                    Cell::from(vals.size.clone())
+                }
             } else {
                 Cell::from(vals.size.clone())
             }
         }
         Column::Base => {
-            if wt.info.ahead.is_none()
-                && wt.info.behind.is_none()
-                && is_cell_loading(FieldSet::BASE_AHEAD_BEHIND)
-            {
+            let unfilled = wt.info.ahead.is_none() && wt.info.behind.is_none();
+            if unfilled && is_cell_unloaded(FieldSet::BASE_AHEAD_BEHIND) {
+                not_loaded_cell()
+            } else if unfilled && is_cell_loading(FieldSet::BASE_AHEAD_BEHIND) {
                 loading_shimmer_cell(width, tick)
             } else {
                 render_base_cell(&wt.info, stat)
             }
         }
         Column::Changes => {
-            if is_cell_loading(FieldSet::CHANGES)
-                && wt.info.staged + wt.info.unstaged + wt.info.untracked == 0
-            {
+            let unfilled = wt.info.staged + wt.info.unstaged + wt.info.untracked == 0;
+            if unfilled && is_cell_unloaded(FieldSet::CHANGES) {
+                not_loaded_cell()
+            } else if unfilled && is_cell_loading(FieldSet::CHANGES) {
                 loading_shimmer_cell(width, tick)
             } else {
                 render_changes_cell(&wt.info, stat)
             }
         }
         Column::Remote => {
-            if wt.info.remote_ahead.is_none()
-                && wt.info.remote_behind.is_none()
-                && is_cell_loading(FieldSet::REMOTE_AHEAD_BEHIND)
-            {
+            let unfilled = wt.info.remote_ahead.is_none() && wt.info.remote_behind.is_none();
+            if unfilled && is_cell_unloaded(FieldSet::REMOTE_AHEAD_BEHIND) {
+                not_loaded_cell()
+            } else if unfilled && is_cell_loading(FieldSet::REMOTE_AHEAD_BEHIND) {
                 loading_shimmer_cell(width, tick)
             } else {
                 render_remote_cell(&wt.info, stat)
             }
         }
         Column::Age => {
-            if vals.branch_age.is_empty() && is_cell_loading(FieldSet::BRANCH_AGE) {
-                loading_shimmer_cell(width, tick)
+            if vals.branch_age.is_empty() {
+                if is_cell_unloaded(FieldSet::BRANCH_AGE) {
+                    not_loaded_cell()
+                } else if is_cell_loading(FieldSet::BRANCH_AGE) {
+                    loading_shimmer_cell(width, tick)
+                } else {
+                    Cell::from(vals.branch_age.clone())
+                }
             } else {
                 let cell = Cell::from(vals.branch_age.clone());
                 if vals.is_old_branch {
@@ -739,25 +757,40 @@ fn render_cell(
             }
         }
         Column::Owner => {
-            if vals.owner.is_empty() && is_cell_loading(FieldSet::OWNER) {
-                loading_shimmer_cell(width, tick)
+            if vals.owner.is_empty() {
+                if is_cell_unloaded(FieldSet::OWNER) {
+                    not_loaded_cell()
+                } else if is_cell_loading(FieldSet::OWNER) {
+                    loading_shimmer_cell(width, tick)
+                } else {
+                    Cell::from(vals.owner.clone())
+                }
             } else {
                 Cell::from(vals.owner.clone())
             }
         }
         Column::Hash => {
-            if vals.hash.is_empty() && is_cell_loading(FieldSet::LAST_COMMIT) {
-                loading_shimmer_cell(width, tick)
+            if vals.hash.is_empty() {
+                if is_cell_unloaded(FieldSet::LAST_COMMIT) {
+                    not_loaded_cell()
+                } else if is_cell_loading(FieldSet::LAST_COMMIT) {
+                    loading_shimmer_cell(width, tick)
+                } else {
+                    Cell::from(vals.hash.clone())
+                }
             } else {
                 Cell::from(vals.hash.clone())
             }
         }
         Column::LastCommit => {
-            if vals.last_commit_age.is_empty()
-                && vals.last_commit_subject.is_empty()
-                && is_cell_loading(FieldSet::LAST_COMMIT)
-            {
-                loading_shimmer_cell(width, tick)
+            if vals.last_commit_age.is_empty() && vals.last_commit_subject.is_empty() {
+                if is_cell_unloaded(FieldSet::LAST_COMMIT) {
+                    not_loaded_cell()
+                } else if is_cell_loading(FieldSet::LAST_COMMIT) {
+                    loading_shimmer_cell(width, tick)
+                } else {
+                    Cell::from("")
+                }
             } else if vals.last_commit_age.is_empty() {
                 Cell::from(vals.last_commit_subject.clone())
             } else if vals.last_commit_subject.is_empty() {
@@ -1265,6 +1298,117 @@ mod tests {
                 .modifier
                 .contains(ratatui::style::Modifier::DIM),
             "not_loaded_cell should be DIM"
+        );
+    }
+
+    #[test]
+    fn render_cell_uses_not_loaded_when_cancelled_and_unfilled() {
+        // For each loadable column, with is_cell_unloaded returning true,
+        // the cell should render the dim em-dash, not the shimmer bar and
+        // not an empty cell.
+        use crate::core::worktree::info_field::FieldSet;
+        use crate::output::format::{compute_column_values, ColumnContext};
+        use crate::output::tui::state::WorktreeRow;
+
+        let info = WorktreeInfo::empty("a");
+        let wt = WorktreeRow::idle(info.clone());
+        let ctx = ColumnContext {
+            project_root: &PathBuf::from("/tmp"),
+            cwd: &PathBuf::from("/tmp"),
+            now: 0,
+            stat: Stat::Lines,
+        };
+        let vals = compute_column_values(&info, &ctx);
+
+        let columns = [
+            (Column::Size, FieldSet::SIZE),
+            (Column::Base, FieldSet::BASE_AHEAD_BEHIND),
+            (Column::Changes, FieldSet::CHANGES),
+            (Column::Remote, FieldSet::REMOTE_AHEAD_BEHIND),
+            (Column::Age, FieldSet::BRANCH_AGE),
+            (Column::Owner, FieldSet::OWNER),
+            (Column::Hash, FieldSet::LAST_COMMIT),
+            (Column::LastCommit, FieldSet::LAST_COMMIT),
+        ];
+
+        for (col, _field) in columns {
+            let backend = TestBackend::new(10, 1);
+            let mut terminal = Terminal::new(backend).unwrap();
+            terminal
+                .draw(|frame| {
+                    let cell = render_cell(
+                        &col,
+                        &wt,
+                        &vals,
+                        0,
+                        Stat::Lines,
+                        10,
+                        |_fs| false, // not loading (cancelled implies collection_complete)
+                        |_fs| true,  // is_cell_unloaded → true
+                    );
+                    let table = Table::new(vec![Row::new(vec![cell])], &[Constraint::Length(10)]);
+                    frame.render_widget(table, frame.area());
+                })
+                .unwrap();
+            let buffer = terminal.backend().buffer();
+            assert_eq!(
+                buffer[(0, 0)].symbol(),
+                "\u{2014}",
+                "column {col:?} should render em-dash when cancelled and unfilled"
+            );
+        }
+    }
+
+    #[test]
+    fn render_cell_uses_value_when_received_even_if_cancelled() {
+        // If the cell value is non-empty (received), is_cell_unloaded should
+        // be false and the value should render. Guards against rendering
+        // "—" over real data.
+        use crate::output::format::{compute_column_values, ColumnContext};
+        use crate::output::tui::state::WorktreeRow;
+
+        let mut info = WorktreeInfo::empty("a");
+        info.size_bytes = Some(1024);
+        let wt = WorktreeRow::idle(info.clone());
+        let ctx = ColumnContext {
+            project_root: &PathBuf::from("/tmp"),
+            cwd: &PathBuf::from("/tmp"),
+            now: 0,
+            stat: Stat::Lines,
+        };
+        let vals = compute_column_values(&info, &ctx);
+
+        let backend = TestBackend::new(10, 1);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                let cell = render_cell(
+                    &Column::Size,
+                    &wt,
+                    &vals,
+                    0,
+                    Stat::Lines,
+                    10,
+                    |_fs| false, // not loading
+                    |_fs| false, // not unloaded — received
+                );
+                let table = Table::new(vec![Row::new(vec![cell])], &[Constraint::Length(10)]);
+                frame.render_widget(table, frame.area());
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+        let row: String = (0..10)
+            .map(|x| buffer[(x, 0)].symbol().to_string())
+            .collect();
+        assert!(
+            !row.contains("\u{2014}"),
+            "received cell should render value, not em-dash; got {row:?}"
+        );
+        assert!(
+            row.trim_end()
+                .chars()
+                .any(|c| c.is_ascii_digit() || c == 'B' || c == 'K'),
+            "received Size cell should render numeric/unit value; got {row:?}"
         );
     }
 }

--- a/src/output/tui/render.rs
+++ b/src/output/tui/render.rs
@@ -157,36 +157,50 @@ pub fn render_table(state: &TuiState, frame: &mut Frame, area: Rect) {
     } else {
         area
     };
-    let columns = match (&state.live.cfg.columns, state.live.cfg.columns_explicit) {
-        // Replace mode: user explicitly chose columns, don't responsively drop.
-        (Some(user_cols), true) => user_cols.clone(),
-        // Modifier mode: user tweaked defaults, responsive dropping still applies.
-        // Opt-in columns (not in ALL_COLUMNS, e.g. Size) that the user explicitly
-        // added are always included — they bypass responsive dropping.
-        (Some(user_cols), false) => {
-            let responsive =
-                select_columns(table_area.width, &state.live.rows, &row_vals, sort_ref);
-            let mut cols: Vec<Column> = responsive
-                .into_iter()
-                .filter(|c| matches!(c, Column::Status) || user_cols.contains(c))
-                .collect();
-            for col in user_cols {
-                if !ALL_COLUMNS.contains(col) && !cols.contains(col) {
-                    cols.push(*col);
-                }
-            }
-            cols
-        }
-        // No column selection: fully responsive.
-        (None, _) => select_columns(table_area.width, &state.live.rows, &row_vals, sort_ref),
-    };
-    // Status is always prepended for TUI commands.
-    let columns = if !columns.contains(&Column::Status) {
-        let mut with_status = vec![Column::Status];
-        with_status.extend(columns);
-        with_status
+    let columns = if state.phases.is_empty() {
+        // Phase-less = daft list. Use user-selected columns as-is in canonical
+        // order (matching the blocking print_table behavior). No Status column
+        // (no operations to track), no responsive dropping (let the table wrap
+        // or truncate via Branch/Path widths instead of dropping data columns).
+        state.live.cfg.columns.clone().unwrap_or_else(|| {
+            // Fallback to defaults converted from ListColumn::list_defaults.
+            crate::core::columns::ListColumn::list_defaults()
+                .iter()
+                .map(|lc| Column::from_list_column(*lc))
+                .collect()
+        })
     } else {
-        columns
+        let columns = match (&state.live.cfg.columns, state.live.cfg.columns_explicit) {
+            // Replace mode: user explicitly chose columns, don't responsively drop.
+            (Some(user_cols), true) => user_cols.clone(),
+            // Modifier mode: user tweaked defaults, responsive dropping still applies.
+            // Opt-in columns (not in ALL_COLUMNS, e.g. Size) that the user explicitly
+            // added are always included — they bypass responsive dropping.
+            (Some(user_cols), false) => {
+                let responsive =
+                    select_columns(table_area.width, &state.live.rows, &row_vals, sort_ref);
+                let mut cols: Vec<Column> = responsive
+                    .into_iter()
+                    .filter(|c| matches!(c, Column::Status) || user_cols.contains(c))
+                    .collect();
+                for col in user_cols {
+                    if !ALL_COLUMNS.contains(col) && !cols.contains(col) {
+                        cols.push(*col);
+                    }
+                }
+                cols
+            }
+            // No column selection: fully responsive.
+            (None, _) => select_columns(table_area.width, &state.live.rows, &row_vals, sort_ref),
+        };
+        // Status is always prepended for TUI commands with phases.
+        if !columns.contains(&Column::Status) {
+            let mut with_status = vec![Column::Status];
+            with_status.extend(columns);
+            with_status
+        } else {
+            columns
+        }
     };
 
     let constraints: Vec<Constraint> = columns

--- a/src/output/tui/render.rs
+++ b/src/output/tui/render.rs
@@ -338,11 +338,18 @@ pub fn render_table(state: &TuiState, frame: &mut Frame, area: Rect) {
             // continuous strikethrough line.
             columns
                 .iter()
-                .map(|col| {
+                .enumerate()
+                .map(|(i, col)| {
                     if matches!(col, Column::Status | Column::Annotation) {
-                        render_cell(col, wt, vals, state.tick, state.live.cfg.stat, |fs| {
-                            state.live.is_cell_loading(row_idx, fs)
-                        })
+                        render_cell(
+                            col,
+                            wt,
+                            vals,
+                            state.tick,
+                            state.live.cfg.stat,
+                            assigned_widths[i],
+                            |fs| state.live.is_cell_loading(row_idx, fs),
+                        )
                     } else {
                         Cell::from("")
                     }
@@ -351,10 +358,17 @@ pub fn render_table(state: &TuiState, frame: &mut Frame, area: Rect) {
         } else {
             columns
                 .iter()
-                .map(|col| {
-                    render_cell(col, wt, vals, state.tick, state.live.cfg.stat, |fs| {
-                        state.live.is_cell_loading(row_idx, fs)
-                    })
+                .enumerate()
+                .map(|(i, col)| {
+                    render_cell(
+                        col,
+                        wt,
+                        vals,
+                        state.tick,
+                        state.live.cfg.stat,
+                        assigned_widths[i],
+                        |fs| state.live.is_cell_loading(row_idx, fs),
+                    )
                 })
                 .collect()
         };
@@ -595,7 +609,9 @@ fn render_remote_cell(info: &WorktreeInfo, stat: Stat) -> Cell<'static> {
     }
 }
 
-/// Render a dim middle-dot for an unfilled cell while the table is still streaming.
+/// Render a dim middle-dot for an unfilled cell while the table is still
+/// streaming. Used as a fallback when the column is too narrow for a shimmer
+/// bar to read clearly.
 fn loading_glyph_cell() -> Cell<'static> {
     Cell::from(Span::styled(
         "\u{00B7}",
@@ -603,13 +619,48 @@ fn loading_glyph_cell() -> Cell<'static> {
     ))
 }
 
+/// Width below which the shimmer bar collapses to a single dim glyph.
+const SHIMMER_MIN_WIDTH: u16 = 3;
+
+/// Width of the bright "highlight" band that sweeps across the shimmer bar.
+const SHIMMER_HIGHLIGHT_WIDTH: u16 = 3;
+
+/// Render a sweeping shimmer placeholder for an unfilled cell. The bar fills
+/// the column's assigned width with a dim block character; a brighter band
+/// sweeps left-to-right driven by the renderer tick. When the column is too
+/// narrow for the sweep to read (< 3 chars), falls back to the dim middle-dot.
+fn loading_shimmer_cell(width: u16, tick: usize) -> Cell<'static> {
+    if width == 0 {
+        return Cell::from("");
+    }
+    if width < SHIMMER_MIN_WIDTH {
+        return loading_glyph_cell();
+    }
+    const BAR_CHAR: &str = "\u{2592}"; // ▒
+    let cycle = width + SHIMMER_HIGHLIGHT_WIDTH;
+    let pos = (tick as u16) % cycle;
+    let dim = Style::default().fg(Color::DarkGray);
+    let bright = Style::default().fg(Color::Gray);
+    let mut spans: Vec<Span<'static>> = Vec::with_capacity(width as usize);
+    for i in 0..width {
+        let in_highlight = pos >= i && pos - i < SHIMMER_HIGHLIGHT_WIDTH;
+        let style = if in_highlight { bright } else { dim };
+        spans.push(Span::styled(BAR_CHAR, style));
+    }
+    Cell::from(Line::from(spans))
+}
+
 /// Render a single cell for the given column and worktree row.
+///
+/// `width` is the column's assigned width — used to size shimmer bars when
+/// the cell is in a loading state.
 fn render_cell(
     col: &Column,
     wt: &super::state::WorktreeRow,
     vals: &ColumnValues,
     tick: usize,
     stat: Stat,
+    width: u16,
     is_cell_loading: impl Fn(FieldSet) -> bool,
 ) -> Cell<'static> {
     match col {
@@ -619,7 +670,7 @@ fn render_cell(
         Column::Path => Cell::from(vals.path.clone()),
         Column::Size => {
             if vals.size.is_empty() && is_cell_loading(FieldSet::SIZE) {
-                loading_glyph_cell()
+                loading_shimmer_cell(width, tick)
             } else {
                 Cell::from(vals.size.clone())
             }
@@ -629,7 +680,7 @@ fn render_cell(
                 && wt.info.behind.is_none()
                 && is_cell_loading(FieldSet::BASE_AHEAD_BEHIND)
             {
-                loading_glyph_cell()
+                loading_shimmer_cell(width, tick)
             } else {
                 render_base_cell(&wt.info, stat)
             }
@@ -638,7 +689,7 @@ fn render_cell(
             if is_cell_loading(FieldSet::CHANGES)
                 && wt.info.staged + wt.info.unstaged + wt.info.untracked == 0
             {
-                loading_glyph_cell()
+                loading_shimmer_cell(width, tick)
             } else {
                 render_changes_cell(&wt.info, stat)
             }
@@ -648,14 +699,14 @@ fn render_cell(
                 && wt.info.remote_behind.is_none()
                 && is_cell_loading(FieldSet::REMOTE_AHEAD_BEHIND)
             {
-                loading_glyph_cell()
+                loading_shimmer_cell(width, tick)
             } else {
                 render_remote_cell(&wt.info, stat)
             }
         }
         Column::Age => {
             if vals.branch_age.is_empty() && is_cell_loading(FieldSet::BRANCH_AGE) {
-                loading_glyph_cell()
+                loading_shimmer_cell(width, tick)
             } else {
                 let cell = Cell::from(vals.branch_age.clone());
                 if vals.is_old_branch {
@@ -667,14 +718,14 @@ fn render_cell(
         }
         Column::Owner => {
             if vals.owner.is_empty() && is_cell_loading(FieldSet::OWNER) {
-                loading_glyph_cell()
+                loading_shimmer_cell(width, tick)
             } else {
                 Cell::from(vals.owner.clone())
             }
         }
         Column::Hash => {
             if vals.hash.is_empty() && is_cell_loading(FieldSet::LAST_COMMIT) {
-                loading_glyph_cell()
+                loading_shimmer_cell(width, tick)
             } else {
                 Cell::from(vals.hash.clone())
             }
@@ -684,7 +735,7 @@ fn render_cell(
                 && vals.last_commit_subject.is_empty()
                 && is_cell_loading(FieldSet::LAST_COMMIT)
             {
-                loading_glyph_cell()
+                loading_shimmer_cell(width, tick)
             } else if vals.last_commit_age.is_empty() {
                 Cell::from(vals.last_commit_subject.clone())
             } else if vals.last_commit_subject.is_empty() {
@@ -1039,6 +1090,76 @@ mod tests {
         // Cell is opaque; the test just confirms it constructs without panic.
         // Detailed visual verification belongs in the PTY scenario tests.
         let _ = cell;
+    }
+
+    #[test]
+    fn loading_shimmer_cell_collapses_to_glyph_when_too_narrow() {
+        // Width below SHIMMER_MIN_WIDTH (3) should fall back to the dim dot —
+        // a single ▒ wouldn't read as "loading" without movement.
+        let _ = loading_shimmer_cell(0, 0);
+        let _ = loading_shimmer_cell(1, 0);
+        let _ = loading_shimmer_cell(2, 0);
+    }
+
+    #[test]
+    fn loading_shimmer_cell_fills_column_with_block_chars() {
+        // Render a shimmer cell into a 1-row buffer and confirm the bar
+        // characters appear across the assigned width.
+        let backend = TestBackend::new(10, 1);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                let cell = loading_shimmer_cell(10, 0);
+                let table = Table::new(vec![Row::new(vec![cell])], &[Constraint::Length(10)]);
+                frame.render_widget(table, frame.area());
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+        let row: String = (0..10)
+            .map(|x| buffer[(x, 0)].symbol().to_string())
+            .collect();
+        assert!(
+            row.chars().all(|c| c == '\u{2592}'),
+            "shimmer row should be all ▒, got {row:?}"
+        );
+    }
+
+    #[test]
+    fn loading_shimmer_cell_highlight_position_advances_with_tick() {
+        // Render two snapshots at different ticks and confirm the bright
+        // highlight is at different positions. We can't easily inspect the fg
+        // color of cells directly, but we can confirm the renders differ when
+        // the highlight band moves enough to land on different cells.
+        let backend1 = TestBackend::new(20, 1);
+        let mut t1 = Terminal::new(backend1).unwrap();
+        t1.draw(|frame| {
+            let cell = loading_shimmer_cell(20, 0);
+            let table = Table::new(vec![Row::new(vec![cell])], &[Constraint::Length(20)]);
+            frame.render_widget(table, frame.area());
+        })
+        .unwrap();
+        let buf1 = t1.backend().buffer().clone();
+
+        let backend2 = TestBackend::new(20, 1);
+        let mut t2 = Terminal::new(backend2).unwrap();
+        t2.draw(|frame| {
+            let cell = loading_shimmer_cell(20, 10);
+            let table = Table::new(vec![Row::new(vec![cell])], &[Constraint::Length(20)]);
+            frame.render_widget(table, frame.area());
+        })
+        .unwrap();
+        let buf2 = t2.backend().buffer().clone();
+
+        // Compare foreground colors at each x — they should differ for at
+        // least one cell because the highlight has moved.
+        let mut differs = false;
+        for x in 0..20 {
+            if buf1[(x, 0)].fg != buf2[(x, 0)].fg {
+                differs = true;
+                break;
+            }
+        }
+        assert!(differs, "highlight should move between tick 0 and tick 10");
     }
 
     #[test]

--- a/src/output/tui/render.rs
+++ b/src/output/tui/render.rs
@@ -664,16 +664,17 @@ fn skeleton_pulse_color(tick: usize) -> u8 {
 }
 
 /// Render a "data didn't load" placeholder for a cell whose patch was not
-/// received before the user cancelled (Ctrl-C). Single em-dash (U+2014),
-/// dim + DarkGray. Distinct from the loading shimmer (which is a full-width
-/// bar of U+25AC) and from a legitimately-empty cell (a blank).
-fn not_loaded_cell() -> Cell<'static> {
-    Cell::from(Span::styled(
-        "\u{2014}",
-        Style::default()
-            .fg(Color::DarkGray)
-            .add_modifier(Modifier::DIM),
-    ))
+/// received before the user cancelled (Ctrl-C). Single em-dash (U+2014) in
+/// `Color::Gray`, centered within the column's assigned `width` via leading
+/// spaces. Distinct from the loading shimmer (full-width bar of U+25AC) and
+/// from a legitimately-empty cell (a blank).
+fn not_loaded_cell(width: u16) -> Cell<'static> {
+    if width == 0 {
+        return Cell::from("");
+    }
+    let left_pad = (width as usize).saturating_sub(1) / 2;
+    let padded: String = " ".repeat(left_pad) + "\u{2014}";
+    Cell::from(Span::styled(padded, Style::default().fg(Color::Gray)))
 }
 
 /// Render a single cell for the given column and worktree row.
@@ -701,7 +702,7 @@ fn render_cell(
         Column::Size => {
             if vals.size.is_empty() {
                 if is_cell_unloaded(FieldSet::SIZE) {
-                    not_loaded_cell()
+                    not_loaded_cell(width)
                 } else if is_cell_loading(FieldSet::SIZE) {
                     loading_shimmer_cell(width, tick)
                 } else {
@@ -714,7 +715,7 @@ fn render_cell(
         Column::Base => {
             let unfilled = wt.info.ahead.is_none() && wt.info.behind.is_none();
             if unfilled && is_cell_unloaded(FieldSet::BASE_AHEAD_BEHIND) {
-                not_loaded_cell()
+                not_loaded_cell(width)
             } else if unfilled && is_cell_loading(FieldSet::BASE_AHEAD_BEHIND) {
                 loading_shimmer_cell(width, tick)
             } else {
@@ -724,7 +725,7 @@ fn render_cell(
         Column::Changes => {
             let unfilled = wt.info.staged + wt.info.unstaged + wt.info.untracked == 0;
             if unfilled && is_cell_unloaded(FieldSet::CHANGES) {
-                not_loaded_cell()
+                not_loaded_cell(width)
             } else if unfilled && is_cell_loading(FieldSet::CHANGES) {
                 loading_shimmer_cell(width, tick)
             } else {
@@ -734,7 +735,7 @@ fn render_cell(
         Column::Remote => {
             let unfilled = wt.info.remote_ahead.is_none() && wt.info.remote_behind.is_none();
             if unfilled && is_cell_unloaded(FieldSet::REMOTE_AHEAD_BEHIND) {
-                not_loaded_cell()
+                not_loaded_cell(width)
             } else if unfilled && is_cell_loading(FieldSet::REMOTE_AHEAD_BEHIND) {
                 loading_shimmer_cell(width, tick)
             } else {
@@ -744,7 +745,7 @@ fn render_cell(
         Column::Age => {
             if vals.branch_age.is_empty() {
                 if is_cell_unloaded(FieldSet::BRANCH_AGE) {
-                    not_loaded_cell()
+                    not_loaded_cell(width)
                 } else if is_cell_loading(FieldSet::BRANCH_AGE) {
                     loading_shimmer_cell(width, tick)
                 } else {
@@ -762,7 +763,7 @@ fn render_cell(
         Column::Owner => {
             if vals.owner.is_empty() {
                 if is_cell_unloaded(FieldSet::OWNER) {
-                    not_loaded_cell()
+                    not_loaded_cell(width)
                 } else if is_cell_loading(FieldSet::OWNER) {
                     loading_shimmer_cell(width, tick)
                 } else {
@@ -775,7 +776,7 @@ fn render_cell(
         Column::Hash => {
             if vals.hash.is_empty() {
                 if is_cell_unloaded(FieldSet::LAST_COMMIT) {
-                    not_loaded_cell()
+                    not_loaded_cell(width)
                 } else if is_cell_loading(FieldSet::LAST_COMMIT) {
                     loading_shimmer_cell(width, tick)
                 } else {
@@ -788,7 +789,7 @@ fn render_cell(
         Column::LastCommit => {
             if vals.last_commit_age.is_empty() && vals.last_commit_subject.is_empty() {
                 if is_cell_unloaded(FieldSet::LAST_COMMIT) {
-                    not_loaded_cell()
+                    not_loaded_cell(width)
                 } else if is_cell_loading(FieldSet::LAST_COMMIT) {
                     loading_shimmer_cell(width, tick)
                 } else {
@@ -1280,28 +1281,55 @@ mod tests {
     }
 
     #[test]
-    fn not_loaded_cell_renders_dim_em_dash() {
-        // The "didn't load" cell should be a single em-dash (U+2014) styled
-        // dim + DarkGray, distinct from the breathing skeleton bar (which
-        // fills the column with U+25AC).
+    fn not_loaded_cell_renders_centered_em_dash_in_gray() {
+        // The "didn't load" cell should be a single em-dash (U+2014) in
+        // Color::Gray, centered within the column's assigned width via
+        // leading spaces. Distinct from the breathing skeleton bar (full
+        // width of U+25AC).
         let backend = TestBackend::new(5, 1);
         let mut terminal = Terminal::new(backend).unwrap();
         terminal
             .draw(|frame| {
-                let cell = not_loaded_cell();
+                let cell = not_loaded_cell(5);
                 let table = Table::new(vec![Row::new(vec![cell])], &[Constraint::Length(5)]);
                 frame.render_widget(table, frame.area());
             })
             .unwrap();
         let buffer = terminal.backend().buffer();
-        assert_eq!(buffer[(0, 0)].symbol(), "\u{2014}");
-        assert_eq!(buffer[(0, 0)].fg, ratatui::style::Color::DarkGray);
+        let row: String = (0..5)
+            .map(|x| buffer[(x, 0)].symbol().to_string())
+            .collect();
         assert!(
-            buffer[(0, 0)]
-                .modifier
-                .contains(ratatui::style::Modifier::DIM),
-            "not_loaded_cell should be DIM"
+            row.contains("\u{2014}"),
+            "expected em-dash in row; got {row:?}"
         );
+        // Em-dash should sit at index 2 (center of 5: left_pad = (5-1)/2 = 2).
+        assert_eq!(
+            buffer[(2, 0)].symbol(),
+            "\u{2014}",
+            "em-dash should be centered at index 2 for width 5; row was {row:?}"
+        );
+        assert_eq!(
+            buffer[(2, 0)].fg,
+            ratatui::style::Color::Gray,
+            "em-dash should be Color::Gray for visibility"
+        );
+    }
+
+    #[test]
+    fn not_loaded_cell_zero_width_returns_empty() {
+        // Width 0 must not panic and should render nothing.
+        let backend = TestBackend::new(1, 1);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                let cell = not_loaded_cell(0);
+                let table = Table::new(vec![Row::new(vec![cell])], &[Constraint::Length(0)]);
+                frame.render_widget(table, frame.area());
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+        assert_eq!(buffer[(0, 0)].symbol(), " ");
     }
 
     #[test]
@@ -1354,10 +1382,12 @@ mod tests {
                 })
                 .unwrap();
             let buffer = terminal.backend().buffer();
-            assert_eq!(
-                buffer[(0, 0)].symbol(),
-                "\u{2014}",
-                "column {col:?} should render em-dash when cancelled and unfilled"
+            let row: String = (0..10)
+                .map(|x| buffer[(x, 0)].symbol().to_string())
+                .collect();
+            assert!(
+                row.contains("\u{2014}"),
+                "column {col:?} should render em-dash when cancelled and unfilled; row was {row:?}"
             );
         }
     }

--- a/src/output/tui/render.rs
+++ b/src/output/tui/render.rs
@@ -639,7 +639,7 @@ fn loading_shimmer_cell(width: u16, tick: usize) -> Cell<'static> {
     if width < SKELETON_MIN_WIDTH {
         return loading_glyph_cell();
     }
-    const BAR_CHAR: &str = "\u{2592}"; // ▒
+    const BAR_CHAR: &str = "\u{2588}"; // █
     let phase = (tick / SKELETON_PULSE_PHASE_FRAMES) % 4;
     let color = match phase {
         0 => Color::DarkGray,
@@ -1120,8 +1120,8 @@ mod tests {
             .map(|x| buffer[(x, 0)].symbol().to_string())
             .collect();
         assert!(
-            row.chars().all(|c| c == '\u{2592}'),
-            "shimmer row should be all ▒, got {row:?}"
+            row.chars().all(|c| c == '\u{2588}'),
+            "skeleton bar should be all █, got {row:?}"
         );
     }
 

--- a/src/output/tui/render.rs
+++ b/src/output/tui/render.rs
@@ -1,6 +1,7 @@
 use super::columns::{column_content_width, select_columns, Column, ALL_COLUMNS};
 use super::state::{FinalStatus, PhaseStatus, TuiState, WorktreeStatus};
 use crate::core::sort::SortSpec;
+use crate::core::worktree::info_field::FieldSet;
 use crate::core::worktree::list::{EntryKind, Stat, WorktreeInfo};
 use crate::output::format::{self, format_human_size, ColumnContext, ColumnValues};
 use crate::styles;
@@ -248,6 +249,7 @@ pub fn render_table(state: &TuiState, frame: &mut Frame, area: Rect) {
         }
 
         let is_pruned = matches!(wt.status, WorktreeStatus::Done(FinalStatus::Pruned));
+        let row_idx = wt_idx;
         let main_cells: Vec<Cell> = if is_pruned {
             // Status and Annotation keep their normal cells; other columns are
             // left empty because their content is overlaid with a single
@@ -256,7 +258,9 @@ pub fn render_table(state: &TuiState, frame: &mut Frame, area: Rect) {
                 .iter()
                 .map(|col| {
                     if matches!(col, Column::Status | Column::Annotation) {
-                        render_cell(col, wt, vals, state.tick, state.live.cfg.stat)
+                        render_cell(col, wt, vals, state.tick, state.live.cfg.stat, |fs| {
+                            state.live.is_cell_loading(row_idx, fs)
+                        })
                     } else {
                         Cell::from("")
                     }
@@ -265,7 +269,11 @@ pub fn render_table(state: &TuiState, frame: &mut Frame, area: Rect) {
         } else {
             columns
                 .iter()
-                .map(|col| render_cell(col, wt, vals, state.tick, state.live.cfg.stat))
+                .map(|col| {
+                    render_cell(col, wt, vals, state.tick, state.live.cfg.stat, |fs| {
+                        state.live.is_cell_loading(row_idx, fs)
+                    })
+                })
                 .collect()
         };
         all_rows.push(Row::new(main_cells));
@@ -505,6 +513,14 @@ fn render_remote_cell(info: &WorktreeInfo, stat: Stat) -> Cell<'static> {
     }
 }
 
+/// Render a dim middle-dot for an unfilled cell while the table is still streaming.
+fn loading_glyph_cell() -> Cell<'static> {
+    Cell::from(Span::styled(
+        "\u{00B7}",
+        Style::default().add_modifier(Modifier::DIM),
+    ))
+}
+
 /// Render a single cell for the given column and worktree row.
 fn render_cell(
     col: &Column,
@@ -512,28 +528,82 @@ fn render_cell(
     vals: &ColumnValues,
     tick: usize,
     stat: Stat,
+    is_cell_loading: impl Fn(FieldSet) -> bool,
 ) -> Cell<'static> {
     match col {
         Column::Status => render_status_cell(wt, tick),
         Column::Annotation => render_annotation_cell(&wt.info),
         Column::Branch => Cell::from(vals.branch.clone()),
         Column::Path => Cell::from(vals.path.clone()),
-        Column::Size => Cell::from(vals.size.clone()),
-        Column::Base => render_base_cell(&wt.info, stat),
-        Column::Changes => render_changes_cell(&wt.info, stat),
-        Column::Remote => render_remote_cell(&wt.info, stat),
-        Column::Age => {
-            let cell = Cell::from(vals.branch_age.clone());
-            if vals.is_old_branch {
-                cell.style(Style::default().add_modifier(Modifier::DIM))
+        Column::Size => {
+            if vals.size.is_empty() && is_cell_loading(FieldSet::SIZE) {
+                loading_glyph_cell()
             } else {
-                cell
+                Cell::from(vals.size.clone())
             }
         }
-        Column::Owner => Cell::from(vals.owner.clone()),
-        Column::Hash => Cell::from(vals.hash.clone()),
+        Column::Base => {
+            if wt.info.ahead.is_none()
+                && wt.info.behind.is_none()
+                && is_cell_loading(FieldSet::BASE_AHEAD_BEHIND)
+            {
+                loading_glyph_cell()
+            } else {
+                render_base_cell(&wt.info, stat)
+            }
+        }
+        Column::Changes => {
+            if is_cell_loading(FieldSet::CHANGES)
+                && wt.info.staged + wt.info.unstaged + wt.info.untracked == 0
+            {
+                loading_glyph_cell()
+            } else {
+                render_changes_cell(&wt.info, stat)
+            }
+        }
+        Column::Remote => {
+            if wt.info.remote_ahead.is_none()
+                && wt.info.remote_behind.is_none()
+                && is_cell_loading(FieldSet::REMOTE_AHEAD_BEHIND)
+            {
+                loading_glyph_cell()
+            } else {
+                render_remote_cell(&wt.info, stat)
+            }
+        }
+        Column::Age => {
+            if vals.branch_age.is_empty() && is_cell_loading(FieldSet::BRANCH_AGE) {
+                loading_glyph_cell()
+            } else {
+                let cell = Cell::from(vals.branch_age.clone());
+                if vals.is_old_branch {
+                    cell.style(Style::default().add_modifier(Modifier::DIM))
+                } else {
+                    cell
+                }
+            }
+        }
+        Column::Owner => {
+            if vals.owner.is_empty() && is_cell_loading(FieldSet::OWNER) {
+                loading_glyph_cell()
+            } else {
+                Cell::from(vals.owner.clone())
+            }
+        }
+        Column::Hash => {
+            if vals.hash.is_empty() && is_cell_loading(FieldSet::LAST_COMMIT) {
+                loading_glyph_cell()
+            } else {
+                Cell::from(vals.hash.clone())
+            }
+        }
         Column::LastCommit => {
-            if vals.last_commit_age.is_empty() {
+            if vals.last_commit_age.is_empty()
+                && vals.last_commit_subject.is_empty()
+                && is_cell_loading(FieldSet::LAST_COMMIT)
+            {
+                loading_glyph_cell()
+            } else if vals.last_commit_age.is_empty() {
                 Cell::from(vals.last_commit_subject.clone())
             } else if vals.last_commit_subject.is_empty() {
                 let cell = Cell::from(vals.last_commit_age.clone());
@@ -852,4 +922,17 @@ fn render_annotation_cell(info: &WorktreeInfo) -> Cell<'static> {
     }
 
     Cell::from(Line::from(spans))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn loading_glyph_cell_renders_dim_middle_dot() {
+        let cell = loading_glyph_cell();
+        // Cell is opaque; the test just confirms it constructs without panic.
+        // Detailed visual verification belongs in the PTY scenario tests.
+        let _ = cell;
+    }
 }

--- a/src/output/tui/render.rs
+++ b/src/output/tui/render.rs
@@ -216,9 +216,10 @@ pub fn render_table(state: &TuiState, frame: &mut Frame, area: Rect) {
         .collect();
     let assigned_widths = fit_widths_to_available(&columns, &natural_widths, table_area.width);
 
-    // When Branch or Path was shrunk below its natural width, pre-truncate the
-    // displayed text so the renderer shows "..." rather than ratatui's silent
-    // hard cut. Other columns are short by construction and don't need this.
+    // When Branch / Path / LastCommit were shrunk below natural, pre-truncate
+    // the displayed text so the renderer shows "..." rather than ratatui's
+    // silent hard cut. For LastCommit the user-visible string is
+    // "<age> <subject>"; truncate the subject so the combined length fits.
     for (i, col) in columns.iter().enumerate() {
         if assigned_widths[i] >= natural_widths[i] {
             continue;
@@ -234,20 +235,35 @@ pub fn render_table(state: &TuiState, frame: &mut Frame, area: Rect) {
                     vals.path = truncate_with_ellipsis(&vals.path, assigned_widths[i]);
                 }
             }
+            Column::LastCommit => {
+                let width = assigned_widths[i];
+                for vals in &mut row_vals {
+                    if vals.last_commit_subject.is_empty() {
+                        // Only age is shown — that's already short, but fall
+                        // back to direct truncation in pathological cases.
+                        if !vals.last_commit_age.is_empty() {
+                            vals.last_commit_age =
+                                truncate_with_ellipsis(&vals.last_commit_age, width);
+                        }
+                        continue;
+                    }
+                    let prefix = if vals.last_commit_age.is_empty() {
+                        0
+                    } else {
+                        vals.last_commit_age.chars().count() as u16 + 1 // " "
+                    };
+                    let subject_room = width.saturating_sub(prefix);
+                    vals.last_commit_subject =
+                        truncate_with_ellipsis(&vals.last_commit_subject, subject_room);
+                }
+            }
             _ => {}
         }
     }
 
-    let constraints: Vec<Constraint> = columns
+    let constraints: Vec<Constraint> = assigned_widths
         .iter()
-        .enumerate()
-        .map(|(i, col)| {
-            if matches!(col, Column::LastCommit) {
-                Constraint::Fill(1)
-            } else {
-                Constraint::Length(assigned_widths[i])
-            }
-        })
+        .map(|w| Constraint::Length(*w))
         .collect();
 
     // X offset where the first data column (Branch) starts — used for

--- a/src/output/tui/state.rs
+++ b/src/output/tui/state.rs
@@ -8,6 +8,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use super::columns::Column;
+use super::live_table::{LiveTable, LiveTableConfig};
 
 /// Status of a high-level operation phase in the header.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -97,22 +98,12 @@ pub struct HookSummaryEntry {
 /// Complete TUI state, rebuilt from DagEvents.
 pub struct TuiState {
     pub phases: Vec<PhaseState>,
-    pub worktrees: Vec<WorktreeRow>,
     pub done: bool,
     pub tick: usize,
-    pub project_root: PathBuf,
-    pub cwd: PathBuf,
-    pub stat: Stat,
     pub hook_summaries: Vec<HookSummaryEntry>,
     pub show_hook_sub_rows: bool,
-    /// User-selected columns (None = use responsive selection).
-    pub columns: Option<Vec<Column>>,
-    /// If true, the user explicitly chose columns (replace mode) — disables responsive dropping.
-    pub columns_explicit: bool,
-    /// Index of the first unowned worktree row (None if no unowned section).
-    pub unowned_start_index: Option<usize>,
-    /// User-specified sort order (None = default alphabetical).
-    pub sort_spec: Option<SortSpec>,
+    /// Worktree-rows widget (rows, sort, partition, patch application).
+    pub live: LiveTable,
 }
 
 /// A single row in the worktree table.
@@ -162,34 +153,24 @@ impl TuiState {
         unowned_start_index: Option<usize>,
         sort_spec: Option<SortSpec>,
     ) -> Self {
-        let mut worktrees: Vec<WorktreeRow> = worktree_infos
-            .into_iter()
-            .map(|info| WorktreeRow {
-                info,
-                status: WorktreeStatus::Idle,
-                prev_terminal_status: None,
-                hook_warned: false,
-                hook_failed: false,
-                hook_sub_rows: Vec::new(),
-                failure_reason: None,
-            })
-            .collect();
-        worktrees.sort_by(|a, b| {
-            // Default branch always first.
-            let default_order = |w: &WorktreeRow| u8::from(!w.info.is_default_branch);
-            let kind_order = |k: &EntryKind| match k {
-                EntryKind::Worktree => 0,
-                EntryKind::LocalBranch => 1,
-                EntryKind::RemoteBranch => 2,
-            };
-            default_order(a)
-                .cmp(&default_order(b))
-                .then_with(|| kind_order(&a.info.kind).cmp(&kind_order(&b.info.kind)))
-                .then_with(|| match &sort_spec {
-                    Some(spec) => spec.compare(&a.info, &b.info),
-                    None => a.info.name.to_lowercase().cmp(&b.info.name.to_lowercase()),
-                })
-        });
+        // Task 9 preserves today's behavior: prune/sync compute
+        // `unowned_start_index` externally and pass it in. We disable
+        // `partition_by_owner` so `LiveTable::resort_and_repartition` does
+        // not overwrite the externally-computed boundary, then inject the
+        // value directly. Task 10 will flip `partition_by_owner` to true and
+        // delete the parameter.
+        let cfg = LiveTableConfig {
+            stat,
+            columns,
+            columns_explicit,
+            sort_spec,
+            pin_default_branch: true,
+            partition_by_owner: false,
+            project_root,
+            cwd,
+        };
+        let mut live = LiveTable::new(worktree_infos, cfg);
+        live.unowned_start_index = unowned_start_index;
         Self {
             phases: phases
                 .into_iter()
@@ -198,18 +179,11 @@ impl TuiState {
                     status: PhaseStatus::Pending,
                 })
                 .collect(),
-            worktrees,
             done: false,
             tick: 0,
-            project_root,
-            cwd,
-            stat,
             hook_summaries: Vec::new(),
             show_hook_sub_rows: verbose >= 1,
-            columns,
-            columns_explicit,
-            unowned_start_index,
-            sort_spec,
+            live,
         }
     }
 
@@ -233,18 +207,15 @@ impl TuiState {
                     } else {
                         EntryKind::Worktree
                     };
-                    self.worktrees.push(WorktreeRow {
-                        info: WorktreeInfo {
-                            kind,
-                            ..WorktreeInfo::empty(branch_name)
-                        },
-                        status: WorktreeStatus::Idle,
-                        prev_terminal_status: None,
-                        hook_warned: false,
-                        hook_failed: false,
-                        hook_sub_rows: Vec::new(),
-                        failure_reason: None,
-                    });
+                    self.live.rows.push(WorktreeRow::idle(WorktreeInfo {
+                        kind,
+                        ..WorktreeInfo::empty(branch_name)
+                    }));
+                    // Keep the per-row patch tracker in lockstep so
+                    // `LiveTable::is_cell_loading` cannot index out of bounds.
+                    self.live
+                        .received_patches
+                        .push(crate::core::worktree::info_field::FieldSet::EMPTY);
                 }
                 if let Some(row) = self.find_row_mut(branch_name) {
                     // Save terminal status so PreconditionFailed can restore it.
@@ -302,7 +273,7 @@ impl TuiState {
                 // Mark any worktrees that were never touched as up-to-date.
                 // This covers prune (where only gone branches get events) and
                 // any other scenario where some rows stay idle.
-                for wt in &mut self.worktrees {
+                for wt in &mut self.live.rows {
                     if wt.status == WorktreeStatus::Idle {
                         wt.status = WorktreeStatus::Done(FinalStatus::UpToDate);
                     }
@@ -449,6 +420,7 @@ impl TuiState {
 
     pub fn tick(&mut self) {
         self.tick += 1;
+        self.live.tick();
     }
 
     fn activate_phase(&mut self, phase: &OperationPhase) {
@@ -470,7 +442,7 @@ impl TuiState {
             OperationPhase::Push => "pushing",
             OperationPhase::Setup => "setting up",
         };
-        let any_active = self.worktrees.iter().any(
+        let any_active = self.live.rows.iter().any(
             |w| matches!(&w.status, WorktreeStatus::Active(label) if label == phase_active_label),
         );
         if !any_active {
@@ -483,7 +455,8 @@ impl TuiState {
     }
 
     fn find_row_mut(&mut self, branch_name: &str) -> Option<&mut WorktreeRow> {
-        self.worktrees
+        self.live
+            .rows
             .iter_mut()
             .find(|w| w.info.name == branch_name)
     }
@@ -600,7 +573,8 @@ mod tests {
             .iter()
             .all(|p| p.status == PhaseStatus::Pending));
         assert!(state
-            .worktrees
+            .live
+            .rows
             .iter()
             .all(|w| w.status == WorktreeStatus::Idle));
         assert!(!state.done);
@@ -633,7 +607,8 @@ mod tests {
         });
 
         let row = state
-            .worktrees
+            .live
+            .rows
             .iter()
             .find(|w| w.info.name == "master")
             .unwrap();
@@ -656,7 +631,8 @@ mod tests {
             branch_name: "feat/old".into(),
         });
         let row = state
-            .worktrees
+            .live
+            .rows
             .iter()
             .find(|w| w.info.name == "feat/old")
             .unwrap();
@@ -671,7 +647,8 @@ mod tests {
         });
 
         let row = state
-            .worktrees
+            .live
+            .rows
             .iter()
             .find(|w| w.info.name == "feat/old")
             .unwrap();
@@ -695,7 +672,8 @@ mod tests {
         });
 
         let row = state
-            .worktrees
+            .live
+            .rows
             .iter()
             .find(|w| w.info.name == "feat/old")
             .unwrap();
@@ -719,7 +697,8 @@ mod tests {
         });
 
         let row = state
-            .worktrees
+            .live
+            .rows
             .iter()
             .find(|w| w.info.name == "master")
             .unwrap();
@@ -739,7 +718,8 @@ mod tests {
         });
 
         let row = state
-            .worktrees
+            .live
+            .rows
             .iter()
             .find(|w| w.info.name == "master")
             .unwrap();
@@ -814,7 +794,8 @@ mod tests {
         });
 
         let row = state
-            .worktrees
+            .live
+            .rows
             .iter()
             .find(|w| w.info.name == "master")
             .unwrap();
@@ -824,7 +805,7 @@ mod tests {
     #[test]
     fn auto_creates_row_for_unknown_branch() {
         let mut state = make_test_state();
-        assert_eq!(state.worktrees.len(), 3);
+        assert_eq!(state.live.rows.len(), 3);
 
         // A TaskStarted for an unknown branch should auto-create a row
         state.apply_event(&DagEvent::TaskStarted {
@@ -832,9 +813,10 @@ mod tests {
             branch_name: "feat/discovered".into(),
         });
 
-        assert_eq!(state.worktrees.len(), 4);
+        assert_eq!(state.live.rows.len(), 4);
         let row = state
-            .worktrees
+            .live
+            .rows
             .iter()
             .find(|w| w.info.name == "feat/discovered")
             .unwrap();
@@ -862,7 +844,8 @@ mod tests {
 
         // feat/old was pruned
         let pruned = state
-            .worktrees
+            .live
+            .rows
             .iter()
             .find(|w| w.info.name == "feat/old")
             .unwrap();
@@ -870,14 +853,16 @@ mod tests {
 
         // The remaining idle rows should now be up-to-date
         let master = state
-            .worktrees
+            .live
+            .rows
             .iter()
             .find(|w| w.info.name == "master")
             .unwrap();
         assert_eq!(master.status, WorktreeStatus::Done(FinalStatus::UpToDate));
 
         let feat_a = state
-            .worktrees
+            .live
+            .rows
             .iter()
             .find(|w| w.info.name == "feat/a")
             .unwrap();
@@ -907,7 +892,8 @@ mod tests {
         });
 
         let row = state
-            .worktrees
+            .live
+            .rows
             .iter()
             .find(|w| w.info.name == "master")
             .unwrap();
@@ -925,7 +911,8 @@ mod tests {
             hook_type: HookType::PreRemove,
         });
         let row = state
-            .worktrees
+            .live
+            .rows
             .iter()
             .find(|w| w.info.name == "feat/old")
             .unwrap();
@@ -945,7 +932,8 @@ mod tests {
             output: Some("warning output".into()),
         });
         let row = state
-            .worktrees
+            .live
+            .rows
             .iter()
             .find(|w| w.info.name == "feat/old")
             .unwrap();
@@ -969,7 +957,8 @@ mod tests {
             output: None,
         });
         let row = state
-            .worktrees
+            .live
+            .rows
             .iter()
             .find(|w| w.info.name == "master")
             .unwrap();
@@ -990,7 +979,8 @@ mod tests {
 
         {
             let row = state
-                .worktrees
+                .live
+                .rows
                 .iter()
                 .find(|w| w.info.name == "feat/a")
                 .unwrap();
@@ -1011,7 +1001,8 @@ mod tests {
         });
 
         let row = state
-            .worktrees
+            .live
+            .rows
             .iter()
             .find(|w| w.info.name == "feat/a")
             .unwrap();
@@ -1037,7 +1028,8 @@ mod tests {
         });
 
         let row = state
-            .worktrees
+            .live
+            .rows
             .iter()
             .find(|w| w.info.name == "feat/a")
             .unwrap();
@@ -1073,7 +1065,8 @@ mod tests {
         });
 
         let row = state
-            .worktrees
+            .live
+            .rows
             .iter()
             .find(|w| w.info.name == "feat/a")
             .unwrap();
@@ -1119,7 +1112,8 @@ mod tests {
         });
 
         let row = state
-            .worktrees
+            .live
+            .rows
             .iter()
             .find(|w| w.info.name == "feat/a")
             .unwrap();
@@ -1162,7 +1156,8 @@ mod tests {
             branch_name: "master".into(),
         });
         let row = state
-            .worktrees
+            .live
+            .rows
             .iter()
             .find(|w| w.info.name == "master")
             .unwrap();
@@ -1176,7 +1171,8 @@ mod tests {
             updated_info: None,
         });
         let row = state
-            .worktrees
+            .live
+            .rows
             .iter()
             .find(|w| w.info.name == "master")
             .unwrap();
@@ -1218,7 +1214,8 @@ mod tests {
         });
 
         let row = state
-            .worktrees
+            .live
+            .rows
             .iter()
             .find(|w| w.info.name == "feat/a")
             .unwrap();
@@ -1263,7 +1260,8 @@ mod tests {
         });
 
         let row = state
-            .worktrees
+            .live
+            .rows
             .iter()
             .find(|w| w.info.name == "master")
             .unwrap();
@@ -1286,7 +1284,8 @@ mod tests {
         });
 
         let row = state
-            .worktrees
+            .live
+            .rows
             .iter()
             .find(|w| w.info.name == "feat/a")
             .unwrap();
@@ -1338,7 +1337,8 @@ mod tests {
 
         // Verify row shows conflict
         let row = state
-            .worktrees
+            .live
+            .rows
             .iter()
             .find(|w| w.info.name == "feat/old")
             .unwrap();
@@ -1361,7 +1361,8 @@ mod tests {
 
         // Row should show conflict again (restored from prev_terminal_status)
         let row = state
-            .worktrees
+            .live
+            .rows
             .iter()
             .find(|w| w.info.name == "feat/old")
             .unwrap();

--- a/src/output/tui/state.rs
+++ b/src/output/tui/state.rs
@@ -152,20 +152,23 @@ impl TuiState {
         columns_explicit: bool,
         unowned_start_index: Option<usize>,
         sort_spec: Option<SortSpec>,
+        pin_default_branch: bool,
+        partition_by_owner: bool,
     ) -> Self {
-        // Task 9 preserves today's behavior: prune/sync compute
-        // `unowned_start_index` externally and pass it in. We disable
-        // `partition_by_owner` so `LiveTable::resort_and_repartition` does
-        // not overwrite the externally-computed boundary, then inject the
-        // value directly. Task 10 will flip `partition_by_owner` to true and
-        // delete the parameter.
+        // For prune/sync the caller passes `partition_by_owner: false` and
+        // injects an externally-computed `unowned_start_index` (richer
+        // predicate via `is_branch_included` with include_filters). Setting
+        // `partition_by_owner: true` would let
+        // `LiveTable::resort_and_repartition` overwrite that injected value,
+        // so callers that supply an external boundary MUST pass `false`.
+        // `daft list` (Phase 2) sets `true` to let LiveTable own partitioning.
         let cfg = LiveTableConfig {
             stat,
             columns,
             columns_explicit,
             sort_spec,
-            pin_default_branch: true,
-            partition_by_owner: false,
+            pin_default_branch,
+            partition_by_owner,
             project_root,
             cwd,
         };
@@ -207,15 +210,10 @@ impl TuiState {
                     } else {
                         EntryKind::Worktree
                     };
-                    self.live.rows.push(WorktreeRow::idle(WorktreeInfo {
+                    self.live.push_row(WorktreeInfo {
                         kind,
                         ..WorktreeInfo::empty(branch_name)
-                    }));
-                    // Keep the per-row patch tracker in lockstep so
-                    // `LiveTable::is_cell_loading` cannot index out of bounds.
-                    self.live
-                        .received_patches
-                        .push(crate::core::worktree::info_field::FieldSet::EMPTY);
+                    });
                 }
                 if let Some(row) = self.find_row_mut(branch_name) {
                     // Save terminal status so PreconditionFailed can restore it.
@@ -532,6 +530,8 @@ mod tests {
             false,
             None,
             None,
+            true,
+            false,
         )
     }
 
@@ -559,6 +559,8 @@ mod tests {
             false,
             None,
             None,
+            true,
+            false,
         )
     }
 
@@ -1146,6 +1148,8 @@ mod tests {
             false,
             None,
             None,
+            true,
+            false,
         );
 
         state.apply_event(&DagEvent::TaskStarted {
@@ -1196,6 +1200,8 @@ mod tests {
             false,
             None,
             None,
+            true,
+            false,
         );
 
         state.apply_event(&DagEvent::TaskStarted {
@@ -1242,6 +1248,8 @@ mod tests {
             false,
             None,
             None,
+            true,
+            false,
         );
 
         state.apply_event(&DagEvent::TaskStarted {
@@ -1312,6 +1320,8 @@ mod tests {
             false,
             None,
             None,
+            true,
+            false,
         )
     }
 

--- a/src/output/tui/state.rs
+++ b/src/output/tui/state.rs
@@ -409,11 +409,8 @@ impl TuiState {
                     }
                 }
             }
-            DagEvent::WorktreeInfoUpdated { .. } => {
-                // Forwarded to LiveTable in Task 9 — ignore for now.
-            }
-            DagEvent::WorktreeInfoCollectionDone => {
-                // Handled in Task 9.
+            DagEvent::WorktreeInfoUpdated { .. } | DagEvent::WorktreeInfoCollectionDone => {
+                self.live.apply_event(event);
             }
         }
     }

--- a/src/output/tui/state.rs
+++ b/src/output/tui/state.rs
@@ -190,6 +190,15 @@ impl TuiState {
         }
     }
 
+    /// True when the table has reached a terminal state and the renderer
+    /// should exit. For commands with phases (prune/sync/clone), this means
+    /// `done` was set by `DagEvent::AllDone`. For phase-less commands
+    /// (`daft list`), it also returns true once
+    /// `live.collection_complete` is set by `WorktreeInfoCollectionDone`.
+    pub fn is_complete(&self) -> bool {
+        self.done || (self.phases.is_empty() && self.live.collection_complete)
+    }
+
     pub fn apply_event(&mut self, event: &DagEvent) {
         match event {
             DagEvent::TaskStarted { phase, branch_name } => {
@@ -561,6 +570,55 @@ mod tests {
             true,
             false,
         )
+    }
+
+    /// Build a TuiState with a caller-specified phase list. Thin wrapper
+    /// over `TuiState::new` that supplies sensible defaults for the rest of
+    /// the args (no worktrees, Stat::Summary, default columns/sort, etc.).
+    fn make_test_state_with_phases(phases: Vec<OperationPhase>) -> TuiState {
+        TuiState::new(
+            phases,
+            Vec::new(),
+            PathBuf::from("/tmp/test"),
+            PathBuf::from("/tmp/test"),
+            Stat::Summary,
+            0,
+            None,
+            false,
+            None,
+            None,
+            true,
+            false,
+        )
+    }
+
+    #[test]
+    fn is_complete_false_initially() {
+        let state = make_test_state_with_phases(vec![OperationPhase::Fetch]);
+        assert!(!state.is_complete());
+    }
+
+    #[test]
+    fn is_complete_true_after_all_done_event() {
+        let mut state = make_test_state_with_phases(vec![OperationPhase::Fetch]);
+        state.apply_event(&DagEvent::AllDone);
+        assert!(state.is_complete());
+    }
+
+    #[test]
+    fn is_complete_true_after_collection_done_when_no_phases() {
+        let mut state = make_test_state_with_phases(vec![]);
+        state.apply_event(&DagEvent::WorktreeInfoCollectionDone);
+        assert!(state.is_complete());
+    }
+
+    #[test]
+    fn is_complete_false_after_collection_done_when_phases_present() {
+        // When phases exist, completion still requires AllDone — collection
+        // finishing is just one input among many.
+        let mut state = make_test_state_with_phases(vec![OperationPhase::Fetch]);
+        state.apply_event(&DagEvent::WorktreeInfoCollectionDone);
+        assert!(!state.is_complete());
     }
 
     #[test]

--- a/src/output/tui/state.rs
+++ b/src/output/tui/state.rs
@@ -228,7 +228,6 @@ impl TuiState {
                 branch_name,
                 status,
                 message,
-                updated_info,
             } => {
                 if *status == TaskStatus::PreconditionFailed {
                     // Restore the previous terminal status (saved by TaskStarted).
@@ -255,9 +254,9 @@ impl TuiState {
                         if failure_reason.is_some() {
                             row.failure_reason = failure_reason;
                         }
-                        if let Some(new_info) = updated_info {
-                            row.info = *new_info.clone();
-                        }
+                        // Refreshed WorktreeInfo cells now flow as
+                        // `WorktreeInfoUpdated` patches with
+                        // `PatchSource::PostTask(phase)` — see `LiveTable`.
                     }
                     self.check_phase_completion(phase);
                 }
@@ -602,7 +601,6 @@ mod tests {
             branch_name: "master".into(),
             status: TaskStatus::Succeeded,
             message: TaskMessage::UpToDate,
-            updated_info: None,
         });
 
         let row = state
@@ -642,7 +640,6 @@ mod tests {
             branch_name: "feat/old".into(),
             status: TaskStatus::Succeeded,
             message: TaskMessage::Removed,
-            updated_info: None,
         });
 
         let row = state
@@ -667,7 +664,6 @@ mod tests {
             branch_name: "feat/old".into(),
             status: TaskStatus::Succeeded,
             message: TaskMessage::SkippedDirty,
-            updated_info: None,
         });
 
         let row = state
@@ -692,7 +688,6 @@ mod tests {
             branch_name: "master".into(),
             status: TaskStatus::Failed,
             message: TaskMessage::Failed("pull failed".into()),
-            updated_info: None,
         });
 
         let row = state
@@ -713,7 +708,6 @@ mod tests {
             branch_name: "master".into(),
             status: TaskStatus::DepFailed,
             message: TaskMessage::Failed("dependency failed".into()),
-            updated_info: None,
         });
 
         let row = state
@@ -750,7 +744,6 @@ mod tests {
             branch_name: String::new(),
             status: TaskStatus::Succeeded,
             message: TaskMessage::Ok("fetched".into()),
-            updated_info: None,
         });
         // Fetch phase should now be completed (fetch task has empty branch_name,
         // so no row was Active for it -- but the phase was Active and now no
@@ -789,7 +782,6 @@ mod tests {
             branch_name: "master".into(),
             status: TaskStatus::Succeeded,
             message: TaskMessage::Ok("Fast-forward".into()),
-            updated_info: None,
         });
 
         let row = state
@@ -836,7 +828,6 @@ mod tests {
             branch_name: "feat/old".into(),
             status: TaskStatus::Succeeded,
             message: TaskMessage::Removed,
-            updated_info: None,
         });
 
         state.apply_event(&DagEvent::AllDone);
@@ -868,39 +859,11 @@ mod tests {
         assert_eq!(feat_a.status, WorktreeStatus::Done(FinalStatus::UpToDate));
     }
 
-    #[test]
-    fn task_completed_with_updated_info_merges_into_row() {
-        let mut state = make_test_state();
-        state.apply_event(&DagEvent::TaskStarted {
-            phase: OperationPhase::Update,
-            branch_name: "master".into(),
-        });
-
-        let mut new_info = WorktreeInfo::empty("master");
-        new_info.remote_ahead = Some(0);
-        new_info.remote_behind = Some(0);
-        new_info.ahead = Some(0);
-        new_info.behind = Some(0);
-
-        state.apply_event(&DagEvent::TaskCompleted {
-            phase: OperationPhase::Update,
-            branch_name: "master".into(),
-            status: TaskStatus::Succeeded,
-            message: TaskMessage::Ok("Fast-forward".into()),
-            updated_info: Some(Box::new(new_info)),
-        });
-
-        let row = state
-            .live
-            .rows
-            .iter()
-            .find(|w| w.info.name == "master")
-            .unwrap();
-        assert_eq!(row.info.remote_ahead, Some(0));
-        assert_eq!(row.info.remote_behind, Some(0));
-        assert_eq!(row.info.ahead, Some(0));
-        assert_eq!(row.info.behind, Some(0));
-    }
+    // The previous `task_completed_with_updated_info_merges_into_row` test
+    // was deleted: refreshed `WorktreeInfo` cells now flow as
+    // `WorktreeInfoUpdated` patches with `PatchSource::PostTask(phase)` rather
+    // than as a `Box<WorktreeInfo>` riding on `TaskCompleted`. The patch
+    // pipeline is covered by the streaming collector's own tests.
 
     #[test]
     fn hook_started_updates_status_label() {
@@ -1169,7 +1132,6 @@ mod tests {
             branch_name: "master".into(),
             status: TaskStatus::Succeeded,
             message: TaskMessage::Pushed,
-            updated_info: None,
         });
         let row = state
             .live
@@ -1213,7 +1175,6 @@ mod tests {
             branch_name: "feat/a".into(),
             status: TaskStatus::Succeeded,
             message: TaskMessage::NoPushUpstream,
-            updated_info: None,
         });
 
         let row = state
@@ -1261,7 +1222,6 @@ mod tests {
             branch_name: "master".into(),
             status: TaskStatus::Succeeded,
             message: TaskMessage::UpToDate,
-            updated_info: None,
         });
 
         let row = state
@@ -1339,7 +1299,6 @@ mod tests {
             branch_name: "feat/old".into(),
             status: TaskStatus::Succeeded,
             message: TaskMessage::Conflict,
-            updated_info: None,
         });
 
         // Verify row shows conflict
@@ -1363,7 +1322,6 @@ mod tests {
             branch_name: "feat/old".into(),
             status: TaskStatus::PreconditionFailed,
             message: TaskMessage::Failed("rebase conflict".into()),
-            updated_info: None,
         });
 
         // Row should show conflict again (restored from prev_terminal_status)

--- a/src/output/tui/state.rs
+++ b/src/output/tui/state.rs
@@ -130,6 +130,24 @@ pub struct WorktreeRow {
     pub failure_reason: Option<String>,
 }
 
+impl WorktreeRow {
+    pub(crate) fn idle(info: WorktreeInfo) -> Self {
+        Self {
+            info,
+            status: WorktreeStatus::Idle,
+            prev_terminal_status: None,
+            hook_warned: false,
+            hook_failed: false,
+            hook_sub_rows: Vec::new(),
+            failure_reason: None,
+        }
+    }
+
+    pub(crate) fn placeholder() -> Self {
+        Self::idle(WorktreeInfo::empty(""))
+    }
+}
+
 impl TuiState {
     #[allow(clippy::too_many_arguments)]
     pub fn new(

--- a/src/output/tui/state.rs
+++ b/src/output/tui/state.rs
@@ -420,6 +420,12 @@ impl TuiState {
                     }
                 }
             }
+            DagEvent::WorktreeInfoUpdated { .. } => {
+                // Forwarded to LiveTable in Task 9 — ignore for now.
+            }
+            DagEvent::WorktreeInfoCollectionDone => {
+                // Handled in Task 9.
+            }
         }
     }
 

--- a/src/output/tui/state.rs
+++ b/src/output/tui/state.rs
@@ -102,6 +102,10 @@ pub struct TuiState {
     pub tick: usize,
     pub hook_summaries: Vec<HookSummaryEntry>,
     pub show_hook_sub_rows: bool,
+    /// Wall-clock duration since the renderer started. Updated by `tick()`
+    /// from the driver's render-loop start instant. Used by the verbose
+    /// footer.
+    pub render_start_elapsed: std::time::Duration,
     /// Worktree-rows widget (rows, sort, partition, patch application).
     pub live: LiveTable,
 }
@@ -186,6 +190,7 @@ impl TuiState {
             tick: 0,
             hook_summaries: Vec::new(),
             show_hook_sub_rows: verbose >= 1,
+            render_start_elapsed: Duration::ZERO,
             live,
         }
     }

--- a/tests/manual/scenarios/list/format-json-bypasses-live.yml
+++ b/tests/manual/scenarios/list/format-json-bypasses-live.yml
@@ -1,0 +1,28 @@
+name: List --format json bypasses live UX
+description:
+  Structured output (--format json/csv/...) always uses blocking rendering so
+  the output is a complete, parseable document — never a partial stream.
+
+repos:
+  - name: test-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone the repository
+    run: git-worktree-clone --layout contained $REMOTE_TEST_REPO
+    expect:
+      exit_code: 0
+
+  - name: List --format json
+    run: git-worktree-list --format json 2>&1
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+      # JSON document is a complete array.
+      output_contains:
+        - "["
+        - '"name": "main"'
+        - "]"
+      # No loading glyph in JSON output.
+      output_not_contains:
+        - "·"

--- a/tests/manual/scenarios/list/no-live-env-var.yml
+++ b/tests/manual/scenarios/list/no-live-env-var.yml
@@ -1,0 +1,29 @@
+name: List with DAFT_NO_LIVE=1 falls back to blocking output
+description:
+  When DAFT_NO_LIVE=1 is set, daft list uses the blocking one-shot rendering
+  even on a TTY. The output should match the historical blocking format.
+
+repos:
+  - name: test-repo
+    use_fixture: standard-remote
+
+env:
+  DAFT_NO_LIVE: "1"
+
+steps:
+  - name: Clone the repository
+    run: git-worktree-clone --layout contained $REMOTE_TEST_REPO
+    expect:
+      exit_code: 0
+
+  - name: List with DAFT_NO_LIVE=1
+    run: NO_COLOR=1 git-worktree-list 2>&1
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "main"
+      # Live UX would emit dim middle-dot glyphs for unfilled cells. The
+      # blocking path computes everything synchronously and never emits them.
+      output_not_contains:
+        - "·"


### PR DESCRIPTION
## Summary

Complete implementation of #402. Originally opened after Phase 1 only; this PR has since absorbed Phases 2–3 plus Phase 4 polish (display fixes, content-addressed cell cache, skeleton loader, current-row highlight) and Phase 5 cancellation UX. All work ships in this single PR.

### Phase 1 — Shared infrastructure (no behavior change)

- **`FieldSet` bitmask** (`src/core/worktree/info_field.rs`) — shared vocabulary across collector subsets, patch deltas, and sort dependencies.
- **`WorktreeInfoPatch` + `PatchSource` enums** in `sync_dag.rs` — typed cell-cluster deltas + source tag for staleness suppression.
- **New `DagEvent` variants**: `WorktreeInfoUpdated { branch_name, patch, source }` and `WorktreeInfoCollectionDone`.
- **`WorktreeInfo::apply_patch`** + **`SortSpec::required_fields`**.
- **Streaming collector** (`src/core/worktree/list_stream.rs`) — phase-agnostic, re-runnable subset engine. One worker thread per branch, cheap-first cluster order, cooperative cancellation between clusters.
- **`PatchSourceLog`** — drops stale `Collector` patches that arrive after `PostFetch`/`PostTask`.
- **`LiveTable` widget** extracted from `TuiState`. Owns rows, sort, partition, patch application, loading-glyph state.
- **`TaskCompleted::updated_info` removed** — orchestrator emits `WorktreeInfoUpdated { source: PostTask(phase) }` patches per task type. Clone refreshes `LAST_COMMIT | BRANCH_AGE` after Setup tasks.
- **`pin_default_branch` + `partition_by_owner` config knobs** on `TableConfig`.

### Phase 2 — `daft list` live UX

- **TTY-only live path** (`src/commands/list_live.rs`): cheap porcelain seed → `LiveTable::new` → `list_stream::spawn(ALL, Collector)` → `TuiRenderer::run`.
- **Dispatcher in `list::run`**: live for TTY + non-structured + `DAFT_NO_LIVE` unset; otherwise blocking (today's behavior).
- **Phase-less rendering** in `TuiRenderer` (zero-height header + `is_complete` predicate covering both `AllDone` and `WorktreeInfoCollectionDone`).
- **Loading-cell rendering** for cells that are `None` AND haven't received their patch (`Size`, `Base`, `Changes`, `Remote`, `Age`, `Owner`, `Hash`, `LastCommit`). Initial dim middle-dot has since been replaced — see Phase 4.
- **Verbose footer** showing `inflight: N · elapsed: 1.2s`.
- **Ctrl-C handling**: cooperative cancellation flag flows through `CollectorHandle::cancel_flag()` → `TuiRenderer::with_cancel_signal`. Visual polish landed in Phase 5.
- **`DAFT_NO_LIVE=1` env var** opt-out.
- **2 dispatcher unit tests** + **2 YAML scenarios** (`no-live-env-var.yml`, `format-json-bypasses-live.yml`).

### Phase 3 — Migrate prune/sync to streaming seed

- **Spinner removed** for prune/sync's `Stat::Lines` and `--columns +size` paths.
- **Synchronous seed** keeps cheap fields (branch, path, ahead/behind, owner, last commit, changes) — required for `shared_owner_lookup` which feeds the include-filter predicate.
- **Streaming collector** spawns concurrently with the orchestrator for the heavy cells the user requested (`SIZE`, `MTIME`, `BASE_LINES`, `CHANGES_LINES`, `REMOTE_LINES`).
- **`spawn_post_fetch_refresh`** in `sync_shared.rs` — re-runs `REMOTE_DERIVED` cells with `PatchSource::PostFetch` after the Fetch phase. Called from both sync and prune orchestrators.
- **Cancel + join cleanup** on the collector handle after the renderer exits.

### Phase 4 — Polish, caching, and live-UX UX (post-bring-up)

Added after the PR was opened. Driven by manual trial of the live path:

**Display correctness**

- `fix(list): exit cleanly on completion + use canonical column ordering` (`19c6e95d`)
- `fix(list): fit Branch/Path widths so LastCommit isn't squeezed` (`2996a302`) — added `fit_widths_to_available()` in `columns.rs` mirroring tabled's `Priority::max(true)` semantics; pre-truncates Branch/Path/LastCommit with ellipsis when shrunk.
- `fix(list): reserve viewport for sort + size summary, ellipsize commits` (`3eaf0847`) — viewport_height now accounts for sort_summary + size_summary rows so the trailing rows aren't cropped; Commit column gets `…` instead of a hard cut.

**Content-addressed cell cache** (`docs/superpowers/plans/2026-04-26-list-cache-content-addressed.md`)

Adopted from worktrunk's pattern: `<git-common-dir>/.daft/cache/<kind>/{sha-pair}.json`. Cache key captures all inputs → hits are provably correct → no TTL, no invalidation logic.

- `feat(cache): add JSON cache primitives under .git/.daft/cache/` (`4b10668e`) — `read_json` / `write_json` / `clear_kind` with corrupt-file tolerance, 7 unit tests.
- `feat(cache): add SHA-resolution helpers for cell-cache wrappers` (`9da7a1ca`)
- 5 per-cell wrappers: `cached_base_ahead_behind` (`6adc6e83`), `cached_remote_ahead_behind` (`e97a7075`), `cached_last_commit` (`a4010546`), `cached_base_lines` (`2300162e`), `cached_remote_lines` (`b5c517fc`). Closure-based compute; failures (None or missing timestamp) are not cached.
- `feat(cache): wire cell-cache wrappers into list_stream collector` (`d6020e95`) — `CollectorContext` gained `git_common_dir`; 5 callers updated. Falls through to direct compute on key-resolution failure.
- `docs(cache): document .daft/cache/ state directory + ship plan` (`77f20499`) — SKILL.md updated.

**Skeleton loader UX**

Iterated through several visual designs — final form is a simple breathing bar so loading cells read as "this column is computing" without competing with real data:

- `feat(tui): replace dot loader with sweeping shimmer fitted to column width` (`944f4fb1`)
- `feat(tui): swap sweeping shimmer for breathing skeleton bar` (`7f3997af`)
- `feat(tui): use solid block for skeleton bar` (`0526652e`)
- `feat(tui): faster pulse + 24-step grayscale ramp for skeleton bar` (`d8cef44f`)
- `feat(tui): use BLACK RECTANGLE U+25AC for skeleton bar` (`955b04b9`) — final glyph

Result: `▬▬▬…▬` sized to the column's assigned width, breathing through the xterm 256-color grayscale ramp (indices 234–253) on a 16-frame triangle wave.

**Current worktree highlight**

- `feat(tui): highlight current worktree row with dim background` (`994bccb1`) — `Style::default().bg(Color::Indexed(235))` on the row whose `info.is_current` is set. The `>` annotation symbol stays for now; we may drop it in a follow-up if the row highlight proves sufficient on its own.

### Phase 5 — Graceful Ctrl-C cancellation

Spec: `docs/superpowers/specs/2026-04-27-graceful-cancellation-design.md`. Plan: `docs/superpowers/plans/2026-04-27-graceful-cancellation.md`. Followed the spec → plan → subagent-driven-development workflow.

Captured symptom: after Ctrl-C the inline viewport left frozen `▬▬▬▬` skeleton bars on unfilled cells and the shell `^C` echo overwrote the last table row (`▬▬▬▬^C%`). Three changes:

- `feat(tui): add cancelled flag and mark_cancelled to LiveTable` (`8306fb67`) — `LiveTable.cancelled: bool` + `mark_cancelled()` method that also flips `collection_complete = true` so `is_cell_loading` naturally returns false post-cancel.
- `feat(tui): add is_cell_unloaded predicate to LiveTable` (`686a8de9`) — sibling predicate for the render path.
- `feat(tui): add not_loaded_cell helper for cancelled-state placeholder` (`a4faf138`) — single dim em-dash `—` (U+2014, DarkGray + DIM).
- `feat(tui): wire is_cell_unloaded through render_cell for cancelled cells` (`497cd0ca`) — `render_cell` accepts `is_cell_unloaded` closure; all 8 loadable column arms (Size, Base, Changes, Remote, Age, Owner, Hash, LastCommit) check unloaded before loading; both `render_table` call sites pass the new closure.
- `feat(tui): append cancelled suffix to verbose footer` (`afc26d17`) — verbose mode shows `· cancelled` after `inflight: N · elapsed: T.Xs`.
- `feat(tui): mark live table cancelled in driver Ctrl-C handler` (`93afb07b`) — driver Ctrl-C arm calls `state.live.mark_cancelled()` before `state.done = true`.
- `feat(tui): write trailing newline after cancelled viewport teardown` (`69bcacb9`) — `final_draw_and_return!` writes `\n` to stderr after viewport teardown when cancelled, so the shell prompt lands on its own line.

Result: Ctrl-C now produces a clean exit — unfilled cells show dim `—` instead of frozen skeleton bars, verbose footer shows `· cancelled`, shell prompt lands on a fresh line. `daft prune` / `daft sync` deferred (different cancellation semantics).

## Spec & plans

- Spec: `docs/superpowers/specs/2026-04-25-live-list-population-design.md`
- Phase 1 plan: `docs/superpowers/plans/2026-04-25-live-list-population-phase-1-shared-infra.md`
- Phase 2 plan: `docs/superpowers/plans/2026-04-26-live-list-population-phase-2-daft-list-live-ux.md`
- Phase 3 plan: `docs/superpowers/plans/2026-04-26-live-list-population-phase-3-migrate-prune-sync.md`
- Phase 4 cache plan: `docs/superpowers/plans/2026-04-26-list-cache-content-addressed.md`
- Phase 5 spec: `docs/superpowers/specs/2026-04-27-graceful-cancellation-design.md`
- Phase 5 plan: `docs/superpowers/plans/2026-04-27-graceful-cancellation.md`

Implementation followed TDD subagent workflow per task; spec + code-quality reviews ran before each task landed. Plan amendments are recorded in dedicated `docs(plan)` commits.

## Test plan

- [x] `mise run test:unit` passes
- [x] `mise run test:integration` passes (Phases 1–3; not re-run for every polish commit)
- [x] `mise run clippy` zero warnings
- [x] `mise run fmt:check` clean
- [x] Phase 2: 2 new dispatcher unit tests, 2 new YAML scenarios
- [x] Phase 4: 7 new unit tests for cache primitives; render-cell tests updated for the `▬` skeleton bar
- [x] Phase 5: 9 new unit tests (`mark_cancelled`, `is_cell_unloaded` x4, `not_loaded_cell` rendering, `render_cell` cancelled+received cases x2, footer cancelled+not-cancelled x2, driver state mutation guard)
- [ ] Phase 5 manual sanity (pending user verification): hit Ctrl-C while `daft list --columns=-path,+size --sort activity --stat lines` is mid-stream → unfilled cells show dim `—` not frozen `▬`; shell prompt returns on fresh line; verbose mode shows `· cancelled` in footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)