### PR TITLE
chore(deps): add 7-day cooldown across cargo, bun, mise, dependabot, and CI

### DIFF
--- a/.dep-age-allowlist
+++ b/.dep-age-allowlist
@@ -1,0 +1,15 @@
+# Lockfile age-check allowlist. One entry per line. Comments start with `#`.
+#
+# Format:
+#   <ecosystem>:<name>           — exempt every version of the package
+#   <ecosystem>:<name>@<version> — exempt one specific version
+#
+# Ecosystems: cargo, npm
+#
+# Always include WHY in a comment above the entry, and remove the entry once
+# the underlying version has aged past the threshold. Entries here weaken our
+# supply-chain posture; they should be temporary.
+#
+# Example:
+#   # CVE-2026-XXXX patched in 0.2.4, no older fix available
+#   cargo:somecrate@0.2.4

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,9 @@
 # Dependabot configuration for automatic dependency updates
 # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Cooldown policy: every ecosystem waits 7 days before opening a version-update
+# PR. Security updates bypass cooldown automatically (Dependabot behavior, not
+# configurable). To exempt a specific package, add it under cooldown.exclude.
 
 version: 2
 updates:
@@ -11,6 +15,8 @@ updates:
       interval: "daily"
       time: "09:00"
       timezone: "Asia/Jerusalem"
+    cooldown:
+      default-days: 7
     # Group all Cargo updates into a single PR when possible
     groups:
       cargo-dependencies:
@@ -37,6 +43,8 @@ updates:
       interval: "daily"
       time: "09:00"
       timezone: "Asia/Jerusalem"
+    cooldown:
+      default-days: 7
     # Group all GitHub Actions updates into a single PR
     groups:
       github-actions:
@@ -51,13 +59,39 @@ updates:
       include: "scope"
     rebase-strategy: "auto"
 
-  - package-ecosystem: "npm"
+  # Root JS deps (prettier dev dep, bun.lock at repo root)
+  - package-ecosystem: "bun"
+    directory: "/"
+    target-branch: "master"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Asia/Jerusalem"
+    cooldown:
+      default-days: 7
+    groups:
+      js-dependencies:
+        patterns:
+          - "*"
+    labels:
+      - "dependencies"
+      - "javascript"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    rebase-strategy: "auto"
+
+  # Docs site JS deps (VitePress + Biome, bun.lock under /docs)
+  - package-ecosystem: "bun"
     directory: "/docs"
     target-branch: "master"
     schedule:
       interval: "daily"
       time: "09:00"
       timezone: "Asia/Jerusalem"
+    cooldown:
+      default-days: 7
     groups:
       docs-dependencies:
         patterns:

--- a/.github/workflows/mise-tool-updates.yml
+++ b/.github/workflows/mise-tool-updates.yml
@@ -7,9 +7,10 @@ name: mise tool updates
 # enter without intent.
 on:
   schedule:
-    # Mondays 08:00 UTC (= 11:00 Asia/Jerusalem). Weekly is enough — mise tools
-    # turn over much slower than the cargo/bun deps Dependabot watches daily.
-    - cron: "0 8 * * 1"
+    # Daily 06:00 UTC (= 09:00 Asia/Jerusalem) — matches the Dependabot
+    # schedule. Most days this is a no-op (nothing has aged into the gate);
+    # the action only opens a PR when there's an actual diff.
+    - cron: "0 6 * * *"
   workflow_dispatch: {} # manual trigger from the Actions UI
 
 permissions:

