### PR TITLE
fix(exec): resolve user shell aliases and functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -722,6 +722,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "serial_test",
+ "shlex",
  "similar",
  "syntect",
  "tabled",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,6 +115,7 @@ csv = "1.3"
 tera = { version = "1.20", default-features = false }
 thiserror = "2.0"
 toon-format = "0.2"
+shlex = "1.3"
 
 # pager is Unix-only (uses fork/pipes)
 [target.'cfg(unix)'.dependencies]

--- a/docs/cli/git-worktree-exec.md
+++ b/docs/cli/git-worktree-exec.md
@@ -50,6 +50,7 @@ git worktree-exec [OPTIONS] [TARGETS] [CMD]
 | `-x, --exec <CMD>` | Shell command to run (repeatable); runs via $SHELL -c |  |
 | `--sequential` | Run worktrees one at a time and stop on first failure |  |
 | `--keep-going` | Run worktrees one at a time and continue through failures |  |
+| `--refresh-aliases` | Re-capture user shell aliases instead of using the cached snapshot |  |
 
 ## Global Options
 

--- a/man/daft-exec.1
+++ b/man/daft-exec.1
@@ -4,7 +4,7 @@
 .SH NAME
 daft\-exec \- Run a command across one or more worktrees
 .SH SYNOPSIS
-\fBdaft\-exec\fR [\fB\-\-all\fR] [\fB\-x\fR|\fB\-\-exec\fR] [\fB\-\-sequential\fR] [\fB\-\-keep\-going\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fITARGETS\fR] [\fICMD\fR] 
+\fBdaft\-exec\fR [\fB\-\-all\fR] [\fB\-x\fR|\fB\-\-exec\fR] [\fB\-\-sequential\fR] [\fB\-\-keep\-going\fR] [\fB\-\-refresh\-aliases\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fITARGETS\fR] [\fICMD\fR] 
 .SH DESCRIPTION
 .PP
 Runs one or more commands against one or more selected worktrees without
@@ -35,6 +35,9 @@ Run worktrees one at a time and stop on first failure
 .TP
 \fB\-\-keep\-going\fR
 Run worktrees one at a time and continue through failures
