### PR TITLE
fix(hooks): gate coordinator IPC behind cfg(unix) so Windows builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,25 @@ jobs:
       - name: Run Rust unit tests
         run: mise run test:unit
 
+  # Windows compile check — ensures the codebase still builds for the
+  # x86_64-pc-windows-msvc target that the release workflow ships. This
+  # only runs `cargo check`, not a full build or test, so it stays fast
+  # while catching platform-specific regressions (e.g. unconditional use
+  # of `std::os::unix::*` or `libc`) before they reach a release tag.
+  windows-check:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Cargo check (Windows)
+        run: cargo check --all-targets
+
   # Test xtask man page generation
   xtask-test:
     runs-on: ubuntu-latest

--- a/src/coordinator/client.rs
+++ b/src/coordinator/client.rs
@@ -4,18 +4,58 @@
 //! Each message is one JSON object followed by `\n`. The client sends a
 //! [`CoordinatorRequest`], and the coordinator responds with a
 //! [`CoordinatorResponse`].
+//!
+//! IPC is Unix-only. On non-Unix platforms `CoordinatorClient` exposes the
+//! same API but `connect()` always returns `Ok(None)` — there is no
+//! coordinator to talk to.
 
-use super::{coordinator_socket_path, CoordinatorRequest, CoordinatorResponse, JobInfo};
-use anyhow::{Context, Result};
+use super::JobInfo;
+#[cfg(unix)]
+use super::{coordinator_socket_path, CoordinatorRequest, CoordinatorResponse};
+#[cfg(unix)]
+use anyhow::Context;
+use anyhow::Result;
+#[cfg(unix)]
 use std::io::{BufRead, BufReader, Write};
+#[cfg(unix)]
 use std::os::unix::net::UnixStream;
+#[cfg(unix)]
 use std::time::Duration;
 
 /// Client for communicating with a running coordinator.
+#[cfg(unix)]
 pub struct CoordinatorClient {
     stream: UnixStream,
 }
 
