### PR TITLE
fix(ci): claude-pr-review self-cancels via bot status comment

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -30,12 +30,6 @@ permissions:
   issues: write
   id-token: write
 
-concurrency:
-  group:
-    claude-review-${{ github.event.issue.number || github.event.inputs.pr_number
-    }}
-  cancel-in-progress: true
-
 jobs:
   review:
     if: |
@@ -45,6 +39,16 @@ jobs:
        contains(github.event.comment.body, '/claude review') &&
        github.event.comment.author_association == 'OWNER')
     runs-on: ubuntu-latest
+    # Concurrency lives at the job level (not workflow level) so the `if:`
+    # filter is evaluated first. Otherwise an unrelated `issue_comment`
+    # event on the same PR -- including the action's own "Claude is
+    # working..." status comment -- would queue a workflow run that
+    # cancels the running review before being skipped itself.
+    concurrency:
+      group:
+        claude-review-${{ github.event.issue.number ||
+        github.event.inputs.pr_number }}
+      cancel-in-progress: true
     environment: claude-review
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
## Summary

Move the \`concurrency\` block on \`.github/workflows/claude-pr-review.yml\` from workflow level to the \`review\` job level so that bot status comments don't cancel the running review.

## What was happening

1. Maintainer comments \`/claude review\` on a PR. Run #1 fires, action starts.
2. \`claude[bot]\` posts a "Claude Code is working..." status comment.
3. That comment is an \`issue_comment\` \`created\` event on the same PR. Workflow run #2 is queued with the same concurrency-group key.
4. \`concurrency.cancel-in-progress: true\` at the workflow level cancels run #1 *before* any \`if:\` is evaluated.
5. Run #2 then evaluates \`if:\` — comment doesn't match \`/claude review\` — and skips.

Net: the action's own progress comment cancels the action.

Reproduced on PR #438, run \`25225661590\` cancelled at 17:48:43Z by the bot comment posted at 17:48:26Z.

## Why job-level concurrency fixes it

GitHub evaluates a job's \`if:\` filter *before* applying its job-level concurrency rule. A skipped job does not occupy the concurrency slot. So the bot's status comment continues to fire \`issue_comment\` events, but those events are skipped by \`if:\` and never reach the cancel-in-progress logic. Only events that actually pass \`/claude review\` + OWNER will queue (and cancel) a real review run.

## Test plan

- [ ] Merge this PR.
- [ ] Open a throwaway PR with a real-code change.
- [ ] Comment \`/claude review\`. Confirm the workflow run completes (does not cancel mid-flight).
- [ ] Confirm Claude posts a review comment referencing the PR's actual diff.
- [ ] As a sanity check, comment something unrelated on the same PR while the review is running. Confirm the running review continues.

Fixes #439