### PR TITLE
fix(shell-init,completions): skip update check and trust prune for shell-eval'd commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,17 @@ temp file and pass its path via `DAFT_CD_FILE`. When set, commands write the cd
 target to that file, and the wrapper reads it after the command finishes to `cd`
 into new worktrees. Stdout flows directly to the terminal.
 
+**Shell-init is on the hot path**: `daft shell-init` is sourced from the user's
+shell rc files (`~/.bashrc`, `~/.zshrc`, etc.) via `eval "$(daft shell-init …)"`
+on every interactive shell startup, so its codepath must remain extremely lean.
+No extra subprocess calls, file IO, network requests, or background-process
+spawns. Stderr output is also problematic — `eval` only captures stdout, so any
+stderr (e.g., the update banner) leaks straight into the user's terminal. Any
+startup-time background work in `src/main.rs` (currently the update check and
+trust prune) must be gated through `daft::skip_startup_tasks_for` so it skips
+`shell-init` and `__*` background tasks. Add new commands with similar
+constraints to that helper rather than introducing a parallel gate.
+
 **Hooks system**: Lifecycle hooks in `.daft/hooks/` with trust-based security.
 Hook types: `post-clone`, `worktree-pre-create`, `worktree-post-create`,
 `worktree-pre-remove`, `worktree-post-remove`. Old names without `worktree-`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,16 +74,18 @@ temp file and pass its path via `DAFT_CD_FILE`. When set, commands write the cd
 target to that file, and the wrapper reads it after the command finishes to `cd`
 into new worktrees. Stdout flows directly to the terminal.
 
-**Shell-init is on the hot path**: `daft shell-init` is sourced from the user's
-shell rc files (`~/.bashrc`, `~/.zshrc`, etc.) via `eval "$(daft shell-init …)"`
-on every interactive shell startup, so its codepath must remain extremely lean.
-No extra subprocess calls, file IO, network requests, or background-process
-spawns. Stderr output is also problematic — `eval` only captures stdout, so any
-stderr (e.g., the update banner) leaks straight into the user's terminal. Any
+**Shell-eval'd commands are on the hot path**: `daft shell-init` and
+`daft completions <shell>` both emit shell code that users `eval` from their rc
+files (`~/.bashrc`, `~/.zshrc`, etc.), so they run on every interactive shell
+startup. Their codepaths must remain extremely lean: no extra subprocess calls,
+file IO, network requests, or background-process spawns. Stderr output is also
+problematic — `eval` only captures stdout, so any stderr (e.g., the update
+banner) leaks straight into the user's terminal. The same applies to the
+`__complete` tab-completion helper, which fires on every Tab keypress. Any
 startup-time background work in `src/main.rs` (currently the update check and
-trust prune) must be gated through `daft::skip_startup_tasks_for` so it skips
-`shell-init` and `__*` background tasks. Add new commands with similar
-constraints to that helper rather than introducing a parallel gate.
+trust prune) must be gated through `daft::skip_startup_tasks_for`, which covers
+`shell-init`, `completions`, and `__*` background tasks. Add new commands with
+similar constraints to that helper rather than introducing a parallel gate.
 
 **Hooks system**: Lifecycle hooks in `.daft/hooks/` with trust-based security.
 Hook types: `post-clone`, `worktree-pre-create`, `worktree-post-create`,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,6 +113,24 @@ pub fn get_clap_args(expected_cmd: &str) -> Vec<String> {
     args
 }
 
+/// Returns `true` if the given argv corresponds to an invocation that should
+/// skip startup-time background work (update checks, trust pruning, etc.).
+///
+/// `shell-init` is sourced from the user's shell rc files on every interactive
+/// shell startup, so its codepath must stay free of subprocess calls, file IO,
+/// network requests, and background-process spawns. `__*` subcommands are
+/// background tasks (e.g., `__check-update`, `__prune-trust`) and skipping
+/// further background work for them prevents recursive fork bombs.
+///
+/// New commands with similar constraints should be added here rather than
+/// introducing a parallel gate at the call sites.
+pub fn skip_startup_tasks_for(args: &[String]) -> bool {
+    let Some(sub) = args.get(1).map(String::as_str) else {
+        return false;
+    };
+    sub.starts_with("__") || sub == "shell-init"
+}
+
 pub mod commands;
 pub mod completion_spinner;
 pub mod core;
@@ -249,5 +267,70 @@ mod tests {
             .to_string()
             .contains("must be an absolute path"));
         env::remove_var(DATA_DIR_ENV);
