### PR TITLE
ci: add Claude Code PR review workflow with subscription auth

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# CODEOWNERS for daft
+#
+# Files listed here trigger required review from the listed owner before
+# merging, IF branch protection on master is configured with "Require review
+# from Code Owners". Without that branch-protection rule, this file only
+# auto-requests reviews -- it does not block merges.
+#
+# Scope is intentionally narrow: only paths whose modification could weaken
+# repository security posture (workflow YAML, this file, Dependabot config)
+# are owner-gated. Day-to-day source changes follow the normal PR flow.
+
+/.github/workflows/    @avihut
+/.github/CODEOWNERS    @avihut
+/.github/dependabot.yml @avihut

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -8,6 +8,9 @@ on:
       - "docs/**"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   bench:
     runs-on: ubuntu-latest

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,16 +1,21 @@
 name: Claude PR Review
 
-# Auto-runs on PRs opened by the repo owner (avihut). External contributors
-# cannot trigger Claude runs implicitly. Maintainers can opt-in by commenting
-# "/claude review" or by running the workflow manually.
+# Reviews are explicitly opt-in. To request a review, a maintainer comments
+# "/claude review" on the target PR, or triggers this workflow manually from
+# the Actions tab. There is no auto-trigger: opening a PR (yours or anyone
+# else's) does not spend Claude subscription quota until someone asks.
+#
+# The CLAUDE_CODE_OAUTH_TOKEN secret is bound to a GitHub Environment with a
+# master-only deployment-branch policy. Both supported triggers (issue_comment,
+# workflow_dispatch) run from the default-branch context, so the policy lets
+# them through. A workflow YAML modified on a feature branch cannot reach the
+# secret -- which is the whole point of routing the auto-trigger out.
 #
 # All untrusted inputs (comment bodies, PR titles, etc.) are referenced only
 # inside `if:` expression contexts via `contains()`, never interpolated into
 # `run:` shell commands. The action's `prompt:` value is a static string.
 
 on:
-  pull_request:
-    types: [opened, synchronize]
   issue_comment:
     types: [created]
   workflow_dispatch:
@@ -27,33 +32,12 @@ permissions:
 
 concurrency:
   group:
-    claude-review-${{ github.event.pull_request.number ||
-    github.event.issue.number || github.event.inputs.pr_number }}
+    claude-review-${{ github.event.issue.number || github.event.inputs.pr_number
+    }}
   cancel-in-progress: true
 
 jobs:
-  review-owner:
-    if: |
-      github.event_name == 'pull_request' &&
-      github.event.pull_request.user.login == 'avihut'
-    runs-on: ubuntu-latest
-    environment: claude-review
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 20
-      - uses: anthropics/claude-code-action@v1
-        with:
-          anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          prompt: |
-            Review this pull request against the project's CLAUDE.md guidelines.
-            Focus on: Rust correctness and idioms, test coverage (every bug fix
-            needs a regression test), shell-eval'd command hot-path constraints,
-            security, and performance. Leave actionable inline comments where
-            applicable.
-          track_progress: true
-
-  review-opt-in:
+  review:
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'issue_comment' &&

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -43,16 +43,15 @@ jobs:
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
        contains(github.event.comment.body, '/claude review') &&
-       (github.event.comment.author_association == 'OWNER' ||
-        github.event.comment.author_association == 'MEMBER' ||
-        github.event.comment.author_association == 'COLLABORATOR'))
+       github.event.comment.author_association == 'OWNER')
     runs-on: ubuntu-latest
     environment: claude-review
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 20
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@fefa07e9c665b7320f08c3b525980457f22f58aa # v1
         with:
           anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,0 +1,78 @@
+name: Claude PR Review
+
+# Auto-runs on PRs opened by the repo owner (avihut). External contributors
+# cannot trigger Claude runs implicitly. Maintainers can opt-in by commenting
+# "/claude review" or by running the workflow manually.
+#
+# All untrusted inputs (comment bodies, PR titles, etc.) are referenced only
+# inside `if:` expression contexts via `contains()`, never interpolated into
+# `run:` shell commands. The action's `prompt:` value is a static string.
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to review
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+
+concurrency:
+  group:
+    claude-review-${{ github.event.pull_request.number ||
+    github.event.issue.number || github.event.inputs.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  review-owner:
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.user.login == 'avihut'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 20
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            Review this pull request against the project's CLAUDE.md guidelines.
+            Focus on: Rust correctness and idioms, test coverage (every bug fix
+            needs a regression test), shell-eval'd command hot-path constraints,
+            security, and performance. Leave actionable inline comments where
+            applicable.
+          track_progress: true
+
+  review-opt-in:
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '/claude review') &&
+       (github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 20
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            Review this pull request against the project's CLAUDE.md guidelines.
+            Focus on: Rust correctness and idioms, test coverage (every bug fix
+            needs a regression test), shell-eval'd command hot-path constraints,
+            security, and performance. Leave actionable inline comments where
+            applicable.
+          track_progress: true

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -37,6 +37,7 @@ jobs:
       github.event_name == 'pull_request' &&
       github.event.pull_request.user.login == 'avihut'
     runs-on: ubuntu-latest
+    environment: claude-review
     steps:
       - uses: actions/checkout@v6
         with:
@@ -62,6 +63,7 @@ jobs:
         github.event.comment.author_association == 'MEMBER' ||
         github.event.comment.author_association == 'COLLABORATOR'))
     runs-on: ubuntu-latest