--- a/.github/workflows/mise-tool-updates.yml
+++ b/.github/workflows/mise-tool-updates.yml
@@ -1,0 +1,54 @@
+name: mise tool updates
+
+# Weekly job that runs `mise upgrade` to refresh tool versions in mise.lock
+# (and mise.toml when --bump-able), then opens a PR if anything changed.
+# The 7-day cooldown in mise.toml's [settings] minimum_release_age means this
+# only ever picks versions that have aged past the gate — no fresh releases
+# enter without intent.
+on:
+  schedule:
+    # Mondays 08:00 UTC (= 11:00 Asia/Jerusalem). Weekly is enough — mise tools
+    # turn over much slower than the cargo/bun deps Dependabot watches daily.
+    - cron: "0 8 * * 1"
+  workflow_dispatch: {} # manual trigger from the Actions UI
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  upgrade:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install mise
+        uses: jdx/mise-action@v4
+
+      - name: Run mise upgrade
+        # Stays within the constraints already in mise.toml (e.g. `bun = "1.3"`
+        # → newest 1.3.x). Use `mise upgrade --bump` manually when you want to
+        # advance the constraint itself.
+        run: mise upgrade
+
+      - name: Open PR
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "deps: bump mise tools"
+          title: "deps: bump mise tools"
+          body: |
+            Automated `mise upgrade` run.
+
+            Versions selected are subject to the 7-day cooldown set in
+            `mise.toml` `[settings] minimum_release_age = "7d"`. To advance a
+            constraint (e.g. `bun = "1.3"` -> `"1.4"`), run
+            `mise upgrade --bump` locally and commit instead.
+
+            Note: PRs opened by the default GITHUB_TOKEN do not trigger other
+            workflows. To run CI on this PR, push an empty commit or close
+            and reopen it. Alternatively, set the action's `token:` input to
+            a PAT with workflow permissions.
+          branch: deps/mise-auto-upgrade
+          delete-branch: true
+          labels: |
+            dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,24 @@ on:
       - "docs/**"
 
 jobs:
+  # Supply-chain gate: refuse PRs that introduce dep-lock entries younger than
+  # 7 days (Cargo.lock + bun.lock). Bypass via .dep-age-allowlist (with
+  # rationale) or commit env ALLOW_FRESH_DEPS=1 in an emergency.
+  dep-age-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check lockfile freshness
+        env:
+          # github.base_ref is a refname (cannot contain shell metacharacters
+          # per git ref-format rules); we still funnel it through env to avoid
+          # interpolating it into the shell command directly.
+          PR_BASE_REF: ${{ github.base_ref }}
+        run: BASE_REF="origin/${PR_BASE_REF}" scripts/check-lockfile-age.sh
+
   # Fast feedback: formatting, linting, unit tests (debug mode only - no release build needed)
   lint:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,17 @@ This project follows the XDG Base Directory Specification. Use the `dirs` crate
 for cross-platform path resolution. Never hardcode `~/` paths for config or data
 storage.
 
+## Dependency Cooldown
+
+7-day age gate across mise tools, Bun (`bunfig.toml`), Dependabot version PRs,
+and a CI lockfile-age check (`scripts/check-lockfile-age.sh`). Dependabot
+security PRs bypass automatically.
+
+When adding a package, pin to a version ≥7 days old: `cargo add foo@<version>`
+or `bun add foo@<version>`. To bypass, add an entry (with `# why:` rationale) to
+`.dep-age-allowlist`, `bunfig.toml` `minimumReleaseAgeExcludes`, or
+`cooldown.toml`; emergency CI override is `ALLOW_FRESH_DEPS=1`.
+
 ## Architecture
 
 **Multicall binary**: All commands route through a single `daft` binary

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,9 @@
+[install]
+# Refuse to install package versions newer than 7 days. Mitigates supply-chain
+# attacks (compromised packages are typically caught and yanked within hours).
+# Security bypass: add the package name to minimumReleaseAgeExcludes with a
+# comment explaining why, then remove the entry once the gate would no longer
+# block it.
+# https://bun.com/docs/runtime/bunfig#install-minimumreleaseage
+minimumReleaseAge = 604800
+minimumReleaseAgeExcludes = []