+    }
+
+    fn args(parts: &[&str]) -> Vec<String> {
+        parts.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn test_skip_startup_tasks_empty_args() {
+        assert!(!skip_startup_tasks_for(&[]));
+    }
+
+    #[test]
+    fn test_skip_startup_tasks_no_subcommand() {
+        assert!(!skip_startup_tasks_for(&args(&["daft"])));
+    }
+
+    #[test]
+    fn test_skip_startup_tasks_shell_init_via_daft() {
+        assert!(skip_startup_tasks_for(&args(&[
+            "daft",
+            "shell-init",
+            "bash"
+        ])));
+    }
+
+    #[test]
+    fn test_skip_startup_tasks_shell_init_via_git_daft() {
+        assert!(skip_startup_tasks_for(&args(&[
+            "git-daft",
+            "shell-init",
+            "zsh"
+        ])));
+    }
+
+    #[test]
+    fn test_skip_startup_tasks_check_update() {
+        assert!(skip_startup_tasks_for(&args(&["daft", "__check-update"])));
+    }
+
+    #[test]
+    fn test_skip_startup_tasks_prune_trust() {
+        assert!(skip_startup_tasks_for(&args(&["daft", "__prune-trust"])));
+    }
+
+    #[test]
+    fn test_skip_startup_tasks_regular_command_clone() {
+        assert!(!skip_startup_tasks_for(&args(&[
+            "daft",
+            "clone",
+            "https://example.invalid/repo.git"
+        ])));
+    }
+
+    #[test]
+    fn test_skip_startup_tasks_regular_command_list() {
+        assert!(!skip_startup_tasks_for(&args(&["daft", "list"])));
+    }
+
+    #[test]
+    fn test_skip_startup_tasks_does_not_match_substring() {
+        // A subcommand that merely contains "shell-init" should not match.
+        assert!(!skip_startup_tasks_for(&args(&[
+            "daft",
+            "shell-init-something"
+        ])));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,11 +116,17 @@ pub fn get_clap_args(expected_cmd: &str) -> Vec<String> {
 /// Returns `true` if the given argv corresponds to an invocation that should
 /// skip startup-time background work (update checks, trust pruning, etc.).
 ///
-/// `shell-init` is sourced from the user's shell rc files on every interactive
-/// shell startup, so its codepath must stay free of subprocess calls, file IO,
-/// network requests, and background-process spawns. `__*` subcommands are
-/// background tasks (e.g., `__check-update`, `__prune-trust`) and skipping
-/// further background work for them prevents recursive fork bombs.
+/// `shell-init` and `completions` both emit shell code to stdout that users
+/// `eval` from their shell rc files, so they run on every interactive shell
+/// startup. Their codepaths must stay free of subprocess calls, file IO,
+/// network requests, and background-process spawns. They must also stay quiet
+/// on stderr — `eval` only captures stdout, so banners on stderr (e.g., the
+/// update-available notice) leak straight into the user's terminal.
+///
+/// `__*` subcommands are background tasks (e.g., `__check-update`,
+/// `__prune-trust`, and the `__complete` tab-completion helper). Skipping
+/// further background work for them prevents recursive fork bombs and keeps
+/// tab completion responsive.
 ///
 /// New commands with similar constraints should be added here rather than
 /// introducing a parallel gate at the call sites.
@@ -128,7 +134,7 @@ pub fn skip_startup_tasks_for(args: &[String]) -> bool {
     let Some(sub) = args.get(1).map(String::as_str) else {
         return false;
     };
-    sub.starts_with("__") || sub == "shell-init"
+    sub.starts_with("__") || matches!(sub, "shell-init" | "completions")
 }
 
 pub mod commands;
@@ -298,6 +304,24 @@ mod tests {
             "git-daft",
             "shell-init",
             "zsh"
+        ])));
+    }
+
+    #[test]
+    fn test_skip_startup_tasks_completions() {
+        assert!(skip_startup_tasks_for(&args(&[
+            "daft",
+            "completions",
+            "zsh"
+        ])));
+    }
+
+    #[test]
+    fn test_skip_startup_tasks_completions_via_git_daft() {
+        assert!(skip_startup_tasks_for(&args(&[
+            "git-daft",
+            "completions",
+            "bash"
         ])));
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,9 +29,15 @@ fn main() -> Result<()> {
         }
     }
 