+    environment: claude-review
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,9 @@ on:
       - ".github/workflows/docs.yml"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-homebrew.yml
+++ b/.github/workflows/test-homebrew.yml
@@ -12,6 +12,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   test-homebrew:
     runs-on: macos-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
       - "*.md"
       - "docs/**"
 
+permissions:
+  contents: read
+
 jobs:
   # Supply-chain gate: refuse PRs that introduce dep-lock entries younger than
   # 7 days (Cargo.lock + bun.lock). Bypass via .dep-age-allowlist (with

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,14 @@ IMPORTANT: These rules must NEVER be violated:
 2. **Never use this repository for testing** — This project's own git repo must
    never be used as a test subject for worktree commands. Tests must always
    create isolated temporary repositories.
+3. **Don't weaken `.github/workflows/claude-pr-review.yml`** — its security
+   properties are deliberate: SHA-pinned actions, `environment: claude-review`
+   (master-only deployment-branch policy), `author_association == 'OWNER'`
+   gating on the `/claude review` comment trigger, no `pull_request` or
+   `pull_request_target` event, and `timeout-minutes`. Never re-introduce a
+   `pull_request[_target]` trigger. Never reference `CLAUDE_CODE_OAUTH_TOKEN`
+   from any other workflow. Never replace SHA pins with mutable refs (Dependabot
+   keeps them current). Workflow changes are CODEOWNERS-gated to `@avihut`.
 
 ## Safe Local Testing with Git
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/claude-pr-review.yml` that wires up Claude Code PR reviews via the [`anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action).
- **Auth**: uses `CLAUDE_CODE_OAUTH_TOKEN` (generated via `claude setup-token`) so reviews bill against the maintainer's Pro/Max subscription rather than a pay-as-you-go Anthropic API key.
- **Fully opt-in** — there is no auto-trigger. Opening a PR (yours or anyone else's) does not spend Claude quota until a maintainer explicitly asks for a review.
- Maintainers request a review by either:
  - commenting `/claude review` on the PR (gated on `author_association` ∈ {OWNER, MEMBER, COLLABORATOR}), or
  - running the workflow manually via `workflow_dispatch` from the Actions tab.
- **Concurrency**: a per-PR concurrency group cancels in-flight reviews on new pushes to avoid wasting subscription quota.

## Why fully opt-in (no auto-trigger)

The secret is bound to a GitHub Environment (`claude-review`) with a deployment-branch policy restricting it to `master`. This blocks an exfiltration vector where someone with push access modifies the workflow YAML on a feature branch to leak the token.

Environment branch policies check `github.ref`, which for `pull_request` events is `refs/pull/<N>/merge` — not `master` and not the head branch. So a `pull_request`-triggered job cannot reach the secret under a `master`-only policy. Both remaining triggers (`issue_comment`, `workflow_dispatch`) run from the default-branch context and pass the policy.

Trade-off: one extra comment per review request, in exchange for the secret only being reachable from a verified-master workflow context.

## Setup steps for the maintainer (one-time)

1. Run `claude setup-token` locally to generate an OAuth token tied to your Pro/Max subscription.
2. Repo → Settings → Environments → New environment → name: `claude-review`.
3. In the environment, set **Deployment branches and tags → Selected branches and tags** → add `master`.
4. In the same environment, add an environment secret named `CLAUDE_CODE_OAUTH_TOKEN` with the token value.
5. If `CLAUDE_CODE_OAUTH_TOKEN` was previously added as a repo-level secret, delete the repo-level copy.
6. Optional: install the [Claude GitHub App](https://github.com/apps/claude) for richer `@claude` mention support.

## Security notes

- Untrusted GitHub event inputs (comment bodies, PR titles, etc.) are referenced **only inside `if:` expression contexts** via `contains()` and `==`, never interpolated into `run:` shell commands. The action's `prompt:` field is a static string. This avoids the workflow-injection class of vulnerabilities.
- `pull_request_target` is intentionally not used — it's the textbook secret-exfiltration footgun.

## Test plan

- [ ] Comment `/claude review` on a PR as the maintainer → confirm the `review` job runs and posts a review.
- [ ] Comment `/claude review` from a non-collaborator account → confirm the job is skipped.
- [ ] Trigger via Actions → "Claude PR Review" → "Run workflow" with a PR number → confirm the `review` job runs.
- [ ] Push a no-op commit to a feature branch (no `pull_request` job exists, so nothing should run).
- [ ] Confirm in run logs that the environment-scoped secret is being used (job page shows the `claude-review` environment).

Fixes #435