### PR TITLE
chore(hooks): warm up dev build via background mise dev job

### DIFF
--- a/daft.yml
+++ b/daft.yml
@@ -42,6 +42,10 @@ hooks:
       - name: bun install
         run: bun install
         needs: [mise install]
+      - name: mise dev
+        run: mise run dev
+        needs: [bun install]
+        background: true
 
   worktree-pre-remove:
     jobs:


### PR DESCRIPTION
## Summary
- Adds a `background: true` job (`mise dev`) to `worktree-post-create`, gated on `bun install`.
- New worktrees return immediately from `daft start`/`go -b`/`worktree-checkout`, while the dev build (cargo compile + symlinks) warms up in the background.
- Also serves as dogfooding for the background-jobs feature introduced in #411.

## Why background
A cold cargo compile takes ~2 minutes, so making it foreground would noticeably regress worktree-create time. As a background job it stays out of the foreground summary and only surfaces if it fails (default `background_output: log`). Foreground/background partitioning is unaffected since no foreground job depends on `mise dev`.

## Test plan
- [x] `daft hooks validate` passes against the new config
- [x] `daft hooks dump` (built from this branch) shows the new job with `background: true`
- [x] `cargo test --lib partition_tests` (5 tests) passes — confirms the `mise dev` job stays in the background partition
- [x] `mise run test:unit` (1491 tests) passes
- [x] `mise run clippy` clean
- [x] `mise run fmt:check` clean
- [ ] Manual: create a sibling worktree on a machine with the new binary on PATH and confirm `mise dev` appears under `daft hooks jobs` with the build artifacts landing in `target/release/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)