-    // Detect background task invocations (__check-update, __prune-trust, etc.)
-    // to skip spawning further background processes — otherwise each background
-    // task recursively spawns more, creating an exponential fork bomb.
+    // Skip startup-time background work for invocations that must stay lean:
+    // - `__*` background tasks (__check-update, __prune-trust, etc.) — spawning
+    //   further background processes from them would recursively fan out into a
+    //   fork bomb.
+    // - `shell-init` — sourced from the user's shell rc files on every
+    //   interactive shell startup; any subprocess call, file IO, network
+    //   request, or background spawn here adds latency to every new shell, and
+    //   stderr output (e.g., the update banner) leaks past `eval`'s stdout
+    //   capture into the user's terminal.
     //
     // If a fork bomb occurs (hundreds of daft processes consuming all CPU):
     //   pkill -9 -f "daft.*__check-update"
@@ -39,13 +45,14 @@ fn main() -> Result<()> {
     // Or more broadly:
     //   pkill -9 -f "<worktree-path>/target/release"
     // Repeat until `ps aux | grep __check-update | wc -l` returns 0.
-    let is_background_task = std::env::args().nth(1).is_some_and(|a| a.starts_with("__"));
+    let argv: Vec<String> = std::env::args().collect();
+    let skip_startup_tasks = daft::skip_startup_tasks_for(&argv);
 
     // Warn if config directory is overridden (security measure against trust DB hijacking).
     // Only in dev builds — release builds ignore DAFT_CONFIG_DIR entirely.
     if cfg!(daft_dev_build) {
         if let Ok(dir) = std::env::var(daft::CONFIG_DIR_ENV) {
-            if !dir.is_empty() && !is_background_task {
+            if !dir.is_empty() && !skip_startup_tasks {
                 eprintln!("warning: config directory overridden via DAFT_CONFIG_DIR");
                 eprintln!("  -> {dir}");
             }
@@ -53,14 +60,14 @@ fn main() -> Result<()> {
     }
 
     // Check for updates (reads cache, spawns background check if stale)
-    let update_notification = if !is_background_task {
+    let update_notification = if !skip_startup_tasks {
         daft::update_check::maybe_check_for_update()
     } else {
         None
     };
 
     // Prune stale trust entries (background, once per 24h)
-    if !is_background_task {
+    if !skip_startup_tasks {
         daft::trust_prune::maybe_prune_trust();
     }
 


### PR DESCRIPTION
## Summary

`daft shell-init` and `daft completions <shell>` both emit shell code that users `eval` from their rc files (`~/.bashrc`, `~/.zshrc`, …), so they run on every interactive shell startup. Two problems on this codepath:

1. **Per-shell startup latency.** The unconditional update-check and trust-prune calls in `src/main.rs` run a `git config --global` subprocess, read `~/.config/daft/update-check.json`, and (when stale) fork-spawn `daft __check-update` which itself forks `curl` to GitHub.
2. **Stray banner on shell startup.** `print_notification` writes to **stderr**; `eval` only captures stdout, so when a newer release is cached and the 24h-per-version throttle has elapsed, the banner leaks straight into the user's terminal at shell startup.

This PR:

- Generalises the existing `is_background_task` gate in `src/main.rs` into a small pure helper `daft::skip_startup_tasks_for` (`src/lib.rs`) that matches `__*` background tasks plus the two shell-eval'd commands `shell-init` and `completions`.
- Routes both `maybe_check_for_update` and `maybe_prune_trust` through the helper.
- Documents the hot-path constraint in `CLAUDE.md` (covers shell-init, completions, and the `__complete` tab-completion helper that is already gated via the `__` prefix) so future commands with similar requirements are added to the same gate rather than introducing a parallel one.

## Test plan

- [x] `mise run fmt`
- [x] `mise run clippy` — zero warnings
- [x] `cargo test --lib skip_startup_tasks` — 11/11 helper tests pass (covers empty argv, no subcommand, `daft shell-init`, `git-daft shell-init`, `daft completions`, `git-daft completions`, `__check-update`, `__prune-trust`, `daft clone …`, `daft list`, no-substring-match guard)
- [x] Manual: built `target/release/daft`, seeded `~/.config/daft/update-check.json` with `latest_version: 999.0.0`, ran `daft shell-init bash` — no banner on stderr, `pgrep` confirmed no `__check-update`/`__prune-trust` background processes spawned

🤖 Generated with [Claude Code](https://claude.com/claude-code)