--- a/cooldown.toml
+++ b/cooldown.toml
@@ -1,0 +1,22 @@
+# cargo-cooldown configuration.
+# https://github.com/dertin/cargo-cooldown
+#
+# Schema below targets cargo-cooldown >= 0.3.0. With 0.2.0 (what mise's own
+# 7-day install gate selects today) only `cooldown_minutes` is honored; the
+# rest of the keys take effect once 0.3.0 ages past the gate.
+#
+# 7 days * 24 hours * 60 minutes = 10080.
+cooldown_minutes = 10080
+
+# Warn rather than fail when Cargo's own resolution forces a fresh version
+# (semver range, target-specific dep, etc.). Pair with the lockfile-age CI
+# check, which is the hard gate.
+enforcement = "cargo_compatible"
+cargo_compatible_accept = "prompt"
+
+# Treat the pre-run Cargo.lock as the version floor — don't downgrade what's
+# already in there.
+lockfile_baseline = "floor"
+
+# Per-crate exemptions go below as `[[allow.exact]]` (specific version) or
+# `[[allow.package]] minutes = 0` (always exempt). Document why in a comment.

--- a/docs/bunfig.toml
+++ b/docs/bunfig.toml
@@ -1,0 +1,5 @@
+[install]
+# See ../bunfig.toml for rationale. Duplicated because Bun reads bunfig.toml
+# from the cwd, and `mise run docs:site*` invokes Bun from this directory.
+minimumReleaseAge = 604800
+minimumReleaseAgeExcludes = []

--- a/mise-tasks/deps/check-age
+++ b/mise-tasks/deps/check-age
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+#MISE description="Fail if Cargo.lock or bun.lock introduces deps newer than 7 days vs base ref"
+set -euo pipefail
+
+base_ref="${1:-${BASE_REF:-origin/master}}"
+exec scripts/check-lockfile-age.sh "$base_ref"

--- a/mise-tasks/deps/cooled-build
+++ b/mise-tasks/deps/cooled-build
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+#MISE description="Build through cargo-cooldown — fails if a fresh transitive crate sneaks in"
+set -euo pipefail
+
+exec cargo cooldown build "$@"

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,15 @@
 # mise configuration for daft
 # Run `mise tasks` to see available tasks
 
+[settings]
+# Refuse to install tool versions younger than 7 days (supply-chain cooldown).
+# Pinned versions like `bun = "1.3.11"` bypass the gate automatically. Override
+# per-invocation with `mise install foo --before <date|duration>`.
+# https://mise.jdx.dev/configuration/settings.html#minimum_release_age
+# Affects backends that report release timestamps: aqua, cargo, npm, pipx,
+# and select core plugins (covers everything in [tools] below).
+minimum_release_age = "7d"
+
 [tools]
 rust = "stable"
 lefthook = "latest"
@@ -8,6 +17,11 @@ cocogitto = "latest"
 bun = "latest"
 bat = "latest"
 neovim = "stable"
+# cargo-cooldown: optional supply-chain guard. Wraps `cargo
+# build|check|test|run|update` to refuse package versions younger than the
+# window in cooldown.toml. Doesn't gate `cargo add` directly — pair it with
+# the lockfile-age CI check (scripts/check-lockfile-age.sh).
+"cargo:cargo-cooldown" = "latest"
 
 [env]
 _.path = ["./target/release"]

--- a/mise.toml
+++ b/mise.toml
@@ -31,16 +31,21 @@ _.source = ["shared-env.sh"]
 INTEGRATION_TESTS_DIR = "tests/integration"
 INTEGRATION_TEMP_DIR = "/tmp/git-worktree-integration-tests"
 
