### PR TITLE
ci: fix release-plz workflow by reusing existing app-id secret

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -17,7 +17,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          client-id: ${{ secrets.WHEATLEY_BOT_CLIENT_ID }}
+          client-id: ${{ secrets.WHEATLEY_BOT_APP_ID }}
           private-key: ${{ secrets.WHEATLEY_BOT_PRIVATE_KEY }}
 
       - name: Checkout repository
@@ -52,7 +52,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          client-id: ${{ secrets.WHEATLEY_BOT_CLIENT_ID }}
+          client-id: ${{ secrets.WHEATLEY_BOT_APP_ID }}
           private-key: ${{ secrets.WHEATLEY_BOT_PRIVATE_KEY }}
 
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- PR #438 switched `actions/create-github-app-token` from the deprecated `app-id` input to `client-id`, but referenced a `WHEATLEY_BOT_CLIENT_ID` secret that was never added — every Release-plz run since has failed on `The 'client-id' (or deprecated 'app-id') input must be set to a non-empty string`.
- Point `client-id` at the existing `WHEATLEY_BOT_APP_ID` secret. The action coalesces both inputs internally (`clientId = getInput("client-id") || getInput("app-id")`) and passes the value as the JWT `iss` claim via `@octokit/auth-app`. GitHub accepts either the numeric App ID or the Client ID for that claim, so the existing secret works through the non-deprecated parameter — no new secret required, no deprecation warning.

## Test plan
- [ ] Merge to master and confirm the `Release-plz release` and `Release-plz PR` jobs succeed
- [ ] Confirm no `app-id` deprecation warning appears in the run logs
- [ ] Confirm the release PR (or release, on the next version-bumping merge) is created end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)