### PR TITLE
ci: fix Claude review auth + narrow path filters + gate test.yml jobs

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -3,9 +3,22 @@ name: Benchmarks
 on:
   push:
     branches: [master]
-    paths-ignore:
-      - "*.md"
-      - "docs/**"
+    # Same model as test.yml: default to running on any change, negate the
+    # things that don't affect benchmark numbers. Self-changes to bench.yml
+    # are intentionally NOT negated.
+    paths:
+      - "**"
+      - "!*.md"
+      - "!docs/**"
+      - "!.github/CODEOWNERS"
+      - "!.github/dependabot.yml"
+      - "!.github/workflows/claude-pr-review.yml"
+      - "!.github/workflows/docs.yml"
+      - "!.github/workflows/mise-tool-updates.yml"
+      - "!.github/workflows/release-plz.yml"
+      - "!.github/workflows/release.yml"
+      - "!.github/workflows/test-homebrew.yml"
+      - "!.github/workflows/test.yml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -57,7 +57,7 @@ jobs:
           fetch-depth: 20
       - uses: anthropics/claude-code-action@fefa07e9c665b7320f08c3b525980457f22f58aa # v1
         with:
-          anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             Review this pull request against the project's CLAUDE.md guidelines.
             Focus on: Rust correctness and idioms, test coverage (every bug fix

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,24 @@ name: Test Git Worktree Workflow
 on:
   pull_request:
     branches: [main, master]
-    paths-ignore:
-      - "*.md"
-      - "docs/**"
+    # Default to running on any change, then negate the things that don't
+    # affect the Rust build/test surface. New files default to triggering
+    # this workflow -- safer than allowlisting and forgetting to update.
+    # Note: .github/workflows/test.yml is intentionally NOT negated, so
+    # changes to this workflow re-run the suite to validate them.
+    paths:
+      - "**"
+      - "!*.md"
+      - "!docs/**"
+      - "!.github/CODEOWNERS"
+      - "!.github/dependabot.yml"
+      - "!.github/workflows/bench.yml"
+      - "!.github/workflows/claude-pr-review.yml"
+      - "!.github/workflows/docs.yml"
+      - "!.github/workflows/mise-tool-updates.yml"
+      - "!.github/workflows/release-plz.yml"
+      - "!.github/workflows/release.yml"
+      - "!.github/workflows/test-homebrew.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,12 +24,74 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
+  # Detect which kinds of files changed in this PR. Each downstream job
+  # gates on these outputs so we only spin up runners when relevant. Any
+  # change to test.yml itself sets `self=true`, which OR's into every
+  # other gate, so editing the workflow re-validates the whole suite.
+  # Skipped jobs consume zero CI minutes.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      self: ${{ steps.detect.outputs.self }}
+      rust: ${{ steps.detect.outputs.rust }}
+      tests: ${{ steps.detect.outputs.tests }}
+      xtask: ${{ steps.detect.outputs.xtask }}
+      man: ${{ steps.detect.outputs.man }}
+      lockfile: ${{ steps.detect.outputs.lockfile }}
+    steps:
+      - id: detect
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          files=$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename')
+          echo "Changed files in this PR:"
+          echo "$files"
+          echo "---"
+
+          self=false
+          rust=false
+          tests=false
+          xtask=false
+          man=false
+          lockfile=false
+
+          if echo "$files" | grep -qxE '\.github/workflows/test\.yml'; then
+            self=true
+          fi
+          if echo "$files" | grep -qE '^(src/|Cargo\.(toml|lock)|mise\.(toml|lock)|lefthook\.yml)'; then
+            rust=true
+          fi
+          if echo "$files" | grep -qE '^(tests/|scripts/)'; then
+            tests=true
+          fi
+          if echo "$files" | grep -qE '^xtask/'; then
+            xtask=true
+          fi
+          if echo "$files" | grep -qE '^(man/|docs/cli/)'; then
+            man=true
+          fi
+          if echo "$files" | grep -qxE '(Cargo\.lock|bun\.lock|\.dep-age-allowlist|cooldown\.toml|bunfig\.toml)'; then
+            lockfile=true
+          fi
+
+          for k in self rust tests xtask man lockfile; do
+            echo "$k=${!k}" | tee -a "$GITHUB_OUTPUT"
+          done
+
   # Supply-chain gate: refuse PRs that introduce dep-lock entries younger than
   # 7 days (Cargo.lock + bun.lock). Bypass via .dep-age-allowlist (with
   # rationale) or commit env ALLOW_FRESH_DEPS=1 in an emergency.
   dep-age-check:
+    needs: changes
+    if:
+      needs.changes.outputs.self == 'true' || needs.changes.outputs.lockfile ==
+      'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -46,6 +108,11 @@ jobs:
 
   # Fast feedback: formatting, linting, unit tests (debug mode only - no release build needed)
   lint:
+    needs: changes
+    if:
+      needs.changes.outputs.self == 'true' || needs.changes.outputs.rust ==
+      'true' || needs.changes.outputs.tests == 'true' ||
+      needs.changes.outputs.xtask == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -82,6 +149,10 @@ jobs:
   # while catching platform-specific regressions (e.g. unconditional use
   # of `std::os::unix::*` or `libc`) before they reach a release tag.
   windows-check:
+    needs: changes
+    if:
+      needs.changes.outputs.self == 'true' || needs.changes.outputs.rust ==
+      'true'
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
@@ -97,6 +168,11 @@ jobs:
 
   # Test xtask man page generation
   xtask-test:
+    needs: changes
+    if:
+      needs.changes.outputs.self == 'true' || needs.changes.outputs.rust ==
+      'true' || needs.changes.outputs.xtask == 'true' ||
+      needs.changes.outputs.man == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -198,6 +274,10 @@ jobs:
 
   # Build release binary once, share across integration test matrix
   build:
+    needs: changes
+    if:
+      needs.changes.outputs.self == 'true' || needs.changes.outputs.rust ==
+      'true' || needs.changes.outputs.tests == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -372,6 +452,10 @@ jobs:
 
   # Homebrew installation simulation (macOS)
   homebrew-simulation:
+    needs: changes
+    if:
+      needs.changes.outputs.self == 'true' || needs.changes.outputs.rust ==
+      'true' || needs.changes.outputs.man == 'true'
     runs-on: macos-latest
 
     steps:


### PR DESCRIPTION
## Summary

Three CI hygiene fixes shipped together:

### 1. fix(ci): OAuth token bug

\`anthropics/claude-code-action\` exposes two auth inputs: \`anthropic_api_key\` (sets the \`x-api-key\` header, for Anthropic API keys) and \`claude_code_oauth_token\` (sets \`Authorization: Bearer ...\`, for OAuth tokens from \`claude setup-token\`). The workflow was passing the OAuth token to \`anthropic_api_key\`, so every run failed with \`Invalid API key · Fix external API key\` from the Claude Agent SDK before any review work happened. Reproduced on PR #438 run \`25226189717\`. Renaming the input fixes it; the secret value is unchanged.

### 2. ci: narrow path filters at the workflow level

\`paths-ignore\` doesn't support \`!\` negation, so a clean "ignore everything in \`.github/\` except this workflow's own file" expression isn't possible there. Switched both \`test.yml\` and \`bench.yml\` to \`paths:\` with negation. Each workflow's own file is intentionally NOT in the negation list, so editing the workflow still triggers it. Other workflow YAMLs, CODEOWNERS, dependabot.yml, \`*.md\`, \`docs/**\` are negated. New files default to triggering — safer fail mode than allowlisting.

### 3. ci: per-job gating in test.yml

Workflow-level filters can't gate individual jobs. Once test.yml fires, every job in it runs — including \`windows-check\` and \`homebrew-simulation\` for changes that don't affect Rust at all. Added a \`changes\` job that fetches the PR's file list via \`gh api\` and emits boolean outputs for six categories (\`self\`, \`rust\`, \`tests\`, \`xtask\`, \`man\`, \`lockfile\`). Each downstream job grew \`needs: changes\` plus an \`if:\` gate ORing the relevant categories. \`integration-tests\` inherits skip behavior implicitly via its existing \`needs: build\`. Skipped jobs consume zero CI minutes.

Per-job gates:
- \`dep-age-check\`: \`self || lockfile\`
- \`lint\`: \`self || rust || tests || xtask\`
- \`windows-check\`: \`self || rust\`
- \`xtask-test\`: \`self || rust || xtask || man\`
- \`build\`: \`self || rust || tests\`
- \`homebrew-simulation\`: \`self || rust || man\`

\`self=true\` (a change to test.yml itself) ORs into every gate, so editing the workflow re-validates the full suite — including this PR.

## Test plan

- [ ] Merge.
- [ ] On PR #438 (or any open PR), comment \`/claude review\`. Confirm the run completes successfully and Claude posts a review on the PR.
- [ ] Open a follow-up PR touching only \`tests/integration/some-file.sh\`. Confirm only \`changes\`, \`lint\`, \`build\`, and \`integration-tests\` run; \`windows-check\`, \`xtask-test\`, \`homebrew-simulation\`, and \`dep-age-check\` are skipped.
- [ ] Open a follow-up PR touching only \`Cargo.lock\` (e.g., a Dependabot PR). Confirm only \`changes\` and \`dep-age-check\` run.

Fixes #441