-# Auto-install JS dependencies (Prettier) when package.json changes
+# Sync mise tools and JS deps automatically on cd. The hash gate keeps this
+# nearly free when nothing changed; when mise.toml/mise.lock or
+# package.json/bun.lock change (e.g. after `git pull` and a re-cd), it
+# proactively re-runs the install commands.
 [hooks]
 enter = """
 mkdir -p .mise
 hashfile=".mise/deps_hash"
-current_hash=$(cat package.json bun.lock 2>/dev/null | md5 -q 2>/dev/null || cat package.json bun.lock 2>/dev/null | md5sum | cut -d' ' -f1)
+hash_inputs() { cat package.json bun.lock mise.toml mise.lock 2>/dev/null; }
+current_hash=$(hash_inputs | md5 -q 2>/dev/null || hash_inputs | md5sum | cut -d' ' -f1)
 if [ ! -d "node_modules" ] || [ ! -f "$hashfile" ] || [ "$(cat "$hashfile" 2>/dev/null)" != "$current_hash" ]; then
-  echo "[mise] Installing JS dependencies..."
+  echo "[mise] Syncing dev tools and JS deps..."
+  mise install
   bun install --frozen-lockfile 2>/dev/null || bun install
-  current_hash=$(cat package.json bun.lock 2>/dev/null | md5 -q 2>/dev/null || cat package.json bun.lock 2>/dev/null | md5sum | cut -d' ' -f1)
+  current_hash=$(hash_inputs | md5 -q 2>/dev/null || hash_inputs | md5sum | cut -d' ' -f1)
   echo "$current_hash" > "$hashfile"
 fi
 """

