### PR TITLE
ci: switch release-plz workflow to client-id input

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -17,7 +17,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.WHEATLEY_BOT_APP_ID }}
+          client-id: ${{ secrets.WHEATLEY_BOT_CLIENT_ID }}
           private-key: ${{ secrets.WHEATLEY_BOT_PRIVATE_KEY }}
 
       - name: Checkout repository
@@ -52,7 +52,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.WHEATLEY_BOT_APP_ID }}
+          client-id: ${{ secrets.WHEATLEY_BOT_CLIENT_ID }}
           private-key: ${{ secrets.WHEATLEY_BOT_PRIVATE_KEY }}
 
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- `actions/create-github-app-token@v3` deprecated the `app-id` input in favor of `client-id`, producing a warning on every Release-plz workflow run
- Switch both jobs to `client-id:` referencing a new `WHEATLEY_BOT_CLIENT_ID` secret

## Action required before merge
- Add a `WHEATLEY_BOT_CLIENT_ID` repo secret containing the Wheatley GitHub App's Client ID (from the app's settings page — distinct from the numeric App ID)
- After this is merged and confirmed working, the old `WHEATLEY_BOT_APP_ID` secret can be deleted

## Test plan
- [ ] Add `WHEATLEY_BOT_CLIENT_ID` secret to the repo
- [ ] On next push to master, confirm Release-plz workflow no longer emits the `app-id` deprecation warning
- [ ] Confirm token generation still succeeds and the release/release-pr commands work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)