### PR TITLE
fix(test): guarantee manual-test sandbox cleanup via Drop

### DIFF
--- a/xtask/src/manual_test/env.rs
+++ b/xtask/src/manual_test/env.rs
@@ -32,6 +32,17 @@ pub struct TestEnv {
     pub daft_data_dir: PathBuf,
     /// Variable store for `$VAR` expansion in step commands and paths.
     vars: HashMap<String, String>,
+    /// When true, `Drop` removes `base_dir` — guarantees cleanup on early
+    /// returns and panics. Set to false for `--keep` and `--setup-only`.
+    cleanup_on_drop: bool,
+}
+
+impl Drop for TestEnv {
+    fn drop(&mut self) {
+        if self.cleanup_on_drop && self.base_dir.exists() {
+            let _ = std::fs::remove_dir_all(&self.base_dir);
+        }
+    }
 }
 
 impl TestEnv {
@@ -40,7 +51,7 @@ impl TestEnv {
     /// This creates the sandbox directory tree and initialises built-in
     /// variables (`WORK_DIR`, `BASE_DIR`, `BINARY_DIR`) plus any extra vars
     /// from `scenario.env`.
-    pub fn create(scenario: &Scenario, project_root: &Path) -> Result<Self> {
+    pub fn create(scenario: &Scenario, project_root: &Path, keep: bool) -> Result<Self> {
         let base_dir = if let Ok(base) = std::env::var("DAFT_MANUAL_TEST_BASE") {
             // Deterministic path under a managed directory (e.g., sandbox/test/).
             let slug = scenario.name.to_lowercase().replace(' ', "-");
@@ -97,6 +108,7 @@ impl TestEnv {
             daft_config_dir,
             daft_data_dir,
             vars,
+            cleanup_on_drop: !keep,
         })
     }
 
@@ -116,6 +128,7 @@ impl TestEnv {
             daft_config_dir: PathBuf::from("/tmp/test-dummy/daft-config"),
             daft_data_dir: PathBuf::from("/tmp/test-dummy/daft-data"),
             vars,
+            cleanup_on_drop: false,
         }
     }
 

--- a/xtask/src/manual_test/mod.rs
+++ b/xtask/src/manual_test/mod.rs
@@ -114,7 +114,7 @@ pub fn run(
             steps: raw.steps,
         };
 
-        let mut test_env = env::TestEnv::create(&scenario, &project_root)?;
+        let mut test_env = env::TestEnv::create(&scenario, &project_root, keep || setup_only)?;
 
         // Register for cleanup on Ctrl+C.
         if let Ok(mut guard) = cleanup_path.lock() {


### PR DESCRIPTION
## Summary

- Manual-test runs were leaking `/tmp/daft-manual-test-<ts>/` sandboxes — 600+ orphans accumulated locally over a single day of testing.
- The existing `TestEnv::cleanup()` call in `mod.rs:169` only ran on the Ok-return path, so any `?` propagation during repo generation, template creation, or step execution skipped cleanup. The SIGINT handler covered Ctrl+C but not panics or other errors.
- Adds an RAII `Drop` impl on `TestEnv` that removes `base_dir` unless `--keep` or `--setup-only` was requested. The `cleanup_on_drop` flag is set inside `create()` itself so the guarantee covers every error path between construction and the explicit cleanup call.
- Pattern mirrors the existing `RawModeGuard` Drop in `interactive.rs:32`. The explicit `cleanup()` (with its UX message) and SIGINT handler both stay — `process::exit` in the SIGINT handler skips destructors, so explicit cleanup there is still load-bearing.

## Test plan

- [x] `cargo build -p xtask` — clean, no warnings
- [x] `mise run clippy` — zero warnings
- [x] `cargo test -p xtask` — 53/53 tests pass
- [x] `mise run test:unit` — pass
- [ ] Verify locally that a forced-error scenario no longer leaks a sandbox dir