### PR TITLE
fix(exec): clarify failed-run output dump format

### DIFF
--- a/src/core/worktree/exec/list_renderer.rs
+++ b/src/core/worktree/exec/list_renderer.rs
@@ -82,6 +82,19 @@ pub fn render_outcome<W: Sink>(
     Ok(())
 }
 
+/// Per-failure output dump. Each failed/cancelled worktree gets:
+///
+/// ```text
+/// <sigil> <branch>  ·  <cmd>  ·  <status>, <elapsed>, exit <code>
+///   │ <captured line 1>
+///   │ <captured line 2>
+/// ```
+///
+/// A blank line separates each failure block from whatever precedes it (the
+/// preceding summary rows or a prior failure block) so the boundary is
+/// obvious. The vertical gutter visually contains the captured output; the
+/// header has no gutter, so absence-of-gutter on the next header is the
+/// section break.
 pub fn render_failed_output_dump<W: Sink>(
     sink: &mut W,
     report: &ExecReport,
@@ -91,19 +104,60 @@ pub fn render_failed_output_dump<W: Sink>(
         if outcome.succeeded() {
             continue;
         }
-        let cmd_desc = pipeline
-            .get(outcome.last_command_index)
-            .map(|s| s.display())
-            .unwrap_or_default();
-        writeln!(
-            sink,
-            "─── {} ── {cmd_desc} → exit {} ────────────────────────────",
-            outcome.target.branch_name, outcome.exit_code
-        )?;
-        sink.write_all(&outcome.captured_output)?;
-        if !outcome.captured_output.ends_with(b"\n") {
-            writeln!(sink)?;
+        writeln!(sink)?;
+        render_failure_block(sink, outcome, pipeline)?;
+    }
+    Ok(())
+}
+
+const GUTTER_PREFIX: &[u8] = "  \u{2502} ".as_bytes(); // "  │ "
+
+fn render_failure_block<W: Sink>(
+    sink: &mut W,
+    outcome: &WorktreeOutcome,
+    pipeline: &[CommandSpec],
+) -> std::io::Result<()> {
+    let cmd_desc = pipeline
+        .get(outcome.last_command_index)
+        .map(|s| s.display())
+        .unwrap_or_default();
+    let sigil = if outcome.cancelled {
+        "\u{2298}"
+    } else {
+        "\u{2717}"
+    };
+    let status = if outcome.cancelled {
+        "cancelled"
+    } else {
+        "failed"
+    };
+    let elapsed = format!("{:.1}s", outcome.elapsed.as_secs_f64());
+    writeln!(
+        sink,
+        "{sigil} {}  \u{00b7}  {cmd_desc}  \u{00b7}  {status}, {elapsed}, exit {}",
+        outcome.target.branch_name, outcome.exit_code,
+    )?;
+    write_gutter_lines(sink, &outcome.captured_output)
+}
+
+/// Prefix each line of `bytes` with the gutter and write it to `sink`. Splits
+/// on `\n` to preserve the original line structure; a trailing line without a
+/// newline still gets the gutter and a terminating newline. Empty input emits
+/// nothing.
+fn write_gutter_lines<W: Sink>(sink: &mut W, bytes: &[u8]) -> std::io::Result<()> {
+    let mut start = 0;
+    for (i, &b) in bytes.iter().enumerate() {
+        if b == b'\n' {
+            sink.write_all(GUTTER_PREFIX)?;
+            sink.write_all(&bytes[start..i])?;
+            sink.write_all(b"\n")?;
+            start = i + 1;
         }
+    }
+    if start < bytes.len() {
+        sink.write_all(GUTTER_PREFIX)?;
+        sink.write_all(&bytes[start..])?;
+        sink.write_all(b"\n")?;
     }
     Ok(())
 }
@@ -111,6 +165,9 @@ pub fn render_failed_output_dump<W: Sink>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
+
+    use crate::core::worktree::exec::ResolvedTarget;
 
     fn split_dashes(line: &str, summary: &str) -> (usize, usize) {
         let needle = format!(" {summary} ");
@@ -151,5 +208,127 @@ mod tests {
         let (prefix, suffix) = split_dashes(&line, "12345678 worktrees · 87654321 commands");
         assert!(prefix >= HEADER_MIN_SIDE_DASHES);
         assert!(suffix >= HEADER_MIN_SIDE_DASHES);
+    }
+
+    fn outcome(branch: &str, exit: i32, cancelled: bool, output: &[u8]) -> WorktreeOutcome {
+        WorktreeOutcome {
+            target: ResolvedTarget {
+                worktree_path: format!("/r/{branch}").into(),
+                branch_name: branch.into(),
+            },
+            last_command_index: 0,
+            exit_code: exit,
+            elapsed: Duration::from_millis(1200),
+            captured_output: output.to_vec(),
+            cancelled,
+        }
+    }
+
+    fn dump(report: &ExecReport, pipeline: &[CommandSpec]) -> String {
+        let mut out = Vec::new();
+        render_failed_output_dump(&mut out, report, pipeline).unwrap();
+        String::from_utf8(out).unwrap()
+    }
+
+    #[test]
+    fn failure_block_uses_gutter_and_status_label() {
+        let pipeline = vec![CommandSpec::Argv(vec!["mise".into(), "dev".into()])];
+        let report = ExecReport {
+            outcomes: vec![outcome("feat/x", 101, false, b"line one\nline two\n")],
+            orphan_branches_skipped: vec![],
+        };
+        let s = dump(&report, &pipeline);
+        // Leading blank separates the block from the preceding summary rows.
+        assert_eq!(
+            s,
+            "\n\u{2717} feat/x  \u{00b7}  mise dev  \u{00b7}  failed, 1.2s, exit 101\n  \
+             \u{2502} line one\n  \u{2502} line two\n",
+        );
+    }
+
+    #[test]
+    fn cancelled_block_uses_distinct_sigil_and_label() {
+        let pipeline = vec![CommandSpec::Argv(vec!["mise".into(), "dev".into()])];
+        let report = ExecReport {
+            outcomes: vec![outcome("feat/y", -1, true, b"interrupted\n")],
+            orphan_branches_skipped: vec![],
+        };
+        let s = dump(&report, &pipeline);
+        assert!(
+            s.starts_with(
+                "\n\u{2298} feat/y  \u{00b7}  mise dev  \u{00b7}  cancelled, 1.2s, exit -1\n"
+            ),
+            "expected leading-blank cancelled header, got: {s}"
+        );
+        assert!(s.contains("  \u{2502} interrupted\n"));
+    }
+
+    #[test]
+    fn each_failure_block_starts_with_blank_line() {
+        // Regression: prior renderer used a single horizontal bar per failure
+        // with no separator, so back-to-back dumps ran together visually and
+        // the first dump landed on the same line as the last summary row.
+        let pipeline = vec![CommandSpec::Argv(vec!["mise".into(), "dev".into()])];
+        let report = ExecReport {
+            outcomes: vec![
+                outcome("feat/a", -1, true, b"a-out\n"),
+                outcome("feat/b", -1, true, b"b-out\n"),
+            ],
+            orphan_branches_skipped: vec![],
+        };
+        let s = dump(&report, &pipeline);
+        // Every failure header is preceded by a blank line. The first one
+        // separates the dump from the live summary rows; subsequent ones
+        // separate consecutive failures.
+        assert!(
+            s.starts_with("\n\u{2298} feat/a"),
+            "missing leading blank: {s:?}"
+        );
+        let between = "  \u{2502} a-out\n\n\u{2298} feat/b";
+        assert!(
+            s.contains(between),
+            "missing blank-line separator between failures: {s}"
+        );
+    }
+
+    #[test]
+    fn successful_outcomes_are_skipped() {
+        let pipeline = vec![CommandSpec::Argv(vec!["mise".into(), "dev".into()])];
+        let report = ExecReport {
+            outcomes: vec![
+                outcome("ok", 0, false, b"ignored\n"),
+                outcome("bad", 2, false, b"shown\n"),
+            ],
+            orphan_branches_skipped: vec![],
+        };
+        let s = dump(&report, &pipeline);
+        assert!(!s.contains("ignored"), "successful output leaked: {s}");
+        assert!(s.contains("  \u{2502} shown\n"));
+        assert!(s.contains("\u{2717} bad"));
+    }
+
+    #[test]
+    fn captured_output_without_trailing_newline_still_gets_gutter() {
+        let pipeline = vec![CommandSpec::Argv(vec!["mise".into(), "dev".into()])];
+        let report = ExecReport {
+            outcomes: vec![outcome("bad", 1, false, b"no-newline-end")],
+            orphan_branches_skipped: vec![],
+        };
+        let s = dump(&report, &pipeline);
+        assert!(s.ends_with("  \u{2502} no-newline-end\n"), "got: {s:?}");
+    }
+
+    #[test]
+    fn empty_captured_output_emits_only_header() {
+        let pipeline = vec![CommandSpec::Argv(vec!["mise".into(), "dev".into()])];
+        let report = ExecReport {
+            outcomes: vec![outcome("bad", 1, false, b"")],
+            orphan_branches_skipped: vec![],
+        };
+        let s = dump(&report, &pipeline);
+        assert!(!s.contains('\u{2502}'), "unexpected gutter line: {s}");
+        // One leading blank + one header line; no gutter lines.
+        assert_eq!(s.lines().count(), 2, "expected blank + header only: {s:?}");
+        assert!(s.starts_with('\n'));
     }
 }

--- a/tests/manual/scenarios/worktree-exec/failure-dump.yml
+++ b/tests/manual/scenarios/worktree-exec/failure-dump.yml
@@ -29,7 +29,8 @@ steps:
     expect:
       exit_code: 1
       output_contains:
-        - "─── feat-a"
-        - "─── main"
+        - "✗ feat-a"
+        - "✗ main"
+        - "failed,"
         - "exit 1"
-        - "marker-line"
+        - "│ marker-line"


### PR DESCRIPTION
## Summary

Reformat `daft exec`'s failed-run output dump so multi-worktree failures are visually distinguishable.

- Replace the single-line `─── branch ── cmd → exit N ───` bar with a structured per-failure block: a sigil-prefixed header (`<sigil> <branch>  ·  <cmd>  ·  <status>, <elapsed>, exit <code>`) followed by captured output prefixed with a vertical `│` gutter.
- Each block is preceded by a blank line so consecutive failures and the boundary with the live summary rows are obvious.
- The vertical gutter visually contains each block's output; the absence of gutter on the next header is the section break.

### Before / after

Before — multi-failure dumps ran together visually, and the first dump landed on the same line as the last summary row:

```
  ⊘  daft-402/...   ❯ mise dev  cancelled after 12.3s          ─── daft-402/... ── mise dev → exit -1 ──────
[build] $ ...
[build] ERROR task failed
─── feat/background-hook-jobs ── mise dev → exit -1 ──────
[build] $ ...
```

After:

```
  ⊘  daft-402/...   ❯ mise dev  cancelled after 12.3s

⊘ daft-402/...  ·  mise dev  ·  cancelled, 12.3s, exit -1
  │ [build] $ ...
  │ [build] ERROR task failed

⊘ feat/background-hook-jobs  ·  mise dev  ·  cancelled, 12.2s, exit -1
  │ [build] $ ...
```

## Test plan

- [x] Unit tests added in `list_renderer.rs` for: gutter format, distinct cancelled sigil, leading-blank separator (regression), success skipping, no-trailing-newline handling, empty-output handling.
- [x] YAML manual scenario `tests/manual/scenarios/worktree-exec/failure-dump.yml` updated to assert the new format and passes.
- [x] `mise run fmt:check`, `mise run clippy`, `mise run test:unit` clean.
- [ ] Manual smoke: run `daft exec --all -- <failing-cmd>` against multiple worktrees and confirm the new format renders correctly in a real terminal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)