### PR TITLE
fix(exec): isolate alias capture from rc-file stdout

### DIFF
--- a/src/core/worktree/exec/alias_cache.rs
+++ b/src/core/worktree/exec/alias_cache.rs
@@ -4,19 +4,28 @@
 //! `mygitfunc()` by routing commands through `$SHELL`. The naive way —
 //! `$SHELL -i -c CMD` — sources the user's full rc file every invocation,
 //! which on heavy setups (zsh with oh-my-zsh, gitstatus, plugins) costs
-//! multiple seconds.
+//! multiple seconds. Worse, rc files frequently misbehave in
+//! non-interactive contexts (p10k instant prompt, plugins that need a
+//! TTY, `exec tmux` patterns) — when they do, `-i -c` fails and renders
+//! `daft exec` itself useless.
 //!
 //! This module captures the alias table and shell-function definitions
-//! once via `$SHELL -i -c '<dump>'`, persists them under
-//! `$XDG_CACHE_HOME/daft/`, and reuses them on subsequent runs. With a
-//! populated cache, command execution skips the rc-file load entirely
-//! (`$SHELL -c` instead of `-i -c`) and inlines the alias definitions
-//! plus a `source` of the functions file before running the user command
-//! via `eval`.
+//! once via `$SHELL -i`, persists them under `$XDG_CACHE_HOME/daft/`,
+//! and reuses them on subsequent runs. With a populated cache, command
+//! execution uses a pristine `$SHELL -c` and inlines the alias
+//! definitions plus a `source` of the functions file before running the
+//! user command via `eval` — no rc-file load at runtime.
+//!
+//! Capture writes alias and function output to dedicated temp files
+//! whose paths are passed to the spawned shell via env vars
+//! (`__DAFT_ALIAS_OUT`, `__DAFT_FN_OUT`). The shell's stdout and
+//! stderr are discarded entirely, so rc-file noise (welcome banners,
+//! p10k instant-prompt output, fortune cookies) cannot corrupt the
+//! captured snapshot. A 10s deadline guards against rc-files that hang.
 //!
 //! Two files per shell:
 //!   * `aliases-<shell>.txt` — small; alias definitions plus a metadata
-//!     header (epoch, shell name).
+//!     header (format version, epoch, shell name).
 //!   * `functions-<shell>.sh` — eval-able function bodies. Sourced by the
 //!     spawned shell rather than inlined, since `typeset -f` output can
 //!     be hundreds of kilobytes (zsh + plugins) and would blow `ARG_MAX`
@@ -24,17 +33,31 @@
 //!
 //! Limitations: only `bash` and `zsh` are supported; per-worktree direnv
 //! aliases are out of scope (the cache reflects the user's base shell
-//! environment). For unsupported shells or capture failures, callers
-//! fall back to `-i` (slow path) and shortcuts still resolve.
+//! environment). When capture fails (unsupported shell, deadline, or
+//! validation rejection) callers fall back to a rc-less `$SHELL -c CMD`
+//! — aliases won't resolve in that path, but commands still run. The
+//! `-i -c` runtime path is no longer used as a fallback because rc-file
+//! breakage in non-interactive mode is precisely what the user's
+//! commands need to survive.
 //!
-//! Cache invalidation is by TTL. `daft exec --refresh-aliases` forces a
-//! re-capture.
+//! Cache invalidation is by TTL plus a format-version header: bumping
+//! `CACHE_FORMAT_HEADER` auto-rejects older on-disk caches without
+//! requiring `--refresh-aliases`.
 
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 /// How long a captured alias snapshot stays fresh on disk.
 pub const CACHE_TTL: Duration = Duration::from_secs(60 * 60 * 24);