+.TP
+\fB\-\-refresh\-aliases\fR
+Re\-capture user shell aliases instead of using the cached snapshot
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help (see a summary with \*(Aq\-h\*(Aq)

--- a/man/git-worktree-exec.1
+++ b/man/git-worktree-exec.1
@@ -4,7 +4,7 @@
 .SH NAME
 git\-worktree\-exec \- Run a command across one or more worktrees
 .SH SYNOPSIS
-\fBgit\-worktree\-exec\fR [\fB\-\-all\fR] [\fB\-x\fR|\fB\-\-exec\fR] [\fB\-\-sequential\fR] [\fB\-\-keep\-going\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fITARGETS\fR] [\fICMD\fR] 
+\fBgit\-worktree\-exec\fR [\fB\-\-all\fR] [\fB\-x\fR|\fB\-\-exec\fR] [\fB\-\-sequential\fR] [\fB\-\-keep\-going\fR] [\fB\-\-refresh\-aliases\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fITARGETS\fR] [\fICMD\fR] 
 .SH DESCRIPTION
 .PP
 Runs one or more commands against one or more selected worktrees without
@@ -35,6 +35,9 @@ Run worktrees one at a time and stop on first failure
 .TP
 \fB\-\-keep\-going\fR
 Run worktrees one at a time and continue through failures
+.TP
+\fB\-\-refresh\-aliases\fR
+Re\-capture user shell aliases instead of using the cached snapshot
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help (see a summary with \*(Aq\-h\*(Aq)

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -78,6 +78,12 @@ pub struct Args {
     )]
     pub keep_going: bool,
 
+    #[arg(
+        long = "refresh-aliases",
+        help = "Re-capture user shell aliases instead of using the cached snapshot"
+    )]
+    pub refresh_aliases: bool,
+
     /// Trailing command vector after `--`. Mutually exclusive with `-x`.
     #[arg(last = true, value_name = "CMD")]
     pub trailing: Vec<String>,
@@ -144,13 +150,19 @@ pub fn run() -> Result<()> {
             .collect()
     };
 
+    // Resolve once and reuse across all targets / commands. The first
+    // capture costs a single rc-file load; subsequent invocations within
+    // the TTL window read from disk and run at native speed.
+    let shell_path = std::env::var("SHELL").unwrap_or_else(|_| "sh".to_string());
+    let alias_cache = core::AliasCache::ensure(&shell_path, args.refresh_aliases);
+
     // Mode A: single-target pass-through. Inherit stdio; propagate exit
     // code verbatim; never render a UI. Handles `daft exec <single> -- claude`
     // and similar interactive cases without any flag ceremony.
     if targets.len() == 1 {
         let target = &targets[0];
         for spec in &pipeline {
-            let mut cmd = core::build_command(spec);
+            let mut cmd = core::build_command(spec, alias_cache.as_ref());
             cmd.current_dir(&target.worktree_path)
                 .env("DAFT_WORKTREE_PATH", &target.worktree_path)
                 .env("DAFT_BRANCH_NAME", &target.branch_name)
@@ -186,7 +198,13 @@ pub fn run() -> Result<()> {
         handler_flag.escalate();
     });
 
-    let report = core::progress_renderer::run_with_progress(&targets, &pipeline, mode, &cancel)?;
+    let report = core::progress_renderer::run_with_progress(
+        &targets,
+        &pipeline,
+        mode,
+        &cancel,
+        alias_cache.as_ref(),
+    )?;
 
     let stdout = std::io::stdout();
     let mut sink = stdout.lock();

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -150,21 +150,7 @@ pub fn run() -> Result<()> {
     if targets.len() == 1 {
         let target = &targets[0];
         for spec in &pipeline {
-            let mut cmd = match spec {
-                core::CommandSpec::Argv(parts) => {
-                    let mut c = std::process::Command::new(&parts[0]);
-                    if parts.len() > 1 {
-                        c.args(&parts[1..]);
-                    }
-                    c
-                }
-                core::CommandSpec::Shell(s) => {
-                    let shell = std::env::var("SHELL").unwrap_or_else(|_| "sh".to_string());
-                    let mut c = std::process::Command::new(shell);
-                    c.arg("-c").arg(s);
-                    c
-                }
-            };
+            let mut cmd = core::build_command(spec);
             cmd.current_dir(&target.worktree_path)
                 .env("DAFT_WORKTREE_PATH", &target.worktree_path)
                 .env("DAFT_BRANCH_NAME", &target.branch_name)

--- a/src/core/worktree/exec/alias_cache.rs
+++ b/src/core/worktree/exec/alias_cache.rs
@@ -1,0 +1,367 @@
+//! Cached snapshot of the user's shell aliases and functions.
+//!
+//! `daft exec` resolves user shortcuts like `gss`, `gcvm`, or
+//! `mygitfunc()` by routing commands through `$SHELL`. The naive way —
+//! `$SHELL -i -c CMD` — sources the user's full rc file every invocation,
+//! which on heavy setups (zsh with oh-my-zsh, gitstatus, plugins) costs
+//! multiple seconds.
+//!
+//! This module captures the alias table and shell-function definitions
+//! once via `$SHELL -i -c '<dump>'`, persists them under
+//! `$XDG_CACHE_HOME/daft/`, and reuses them on subsequent runs. With a
+//! populated cache, command execution skips the rc-file load entirely
+//! (`$SHELL -c` instead of `-i -c`) and inlines the alias definitions
+//! plus a `source` of the functions file before running the user command
+//! via `eval`.
+//!
+//! Two files per shell:
+//!   * `aliases-<shell>.txt` — small; alias definitions plus a metadata
+//!     header (epoch, shell name).
+//!   * `functions-<shell>.sh` — eval-able function bodies. Sourced by the
+//!     spawned shell rather than inlined, since `typeset -f` output can
+//!     be hundreds of kilobytes (zsh + plugins) and would blow `ARG_MAX`
+//!     if passed on the command line.
+//!
+//! Limitations: only `bash` and `zsh` are supported; per-worktree direnv
+//! aliases are out of scope (the cache reflects the user's base shell
+//! environment). For unsupported shells or capture failures, callers
+//! fall back to `-i` (slow path) and shortcuts still resolve.
+//!
+//! Cache invalidation is by TTL. `daft exec --refresh-aliases` forces a
+//! re-capture.
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+/// How long a captured alias snapshot stays fresh on disk.
+pub const CACHE_TTL: Duration = Duration::from_secs(60 * 60 * 24);
+
+/// One of the shells whose alias output `daft` knows how to capture.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShellKind {
+    Bash,
+    Zsh,
+}
+
+impl ShellKind {
+    /// Detect the shell from a `$SHELL`-style absolute path.
+    pub fn from_path(shell_path: &str) -> Option<Self> {
+        let basename = Path::new(shell_path).file_name()?.to_str()?;
+        match basename {
+            "bash" => Some(Self::Bash),
+            "zsh" => Some(Self::Zsh),
+            _ => None,
+        }
+    }
+
+    /// The builtin invocation that prints eval-able alias definitions
+    /// (one per line, in `alias name='body'` form for both shells).
+    fn alias_print_command(self) -> &'static str {
+        match self {
+            Self::Bash => "alias -p",
+            // zsh's `-p` doesn't exist; `-L` emits eval-able output with
+            // a leading `alias ` keyword to match bash's format.
+            Self::Zsh => "alias -L",
+        }
+    }
+
+    /// The builtin invocation that prints eval-able shell-function
+    /// definitions (one block per function).
+    fn functions_print_command(self) -> &'static str {
+        match self {
+            // Both bash's `declare -f` and zsh's `typeset -f` emit
+            // shell-eval-able function bodies. `typeset -f` is a synonym
+            // accepted by zsh; bash also accepts it but defaults to
+            // `declare -f` semantics, so we keep them shell-specific for
+            // clarity.
+            Self::Bash => "declare -f",
+            Self::Zsh => "typeset -f",
+        }
+    }
+
+    /// Shell-specific prefix that must precede the inlined alias
+    /// definitions to make alias expansion work in non-interactive mode.
+    /// bash needs `shopt -s expand_aliases`; zsh expands aliases by
+    /// default.
+    pub fn alias_expansion_prefix(self) -> &'static str {
+        match self {
+            Self::Bash => "shopt -s expand_aliases\n",
+            Self::Zsh => "",
+        }
+    }
+
+    fn name(self) -> &'static str {
+        match self {
+            Self::Bash => "bash",
+            Self::Zsh => "zsh",
+        }
+    }
+}
+
+/// On-disk snapshot of the user's alias table and shell functions for
+/// one shell.
+#[derive(Debug, Clone)]
+pub struct AliasCache {
+    pub shell: ShellKind,
+    /// Eval-able alias definitions joined by newlines; safe to inline
+    /// verbatim into a `$SHELL -c` script before the user command.
+    pub alias_lines: String,
+    /// On-disk path to the functions snapshot, sourced by the spawned
+    /// shell. `None` when functions weren't captured (capture failed or
+    /// in-memory caches built by tests).
+    pub functions_path: Option<PathBuf>,
+    pub captured_at: SystemTime,
+}
+
+/// Daft's per-user cache directory.
+fn cache_dir() -> Option<PathBuf> {
+    Some(dirs::cache_dir()?.join("daft"))
+}
+
+/// Path to the alias snapshot file for `shell`.
+fn aliases_cache_path(shell: ShellKind) -> Option<PathBuf> {
+    Some(cache_dir()?.join(format!("aliases-{}.txt", shell.name())))
+}
+
+/// Path to the functions snapshot file for `shell`.
+fn functions_cache_path(shell: ShellKind) -> Option<PathBuf> {
+    Some(cache_dir()?.join(format!("functions-{}.sh", shell.name())))
+}
+
+impl AliasCache {
+    /// Return a usable cache for `shell_path`, capturing afresh if the
+    /// on-disk copy is missing, stale, or `force_refresh` is set.
+    /// Returns `None` for unsupported shells or if capture fails — in
+    /// that case the caller should fall back to `-i`.
+    pub fn ensure(shell_path: &str, force_refresh: bool) -> Option<Self> {
+        let kind = ShellKind::from_path(shell_path)?;
+        let aliases_path = aliases_cache_path(kind)?;
+        let functions_path = functions_cache_path(kind)?;
+
+        if !force_refresh {
+            if let Some(loaded) = Self::load(&aliases_path, &functions_path) {
+                if loaded.is_fresh(CACHE_TTL) {
+                    return Some(loaded);
+                }
+            }
+        }
+
+        let (alias_lines, functions_body) = Self::capture(shell_path, kind).ok()?;
+        let captured_at = SystemTime::now();
+
+        // Best-effort save: a write failure (e.g. read-only HOME)
+        // shouldn't prevent the captured cache from being used in this
+        // process. `functions_path` is recorded only if its file write
+        // succeeded — the spawned shell would error on a missing file
+        // otherwise.
+        let alias_saved = save_aliases(&aliases_path, &alias_lines, kind, captured_at).is_ok();
+        let functions_saved = save_functions(&functions_path, &functions_body).is_ok();
+
+        Some(Self {
+            shell: kind,
+            alias_lines,
+            functions_path: (alias_saved && functions_saved).then_some(functions_path),
+            captured_at,
+        })
+    }
+
+    fn is_fresh(&self, ttl: Duration) -> bool {
+        SystemTime::now()
+            .duration_since(self.captured_at)
+            .map(|age| age < ttl)
+            .unwrap_or(false)
+    }
+
+    fn load(aliases_path: &Path, functions_path: &Path) -> Option<Self> {
+        let content = std::fs::read_to_string(aliases_path).ok()?;
+        let mut parsed = Self::parse_aliases(&content)?;
+        // Functions file is optional — its absence just means the fast
+        // path skips function sourcing. The unit-test-friendly parser
+        // doesn't know about disk paths, so we attach the path here.
+        if std::fs::metadata(functions_path).is_ok() {
+            parsed.functions_path = Some(functions_path.to_path_buf());
+        }
+        Some(parsed)
+    }
+
+    fn parse_aliases(content: &str) -> Option<Self> {
+        let mut lines = content.lines();
+        let epoch: u64 = lines.next()?.parse().ok()?;
+        let shell = match lines.next()? {
+            "bash" => ShellKind::Bash,
+            "zsh" => ShellKind::Zsh,
+            _ => return None,
+        };
+        let alias_lines = lines.collect::<Vec<_>>().join("\n");
+        Some(Self {
+            shell,
+            alias_lines,
+            functions_path: None,
+            captured_at: UNIX_EPOCH + Duration::from_secs(epoch),
+        })
+    }
+
+    /// Run a one-shot capture of aliases and functions via `$SHELL -i`.
+    /// Returns `(alias_lines, functions_body)`. Stderr is discarded so
+    /// rc-file noise doesn't leak into the cache.
+    fn capture(shell_path: &str, kind: ShellKind) -> std::io::Result<(String, String)> {
+        // Single `$SHELL -i` invocation runs `<alias-cmd>; echo …; <fn-cmd>`
+        // and we split the output on the sentinel. One rc-file load instead
+        // of two.
+        const SENTINEL: &str = "::DAFT_ALIAS_CACHE_SENTINEL::";
+        let combined = format!(
+            "{}; echo '{}'; {}",
+            kind.alias_print_command(),
+            SENTINEL,
+            kind.functions_print_command(),
+        );
+        let output = std::process::Command::new(shell_path)
+            .arg("-i")
+            .arg("-c")
+            .arg(combined)
+            .stderr(std::process::Stdio::null())
+            .output()?;
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let (alias_part, functions_part) = stdout.split_once(SENTINEL).unwrap_or((&stdout, ""));
+        Ok((
+            alias_part.trim_end().to_string(),
+            functions_part.trim_start_matches('\n').to_string(),
+        ))
+    }
+}
+
+fn save_aliases(
+    path: &Path,
+    alias_lines: &str,
+    shell: ShellKind,
+    captured_at: SystemTime,
+) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let epoch = captured_at
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    std::fs::write(
+        path,
+        format!("{}\n{}\n{}", epoch, shell.name(), alias_lines),
+    )
+}
+
+fn save_functions(path: &Path, body: &str) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(path, body)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_bash_and_zsh_from_path() {
+        assert_eq!(ShellKind::from_path("/bin/bash"), Some(ShellKind::Bash));
+        assert_eq!(
+            ShellKind::from_path("/usr/local/bin/zsh"),
+            Some(ShellKind::Zsh)
+        );
+        assert_eq!(ShellKind::from_path("/bin/sh"), None);
+        assert_eq!(ShellKind::from_path("/usr/bin/fish"), None);
+    }
+
+    #[test]
+    fn parses_serialized_aliases_round_trip() {
+        let captured_at = UNIX_EPOCH + Duration::from_secs(1_700_000_000);
+        let dir = tempfile::tempdir().unwrap();
+        let aliases_path = dir.path().join("aliases-zsh.txt");
+        save_aliases(
+            &aliases_path,
+            "alias gss='git status -s'\nalias gcvm='git checkout master'",
+            ShellKind::Zsh,
+            captured_at,
+        )
+        .unwrap();
+
+        let parsed = AliasCache::parse_aliases(&std::fs::read_to_string(&aliases_path).unwrap())
+            .expect("parses");
+        assert_eq!(parsed.shell, ShellKind::Zsh);
+        assert_eq!(
+            parsed.alias_lines,
+            "alias gss='git status -s'\nalias gcvm='git checkout master'"
+        );
+        assert_eq!(parsed.captured_at, captured_at);
+        assert!(parsed.functions_path.is_none());
+    }
+
+    #[test]
+    fn rejects_unknown_shell_in_serialized_cache() {
+        let payload = "1700000000\nfish\nabbr gss git status";
+        assert!(AliasCache::parse_aliases(payload).is_none());
+    }
+
+    #[test]
+    fn is_fresh_respects_ttl() {
+        let recent = AliasCache {
+            shell: ShellKind::Bash,
+            alias_lines: String::new(),
+            functions_path: None,
+            captured_at: SystemTime::now() - Duration::from_secs(60),
+        };
+        assert!(recent.is_fresh(Duration::from_secs(3600)));
+
+        let stale = AliasCache {
+            shell: ShellKind::Bash,
+            alias_lines: String::new(),
+            functions_path: None,
+            captured_at: SystemTime::now() - Duration::from_secs(7200),
+        };
+        assert!(!stale.is_fresh(Duration::from_secs(3600)));
+    }
+
+    #[test]
+    fn save_then_load_attaches_functions_path_when_present() {
+        let dir = tempfile::tempdir().unwrap();
+        let aliases_path = dir.path().join("nested").join("aliases-zsh.txt");
+        let functions_path = dir.path().join("nested").join("functions-zsh.sh");
+        let captured_at = UNIX_EPOCH + Duration::from_secs(1_700_000_001);
+
+        save_aliases(&aliases_path, "alias g='git'", ShellKind::Zsh, captured_at).unwrap();
+        save_functions(&functions_path, "myfn () { echo hi; }\n").unwrap();
+
+        let loaded = AliasCache::load(&aliases_path, &functions_path).unwrap();
+        assert_eq!(loaded.shell, ShellKind::Zsh);
+        assert_eq!(loaded.alias_lines, "alias g='git'");
+        assert_eq!(loaded.captured_at, captured_at);
+        assert_eq!(
+            loaded.functions_path.as_deref(),
+            Some(functions_path.as_path())
+        );
+    }
+
+    #[test]
+    fn load_omits_functions_path_when_file_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let aliases_path = dir.path().join("aliases-zsh.txt");
+        let functions_path = dir.path().join("functions-zsh.sh"); // never written
+        save_aliases(
+            &aliases_path,
+            "alias g='git'",
+            ShellKind::Zsh,
+            SystemTime::now(),
+        )
+        .unwrap();
+
+        let loaded = AliasCache::load(&aliases_path, &functions_path).unwrap();
+        assert!(loaded.functions_path.is_none());
+    }
+
+    #[test]
+    fn alias_expansion_prefix_is_shell_specific() {
+        assert!(ShellKind::Bash
+            .alias_expansion_prefix()
+            .contains("expand_aliases"));
+        assert_eq!(ShellKind::Zsh.alias_expansion_prefix(), "");
+    }
+}