--- a/scripts/check-lockfile-age.sh
+++ b/scripts/check-lockfile-age.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Fail if the current branch introduces dep entries (in Cargo.lock or bun.lock)
+# whose release date is younger than MIN_AGE_DAYS (default: 7) compared to the
+# given base ref (default: origin/master).
+#
+# Allowlist: .dep-age-allowlist (one per line, format `<ecosystem>:<name>` or
+# `<ecosystem>:<name>@<version>`; lines starting with `#` are comments).
+# Bypass via env: ALLOW_FRESH_DEPS=1.
+set -euo pipefail
+
+base_ref="${1:-${BASE_REF:-origin/master}}"
+min_age_days="${MIN_AGE_DAYS:-7}"
+min_age_secs=$((min_age_days * 86400))
+allowlist_file=".dep-age-allowlist"
+
+if [[ "${ALLOW_FRESH_DEPS:-0}" == "1" ]]; then
+  echo "ALLOW_FRESH_DEPS=1 set; skipping lockfile age check." >&2
+  exit 0
+fi
+
+for cmd in jq curl git perl; do
+  command -v "$cmd" >/dev/null || { echo "missing required tool: $cmd" >&2; exit 2; }
+done
+
+if ! git rev-parse --verify "$base_ref" >/dev/null 2>&1; then
+  echo "base ref not found: $base_ref" >&2
+  echo "in CI, check out with fetch-depth: 0 and fetch the base branch first." >&2
+  exit 2
+fi
+
+now_secs=$(date -u +%s)
+violations=()
+
+is_allowlisted() {
+  local entry="$1" name="${1#*:}" name_only="${name%@*}" eco="${1%%:*}"
+  [[ -f "$allowlist_file" ]] || return 1
+  grep -vE '^\s*(#|$)' "$allowlist_file" | grep -Fxq "$entry" && return 0
+  grep -vE '^\s*(#|$)' "$allowlist_file" | grep -Fxq "${eco}:${name_only}"
+}
+
+extract_cargo_pkgs() {
+  # Emit `name<TAB>version` lines from the [[package]] entries of a Cargo.lock
+  # blob on stdin. Skips workspace members (entries with no `source` field).
+  awk '
+    /^\[\[package\]\]/ { in_pkg = 1; name = ""; version = ""; has_src = 0; next }
+    in_pkg && /^name = / { gsub(/"/, "", $3); name = $3; next }
+    in_pkg && /^version = / { gsub(/"/, "", $3); version = $3; next }
+    in_pkg && /^source = / { has_src = 1; next }
+    /^$/ {
+      if (in_pkg && has_src && name != "" && version != "") print name "\t" version
+      in_pkg = 0
+    }
+    END {
+      if (in_pkg && has_src && name != "" && version != "") print name "\t" version
+    }
+  '
+}
+
+extract_bun_pkgs() {
+  # bun.lock is JSON5-ish (trailing commas across newlines). Slurp the whole
+  # file with perl -0777 to strip them, then parse with jq. Each
+  # .packages[<key>] is an array; element 0 is "<name>@<version>".
+  perl -0777 -pe 's/,(\s*[}\]])/$1/g' \
+    | jq -r '.packages // {} | to_entries[] | .value[0]' \
+    | awk -F'@' 'NF >= 2 {
+        # rejoin in case of scoped names like @scope/foo@1.2.3
+        n = NF; v = $n; n_name = ""
+        for (i = 1; i < n; i++) n_name = n_name (i > 1 ? "@" : "") $i
+        print n_name "\t" v
+      }'
+}
+
+diff_added() {
+  # Print added/changed `name<TAB>version` lines (after - before).
+  local before="$1" after="$2"
+  comm -13 <(printf '%s\n' "$before" | sort -u) \
+           <(printf '%s\n' "$after" | sort -u)
+}
+
+check_crates_io() {
+  local name="$1" version="$2"
+  local url="https://crates.io/api/v1/crates/${name}/${version}"
+  curl -fsSL -A "daft-dep-age-check" "$url" | jq -r '.version.created_at // empty'
+}
+
+check_npm() {
+  local name="$1" version="$2"
+  # https://registry.npmjs.org/<name> returns time map under .time
+  local url="https://registry.npmjs.org/${name}"
+  curl -fsSL "$url" | jq -r --arg v "$version" '.time[$v] // empty'
+}
+
+age_secs() {
+  # macOS and GNU date both accept ISO-8601 with -d/-jf via different flags.
+  local iso="$1" published_secs
+  if date -u -d "$iso" +%s >/dev/null 2>&1; then
+    published_secs=$(date -u -d "$iso" +%s)
+  else
+    published_secs=$(date -u -jf "%Y-%m-%dT%H:%M:%S" "${iso%.*}" +%s 2>/dev/null \
+      || date -u -jf "%Y-%m-%dT%H:%M:%SZ" "${iso%.*}Z" +%s)
+  fi
+  echo $((now_secs - published_secs))
+}
+
+check_lockfile() {
+  local eco="$1" path="$2" extractor="$3" registry_check="$4"
+  [[ -f "$path" ]] || return 0
+
+  local before after added
+  before=$(git show "${base_ref}:${path}" 2>/dev/null | "$extractor" || true)
+  after=$(<"$path" "$extractor")
+  added=$(diff_added "$before" "$after" || true)
+  [[ -z "$added" ]] && return 0
+
+  echo "Checking ${#} new/changed entries in ${path}..." >&2
+  while IFS=$'\t' read -r name version; do
+    [[ -z "$name" || -z "$version" ]] && continue
+    local key="${eco}:${name}@${version}"
+    if is_allowlisted "$key"; then
+      echo "  allow: $key" >&2
+      continue
+    fi
+    local published age days
+    published=$("$registry_check" "$name" "$version" 2>/dev/null || true)
+    if [[ -z "$published" ]]; then
+      echo "  skip:  $key (no pubtime from registry)" >&2
+      continue
+    fi
+    age=$(age_secs "$published")
+    days=$((age / 86400))
+    if (( age < min_age_secs )); then
+      violations+=("$key  age=${days}d  published=${published}")
+      echo "  FRESH: $key (age ${days}d, threshold ${min_age_days}d)" >&2
+    else
+      echo "  ok:    $key (age ${days}d)" >&2
+    fi
+  done <<< "$added"
+}
+
+check_lockfile cargo Cargo.lock extract_cargo_pkgs check_crates_io
+check_lockfile npm bun.lock extract_bun_pkgs check_npm
+check_lockfile npm docs/bun.lock extract_bun_pkgs check_npm
+
+if (( ${#violations[@]} > 0 )); then
+  echo >&2
+  echo "Lockfile-age check failed: ${#violations[@]} entry(ies) younger than ${min_age_days} days." >&2
+  printf '  - %s\n' "${violations[@]}" >&2
+  echo >&2
+  echo "Options:" >&2
+  echo "  1. Wait for the package to age past the threshold." >&2
+  echo "  2. Add an entry to ${allowlist_file} with rationale (e.g. security fix)." >&2
+  echo "  3. Set ALLOW_FRESH_DEPS=1 in the environment for an emergency override." >&2
+  exit 1
+fi
+
+echo "Lockfile-age check passed." >&2


### PR DESCRIPTION
## Summary

Adds a layered supply-chain age gate so freshly-published package versions
don't enter the dep graph without intent. Security-only updates still flow
through (Dependabot bypasses cooldown for security PRs).

### Cooldown layers

- **mise tools** — `mise.toml` `[settings] minimum_release_age = "7d"`
- **Bun installs** — `bunfig.toml` + `docs/bunfig.toml` `minimumReleaseAge = 604800`
- **Dependabot version PRs** — `cooldown.default-days: 7` across cargo, bun, github-actions
  - Also switches the existing `/docs` entry from `npm` → `bun` (the docs site
    is bun-managed; the npm ecosystem doesn't read `bun.lock`)
  - Adds a new `bun` entry for `/` (prettier dev dep, previously uncovered)
- **`cargo-cooldown`** registered via mise + `cooldown.toml` — local cargo build guard
- **CI lockfile-age check** — `scripts/check-lockfile-age.sh` + new `dep-age-check`
  job in `test.yml`. Diffs `Cargo.lock` and `bun.lock` against the PR base ref,
  queries crates.io / npm for pubtime, fails PRs that introduce <7-day-old entries

### Bypass paths

- Per-package, persistent: `.dep-age-allowlist`, `bunfig.toml`
  `minimumReleaseAgeExcludes`, or `cooldown.toml` `[[allow.exact]]`
- Emergency CI override: `ALLOW_FRESH_DEPS=1`
- Dependabot security PRs bypass automatically

### Also bundled (related supporting work)

- New `.github/workflows/mise-tool-updates.yml` — daily `mise upgrade` cron
  that opens a PR when anything moves (matches the Dependabot schedule). Fills
  the gap that Dependabot has no `mise` ecosystem support.
- Extended `mise.toml` `[hooks] enter` to also hash `mise.toml`/`mise.lock` and
  run `mise install` when they change — so `cd`-ing into a worktree with stale
  pinned tool versions auto-syncs them.
- `CLAUDE.md` Dependency Cooldown section documenting the gate and how to add
  packages under it.

## Test plan

- [x] Bun gate: `bun add @aws-sdk/client-s3@3.1040.0` (1d old) blocked with
      `minimum-release-age` error; `@3.700.0` (Nov 2024) installed cleanly
- [x] mise gate: `mise install cargo:cargo-cooldown` selected `0.2.0` instead
      of `0.3.0` (5d old at the time)
- [x] Lockfile-age script: against `c8b0bd37` (parent of edtui bump), correctly
      flagged `cargo:edtui@0.11.3` (1d old). Allowlist entry suppressed it.
      `ALLOW_FRESH_DEPS=1` env-var bypass also verified.
- [x] `mise run fmt`, `mise run clippy`, `mise run test:unit` all pass
- [x] `actionlint` clean on all new/modified workflow files
- [ ] CI green on this PR
- [ ] First scheduled run of `mise-tool-updates.yml` produces a no-op or a
      reasonable PR (will validate after merge)