+/// Stub on non-Unix platforms — the field is `Infallible`, so the type
+/// can never be instantiated. `connect()` always returns `Ok(None)` and
+/// the rest of the surface is reachable only through an instance, so it
+/// is statically unreachable.
+#[cfg(not(unix))]
+pub struct CoordinatorClient(std::convert::Infallible);
+
+#[cfg(not(unix))]
+impl CoordinatorClient {
+    /// No coordinator IPC on non-Unix platforms.
+    pub fn connect(_repo_hash: &str) -> Result<Option<Self>> {
+        Ok(None)
+    }
+
+    pub fn list_jobs(&mut self) -> Result<Vec<JobInfo>> {
+        match self.0 {}
+    }
+
+    pub fn cancel_job(&mut self, _name: &str) -> Result<String> {
+        match self.0 {}
+    }
+
+    pub fn cancel_all(&mut self) -> Result<String> {
+        match self.0 {}
+    }
+}
+
+#[cfg(unix)]
 impl CoordinatorClient {
     /// Connect to the coordinator for the given repo.
     /// Returns `None` if no coordinator is running.
@@ -93,7 +133,7 @@ impl CoordinatorClient {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
     use std::io::{BufRead, BufReader, Write};

--- a/src/coordinator/process.rs
+++ b/src/coordinator/process.rs
@@ -9,6 +9,7 @@
 //! handling IPC requests from CLI commands (`daft hooks jobs`).
 
 use super::log_store::{JobMeta, JobStatus, LogStore};
+#[cfg(unix)]
 use super::{
     coordinator_pid_path, coordinator_socket_path, CoordinatorRequest, CoordinatorResponse, JobInfo,
 };
@@ -368,6 +369,7 @@ fn run_single_background_job(
 /// - The `shutdown` flag is set (e.g., when all jobs complete)
 ///
 /// Returns a `JoinHandle` for the listener thread.
+#[cfg(unix)]
 fn start_socket_listener(
     repo_hash: &str,
     store_base: std::path::PathBuf,
@@ -427,6 +429,7 @@ fn start_socket_listener(
 }
 
 /// Handle a single client connection: read a request, process it, send a response.
+#[cfg(unix)]
 fn handle_client_connection(
     stream: std::os::unix::net::UnixStream,
     store: &LogStore,
@@ -518,6 +521,7 @@ fn handle_client_connection(
 }
 
 /// Build a list of job info from the log store.
+#[cfg(unix)]
 fn build_job_list(store: &LogStore) -> Vec<JobInfo> {
     let job_dirs = match store.list_job_dirs() {
         Ok(dirs) => dirs,
@@ -553,6 +557,7 @@ fn build_job_list(store: &LogStore) -> Vec<JobInfo> {
 /// Cancel a single job by name. Records the name in `cancelled_jobs` so
 /// the post-run classifier reports `JobStatus::Cancelled` rather than
 /// `JobStatus::Failed`.
+#[cfg(unix)]
 fn cancel_single_job(
     name: &str,
     child_pids: &ChildPidMap,
@@ -579,6 +584,7 @@ fn cancel_single_job(
 }
 
 /// Write a JSON response to the stream.
+#[cfg(unix)]
 fn send_response(stream: &std::os::unix::net::UnixStream, response: &CoordinatorResponse) {
     use std::io::Write;
     let mut msg = match serde_json::to_string(response) {
@@ -591,6 +597,7 @@ fn send_response(stream: &std::os::unix::net::UnixStream, response: &Coordinator
 }
 
 /// Write the coordinator PID file.
+#[cfg(unix)]
 fn write_pid_file(repo_hash: &str) -> Result<std::path::PathBuf> {
     let pid_path = coordinator_pid_path(repo_hash)?;
     if let Some(parent) = pid_path.parent() {
@@ -683,7 +690,7 @@ pub fn fork_coordinator(
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
     use crate::executor::JobSpec;

--- a/src/hooks/executor.rs
+++ b/src/hooks/executor.rs
@@ -642,6 +642,7 @@ mod tests {
     use crate::hooks::PROJECT_HOOKS_DIR;
     use crate::output::TestOutput;
     use std::fs;
+    #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
     use tempfile::tempdir;
 


### PR DESCRIPTION
## Summary

- Gate all Unix-only socket / `libc` code in `src/coordinator/{client,process}.rs` (and their `mod tests`) behind `#[cfg(unix)]`, with a `#[cfg(not(unix))]` `CoordinatorClient` stub whose `connect()` returns `Ok(None)`.
- Add a `windows-check` job to `.github/workflows/test.yml` that runs `cargo check --all-targets` on `windows-latest`, so this class of break is caught on every PR instead of only at release tag time.

Fixes #424.

## Why

The v1.10.0 release ([run #25074742437](https://github.com/avihut/daft/actions/runs/25074742437)) failed the `build-local-artifacts (x86_64-pc-windows-msvc)` job with 16 errors in the new background-hook coordinator (#411): unconditional uses of `std::os::unix::net::{UnixStream, UnixListener}`, `libc::kill`, `libc::SIGTERM`, `libc::pid_t`. The `libc` crate is already a `[target.'cfg(unix)'.dependencies]`, so any reference outside a `#[cfg(unix)]` scope fails on Windows.

The Unix-only `fork_coordinator` was already `#[cfg(unix)]` and both invokers (`hooks/yaml_executor`, `commands/hooks/jobs`) already branch on `#[cfg(unix)]`. The remaining IPC helpers (`start_socket_listener`, `handle_client_connection`, `cancel_single_job`, `send_response`, `build_job_list`, `write_pid_file`) are only reached from those gated entry points, so gating them is safe and keeps the public surface unchanged. `CoordinatorClient` callers (`commands/hooks/jobs.rs`, `core/worktree/prune.rs`) already treat `Ok(None)` as "no coordinator running", which is the truthful state on Windows.

## Why this slipped past CI

PR CI (`test.yml`) ran only on Ubuntu and macOS; the Windows target was built only by the release workflow on tag push. The new `windows-check` job closes that gap with a fast `cargo check` (no full build, no tests) so any future un-gated `std::os::unix::*` or `libc::*` reference fails the PR rather than the release.

## Verification

- `mise run fmt:check` ✓
- `mise run clippy` ✓ (zero warnings)
- `mise run test:unit -- coordinator::` — all 80 coordinator tests pass on macOS
- Greppable invariant: every remaining `std::os::unix::` / `libc::` hit in `src/coordinator/` is now inside a `#[cfg(unix)]` (or `#[cfg(all(test, unix))]`) scope.
- Couldn't cross-compile to `x86_64-pc-windows-msvc` locally (`aws-lc-sys` needs `windows.h`); the new `windows-check` CI job is the authoritative validation.

## Test plan

- [ ] PR CI passes, including the new `windows-check` job on `windows-latest`.
- [ ] Once merged, kick the next release and confirm `build-local-artifacts (x86_64-pc-windows-msvc)` succeeds end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)