### PR TITLE
fix(clone): reject --no-checkout for non-bare layouts and cd into root on success

### DIFF
--- a/docs/cli/git-worktree-clone.md
+++ b/docs/cli/git-worktree-clone.md
@@ -44,7 +44,7 @@ git worktree-clone [OPTIONS] <REPOSITORY_URL>
 | Option | Description | Default |
 |--------|-------------|----------|
 | `-b, --branch <BRANCH>` | Branch to check out (repeatable; use HEAD or @ for default branch) |  |
-| `-n, --no-checkout` | Perform a bare clone only; do not create any worktree |  |
+| `-n, --no-checkout` | Perform a bare clone only; do not create any worktree (requires a bare layout: contained or contained-flat) |  |
 | `-q, --quiet` | Operate quietly; suppress progress reporting |  |
 | `-v, --verbose` | Increase verbosity (-v for hook details, -vv for full sequential output) |  |
 | `-a, --all-branches` | Create a worktree for each remote branch, not just the default |  |

--- a/man/daft-clone.1
+++ b/man/daft-clone.1
@@ -26,7 +26,7 @@ trusted, lifecycle hooks are executed. See git\-daft(1) for hook management.
 Branch to check out (repeatable; use HEAD or @ for default branch)
 .TP
 \fB\-n\fR, \fB\-\-no\-checkout\fR
-Perform a bare clone only; do not create any worktree
+Perform a bare clone only; do not create any worktree (requires a bare layout: contained or contained\-flat)
 .TP
 \fB\-q\fR, \fB\-\-quiet\fR
 Operate quietly; suppress progress reporting

--- a/man/git-worktree-clone.1
+++ b/man/git-worktree-clone.1
@@ -26,7 +26,7 @@ trusted, lifecycle hooks are executed. See git\-daft(1) for hook management.
 Branch to check out (repeatable; use HEAD or @ for default branch)
 .TP
 \fB\-n\fR, \fB\-\-no\-checkout\fR
-Perform a bare clone only; do not create any worktree
+Perform a bare clone only; do not create any worktree (requires a bare layout: contained or contained\-flat)
 .TP
 \fB\-q\fR, \fB\-\-quiet\fR
 Operate quietly; suppress progress reporting

--- a/src/commands/clone.rs
+++ b/src/commands/clone.rs
@@ -1505,6 +1505,12 @@ mod tests {
         };
         assert!(!layout.needs_bare());
         let err = check_no_checkout_compat(true, &layout).unwrap_err();
-        assert!(err.to_string().contains("'my-custom'"));
+        let msg = err.to_string();
+        assert!(msg.contains("'my-custom'"), "got: {msg}");
+        assert!(msg.contains("--no-checkout"), "got: {msg}");
+        assert!(
+            msg.contains("contained") && msg.contains("contained-flat"),
+            "got: {msg}"
+        );
     }
 }

--- a/src/commands/clone.rs
+++ b/src/commands/clone.rs
@@ -501,6 +501,12 @@ fn run_clone(args: &Args, settings: &DaftSettings, output: &mut dyn Output) -> R
             output.cd_path(cd_target);
         }
         maybe_show_shell_hint(output)?;
+    } else if result.no_checkout {
+        // No worktree exists for --no-checkout, but the user still ran a
+        // clone — drop them into the project root (the directory holding
+        // the bare .git) so they can immediately operate on the new repo.
+        output.cd_path(&result.parent_dir);
+        maybe_show_shell_hint(output)?;
     }
 
     Ok(())

--- a/src/commands/clone.rs
+++ b/src/commands/clone.rs
@@ -74,7 +74,7 @@ pub struct Args {
     #[arg(
         short = 'n',
         long = "no-checkout",
-        help = "Perform a bare clone only; do not create any worktree"
+        help = "Perform a bare clone only; do not create any worktree (requires a bare layout: contained or contained-flat)"
     )]
     no_checkout: bool,
 
@@ -183,6 +183,21 @@ fn validate_arg_combinations(args: &Args) -> Result<()> {
     Ok(())
 }
 
+/// Reject `--no-checkout` for layouts where the resolved `repo_path` is also
+/// the working tree. Without a separate bare directory, `-n` cannot leave an
+/// "empty bare" state — it would silently degrade to a non-bare clone with no
+/// working files, which is not what the user asked for.
+fn check_no_checkout_compat(no_checkout: bool, layout: &Layout) -> Result<()> {
+    if no_checkout && !layout.needs_bare() {
+        anyhow::bail!(
+            "--no-checkout requires a bare layout. The '{}' layout uses a non-bare repository.\n\
+             Pick one of the bare-using layouts: contained or contained-flat.",
+            layout.name
+        );
+    }
+    Ok(())
+}
+
 fn run_clone(args: &Args, settings: &DaftSettings, output: &mut dyn Output) -> Result<()> {
     check_dependencies()?;
 
@@ -265,6 +280,14 @@ fn run_clone(args: &Args, settings: &DaftSettings, output: &mut dyn Output) -> R
         global_config: &global_config,
         detection: None,
     });