--- a/src/core/worktree/exec/mod.rs
+++ b/src/core/worktree/exec/mod.rs
@@ -81,11 +81,15 @@ pub struct ResolvedTarget {
 /// One command in a per-worktree pipeline.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CommandSpec {
-    /// Direct argv exec, e.g. from `-- CMD ARGS…`. First element is the
-    /// program; remaining are its arguments. Never touches a shell.
+    /// Argv form, e.g. from `-- CMD ARGS…`. First element is the program;
+    /// remaining are its arguments. Routed through `$SHELL -i -c` after
+    /// shell-quoting so that user-defined aliases and functions resolve
+    /// the same as they would in an interactive shell.
     Argv(Vec<String>),
-    /// Shell-parsed string, e.g. from `-x 'CMD'`. Run via `$SHELL -c`,
-    /// falling back to `sh -c` if `$SHELL` is unset.
+    /// Shell-parsed string, e.g. from `-x 'CMD'`. Run via `$SHELL -i -c`,
+    /// falling back to `sh -i -c` if `$SHELL` is unset. Interactive mode
+    /// is required so the user's rc files load and their aliases / shell
+    /// functions resolve.
     Shell(String),
 }
 
@@ -684,22 +688,37 @@ where
     })
 }
 
-fn build_command(spec: &CommandSpec) -> Command {
-    match spec {
-        CommandSpec::Argv(parts) => {
-            let mut c = Command::new(&parts[0]);
-            if parts.len() > 1 {
-                c.args(&parts[1..]);
-            }
-            c
-        }
-        CommandSpec::Shell(s) => {
-            let shell = std::env::var("SHELL").unwrap_or_else(|_| "sh".to_string());
-            let mut c = Command::new(shell);
-            c.arg("-c").arg(s);
-            c
-        }
-    }
+/// Build the `Command` that runs a `CommandSpec` for one worktree.
+///
+/// Both forms route through `$SHELL -i -c` so that user-defined aliases
+/// and shell functions resolve the same way they do in an interactive
+/// shell. This matches the behavior of `-x` on `daft go` / `daft start`
+/// (see #242). For `Argv`, parts are shell-quoted and joined before being
+/// handed to `-c`.
+pub(crate) fn build_command(spec: &CommandSpec) -> Command {
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| "sh".to_string());
+    let cmd_string = match spec {
+        CommandSpec::Argv(parts) => quote_argv(parts),
+        CommandSpec::Shell(s) => s.clone(),
+    };
+    let mut c = Command::new(shell);
+    c.arg("-i").arg("-c").arg(cmd_string);
+    c
+}
+
+/// Shell-quote each argv element (POSIX) and join with spaces so the
+/// result can be handed to `$SHELL -c` while preserving the original
+/// argument boundaries.
+fn quote_argv(parts: &[String]) -> String {
+    parts
+        .iter()
+        .map(|p| {
+            shlex::try_quote(p)
+                .map(|c| c.into_owned())
+                .unwrap_or_else(|_| p.clone())
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 /// Run the pipeline across all targets in the requested mode. Returns the
@@ -985,16 +1004,31 @@ mod tests {
         );
     }
 
+    /// Captured output from `run_pipeline` may include benign stderr noise
+    /// from the user's interactive shell (rc-file output, bash's
+    /// "no job control in this shell" warning). Tests that look for a
+    /// specific line should grep — not exact-match — the captured output.
+    fn captured_lines(outcome: &WorktreeOutcome) -> Vec<String> {
+        String::from_utf8_lossy(&outcome.captured_output)
+            .lines()
+            .map(|l| l.trim().to_string())
+            .filter(|l| !l.is_empty())
+            .collect()
+    }
+
     #[test]
     fn cwd_is_worktree_path() {
         let dir = TempDir::new().unwrap();
         let target = dummy_target(&dir, "master");
         let spec = CommandSpec::Argv(vec!["pwd".into()]);
         let outcome = run_pipeline(&target, &[spec], &CancelFlag::new()).unwrap();
-        let out = String::from_utf8_lossy(&outcome.captured_output);
         let expected = dir.path().canonicalize().unwrap();
-        let got = std::path::PathBuf::from(out.trim()).canonicalize().unwrap();
-        assert_eq!(got, expected);
+        let lines = captured_lines(&outcome);
+        let found = lines
+            .iter()
+            .filter_map(|l| std::path::PathBuf::from(l).canonicalize().ok())
+            .any(|p| p == expected);
+        assert!(found, "expected pwd output {:?} in: {lines:?}", expected);
     }
 
     #[test]
@@ -1004,12 +1038,13 @@ mod tests {
         let spec = CommandSpec::Argv(vec![
             "sh".into(),
             "-c".into(),
-            "printf %s \"$DAFT_BRANCH_NAME\"".into(),
+            "printf '%s\\n' \"$DAFT_BRANCH_NAME\"".into(),
         ]);
         let outcome = run_pipeline(&target, &[spec], &CancelFlag::new()).unwrap();
-        assert_eq!(
-            String::from_utf8_lossy(&outcome.captured_output).trim(),
-            "feat/abc"
+        let lines = captured_lines(&outcome);
+        assert!(
+            lines.iter().any(|l| l == "feat/abc"),
+            "expected branch name line in: {lines:?}"
         );
     }
 
@@ -1021,9 +1056,10 @@ mod tests {
         let spec = CommandSpec::Shell("echo $((1+2))".into());
         let outcome = run_pipeline(&target, &[spec], &CancelFlag::new()).unwrap();
         assert_eq!(outcome.exit_code, 0);
-        assert_eq!(
-            String::from_utf8_lossy(&outcome.captured_output).trim(),
-            "3"
+        let lines = captured_lines(&outcome);
+        assert!(
+            lines.iter().any(|l| l == "3"),
+            "expected arithmetic result in: {lines:?}"
         );
     }
 
@@ -1071,21 +1107,31 @@ mod tests {
     }
 
     #[test]
-    fn shell_form_does_not_use_interactive_flag() {
-        // Regression guard: the legacy src/exec.rs passes -i which loads
-        // rcfiles. `daft exec -x` must NOT do that — the test passes an
-        // env var with a value that an rcfile would likely clobber, and
-        // asserts we see the outer env.
-        std::env::set_var("DAFT_EXEC_TEST_MARKER", "outer-value");
-        let dir = TempDir::new().unwrap();
-        let target = dummy_target(&dir, "master");
-        let spec = CommandSpec::Shell("echo $DAFT_EXEC_TEST_MARKER".into());
-        let outcome = run_pipeline(&target, &[spec], &CancelFlag::new()).unwrap();
-        std::env::remove_var("DAFT_EXEC_TEST_MARKER");
-        assert_eq!(
-            String::from_utf8_lossy(&outcome.captured_output).trim(),
-            "outer-value"
-        );
+    fn build_command_uses_interactive_shell_for_alias_resolution() {
+        // Regression: aliases / shell functions defined in the user's rc
+        // files must resolve through `daft exec`, matching the precedent
+        // set for `-x` on `daft go` / `daft start` in #242. Both Shell and
+        // Argv forms route through `$SHELL -i -c`.
+        let shell_cmd = build_command(&CommandSpec::Shell("gss".into()));
+        let args: Vec<&std::ffi::OsStr> = shell_cmd.get_args().collect();
+        assert_eq!(args, vec!["-i", "-c", "gss"]);
+
+        let argv_cmd = build_command(&CommandSpec::Argv(vec![
+            "git".into(),
+            "status".into(),
+            "-s".into(),
+        ]));
+        let args: Vec<&std::ffi::OsStr> = argv_cmd.get_args().collect();
+        assert_eq!(args, vec!["-i", "-c", "git status -s"]);
+
+        // Argv with whitespace / quotes must be shell-quoted so the inner
+        // shell sees the same argument boundaries.
+        let argv_cmd = build_command(&CommandSpec::Argv(vec![
+            "echo".into(),
+            "hello world".into(),
+        ]));
+        let args: Vec<&std::ffi::OsStr> = argv_cmd.get_args().collect();
+        assert_eq!(args, vec!["-i", "-c", "echo 'hello world'"]);
     }
 
     #[test]

--- a/src/core/worktree/exec/mod.rs
+++ b/src/core/worktree/exec/mod.rs
@@ -4,8 +4,11 @@
 //! `ExecReport` data type that the command layer renders. No IO to stdout
 //! lives here; renderers are separate.
 
+pub mod alias_cache;
 pub mod list_renderer;
 pub mod progress_renderer;
+
+pub use alias_cache::AliasCache;
 
 use crate::executor::presenter::{JobPresenter, NullPresenter};
 use std::io::{BufRead, BufReader};
@@ -82,14 +85,11 @@ pub struct ResolvedTarget {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CommandSpec {
     /// Argv form, e.g. from `-- CMD ARGS…`. First element is the program;
-    /// remaining are its arguments. Routed through `$SHELL -i -c` after
-    /// shell-quoting so that user-defined aliases and functions resolve
-    /// the same as they would in an interactive shell.
+    /// remaining are its arguments. Routed through `$SHELL` after
+    /// shell-quoting so that user-defined aliases resolve.
     Argv(Vec<String>),
-    /// Shell-parsed string, e.g. from `-x 'CMD'`. Run via `$SHELL -i -c`,
-    /// falling back to `sh -i -c` if `$SHELL` is unset. Interactive mode
-    /// is required so the user's rc files load and their aliases / shell
-    /// functions resolve.
+    /// Shell-parsed string, e.g. from `-x 'CMD'`. Run via `$SHELL`, with
+    /// alias expansion enabled.
     Shell(String),
 }
 
@@ -515,7 +515,7 @@ pub fn run_pipeline(
     cancel: &CancelFlag,
 ) -> anyhow::Result<WorktreeOutcome> {
     let presenter: Arc<dyn JobPresenter> = NullPresenter::arc();
-    run_pipeline_streaming(target, pipeline, "", &presenter, cancel)
+    run_pipeline_streaming(target, pipeline, "", &presenter, cancel, None)
 }
 
 /// Run the full pipeline against one worktree, streaming output through the
@@ -526,12 +526,16 @@ pub fn run_pipeline(
 /// otherwise the target's branch name. Step identity within a multi-command
 /// pipeline is conveyed via the `command_preview` argument on `on_job_start`
 /// — not via the job name itself.
+///
+/// `alias_cache`, when supplied, replaces the slow `$SHELL -i -c` rc-file
+/// load with an inlined alias table for the spawned shell.
 pub fn run_pipeline_streaming(
     target: &ResolvedTarget,
     pipeline: &[CommandSpec],
     name_prefix: &str,
     presenter: &Arc<dyn JobPresenter>,
     cancel: &CancelFlag,
+    alias_cache: Option<&AliasCache>,
 ) -> anyhow::Result<WorktreeOutcome> {
     let start = Instant::now();
     let tail = Arc::new(Mutex::new(TailBuffer::new(OUTPUT_CAP_BYTES)));
@@ -565,7 +569,7 @@ pub fn run_pipeline_streaming(
         let cmd_start = Instant::now();
         presenter.on_job_start(&job_name, None, Some(&preview));
 
-        let mut cmd = build_command(spec);
+        let mut cmd = build_command(spec, alias_cache);
         cmd.current_dir(&target.worktree_path)
             .env("DAFT_WORKTREE_PATH", &target.worktree_path)
             .env("DAFT_BRANCH_NAME", &target.branch_name)
@@ -690,19 +694,52 @@ where
 
 /// Build the `Command` that runs a `CommandSpec` for one worktree.
 ///
-/// Both forms route through `$SHELL -i -c` so that user-defined aliases
-/// and shell functions resolve the same way they do in an interactive
-/// shell. This matches the behavior of `-x` on `daft go` / `daft start`
-/// (see #242). For `Argv`, parts are shell-quoted and joined before being
-/// handed to `-c`.
-pub(crate) fn build_command(spec: &CommandSpec) -> Command {
+/// User-defined aliases (e.g. `gss`, `gcvm`) resolve the same way they
+/// would in an interactive shell. The fast path inlines a cached alias
+/// table and runs `$SHELL -c '<aliases>; eval "$1"' -- <cmd>`, skipping
+/// the rc-file load (`-i`) entirely. The slow path falls back to
+/// `$SHELL -i -c <cmd>` so aliases still resolve when no cache is
+/// available (unsupported shell, capture failure, first run before
+/// caching). For `Argv`, parts are POSIX-quoted and joined first so the
+/// inner shell sees the same argument boundaries.
+pub(crate) fn build_command(spec: &CommandSpec, alias_cache: Option<&AliasCache>) -> Command {
     let shell = std::env::var("SHELL").unwrap_or_else(|_| "sh".to_string());
     let cmd_string = match spec {
         CommandSpec::Argv(parts) => quote_argv(parts),
         CommandSpec::Shell(s) => s.clone(),
     };
-    let mut c = Command::new(shell);
-    c.arg("-i").arg("-c").arg(cmd_string);
+
+    let mut c = Command::new(&shell);
+    match alias_cache {
+        Some(cache) => {
+            // Fast path: aliases (and functions) pre-cached. Source the
+            // functions file (if any), inline the alias definitions,
+            // then `eval` the user command so alias expansion (a
+            // parse-time step) sees the definitions before the user
+            // command is parsed.
+            let mut body = String::new();
+            body.push_str(cache.shell.alias_expansion_prefix());
+            if let Some(p) = cache.functions_path.as_ref().and_then(|p| p.to_str()) {
+                // Errors from the sourced file (e.g. a plugin helper
+                // that doesn't apply in our minimal env) are best-effort
+                // suppressed — the user's command itself will still
+                // surface its own errors visibly.
+                let quoted = shlex::try_quote(p)
+                    .map(|c| c.into_owned())
+                    .unwrap_or_else(|_| p.to_string());
+                body.push_str(&format!("source {quoted} 2>/dev/null\n"));
+            }
+            body.push_str(&cache.alias_lines);
+            body.push_str("\neval \"$1\"");
+            c.arg("-c").arg(body).arg("--").arg(cmd_string);
+        }
+        None => {
+            // Slow path: load the user's rc files via `-i` so any aliases
+            // (and shell functions) resolve. Used when no cache is
+            // available — e.g. unsupported shell or capture failure.
+            c.arg("-i").arg("-c").arg(cmd_string);
+        }
+    }
     c
 }
 
@@ -1107,31 +1144,96 @@ mod tests {
     }
 
     #[test]
-    fn build_command_uses_interactive_shell_for_alias_resolution() {
-        // Regression: aliases / shell functions defined in the user's rc
-        // files must resolve through `daft exec`, matching the precedent
-        // set for `-x` on `daft go` / `daft start` in #242. Both Shell and
-        // Argv forms route through `$SHELL -i -c`.
-        let shell_cmd = build_command(&CommandSpec::Shell("gss".into()));
+    fn build_command_falls_back_to_interactive_shell_when_no_cache() {
+        // Slow path: when no alias cache is available (unsupported shell
+        // or capture failure), fall back to `$SHELL -i -c` so aliases
+        // still resolve via the user's rc files. Matches the behavior
+        // shipped for `-x` on `daft go` / `daft start` in #242.
+        let shell_cmd = build_command(&CommandSpec::Shell("gss".into()), None);
         let args: Vec<&std::ffi::OsStr> = shell_cmd.get_args().collect();
         assert_eq!(args, vec!["-i", "-c", "gss"]);
 
-        let argv_cmd = build_command(&CommandSpec::Argv(vec![
-            "git".into(),
-            "status".into(),
-            "-s".into(),
-        ]));
-        let args: Vec<&std::ffi::OsStr> = argv_cmd.get_args().collect();
-        assert_eq!(args, vec!["-i", "-c", "git status -s"]);
-
-        // Argv with whitespace / quotes must be shell-quoted so the inner
-        // shell sees the same argument boundaries.
-        let argv_cmd = build_command(&CommandSpec::Argv(vec![
-            "echo".into(),
-            "hello world".into(),
-        ]));
+        // Argv parts are POSIX-quoted and joined so the inner shell sees
+        // the same argument boundaries as the original argv.
+        let argv_cmd = build_command(
+            &CommandSpec::Argv(vec!["echo".into(), "hello world".into()]),
+            None,
+        );
         let args: Vec<&std::ffi::OsStr> = argv_cmd.get_args().collect();
         assert_eq!(args, vec!["-i", "-c", "echo 'hello world'"]);
+    }
+
+    #[test]
+    fn build_command_uses_cached_aliases_without_interactive_shell() {
+        // Fast path: a populated alias cache lets us skip the rc-file
+        // load (`-i`). Cached `alias …` lines are inlined and the user
+        // command is `eval`-ed so alias expansion sees them at parse
+        // time.
+        use super::alias_cache::{AliasCache, ShellKind};
+        let cache = AliasCache {
+            shell: ShellKind::Zsh,
+            alias_lines: "alias gss='git status -s'".into(),
+            functions_path: None,
+            captured_at: std::time::SystemTime::now(),
+        };
+
+        let cmd = build_command(&CommandSpec::Shell("gss --short".into()), Some(&cache));
+        let args: Vec<&std::ffi::OsStr> = cmd.get_args().collect();
+        // No `-i`, and the body splits cleanly into:
+        //   -c, "<aliases>; eval $1", --, <user cmd>
+        assert_eq!(args[0], "-c");
+        let body = args[1].to_string_lossy();
+        assert!(
+            body.contains("alias gss='git status -s'"),
+            "missing alias inline: {body}"
+        );
+        assert!(body.contains("eval \"$1\""), "missing eval: {body}");
+        assert_eq!(args[2], "--");
+        assert_eq!(args[3], "gss --short");
+        assert_eq!(args.len(), 4);
+    }
+
+    #[test]
+    fn build_command_with_bash_cache_includes_expand_aliases_shopt() {
+        // bash needs `shopt -s expand_aliases` before alias expansion in
+        // non-interactive mode. zsh expands by default and gets no prefix.
+        use super::alias_cache::{AliasCache, ShellKind};
+        let cache = AliasCache {
+            shell: ShellKind::Bash,
+            alias_lines: "alias gss='git status -s'".into(),
+            functions_path: None,
+            captured_at: std::time::SystemTime::now(),
+        };
+        let cmd = build_command(&CommandSpec::Shell("gss".into()), Some(&cache));
+        let args: Vec<&std::ffi::OsStr> = cmd.get_args().collect();
+        let body = args[1].to_string_lossy();
+        assert!(
+            body.contains("shopt -s expand_aliases"),
+            "bash body must opt into alias expansion: {body}"
+        );
+    }
+
+    #[test]
+    fn build_command_sources_functions_file_when_cached() {
+        // When a functions snapshot exists on disk, the fast path sources
+        // it before defining aliases so user shell functions resolve too.
+        use super::alias_cache::{AliasCache, ShellKind};
+        use std::path::PathBuf;
+        let funcs_path = PathBuf::from("/tmp/daft test/functions-zsh.sh");
+        let cache = AliasCache {
+            shell: ShellKind::Zsh,
+            alias_lines: "alias g='git'".into(),
+            functions_path: Some(funcs_path),
+            captured_at: std::time::SystemTime::now(),
+        };
+        let cmd = build_command(&CommandSpec::Shell("mygitfunc".into()), Some(&cache));
+        let args: Vec<&std::ffi::OsStr> = cmd.get_args().collect();
+        let body = args[1].to_string_lossy();
+        // Path with whitespace must be shell-quoted to source correctly.
+        assert!(
+            body.contains("source '/tmp/daft test/functions-zsh.sh'"),
+            "must source functions file (quoted): {body}"
+        );
     }
 
     #[test]
@@ -1345,7 +1447,8 @@ mod streaming_skip_emission_tests {
             Arc::clone(&recorder) as Arc<dyn crate::executor::presenter::JobPresenter>;
 
         let outcome =
-            run_pipeline_streaming(&target, &pipeline, "", &presenter, &CancelFlag::new()).unwrap();
+            run_pipeline_streaming(&target, &pipeline, "", &presenter, &CancelFlag::new(), None)
+                .unwrap();
 
         assert!(!outcome.succeeded(), "first step should fail");
         let events = recorder.take();
@@ -1380,7 +1483,8 @@ mod streaming_skip_emission_tests {
         let cancel = CancelFlag::new();
         cancel.escalate();
 
-        let outcome = run_pipeline_streaming(&target, &pipeline, "", &presenter, &cancel).unwrap();
+        let outcome =
+            run_pipeline_streaming(&target, &pipeline, "", &presenter, &cancel, None).unwrap();
 
         assert!(outcome.cancelled, "expected cancelled outcome");
         let events = recorder.take();
@@ -1430,7 +1534,7 @@ mod streaming_skip_emission_tests {
                 std::thread::sleep(std::time::Duration::from_millis(200));
                 cancel.escalate();
             });
-            run_pipeline_streaming(&target, &pipeline, "", &presenter, &cancel)
+            run_pipeline_streaming(&target, &pipeline, "", &presenter, &cancel, None)
         })
         .unwrap();
 

--- a/src/core/worktree/exec/progress_renderer.rs
+++ b/src/core/worktree/exec/progress_renderer.rs
@@ -9,7 +9,8 @@
 //! [`super::run_pipeline_streaming`](crate::core::worktree::exec::run_pipeline_streaming).
 
 use super::{
-    run_pipeline_streaming, CancelFlag, CommandSpec, ExecMode, ExecReport, ResolvedTarget,
+    alias_cache::AliasCache, run_pipeline_streaming, CancelFlag, CommandSpec, ExecMode, ExecReport,
+    ResolvedTarget,
 };
 use crate::executor::cli_presenter::CliPresenter;
 use crate::executor::presenter::JobPresenter;
@@ -92,6 +93,7 @@ pub fn run_with_progress(
     pipeline: &[CommandSpec],
     mode: ExecMode,
     cancel: &CancelFlag,
+    alias_cache: Option<&AliasCache>,
 ) -> anyhow::Result<ExecReport> {
     // Suppress the TTY's `^C` echo for the duration of the live render so
     // Ctrl-C cancellation doesn't corrupt indicatif's terminal tracking.
@@ -123,9 +125,13 @@ pub fn run_with_progress(
     // header. The list-mode header above replaces it.
 
     let outcomes = match mode {
-        ExecMode::Parallel => run_parallel(targets, pipeline, &presenter, cancel)?,
-        ExecMode::Sequential => run_sequential(targets, pipeline, false, &presenter, cancel)?,
-        ExecMode::KeepGoing => run_sequential(targets, pipeline, true, &presenter, cancel)?,
+        ExecMode::Parallel => run_parallel(targets, pipeline, &presenter, cancel, alias_cache)?,
+        ExecMode::Sequential => {
+            run_sequential(targets, pipeline, false, &presenter, cancel, alias_cache)?
+        }
+        ExecMode::KeepGoing => {
+            run_sequential(targets, pipeline, true, &presenter, cancel, alias_cache)?
+        }
     };
 
     // Deliberately skip presenter.on_phase_complete — it prints the hook
@@ -164,6 +170,7 @@ fn run_parallel(
     pipeline: &[CommandSpec],
     presenter: &Arc<dyn JobPresenter>,
     cancel: &CancelFlag,
+    alias_cache: Option<&AliasCache>,
 ) -> anyhow::Result<Vec<super::WorktreeOutcome>> {
     // `thread::scope` lets worker threads borrow `cancel`, `pipeline`, and
     // `presenter` for their entire lifetime without `'static`, which keeps
@@ -173,7 +180,9 @@ fn run_parallel(
             .iter()
             .map(|t| {
                 let pres = Arc::clone(presenter);
-                scope.spawn(move || run_pipeline_streaming(t, pipeline, "", &pres, cancel))
+                scope.spawn(move || {
+                    run_pipeline_streaming(t, pipeline, "", &pres, cancel, alias_cache)
+                })
             })
             .collect();
 
@@ -202,13 +211,14 @@ fn run_sequential(
     keep_going: bool,
     presenter: &Arc<dyn JobPresenter>,
     cancel: &CancelFlag,
+    alias_cache: Option<&AliasCache>,
 ) -> anyhow::Result<Vec<super::WorktreeOutcome>> {
     let mut outcomes = Vec::with_capacity(targets.len());
     for t in targets {
         if cancel.is_cancelled() {
             break;
         }
-        let outcome = run_pipeline_streaming(t, pipeline, "", presenter, cancel)?;
+        let outcome = run_pipeline_streaming(t, pipeline, "", presenter, cancel, alias_cache)?;
         let succeeded = outcome.succeeded();
         outcomes.push(outcome);
         if !succeeded && !keep_going {
@@ -231,8 +241,14 @@ mod tests {
             branch_name: "master".into(),
         }];
         let pipeline = vec![CommandSpec::Argv(vec!["echo".into(), "hi".into()])];
-        let report =
-            run_with_progress(&targets, &pipeline, ExecMode::Parallel, &CancelFlag::new()).unwrap();
+        let report = run_with_progress(
+            &targets,
+            &pipeline,
+            ExecMode::Parallel,
+            &CancelFlag::new(),
+            None,
+        )
+        .unwrap();
         assert_eq!(report.outcomes.len(), 1);
         assert_eq!(report.aggregate_exit_code(), 0);
         assert!(report.outcomes[0].succeeded());
@@ -266,7 +282,8 @@ mod tests {
         let cancel = CancelFlag::new();
         cancel.escalate();
 
-        let report = run_with_progress(&targets, &pipeline, ExecMode::Sequential, &cancel).unwrap();
+        let report =
+            run_with_progress(&targets, &pipeline, ExecMode::Sequential, &cancel, None).unwrap();
 
         assert!(
             report.outcomes.is_empty(),

--- a/tests/manual/scenarios/worktree-exec/user-shell-aliases.yml
+++ b/tests/manual/scenarios/worktree-exec/user-shell-aliases.yml
@@ -1,0 +1,59 @@
+name: "Exec resolves user shell aliases"
+description: |
+  Regression: aliases / shell functions defined in the user's rc file
+  must resolve through `daft exec` for both `-x CMD` and `-- CMD` forms.
+  Mirrors the same behavior shipped for `-x` on `daft go` / `daft start`
+  in #242.
+
+repos:
+  - name: exec-aliases
+    use_fixture: standard-remote
+
+steps:
+  - name: "Set up fake HOME with .bashrc that defines a test alias"
+    run: |
+      mkdir -p "$WORK_DIR/fakehome" && \
+        printf '%s\n' 'alias daft_test_alias="echo aliased > alias_marker.txt"' \
+          > "$WORK_DIR/fakehome/.bashrc"
+    expect:
+      exit_code: 0
+      files_exist:
+        - "$WORK_DIR/fakehome/.bashrc"
+
+  - name: "Clone the repository"
+    run: "git-worktree-clone --layout contained $REMOTE_EXEC_ALIASES"
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/exec-aliases/main"
+
+  - name: "Resolve alias passed via -x (shell form)"
+    run: |
+      HOME="$WORK_DIR/fakehome" SHELL=/bin/bash \
+        git-worktree-exec main -x 'daft_test_alias' 2>/dev/null
+    cwd: "$WORK_DIR/exec-aliases/main"
+    expect:
+      exit_code: 0
+      files_exist:
+        - "$WORK_DIR/exec-aliases/main/alias_marker.txt"
+      file_contains:
+        - path: "$WORK_DIR/exec-aliases/main/alias_marker.txt"
+          content: "aliased"
+
+  - name: "Clear marker between tests"
+    run: "rm -f $WORK_DIR/exec-aliases/main/alias_marker.txt"
+    expect:
+      exit_code: 0
+
+  - name: "Resolve alias passed after -- (argv form)"
+    run: |
+      HOME="$WORK_DIR/fakehome" SHELL=/bin/bash \
+        git-worktree-exec main -- daft_test_alias 2>/dev/null
+    cwd: "$WORK_DIR/exec-aliases/main"
+    expect:
+      exit_code: 0
+      files_exist:
+        - "$WORK_DIR/exec-aliases/main/alias_marker.txt"
+      file_contains:
+        - path: "$WORK_DIR/exec-aliases/main/alias_marker.txt"
+          content: "aliased"

--- a/tests/manual/scenarios/worktree-exec/user-shell-aliases.yml
+++ b/tests/manual/scenarios/worktree-exec/user-shell-aliases.yml
@@ -1,19 +1,21 @@
-name: "Exec resolves user shell aliases"
+name: "Exec resolves user shell aliases and functions"
 description: |
-  Regression: aliases / shell functions defined in the user's rc file
+  Regression: aliases AND shell functions defined in the user's rc file
   must resolve through `daft exec` for both `-x CMD` and `-- CMD` forms.
   Mirrors the same behavior shipped for `-x` on `daft go` / `daft start`
-  in #242.
+  in #242, plus the alias/function cache that keeps subsequent runs fast.
 
 repos:
   - name: exec-aliases
     use_fixture: standard-remote
 
 steps:
-  - name: "Set up fake HOME with .bashrc that defines a test alias"
+  - name: "Set up fake HOME with .bashrc defining a test alias and function"
     run: |
       mkdir -p "$WORK_DIR/fakehome" && \
-        printf '%s\n' 'alias daft_test_alias="echo aliased > alias_marker.txt"' \
+        printf '%s\n%s\n' \
+          'alias daft_test_alias="echo aliased > alias_marker.txt"' \
+          'daft_test_function() { echo "from-function" > function_marker.txt; }' \
           > "$WORK_DIR/fakehome/.bashrc"
     expect:
       exit_code: 0
@@ -57,3 +59,27 @@ steps:
       file_contains:
         - path: "$WORK_DIR/exec-aliases/main/alias_marker.txt"
           content: "aliased"
+
+  - name: "Resolve user-defined shell function (cached fast path)"
+    run: |
+      HOME="$WORK_DIR/fakehome" SHELL=/bin/bash \
+        git-worktree-exec main -- daft_test_function 2>/dev/null
+    cwd: "$WORK_DIR/exec-aliases/main"
+    expect:
+      exit_code: 0
+      files_exist:
+        - "$WORK_DIR/exec-aliases/main/function_marker.txt"
+      file_contains:
+        - path: "$WORK_DIR/exec-aliases/main/function_marker.txt"
+          content: "from-function"
+
+  - name: "--refresh-aliases re-captures aliases and functions"
+    run: |
+      rm -f $WORK_DIR/exec-aliases/main/function_marker.txt && \
+      HOME="$WORK_DIR/fakehome" SHELL=/bin/bash \
+        git-worktree-exec main --refresh-aliases -- daft_test_function 2>/dev/null
+    cwd: "$WORK_DIR/exec-aliases/main"
+    expect:
+      exit_code: 0
+      files_exist:
+        - "$WORK_DIR/exec-aliases/main/function_marker.txt"


### PR DESCRIPTION
## Summary

`daft exec` (both `-x CMD` and `-- CMD ARGS` forms) now resolves user-defined aliases like `gss` and shell functions like `mygitfn`, matching the precedent set in #242 for `-x` on `daft go` / `daft start`. A persistent cache keeps subsequent invocations fast (~50ms vs ~3s on plugin-heavy zsh setups).

## Two commits

**1. `fix(exec): resolve user shell aliases and functions`** — routes both forms through `\$SHELL -i -c`. For argv form, parts are POSIX-quoted via \`shlex::try_quote\` so the inner shell sees the same argument boundaries. Single-target pass-through reuses \`core::build_command\` to avoid duplication. Replaces the prior \`shell_form_does_not_use_interactive_flag\` regression guard (which intentionally blocked \`-i\` for env-var purity) with a structural test for the new behavior. Three tests that exact-matched captured output now line-grep, since interactive shells emit benign stderr noise (\`no job control in this shell\`, rc-file output) into the captured buffer.

**2. \`perf(exec): cache user aliases and functions to skip rc-file load\`** — captures aliases (\`alias -p\` / \`alias -L\`) and functions (\`declare -f\` / \`typeset -f\`) once per TTL via a single \`\$SHELL -i -c '<dump>'\` call. Persists to \`\$XDG_CACHE_HOME/daft/\`:
- \`aliases-<shell>.txt\` — small; alias defs plus epoch / shell-name header.
- \`functions-<shell>.sh\` — eval-able function bodies. **Sourced** rather than inlined because zsh's \`typeset -f\` output can be ~1MB on plugin-heavy setups, well over \`ARG_MAX\`.

Fast path: \`\$SHELL -c '<aliases>; source <funcs>; eval \"\$1\"' -- <cmd>\` — no \`-i\`, no rc-load. Slow path (\`\$SHELL -i -c\`) still runs when the cache is unavailable (unsupported shell, capture failure, IO error).

## Performance impact

| | cold cache | warm cache |
|---|---|---|
| plugin-heavy zsh, \`daft exec main -- echo hi\` | ~3.0s | **~50ms** (≈60×) |
| \`gss\` (alias) | resolves | resolves |
| \`mygitfn\` (function) | resolves | resolves |

\`--refresh-aliases\` forces a re-capture; default TTL is 24h.

## Caveats

- **Caching scope**: bash and zsh only. sh, fish, etc. fall through to the slow \`-i\` path.
- **direnv per-worktree aliases** aren't captured (the cache reflects the user's base shell environment); affected users would need \`--refresh-aliases\` after \`cd\`-ing into a different envrc context, or rely on the slow path.
- **Stderr noise**: in multi-target capture mode (and in the slow-path fallback) interactive-shell startup may put \`no job control in this shell\` and rc-file output into the captured buffer. Same trade-off accepted in #242 for \`daft go -x\`. Single-target pass-through inherits the parent TTY so the warning doesn't fire.

Fixes the issue where \`daft exec --all -x gss\` reported \`gss: command not found\`.

## Test plan

- [x] \`cargo test --lib\` — 1189 passing (9 new for alias_cache + build_command).
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` — clean.
- [x] \`cargo fmt --all -- --check\` — clean.
- [x] All 10 \`worktree-exec:*\` YAML scenarios pass (39 steps), including new function-resolution and \`--refresh-aliases\` checks.
- [x] All 8 legacy \`exec:*\` scenarios still pass (the ones for \`-x\` on \`init\`/\`checkout\`).
- [x] End-to-end: cleared cache, ran \`daft worktree-exec main -- echo hi\` against a real plugin-heavy zsh — first run ~3.0s (capture), second run ~50ms.
- [x] End-to-end: alias \`gss\` from \`.zshrc\` resolves correctly through both \`-x gss\` and \`-- gss\` forms.
- [x] End-to-end: shell function defined in fake \`.bashrc\` resolves through cached fast path (covered by YAML scenario).

🤖 Generated with [Claude Code](https://claude.com/claude-code)