+
+/// Magic header on every saved alias snapshot. Bumping the integer
+/// auto-invalidates older caches without requiring `--refresh-aliases`
+/// — important when a previous daft version persisted poisoned
+/// captures (rc-file stdout mixed into the alias body).
+///
+/// v1 was implicit (no header); v2 adds this line and FD-isolated
+/// capture.
+pub const CACHE_FORMAT_HEADER: &str = "# daft-alias-cache v2";
 
 /// One of the shells whose alias output `daft` knows how to capture.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -131,22 +154,56 @@ fn functions_cache_path(shell: ShellKind) -> Option<PathBuf> {
 impl AliasCache {
     /// Return a usable cache for `shell_path`, capturing afresh if the
     /// on-disk copy is missing, stale, or `force_refresh` is set.
-    /// Returns `None` for unsupported shells or if capture fails — in
-    /// that case the caller should fall back to `-i`.
+    /// Returns `None` for unsupported shells, capture failures (timeout
+    /// or spawn error), or captures that fail post-validation — in any
+    /// of those cases the caller should fall back to a rc-less
+    /// `$SHELL -c CMD` so the command still runs (without alias
+    /// resolution).
     pub fn ensure(shell_path: &str, force_refresh: bool) -> Option<Self> {
-        let kind = ShellKind::from_path(shell_path)?;
+        let kind = match ShellKind::from_path(shell_path) {
+            Some(k) => k,
+            None => {
+                debug_log_capture(&format!(
+                    "shell {shell_path:?} is not bash/zsh — skipping alias capture"
+                ));
+                return None;
+            }
+        };
         let aliases_path = aliases_cache_path(kind)?;
         let functions_path = functions_cache_path(kind)?;
 
         if !force_refresh {
             if let Some(loaded) = Self::load(&aliases_path, &functions_path) {
                 if loaded.is_fresh(CACHE_TTL) {
+                    debug_log_capture(&format!(
+                        "using cached snapshot at {}",
+                        aliases_path.display()
+                    ));
                     return Some(loaded);
                 }
             }
         }
 
-        let (alias_lines, functions_body) = Self::capture(shell_path, kind).ok()?;
+        let (alias_lines, functions_body) = match Self::capture(shell_path, kind) {
+            Ok(out) => out,
+            Err(e) => {
+                debug_log_capture(&format!("capture failed: {e}"));
+                return None;
+            }
+        };
+        if !looks_like_alias_dump(&alias_lines) {
+            // Capture ran but produced something that doesn't match the
+            // expected `alias <name>=…` shape. Likely the rc-file aborted
+            // early or the shell isn't actually bash/zsh-compatible.
+            // Better to fall back to the rc-less path than to persist a
+            // garbage cache.
+            debug_log_capture(&format!(
+                "capture produced unrecognized output (first non-blank line not `alias …`); \
+                 first 80 chars: {:?}",
+                alias_lines.chars().take(80).collect::<String>()
+            ));
+            return None;
+        }
         let captured_at = SystemTime::now();
 
         // Best-effort save: a write failure (e.g. read-only HOME)
@@ -186,6 +243,11 @@ impl AliasCache {
 
     fn parse_aliases(content: &str) -> Option<Self> {
         let mut lines = content.lines();
+        // Reject anything that isn't the current format version. v1
+        // caches have no header — they fail this check naturally.
+        if lines.next()? != CACHE_FORMAT_HEADER {
+            return None;
+        }
         let epoch: u64 = lines.next()?.parse().ok()?;
         let shell = match lines.next()? {
             "bash" => ShellKind::Bash,
@@ -202,33 +264,89 @@ impl AliasCache {
     }
 
     /// Run a one-shot capture of aliases and functions via `$SHELL -i`.
-    /// Returns `(alias_lines, functions_body)`. Stderr is discarded so
-    /// rc-file noise doesn't leak into the cache.
+    /// Returns `(alias_lines, functions_body)`.
+    ///
+    /// The spawned shell writes its `alias`/`typeset` output directly to
+    /// two temp files whose paths are passed via env vars
+    /// (`__DAFT_ALIAS_OUT`, `__DAFT_FN_OUT`). Stdout and stderr are
+    /// discarded entirely. This isolates the captured snapshot from any
+    /// rc-file pollution — `echo` calls, p10k instant prompt output,
+    /// plugin status banners, fortune cookies — that would otherwise be
+    /// indistinguishable from real `alias` output and end up in the
+    /// cached file.
+    ///
+    /// A 10-second timeout guards against rc-files that hang the shell
+    /// (e.g. `exec tmux` patterns waiting on a controlling terminal).
     fn capture(shell_path: &str, kind: ShellKind) -> std::io::Result<(String, String)> {
-        // Single `$SHELL -i` invocation runs `<alias-cmd>; echo …; <fn-cmd>`
-        // and we split the output on the sentinel. One rc-file load instead
-        // of two.
-        const SENTINEL: &str = "::DAFT_ALIAS_CACHE_SENTINEL::";
-        let combined = format!(
-            "{}; echo '{}'; {}",
+        let dir = tempfile::tempdir()?;
+        let alias_out = dir.path().join("aliases.out");
+        let fn_out = dir.path().join("functions.out");
+
+        // The shell uses `>"$VAR"` rather than the static path so that a
+        // rc-file with `set -u` doesn't blow up on the redirection
+        // itself. `2>/dev/null` on the redirections suppresses errors
+        // from shells that don't have `typeset -f` (defensive — both
+        // bash and zsh do).
+        let body = format!(
+            r#"{} >"$__DAFT_ALIAS_OUT" 2>/dev/null
+{} >"$__DAFT_FN_OUT" 2>/dev/null
+"#,
             kind.alias_print_command(),
-            SENTINEL,
             kind.functions_print_command(),
         );
-        let output = std::process::Command::new(shell_path)
+
+        let mut child = std::process::Command::new(shell_path)
             .arg("-i")
             .arg("-c")
-            .arg(combined)
+            .arg(body)
+            .env("__DAFT_ALIAS_OUT", &alias_out)
+            .env("__DAFT_FN_OUT", &fn_out)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
-            .output()?;
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let (alias_part, functions_part) = stdout.split_once(SENTINEL).unwrap_or((&stdout, ""));
+            .spawn()?;
+
+        // Bounded wait. A rc-file that does `exec tmux` or similar would
+        // otherwise block forever; the deadline lets the caller fall
+        // back gracefully.
+        let deadline = std::time::Instant::now() + CAPTURE_TIMEOUT;
+        loop {
+            match child.try_wait()? {
+                Some(_status) => break,
+                None => {
+                    if std::time::Instant::now() >= deadline {
+                        let _ = child.kill();
+                        let _ = child.wait();
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::TimedOut,
+                            format!(
+                                "shell capture exceeded {}s — rc-file likely hangs in non-interactive mode",
+                                CAPTURE_TIMEOUT.as_secs()
+                            ),
+                        ));
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(50));
+                }
+            }
+        }
+
+        // The files may not exist if the rc-file aborted before the body
+        // ran (e.g. `set -e` plus a failing line). Treat absence as
+        // empty rather than erroring so the validator below can decide.
+        let alias_lines = std::fs::read_to_string(&alias_out).unwrap_or_default();
+        let functions_body = std::fs::read_to_string(&fn_out).unwrap_or_default();
+
         Ok((
-            alias_part.trim_end().to_string(),
-            functions_part.trim_start_matches('\n').to_string(),
+            alias_lines.trim_end().to_string(),
+            functions_body.trim_start_matches('\n').to_string(),
         ))
     }
 }
+
+/// Upper bound on how long the shell capture is allowed to run. rc-files
+/// that hang (`exec tmux`, blocking reads, etc.) get killed at this
+/// deadline so the caller falls back to the rc-less path.
+pub const CAPTURE_TIMEOUT: Duration = Duration::from_secs(10);
 
 fn save_aliases(
     path: &Path,
@@ -245,7 +363,13 @@ fn save_aliases(
         .as_secs();
     std::fs::write(
         path,
-        format!("{}\n{}\n{}", epoch, shell.name(), alias_lines),
+        format!(
+            "{}\n{}\n{}\n{}",
+            CACHE_FORMAT_HEADER,
+            epoch,
+            shell.name(),
+            alias_lines
+        ),
     )
 }
 
@@ -254,6 +378,31 @@ fn save_functions(path: &Path, body: &str) -> std::io::Result<()> {
         std::fs::create_dir_all(parent)?;
     }
     std::fs::write(path, body)
+}
+
+/// Stderr trace of capture-pipeline state when `DAFT_EXEC_DEBUG=1` is
+/// set. Helps users diagnose why aliases aren't resolving — without
+/// this, a capture failure is invisible (exec just falls back to the
+/// rc-less path, which works but doesn't expand shortcuts).
+fn debug_log_capture(msg: &str) {
+    if std::env::var_os("DAFT_EXEC_DEBUG").is_none() {
+        return;
+    }
+    eprintln!("[daft-exec-debug] capture: {msg}");
+}
+
+/// Quick sanity check on captured alias output. An empty body is fine
+/// (some users just have no aliases). Otherwise the first non-blank
+/// line must look like `alias name=…`. This catches the case where a
+/// rc-file aborts before `alias -L` runs but the wrapper still
+/// produces *some* output (e.g. a stray comment), which would otherwise
+/// be persisted as a "valid but empty" snapshot.
+pub(crate) fn looks_like_alias_dump(body: &str) -> bool {
+    let mut non_blank = body.lines().filter(|l| !l.trim().is_empty());
+    match non_blank.next() {
+        None => true, // empty is legitimate
+        Some(line) => line.trim_start().starts_with("alias "),
+    }
 }
 
 #[cfg(test)]
@@ -297,8 +446,42 @@ mod tests {
 
     #[test]
     fn rejects_unknown_shell_in_serialized_cache() {
-        let payload = "1700000000\nfish\nabbr gss git status";
-        assert!(AliasCache::parse_aliases(payload).is_none());
+        let payload = format!("{CACHE_FORMAT_HEADER}\n1700000000\nfish\nabbr gss git status");
+        assert!(AliasCache::parse_aliases(&payload).is_none());
+    }
+
+    #[test]
+    fn rejects_v1_cache_without_format_header() {
+        // A pre-v2 cache (no header) — shipped before FD-isolated capture
+        // landed and likely contains poisoned content. parse must reject
+        // so the next run forces a fresh capture instead of replaying
+        // the stale data.
+        let v1_payload = "1700000000\nzsh\nalias gss='git status -s'";
+        assert!(
+            AliasCache::parse_aliases(v1_payload).is_none(),
+            "v1 caches must be rejected to force re-capture"
+        );
+    }
+
+    #[test]
+    fn looks_like_alias_dump_accepts_empty_and_real_aliases() {
+        assert!(looks_like_alias_dump(""));
+        assert!(looks_like_alias_dump("\n\n  \n"));
+        assert!(looks_like_alias_dump("alias g='git'"));
+        assert!(looks_like_alias_dump(
+            "alias g='git'\nalias gs='git status'"
+        ));
+    }
+
+    #[test]
+    fn looks_like_alias_dump_rejects_non_alias_first_line() {
+        // Captured pollution shouldn't survive validation. (FD-isolated
+        // capture means this is a defense-in-depth check, not the
+        // primary defense.)
+        assert!(!looks_like_alias_dump(
+            "Welcome to my shell!\nalias g='git'"
+        ));
+        assert!(!looks_like_alias_dump("# random comment\nalias g='git'"));
     }
 
     #[test]
@@ -363,5 +546,77 @@ mod tests {
             .alias_expansion_prefix()
             .contains("expand_aliases"));
         assert_eq!(ShellKind::Zsh.alias_expansion_prefix(), "");
+    }
+
+    /// Regression: rc-files that print to stdout (p10k instant prompt,
+    /// "welcome" banners, plugin status messages, fortune cookies) must
+    /// not corrupt the captured alias snapshot. Pre-fix, capture split
+    /// `alias -p` output from the shell's stdout via a sentinel — but
+    /// any rc-file pollution was indistinguishable from alias output and
+    /// got persisted, then re-injected into every subsequent fast-path
+    /// invocation, breaking the user's commands.
+    #[cfg(unix)]
+    #[test]
+    fn capture_survives_rc_file_stdout_pollution() {
+        use std::os::unix::fs::PermissionsExt;
+        if std::process::Command::new("bash")
+            .arg("-c")
+            .arg("true")
+            .status()
+            .map(|s| !s.success())
+            .unwrap_or(true)
+        {
+            // bash unavailable — skip rather than fail on minimal CI images.
+            return;
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+
+        // A rc-file that emits a "welcome banner" before defining the
+        // alias, plus more pollution after. Mimics real-world setups
+        // (Powerlevel10k instant prompt, oh-my-zsh plugin status, nvm
+        // version banners, etc.).
+        std::fs::write(
+            dir.path().join(".bashrc"),
+            "echo 'POLLUTION_BEFORE_PROMPT_INIT'\n\
+             printf 'fortune cookie quote\\n'\n\
+             alias daft_pollution_marker='echo pmark'\n\
+             echo 'POLLUTION_AFTER'\n",
+        )
+        .unwrap();
+
+        // Wrapper executable that scopes HOME to the temp dir, so bash
+        // -i sources our fixture .bashrc instead of the real user's.
+        let wrapper = dir.path().join("bash-wrapper.sh");
+        std::fs::write(
+            &wrapper,
+            format!(
+                "#!/bin/sh\nexport HOME={}\nexec bash \"$@\"\n",
+                dir.path().to_str().unwrap()
+            ),
+        )
+        .unwrap();
+        std::fs::set_permissions(&wrapper, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let (alias_lines, _functions) =
+            AliasCache::capture(wrapper.to_str().unwrap(), ShellKind::Bash)
+                .expect("capture should spawn the wrapper shell");
+
+        assert!(
+            alias_lines.contains("daft_pollution_marker"),
+            "real alias must be captured: {alias_lines:?}"
+        );
+        assert!(
+            !alias_lines.contains("POLLUTION_BEFORE_PROMPT_INIT"),
+            "rc-file stdout must NOT leak into the cache: {alias_lines:?}"
+        );
+        assert!(
+            !alias_lines.contains("POLLUTION_AFTER"),
+            "rc-file stdout must NOT leak into the cache: {alias_lines:?}"
+        );
+        assert!(
+            !alias_lines.contains("fortune cookie quote"),
+            "rc-file stdout must NOT leak into the cache: {alias_lines:?}"
+        );
     }
 }

--- a/src/core/worktree/exec/mod.rs
+++ b/src/core/worktree/exec/mod.rs
@@ -527,8 +527,9 @@ pub fn run_pipeline(
 /// pipeline is conveyed via the `command_preview` argument on `on_job_start`
 /// — not via the job name itself.
 ///
-/// `alias_cache`, when supplied, replaces the slow `$SHELL -i -c` rc-file
-/// load with an inlined alias table for the spawned shell.
+/// `alias_cache`, when supplied, lets `build_command` skip rc-file
+/// loading entirely by inlining a previously captured alias table for
+/// the spawned shell.
 pub fn run_pipeline_streaming(
     target: &ResolvedTarget,
     pipeline: &[CommandSpec],
@@ -694,14 +695,26 @@ where
 
 /// Build the `Command` that runs a `CommandSpec` for one worktree.
 ///
-/// User-defined aliases (e.g. `gss`, `gcvm`) resolve the same way they
-/// would in an interactive shell. The fast path inlines a cached alias
-/// table and runs `$SHELL -c '<aliases>; eval "$1"' -- <cmd>`, skipping
-/// the rc-file load (`-i`) entirely. The slow path falls back to
-/// `$SHELL -i -c <cmd>` so aliases still resolve when no cache is
-/// available (unsupported shell, capture failure, first run before
-/// caching). For `Argv`, parts are POSIX-quoted and joined first so the
-/// inner shell sees the same argument boundaries.
+/// User-defined aliases (e.g. `gss`, `gcvm`) resolve via a cached
+/// snapshot of the alias table and shell functions. The fast path
+/// inlines that snapshot and runs `$SHELL -c '<aliases>; eval "$1"' -- <cmd>`,
+/// avoiding any rc-file load.
+///
+/// The fallback path — used only when no cache is available
+/// (unsupported shell, capture timed out, capture aborted, or first run
+/// before the snapshot exists) — runs `$SHELL -c <cmd>` *without*
+/// `-i`. Earlier versions used `$SHELL -i -c <cmd>` so that aliases
+/// would still resolve from the rc-file in the no-cache case, but rc
+/// files frequently misbehave in non-interactive contexts (p10k instant
+/// prompt, `tput` without a TTY, plugins that read from stdin), and
+/// when they do, a `-i -c` fallback fails outright — making `daft exec`
+/// itself unusable. The rc-less path sacrifices alias resolution in the
+/// fallback to guarantee the user's command actually runs. With
+/// FD-isolated capture, the cache succeeds for the vast majority of
+/// setups, so this fallback rarely fires.
+///
+/// For `Argv`, parts are POSIX-quoted and joined first so the inner
+/// shell sees the same argument boundaries.
 pub(crate) fn build_command(spec: &CommandSpec, alias_cache: Option<&AliasCache>) -> Command {
     let shell = std::env::var("SHELL").unwrap_or_else(|_| "sh".to_string());
     let cmd_string = match spec {
@@ -732,15 +745,31 @@ pub(crate) fn build_command(spec: &CommandSpec, alias_cache: Option<&AliasCache>
             body.push_str(&cache.alias_lines);
             body.push_str("\neval \"$1\"");
             c.arg("-c").arg(body).arg("--").arg(cmd_string);
+            debug_log_command(&shell, "fast-path (cache)", &c);
         }
         None => {
-            // Slow path: load the user's rc files via `-i` so any aliases
-            // (and shell functions) resolve. Used when no cache is
-            // available — e.g. unsupported shell or capture failure.
-            c.arg("-i").arg("-c").arg(cmd_string);
+            // Rc-less fallback. Aliases won't resolve, but the user's
+            // command runs — preferred over `-i -c` for users whose rc
+            // files break in non-interactive mode.
+            c.arg("-c").arg(&cmd_string);
+            debug_log_command(&shell, "no-cache (rc-less)", &c);
         }
     }
     c
+}
+
+/// Stderr trace of the constructed command when `DAFT_EXEC_DEBUG=1` is
+/// set. Helps users diagnose alias-resolution problems they'd otherwise
+/// have no logs for. Silent unless the env var is set.
+fn debug_log_command(shell: &str, mode: &str, cmd: &Command) {
+    if std::env::var_os("DAFT_EXEC_DEBUG").is_none() {
+        return;
+    }
+    let args: Vec<String> = cmd
+        .get_args()
+        .map(|a| a.to_string_lossy().into_owned())
+        .collect();
+    eprintln!("[daft-exec-debug] mode={mode} shell={shell} args={args:?}");
 }
 
 /// Shell-quote each argv element (POSIX) and join with spaces so the
@@ -1144,14 +1173,16 @@ mod tests {
     }
 
     #[test]
-    fn build_command_falls_back_to_interactive_shell_when_no_cache() {
-        // Slow path: when no alias cache is available (unsupported shell
-        // or capture failure), fall back to `$SHELL -i -c` so aliases
-        // still resolve via the user's rc files. Matches the behavior
-        // shipped for `-x` on `daft go` / `daft start` in #242.
+    fn build_command_no_cache_uses_rc_less_shell() {
+        // No-cache path: do NOT pass `-i` — rc-file evaluation fails for
+        // some users in non-interactive contexts (p10k instant prompt,
+        // plugins that need a TTY) and was making `daft exec` unusable.
+        // A pristine `$SHELL -c` is the safer default; aliases simply
+        // don't resolve in this fallback. With FD-isolated capture the
+        // cache succeeds for almost all users, so this rarely fires.
         let shell_cmd = build_command(&CommandSpec::Shell("gss".into()), None);
         let args: Vec<&std::ffi::OsStr> = shell_cmd.get_args().collect();
-        assert_eq!(args, vec!["-i", "-c", "gss"]);
+        assert_eq!(args, vec!["-c", "gss"]);
 
         // Argv parts are POSIX-quoted and joined so the inner shell sees
         // the same argument boundaries as the original argv.
@@ -1160,7 +1191,7 @@ mod tests {
             None,
         );
         let args: Vec<&std::ffi::OsStr> = argv_cmd.get_args().collect();
-        assert_eq!(args, vec!["-i", "-c", "echo 'hello world'"]);
+        assert_eq!(args, vec!["-c", "echo 'hello world'"]);
     }
 
     #[test]

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -1,16 +1,30 @@
 use anyhow::Result;
-use std::process::Command;
 
+use crate::core::worktree::exec::{build_command, AliasCache, CommandSpec};
 use crate::output::Output;
 
+/// Run a sequence of `-x` shell commands as part of worktree creation
+/// (`daft clone -x`, `daft init -x`, `daft checkout/go/start -x`).
+///
+/// Routes through the same `build_command` used by `daft exec` so user
+/// shortcuts (aliases, shell functions) resolve consistently. With a
+/// captured alias snapshot the spawned shell skips the rc-file load
+/// entirely; without one — unsupported shell, capture timeout, or first
+/// run before the snapshot exists — falls back to a rc-less `$SHELL -c`.
+/// The earlier implementation used `$SHELL -i -c CMD` unconditionally,
+/// which made these commands unusable for users whose rc files break in
+/// non-interactive contexts.
 pub fn run_exec_commands(commands: &[String], output: &mut dyn Output) -> Result<()> {
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| "sh".to_string());
+    // One capture covers the whole `-x` sequence; the snapshot is
+    // shared across commands so a heavy rc-file (oh-my-zsh, p10k) is
+    // paid for at most once per invocation.
+    let alias_cache = AliasCache::ensure(&shell, false);
+
     for cmd in commands {
         output.step(&format!("Executing: {cmd}"));
-        let shell = std::env::var("SHELL").unwrap_or_else(|_| "sh".to_string());
-        let status = Command::new(&shell)
-            .arg("-i")
-            .arg("-c")
-            .arg(cmd)
+        let spec = CommandSpec::Shell(cmd.clone());
+        let status = build_command(&spec, alias_cache.as_ref())
             .stdin(std::process::Stdio::inherit())
             .stdout(std::process::Stdio::inherit())
             .stderr(std::process::Stdio::inherit())

--- a/tests/manual/scenarios/worktree-exec/polluted-rcfile.yml
+++ b/tests/manual/scenarios/worktree-exec/polluted-rcfile.yml
@@ -1,0 +1,66 @@
+name: "Exec survives rc-file stdout pollution"
+description: |
+  Regression for the "completely useless" failure mode reported after
+  #414: a user with a working .zshrc/.bashrc that prints to stdout
+  during rc evaluation (p10k instant prompt, plugin status banners,
+  fortune cookies, "Welcome" echoes, etc.) would have that stdout
+  output spliced into the captured alias snapshot. The poisoned cache
+  was then replayed on every subsequent invocation, breaking every
+  command run through `daft exec`.
+
+  The fix routes captured `alias`/`typeset -f` output to dedicated temp
+  files inside the spawned shell (via env-var paths), so rc-file stdout
+  no longer corrupts the snapshot. This scenario exercises that
+  end-to-end with a deliberately noisy .bashrc.
+
+repos:
+  - name: exec-polluted
+    use_fixture: standard-remote
+
+steps:
+  - name: "Set up fake HOME with a noisy .bashrc that prints to stdout"
+    run: |
+      mkdir -p "$WORK_DIR/fakehome" && \
+        printf '%s\n%s\n%s\n%s\n' \
+          'echo "POLLUTION_BEFORE_PROMPT"' \
+          'printf "fortune cookie of the day\n"' \
+          'alias daft_polluted_alias="echo aliased > polluted_marker.txt"' \
+          'echo "POLLUTION_AFTER_ALIAS"' \
+          > "$WORK_DIR/fakehome/.bashrc"
+    expect:
+      exit_code: 0
+      files_exist:
+        - "$WORK_DIR/fakehome/.bashrc"
+
+  - name: "Clone the repository"
+    run: "git-worktree-clone --layout contained $REMOTE_EXEC_POLLUTED"
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/exec-polluted/main"
+
+  - name: "Alias resolves through the cache despite rc-file pollution"
+    run: |
+      HOME="$WORK_DIR/fakehome" SHELL=/bin/bash \
+        git-worktree-exec main -- daft_polluted_alias 2>/dev/null
+    cwd: "$WORK_DIR/exec-polluted/main"
+    expect:
+      exit_code: 0
+      files_exist:
+        - "$WORK_DIR/exec-polluted/main/polluted_marker.txt"
+      file_contains:
+        - path: "$WORK_DIR/exec-polluted/main/polluted_marker.txt"
+          content: "aliased"
+
+  - name: "Plain command runs even when no alias is involved"
+    run: |
+      HOME="$WORK_DIR/fakehome" SHELL=/bin/bash \
+        git-worktree-exec main -- sh -c 'echo plain > plain_marker.txt' 2>/dev/null
+    cwd: "$WORK_DIR/exec-polluted/main"
+    expect:
+      exit_code: 0
+      files_exist:
+        - "$WORK_DIR/exec-polluted/main/plain_marker.txt"
+      file_contains:
+        - path: "$WORK_DIR/exec-polluted/main/plain_marker.txt"
+          content: "plain"


### PR DESCRIPTION
## Summary

- `daft exec` (and the `-x` flag on `daft clone` / `daft init` / `daft checkout` / `daft go` / `daft start`) became unusable for users whose `.zshrc`/`.bashrc` printed anything to stdout during rc evaluation — p10k instant prompt, plugin status banners, "welcome" echoes, fortune cookies. Their stdout output was indistinguishable from real `alias` output and got persisted into the cached snapshot, then re-injected into every subsequent invocation.
- Capture now writes `alias`/`typeset -f` output to dedicated temp files inside the spawned shell (paths passed via env vars). The shell's own stdout/stderr is discarded entirely, so rc-file noise can't corrupt the snapshot. A 10s deadline kills hangs from `exec tmux`-style rc-files. A `# daft-alias-cache v2` header auto-invalidates already-poisoned caches on disk without requiring `--refresh-aliases`.
- The no-cache fallback is now a pristine `$SHELL -c CMD` instead of `$SHELL -i -c CMD`. Aliases won't resolve in the fallback, but the user's command runs — strictly better than today's "completely useless" failure for users whose rc files break in non-interactive contexts.
- `run_exec_commands` (the legacy `-x` path on worktree-creation flows) now reuses the same `build_command`, so the cache + rc-less fallback covers both surfaces.
- `DAFT_EXEC_DEBUG=1` emits stderr lines for chosen execution mode, capture failures, validation rejections, and cache hits — the reporter had no logs, so the fix ships its own.

## Test plan

- [x] New unit test reproduces the bug: a polluting `.bashrc` previously corrupted `alias_lines` with `POLLUTION_BEFORE_PROMPT_INIT` etc.; now passes after the FD-isolated capture.
- [x] Manual scenario `tests/manual/scenarios/worktree-exec/polluted-rcfile.yml` covers the end-to-end flow.
- [x] End-to-end smoke: polluting `.bashrc` → fast-path resolves alias cleanly.
- [x] End-to-end smoke: `SHELL=/bin/sh` → rc-less fallback, command runs.
- [x] End-to-end smoke: planted v1 cache → header rejected, fresh capture, fresh alias used.
- [x] End-to-end smoke: `daft init -x 'alias_name'` with polluting bashrc → alias resolves through cache.
- [x] `mise run fmt:check`, `mise run clippy`, `cargo test --lib core::worktree::exec` all clean (47 tests pass).

## Notes for users

- Existing alias caches on disk are silently invalidated on first run of this build. The next invocation triggers a fresh capture; users will see a one-time alias-capture cost (the same cost as before any cache existed). No action required.
- If shortcuts still don't resolve, run with `DAFT_EXEC_DEBUG=1` and the stderr trace will show whether capture succeeded, which mode was chosen, and the constructed shell args.

🤖 Generated with [Claude Code](https://claude.com/claude-code)