+
+    if let Err(e) = check_no_checkout_compat(args.no_checkout, &layout) {
+        // The bare clone already landed on disk — remove it so a rejected
+        // clone leaves no orphan directory behind.
+        change_directory(&original_dir).ok();
+        remove_directory(&bare_result.parent_dir).ok();
+        return Err(e);
+    }
 
     // Report layout decision
     if layout.needs_bare() {
@@ -1410,4 +1433,72 @@ fn spawn_post_clone_refresh(
         tx.clone(),
     );
     handle.join();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::layout::BuiltinLayout;
+
+    #[test]
+    fn no_checkout_disabled_is_always_ok() {
+        for builtin in BuiltinLayout::all() {
+            let layout = builtin.to_layout();
+            assert!(check_no_checkout_compat(false, &layout).is_ok());
+        }
+    }
+
+    #[test]
+    fn no_checkout_accepts_bare_layouts() {
+        for builtin in [BuiltinLayout::Contained, BuiltinLayout::ContainedFlat] {
+            let layout = builtin.to_layout();
+            assert!(layout.needs_bare(), "{} should be bare", layout.name);
+            assert!(
+                check_no_checkout_compat(true, &layout).is_ok(),
+                "{} should accept --no-checkout",
+                layout.name
+            );
+        }
+    }
+
+    #[test]
+    fn no_checkout_rejects_non_bare_layouts() {
+        for builtin in [
+            BuiltinLayout::ContainedClassic,
+            BuiltinLayout::Sibling,
+            BuiltinLayout::Nested,
+            BuiltinLayout::Centralized,
+        ] {
+            let layout = builtin.to_layout();
+            assert!(!layout.needs_bare(), "{} should be non-bare", layout.name);
+            let err = check_no_checkout_compat(true, &layout)
+                .expect_err(&format!("{} should reject --no-checkout", layout.name));
+            let msg = err.to_string();
+            assert!(
+                msg.contains(&layout.name),
+                "error message should name the layout '{}', got: {msg}",
+                layout.name
+            );
+            assert!(
+                msg.contains("--no-checkout"),
+                "error message should mention --no-checkout, got: {msg}"
+            );
+            assert!(
+                msg.contains("contained") && msg.contains("contained-flat"),
+                "error message should suggest bare-using layouts, got: {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn no_checkout_rejects_custom_non_bare_layout() {
+        let layout = Layout {
+            name: "my-custom".into(),
+            template: "{{ repo }}/{{ branch | sanitize }}".into(),
+            bare: None,
+        };
+        assert!(!layout.needs_bare());
+        let err = check_no_checkout_compat(true, &layout).unwrap_err();
+        assert!(err.to_string().contains("'my-custom'"));
+    }
 }

--- a/tests/manual/scenarios/clone/no-checkout-non-bare-rejected.yml
+++ b/tests/manual/scenarios/clone/no-checkout-non-bare-rejected.yml
@@ -43,6 +43,13 @@ steps:
         - "--no-checkout requires a bare layout"
         - "'nested'"
 
+  - name: Verify no orphan directory left after nested rejection
+    run: "test ! -e $WORK_DIR/test-repo-no-co-nested && echo CLEAN"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "CLEAN"
+
   - name: Reject --no-checkout with centralized layout
     run:
       git-worktree-clone --no-checkout --layout centralized
@@ -53,6 +60,13 @@ steps:
         - "--no-checkout requires a bare layout"
         - "'centralized'"
 
+  - name: Verify no orphan directory left after centralized rejection
+    run: "test ! -e $WORK_DIR/test-repo-no-co-centralized && echo CLEAN"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "CLEAN"
+
   - name: Reject --no-checkout with contained-classic layout
     run:
       git-worktree-clone --no-checkout --layout contained-classic
@@ -62,3 +76,10 @@ steps:
       output_contains:
         - "--no-checkout requires a bare layout"
         - "'contained-classic'"
+
+  - name: Verify no orphan directory left after contained-classic rejection
+    run: "test ! -e $WORK_DIR/test-repo-no-co-classic && echo CLEAN"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "CLEAN"

--- a/tests/manual/scenarios/clone/no-checkout-non-bare-rejected.yml
+++ b/tests/manual/scenarios/clone/no-checkout-non-bare-rejected.yml
@@ -1,0 +1,64 @@
+name: Clone rejects --no-checkout for non-bare layouts
+description:
+  --no-checkout requires a layout that uses a bare repository. Non-bare layouts
+  (sibling, nested, centralized, contained-classic) must be rejected so the user
+  does not end up with an empty working tree they did not ask for.
+
+repos:
+  - name: test-repo-no-co-sibling
+    use_fixture: standard-remote
+  - name: test-repo-no-co-nested
+    use_fixture: standard-remote
+  - name: test-repo-no-co-centralized
+    use_fixture: standard-remote
+  - name: test-repo-no-co-classic
+    use_fixture: standard-remote
+
+steps:
+  - name: Reject --no-checkout with sibling layout
+    run:
+      git-worktree-clone --no-checkout --layout sibling
+      $REMOTE_TEST_REPO_NO_CO_SIBLING 2>&1
+    expect:
+      exit_code: 1
+      output_contains:
+        - "--no-checkout requires a bare layout"
+        - "'sibling'"
+        - "contained or contained-flat"
+
+  - name: Verify no orphan directory left after sibling rejection
+    run: "test ! -e $WORK_DIR/test-repo-no-co-sibling && echo CLEAN"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "CLEAN"
+
+  - name: Reject --no-checkout with nested layout
+    run:
+      git-worktree-clone --no-checkout --layout nested
+      $REMOTE_TEST_REPO_NO_CO_NESTED 2>&1
+    expect:
+      exit_code: 1
+      output_contains:
+        - "--no-checkout requires a bare layout"
+        - "'nested'"
+
+  - name: Reject --no-checkout with centralized layout
+    run:
+      git-worktree-clone --no-checkout --layout centralized
+      $REMOTE_TEST_REPO_NO_CO_CENTRALIZED 2>&1
+    expect:
+      exit_code: 1
+      output_contains:
+        - "--no-checkout requires a bare layout"
+        - "'centralized'"
+
+  - name: Reject --no-checkout with contained-classic layout
+    run:
+      git-worktree-clone --no-checkout --layout contained-classic
+      $REMOTE_TEST_REPO_NO_CO_CLASSIC 2>&1
+    expect:
+      exit_code: 1
+      output_contains:
+        - "--no-checkout requires a bare layout"
+        - "'contained-classic'"

--- a/tests/manual/scenarios/clone/no-checkout.yml
+++ b/tests/manual/scenarios/clone/no-checkout.yml
@@ -6,6 +6,8 @@ description:
 repos:
   - name: test-repo-no-checkout
     use_fixture: standard-remote
+  - name: test-repo-no-checkout-cd
+    use_fixture: standard-remote
 
 steps:
   - name: "Clone with --no-checkout flag"
@@ -22,3 +24,15 @@ steps:
     run: "test ! -d test-repo-no-checkout/main"
     expect:
       exit_code: 0
+
+  - name: "Cd to project root for --no-checkout success"
+    run: |
+      cd_file=$(mktemp)
+      DAFT_CD_FILE="$cd_file" git-worktree-clone --no-checkout --layout contained $REMOTE_TEST_REPO_NO_CHECKOUT_CD 2>&1
+      cat "$cd_file" > $WORK_DIR/cd_target.txt
+      rm -f "$cd_file"
+    expect:
+      exit_code: 0
+      file_contains:
+        - path: "$WORK_DIR/cd_target.txt"
+          content: "test-repo-no-checkout-cd"


### PR DESCRIPTION
## Summary

Two related `--no-checkout` fixes for `git-worktree-clone`:

- **Reject `--no-checkout` for non-bare layouts.** The flag promises a bare clone with no worktree, but for non-bare layouts (`sibling`, `nested`, `centralized`, `contained-classic`) the resolved `repo_path` *is* the working tree — there's no separate bare directory to leave behind. The flag silently degraded to a regular clone with an empty working tree. Now bails after layout resolution with an error naming the resolved layout and pointing to bare alternatives (`contained`, `contained-flat`). Cleans up the bare clone (already on disk from `clone_bare_phase`) so a rejected clone leaves no orphan directory.
- **Cd into project root after successful `--no-checkout`.** Previously the cd-redirect was gated on `worktree_dir.is_some()` (or `branch_not_found`), so the bare-only success case fell through and left the user in their original directory. Now writes `parent_dir` to `DAFT_CD_FILE` so the user lands in the new project root immediately. `--no-cd` still suppresses via the existing `autocd` check inside `output.cd_path`.

Updated `--no-checkout` help text and regenerated man pages + CLI docs to describe the bare-layout constraint.

Fixes #443

## Test plan

- [x] Unit tests cover all 6 builtin layouts plus a custom non-bare layout (`cargo test --lib commands::clone::tests`)
- [x] YAML scenario `clone:no-checkout-non-bare-rejected` covers each non-bare builtin and asserts no orphan directory is left after rejection
- [x] `clone:no-checkout` extended to assert cd target is the project root via `DAFT_CD_FILE`
- [x] `clone:empty-repo-no-checkout` regression check still passes
- [x] `mise run fmt`, `mise run clippy`, `cargo clippy --all-targets -- -D warnings` clean
- [x] Live binary test confirmed cleanup preserves unrelated files in cwd

🤖 Generated with [Claude Code](https://claude.com/claude-code)