### PR TITLE
fix: do not create default-branch worktree for multi-branch bare clones

### DIFF
--- a/src/commands/clone.rs
+++ b/src/commands/clone.rs
@@ -295,11 +295,25 @@ fn run_clone(args: &Args, settings: &DaftSettings, output: &mut dyn Output) -> R
     // satellites to create beyond what Phase 4 handles).
     let is_multi_branch = matches!(branch_source, BranchSource::Multiple(_));
 
-    // For multi-branch, override bare_result's target_branch to the base branch
-    // so that Phase 4 creates the correct base worktree.
+    // For multi-branch, override bare_result's target_branch so that Phase 4
+    // creates the correct worktree. For non-bare layouts, this is the base
+    // branch (`branch_plan.base`). For bare layouts, `branch_plan.base` is
+    // None — Phase 4 must instead target the first valid requested branch
+    // (`branch_plan.cd_target`), or skip worktree creation entirely when no
+    // requested branch was found on the remote. Without this, Phase 4 keeps
+    // the default-branch target set by `detect_branches` and creates an
+    // unwanted worktree for the default branch (#451).
     let mut bare_result = bare_result;
     if is_multi_branch {
-        if let Some(ref base) = branch_plan.base {
+        if layout.needs_bare() {
+            if let Some(ref first_valid) = branch_plan.cd_target {
+                bare_result.target_branch = first_valid.clone();
+                bare_result.branch_exists = true;
+            } else if let Some(first_missing) = branch_plan.not_found.first() {
+                bare_result.target_branch = first_missing.clone();
+                bare_result.branch_exists = false;
+            }
+        } else if let Some(ref base) = branch_plan.base {
             bare_result.target_branch = base.clone();
             bare_result.branch_exists = remote_branches.contains(base);
         }

--- a/tests/manual/scenarios/clone/multi-branch-all-missing.yml
+++ b/tests/manual/scenarios/clone/multi-branch-all-missing.yml
@@ -18,6 +18,11 @@ steps:
       dirs_exist:
         - "$WORK_DIR/test-repo"
         - "$WORK_DIR/test-repo/.git"
+      # Regression for #451: the load-bearing assertion is that
+      # `$WORK_DIR/test-repo/main` does NOT exist - before the fix, Phase 4
+      # would still create a default-branch worktree even though every
+      # requested -b branch was missing. The nope-* paths are belt-and-
+      # suspenders to verify nothing else slipped through.
       files_not_exist:
         - "$WORK_DIR/test-repo/main"
         - "$WORK_DIR/test-repo/nope-one"

--- a/tests/manual/scenarios/clone/multi-branch-all-missing.yml
+++ b/tests/manual/scenarios/clone/multi-branch-all-missing.yml
@@ -1,0 +1,24 @@
+name: Clone with multiple -b flags where all branches are missing
+description: Regression for #451 when every -b branch is absent from the remote.
+
+repos:
+  - name: test-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone with two missing branches
+    run:
+      git-worktree-clone --layout contained -b nope-one -b nope-two
+      $REMOTE_TEST_REPO 2>&1
+    expect:
+      exit_code: 0
+      output_contains:
+        - "Branch 'nope-one' not found on remote"
+        - "Branch 'nope-two' not found on remote"
+      dirs_exist:
+        - "$WORK_DIR/test-repo"
+        - "$WORK_DIR/test-repo/.git"
+      files_not_exist:
+        - "$WORK_DIR/test-repo/main"
+        - "$WORK_DIR/test-repo/nope-one"
+        - "$WORK_DIR/test-repo/nope-two"

--- a/tests/manual/scenarios/clone/multi-branch-contained.yml
+++ b/tests/manual/scenarios/clone/multi-branch-contained.yml
@@ -18,6 +18,11 @@ steps:
         - "$WORK_DIR/test-repo/.git"
         - "$WORK_DIR/test-repo/develop"
         - "$WORK_DIR/test-repo/feature/test-feature"
+      # Regression for #451: only the explicitly requested branches should
+      # get worktrees. The default branch (`main`) was previously created
+      # for free.
+      files_not_exist:
+        - "$WORK_DIR/test-repo/main"
       is_git_worktree:
         - dir: "$WORK_DIR/test-repo/develop"
           branch: develop

--- a/tests/manual/scenarios/clone/multi-branch-missing.yml
+++ b/tests/manual/scenarios/clone/multi-branch-missing.yml
@@ -17,6 +17,10 @@ steps:
         - "not found on remote"
       dirs_exist:
         - "$WORK_DIR/test-repo/develop"
+      # Regression for #451: the default branch must NOT get an unwanted
+      # worktree when at least one requested -b branch is missing.
+      files_not_exist:
+        - "$WORK_DIR/test-repo/main"
       is_git_worktree:
         - dir: "$WORK_DIR/test-repo/develop"
           branch: develop


### PR DESCRIPTION
## Summary

- For bare layouts with `BranchSource::Multiple`, `branch_plan.base` is `None` by design, so the override at `clone.rs:301-306` was a no-op and Phase 4 kept the remote-default `target_branch` set in `detect_branches`. That created an unwanted worktree for the default branch on top of the requested satellites (`-b feature -b test` produced `master + feature` instead of just `feature`).
- Fix: in the bare branch of the override, target `branch_plan.cd_target` (the first valid requested branch) for Phase 4. When all requested branches are missing on the remote, fall back to `branch_plan.not_found.first()` with `branch_exists = false` so no worktree is created.
- The existing `filtered_satellites` filter already prevents duplication once `target_branch` is one of the requested branches.

## Test plan

- [x] `mise run test:unit` (1493 passed)
- [x] `mise run clippy` (clean)
- [x] `mise run fmt:check` (clean)
- [x] New `clone:multi-branch-all-missing` scenario covers the all-missing case.
- [x] `clone:multi-branch-contained` and `clone:multi-branch-missing` strengthened with `files_not_exist` for the default-branch path (regression for #451).
- [x] `clone:multi-branch-head-token`, `clone:multi-branch-sibling`, `clone:multi-branch-hooks` all still pass.

Fixes #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)