### PR TITLE
fix(completions): offer path completions and out-of-repo path remove

### DIFF
--- a/docs/cli/daft-remove.md
+++ b/docs/cli/daft-remove.md
@@ -22,6 +22,11 @@ force-delete branches regardless of merge status (`git worktree-branch -D`).
 Deletes one or more local branches along with their associated worktrees in
 a single operation. Arguments can be branch names or worktree paths.
 
+When invoked outside any git repository, `daft remove` accepts absolute or
+relative worktree paths and discovers the owning repository from the path
+itself, so worktrees can be cleaned up without first `cd`-ing into a sibling
+worktree. All paths in a single invocation must belong to the same repository.
+
 By default, the remote branch is not deleted. To also delete the remote branch,
 set `daft.branchDelete.remote true` or use `daft config remote-sync --on`. You
 can also pass `--remote` to delete only the remote branch while keeping the

--- a/src/commands/completions/bash.rs
+++ b/src/commands/completions/bash.rs
@@ -1,6 +1,6 @@
 use super::{
-    emit_formats_for, extract_flags, get_command_for_name, uses_fetch_on_miss,
-    uses_rich_completions,
+    allows_path_completion, emit_formats_for, extract_flags, get_command_for_name,
+    uses_fetch_on_miss, uses_rich_completions,
 };
 use anyhow::{Context, Result};
 
@@ -163,6 +163,35 @@ fn generate_bash_rich_completion(command_name: &str) -> String {
     } else {
         ""
     };
+    // Path-accepting commands (daft-remove, daft-rename) also offer directory
+    // completion. When the user types a path-like prefix (./, ../, /, ~/) we
+    // skip the dynamic branch source entirely; otherwise paths are appended
+    // alongside any branch matches so both worlds work in one keystroke.
+    let path_pre = if allows_path_completion(command_name) {
+        r#"    case "$cur" in
+        /*|./*|../*|~/*|~)
+            COMPREPLY=( $(compgen -d -- "$cur") )
+            compopt -o filenames 2>/dev/null || true
+            return 0
+            ;;
+    esac
+"#
+    } else {
+        ""
+    };
+    let path_post = if allows_path_completion(command_name) {
+        r#"    local dirs
+    dirs=$(compgen -d -- "$cur")
+    if [[ -n "$dirs" ]]; then
+        while IFS=$'\n' read -r d; do
+            COMPREPLY+=("$d")
+        done <<< "$dirs"
+        compopt -o filenames 2>/dev/null || true
+    fi
+"#
+    } else {
+        ""
+    };
 
     let mut output = format!(
         r#"_{func_name}() {{
@@ -175,11 +204,13 @@ fn generate_bash_rich_completion(command_name: &str) -> String {
         return 0
     fi
 
-    local raw
+{path_pre}    local raw
     raw=$(daft __complete {command_name} "$cur" --position "$cword"{fetch_flag} 2>/dev/null | cut -f1)
     if [[ -n "$raw" ]]; then
         COMPREPLY=( $(compgen -W "$raw" -- "$cur") )
         compopt -o nosort 2>/dev/null || true
+    fi
+{path_post}    if [[ ${{#COMPREPLY[@]}} -gt 0 ]]; then
         return 0
     fi
 }}

--- a/src/commands/completions/bash.rs
+++ b/src/commands/completions/bash.rs
@@ -167,10 +167,14 @@ fn generate_bash_rich_completion(command_name: &str) -> String {
     // completion. When the user types a path-like prefix (./, ../, /, ~/) we
     // skip the dynamic branch source entirely; otherwise paths are appended
     // alongside any branch matches so both worlds work in one keystroke.
+    //
+    // Both branches use `mapfile -t` (bash 4+, already required by
+    // `_init_completion`) so directory names containing spaces/tabs/newlines
+    // arrive as a single COMPREPLY entry rather than being word-split on $IFS.
     let path_pre = if allows_path_completion(command_name) {
         r#"    case "$cur" in
         /*|./*|../*|~/*|~)
-            COMPREPLY=( $(compgen -d -- "$cur") )
+            mapfile -t COMPREPLY < <(compgen -d -- "$cur")
             compopt -o filenames 2>/dev/null || true
             return 0
             ;;

--- a/src/commands/completions/fish.rs
+++ b/src/commands/completions/fish.rs
@@ -1,6 +1,6 @@
 use super::{
-    emit_formats_for, get_command_for_name, get_flag_descriptions, uses_fetch_on_miss,
-    uses_rich_completions, VERB_ALIAS_GROUPS,
+    allows_path_completion, emit_formats_for, get_command_for_name, get_flag_descriptions,
+    uses_fetch_on_miss, uses_rich_completions, VERB_ALIAS_GROUPS,
 };
 use anyhow::{Context, Result};
 
@@ -271,6 +271,18 @@ fn generate_fish_rich_completion(command_name: &str) -> Result<String> {
             "complete -c git -n '__fish_seen_subcommand_from {git_subcommand}' -f -a \"(daft __complete {command_name} (commandline -ct) --position 1{fetch_flag} 2>/dev/null | awk -F'\\t' '{awk_body}')\"\n",
         ));
     }
+    // Path-accepting commands (daft-remove, daft-rename) also offer directory
+    // completion so worktrees can be removed by path inside or outside a repo.
+    if allows_path_completion(command_name) {
+        output.push_str(&format!(
+            "complete -c {command_name} -a \"(__fish_complete_directories (commandline -ct))\"\n",
+        ));
+        if is_git_command {
+            output.push_str(&format!(
+                "complete -c git -n '__fish_seen_subcommand_from {git_subcommand}' -a \"(__fish_complete_directories (commandline -ct))\"\n",
+            ));
+        }
+    }
     output.push('\n');
     output.push_str("# Static flag completions (extracted from clap)\n");
 
@@ -343,7 +355,9 @@ complete -c daft -n '__fish_seen_subcommand_from carry' -f -a "(daft __complete 
 complete -c daft -n '__fish_seen_subcommand_from exec' -f -a "(daft __complete git-worktree-exec (commandline -ct) --position 1 2>/dev/null | awk -F'\t' '{c=$1; sub(/[*?]+$/,\"\",c); s=substr($1,length(c)+1); if (NF>=5) printf \"%s\t%s %s · %s · %s\n\",c,s,$3,$4,$5; else printf \"%s\t%s %s · %s\n\",c,s,$3,$4}')"
 complete -c daft -n '__fish_seen_subcommand_from update' -f -a "(daft __complete git-worktree-fetch (commandline -ct) --position 1 2>/dev/null | awk -F'\t' '{c=$1; sub(/[*?]+$/,\"\",c); s=substr($1,length(c)+1); if (NF>=5) printf \"%s\t%s %s · %s · %s\n\",c,s,$3,$4,$5; else printf \"%s\t%s %s · %s\n\",c,s,$3,$4}')"
 complete -c daft -n '__fish_seen_subcommand_from remove' -f -a "(daft __complete daft-remove (commandline -ct) --position 1 2>/dev/null | awk -F'\t' '{c=$1; sub(/[*?]+$/,\"\",c); s=substr($1,length(c)+1); if (NF>=5) printf \"%s\t%s %s · %s · %s\n\",c,s,$3,$4,$5; else printf \"%s\t%s %s · %s\n\",c,s,$3,$4}')"
+complete -c daft -n '__fish_seen_subcommand_from remove' -a "(__fish_complete_directories (commandline -ct))"
 complete -c daft -n '__fish_seen_subcommand_from rename' -f -a "(daft __complete daft-rename (commandline -ct) --position 1 2>/dev/null | awk -F'\t' '{c=$1; sub(/[*?]+$/,\"\",c); s=substr($1,length(c)+1); if (NF>=5) printf \"%s\t%s %s · %s · %s\n\",c,s,$3,$4,$5; else printf \"%s\t%s %s · %s\n\",c,s,$3,$4}')"
+complete -c daft -n '__fish_seen_subcommand_from rename' -a "(__fish_complete_directories (commandline -ct))"
 complete -c daft -n '__fish_seen_subcommand_from layout; and not __fish_seen_subcommand_from default list show transform' -f -a 'default list show transform'
 complete -c daft -n '__fish_seen_subcommand_from layout; and __fish_seen_subcommand_from show' -F
 complete -c daft -n '__fish_seen_subcommand_from layout; and __fish_seen_subcommand_from transform' -f -a "(daft __complete layout-transform '' 2>/dev/null)"

--- a/src/commands/completions/mod.rs
+++ b/src/commands/completions/mod.rs
@@ -945,6 +945,20 @@ before adding flags (zsh flag-leak regression)"
                 script.contains("/*|./*|../*|~/*|~"),
                 "{cmd} bash must short-circuit to dir completion when prefix is path-like"
             );
+            // Both the path-prefix short-circuit and the post-branch fallback
+            // must avoid unquoted command substitution into COMPREPLY, which
+            // would word-split directory names on $IFS (e.g. `my worktree/`
+            // would produce two entries `my` and `worktree/`).
+            assert!(
+                script.contains("mapfile -t COMPREPLY < <(compgen -d"),
+                "{cmd} bash path-prefix branch must use `mapfile -t` to preserve \
+                 directory names with whitespace"
+            );
+            assert!(
+                !script.contains("COMPREPLY=( $(compgen -d"),
+                "{cmd} bash must NOT assign `COMPREPLY=( $(compgen -d ...) )` \
+                 directly — that word-splits dirs containing whitespace"
+            );
         }
     }
 

--- a/src/commands/completions/mod.rs
+++ b/src/commands/completions/mod.rs
@@ -104,6 +104,16 @@ pub(super) fn uses_fetch_on_miss(command_name: &str) -> bool {
     matches!(command_name, "daft-go")
 }
 
+/// Whether a command accepts worktree paths as positional arguments and should
+/// fall back to filesystem directory completion when the dynamic source has
+/// nothing to offer (or as an additional candidate set). This keeps the
+/// "remove this worktree by path" UX usable both inside a repo (where the user
+/// might type `./` or `../`) and outside any repo (where the dynamic source
+/// can't return branches at all).
+pub(super) fn allows_path_completion(command_name: &str) -> bool {
+    matches!(command_name, "daft-remove" | "daft-rename")
+}
+
 /// Extract flag strings from a clap Command for shell completions
 /// Returns a tuple of (short_and_long_flags, short_flags, long_flags)
 pub(super) fn extract_flags(cmd: &Command) -> (Vec<String>, Vec<String>, Vec<String>) {
@@ -912,5 +922,97 @@ before adding flags (zsh flag-leak regression)"
             script.contains("release-notes|\"multi-remote status\"|\"hooks run\""),
             "bash umbrella must dispatch document/sectioned paths to 4-format list"
         );
+    }
+
+    // ── Path completions for daft-remove and daft-rename ─────────────────
+    //
+    // Both commands document that positional args may be branch names OR
+    // worktree paths. Without path completion in the stubs, Tab on `./` or
+    // an absolute prefix produces nothing — and outside a repo the dynamic
+    // source returns empty so Tab is dead. These tests pin the stubs that
+    // restore directory completion for both inside-repo and outside-repo use.
+
+    #[test]
+    fn bash_path_accepting_commands_offer_directory_completion() {
+        for cmd in ["daft-remove", "daft-rename"] {
+            let script = bash::generate_bash_completion_string(cmd)
+                .unwrap_or_else(|e| panic!("bash generator must succeed for {cmd}: {e}"));
+            assert!(
+                script.contains("compgen -d"),
+                "{cmd} bash must offer directory completion via `compgen -d`"
+            );
+            assert!(
+                script.contains("/*|./*|../*|~/*|~"),
+                "{cmd} bash must short-circuit to dir completion when prefix is path-like"
+            );
+        }
+    }
+
+    #[test]
+    fn zsh_path_accepting_commands_offer_directory_completion() {
+        for cmd in ["daft-remove", "daft-rename"] {
+            let script = zsh::generate_zsh_completion_string(cmd)
+                .unwrap_or_else(|e| panic!("zsh generator must succeed for {cmd}: {e}"));
+            assert!(
+                script.contains("_files -/"),
+                "{cmd} zsh must offer directory completion via `_files -/`"
+            );
+            assert!(
+                script.contains("/*|./*|../*|~/*|~"),
+                "{cmd} zsh must short-circuit to dir completion when prefix is path-like"
+            );
+        }
+    }
+
+    #[test]
+    fn fish_path_accepting_commands_offer_directory_completion() {
+        for cmd in ["daft-remove", "daft-rename"] {
+            let script = fish::generate_fish_completion_string(cmd)
+                .unwrap_or_else(|e| panic!("fish generator must succeed for {cmd}: {e}"));
+            assert!(
+                script.contains("__fish_complete_directories"),
+                "{cmd} fish must offer directory completion via __fish_complete_directories"
+            );
+        }
+    }
+
+    #[test]
+    fn fish_daft_umbrella_offers_directory_completion_for_remove_and_rename() {
+        let script = fish::generate_daft_fish_completions();
+        for verb in ["remove", "rename"] {
+            let needle =
+                format!("__fish_seen_subcommand_from {verb}' -a \"(__fish_complete_directories");
+            assert!(
+                script.contains(&needle),
+                "fish umbrella must offer dir completion for `daft {verb}`\n\
+                 expected to contain: {needle}"
+            );
+        }
+    }
+
+    #[test]
+    fn non_path_commands_do_not_offer_directory_completion() {
+        // Sanity: only the path-accepting commands enable filesystem
+        // completion; other rich commands stay branch-only.
+        for cmd in [
+            "git-worktree-checkout",
+            "git-worktree-carry",
+            "git-worktree-fetch",
+            "daft-go",
+            "git-worktree-exec",
+        ] {
+            let zsh = zsh::generate_zsh_completion_string(cmd)
+                .unwrap_or_else(|e| panic!("zsh generator must succeed for {cmd}: {e}"));
+            assert!(
+                !zsh.contains("_files -/"),
+                "{cmd} zsh must NOT offer directory completion (branches only)"
+            );
+            let bash = bash::generate_bash_completion_string(cmd)
+                .unwrap_or_else(|e| panic!("bash generator must succeed for {cmd}: {e}"));
+            assert!(
+                !bash.contains("compgen -d"),
+                "{cmd} bash must NOT offer directory completion (branches only)"
+            );
+        }
     }
 }

--- a/src/commands/completions/zsh.rs
+++ b/src/commands/completions/zsh.rs
@@ -1,6 +1,6 @@
 use super::{
-    emit_formats_for, extract_flags, get_command_for_name, uses_fetch_on_miss,
-    uses_rich_completions,
+    allows_path_completion, emit_formats_for, extract_flags, get_command_for_name,
+    uses_fetch_on_miss, uses_rich_completions,
 };
 use anyhow::{Context, Result};
 
@@ -251,6 +251,26 @@ fn generate_zsh_rich_completion(command_name: &str) -> String {
     } else {
         ""
     };
+    // Path-accepting commands (daft-remove, daft-rename) also offer directory
+    // completion. A path-like prefix (./, ../, /, ~/) skips the dynamic branch
+    // source entirely; otherwise directories are appended after the branch
+    // groups so a single Tab works in both inside-repo and outside-repo cases.
+    let path_pre = if allows_path_completion(command_name) {
+        r#"    case "$curword" in
+        /*|./*|../*|~/*|~)
+            _files -/
+            return
+            ;;
+    esac
+"#
+    } else {
+        ""
+    };
+    let path_post = if allows_path_completion(command_name) {
+        "    _files -/\n"
+    } else {
+        ""
+    };
 
     let mut output = format!(
         r#"#compdef {command_name}
@@ -267,7 +287,7 @@ __{func_name}_impl() {{
         return
     fi
 
-    local -a raw
+{path_pre}    local -a raw
     local -a wt_names wt_raw_names wt_ages wt_authors wt_paths
     local -a local_names local_ages local_authors
     local -a remote_names remote_ages remote_authors
@@ -357,7 +377,7 @@ __{func_name}_impl() {{
     (( ${{#wt_names}} ))     && compadd -V worktree -l -d wt_display -a wt_names
     (( ${{#local_names}} ))  && compadd -V local -l -d local_display -a local_names
     (( ${{#remote_names}} )) && compadd -V remote -l -d remote_display -a remote_names
-}}
+{path_post}}}
 
 _{func_name}() {{
     __{func_name}_impl

--- a/src/commands/worktree_branch.rs
+++ b/src/commands/worktree_branch.rs
@@ -205,7 +205,7 @@ pub fn run_remove() -> Result<()> {
     // chdir-ing to its project root. All path arguments are canonicalized first
     // so the subsequent chdir doesn't break their resolution.
     if !is_git_repository()? {
-        prepare_out_of_repo_remove(&mut remove_args.branches)?;
+        prepare_out_of_repo_paths(&mut remove_args.branches, "daft remove")?;
     }
 
     let settings = DaftSettings::load()?;
@@ -223,14 +223,19 @@ pub fn run_remove() -> Result<()> {
     )
 }
 
-/// Prepare `daft remove` to run when the user's current directory is not inside
-/// any git repository. Resolves path arguments to absolute canonical paths,
-/// discovers the owning repository from the first one, ensures all paths share
-/// the same repository, and `chdir`s into the project root so the cwd-based
-/// branch_delete pipeline can take over unchanged.
-fn prepare_out_of_repo_remove(args: &mut Vec<String>) -> Result<()> {
-    // clap enforces `required = true` on `branches`, so an empty `args` here
-    // would have already been rejected before this function runs.
+/// Prepare a path-accepting daft command (currently `daft remove` and `daft
+/// rename`) to run when the user's current directory is not inside any git
+/// repository. Resolves path arguments to absolute canonical paths, discovers
+/// the owning repository from the first one, ensures all paths share the same
+/// repository, and `chdir`s into the project root so the cwd-based pipeline
+/// can take over unchanged.
+///
+/// `command_name` is used only in user-facing error messages (e.g. "Run
+/// `daft remove` inside a repository"); the resolution logic is identical
+/// across commands.
+fn prepare_out_of_repo_paths(args: &mut Vec<String>, command_name: &str) -> Result<()> {
+    // clap enforces `required = true` on the positional args of every caller,
+    // so an empty `args` here would have already been rejected.
     let cwd = std::env::current_dir()
         .map_err(|e| anyhow::anyhow!("failed to read current working directory: {e}"))?;
     let mut absolute_paths: Vec<std::path::PathBuf> = Vec::with_capacity(args.len());
@@ -244,8 +249,9 @@ fn prepare_out_of_repo_remove(args: &mut Vec<String>) -> Result<()> {
         let canonical = std::fs::canonicalize(&candidate).map_err(|_| {
             anyhow::anyhow!(
                 "Not inside a Git repository, and '{}' is not an existing path. \
-                 Run `daft remove` inside a repository, or pass an existing worktree path.",
-                arg
+                 Run `{}` inside a repository, or pass an existing worktree path.",
+                arg,
+                command_name
             )
         })?;
         absolute_paths.push(canonical);
@@ -256,8 +262,9 @@ fn prepare_out_of_repo_remove(args: &mut Vec<String>) -> Result<()> {
         let repo = gix::discover(path).map_err(|_| {
             anyhow::anyhow!(
                 "'{}' is not inside a Git repository. \
-                 Run `daft remove` inside a repository, or pass a worktree path.",
-                original
+                 Run `{}` inside a repository, or pass a worktree path.",
+                original,
+                command_name
             )
         })?;
         let canonical_common = std::fs::canonicalize(repo.common_dir())
@@ -335,12 +342,22 @@ pub struct RenameArgs {
 pub fn run_rename() -> Result<()> {
     let mut raw = crate::get_clap_args("daft-rename");
     raw[0] = "daft rename".to_string();
-    let rename_args = RenameArgs::parse_from(raw);
+    let mut rename_args = RenameArgs::parse_from(raw);
 
     init_logging(rename_args.verbose);
 
+    // When invoked outside a git repository, allow renaming a worktree by
+    // path: discover the owning repo from the source argument and chdir into
+    // its project root so the cwd-based rename pipeline runs unchanged. Only
+    // the `source` arg is treated as a path; `new_branch` is always a branch
+    // name, never a path.
     if !is_git_repository()? {
-        anyhow::bail!("Not inside a Git repository");
+        let mut source_arg = vec![rename_args.source.clone()];
+        prepare_out_of_repo_paths(&mut source_arg, "daft rename")?;
+        rename_args.source = source_arg
+            .into_iter()
+            .next()
+            .expect("one arg in, one arg out");
     }
 
     let settings = DaftSettings::load()?;

--- a/src/commands/worktree_branch.rs
+++ b/src/commands/worktree_branch.rs
@@ -196,12 +196,16 @@ pub struct RemoveArgs {
 pub fn run_remove() -> Result<()> {
     let mut raw = crate::get_clap_args("daft-remove");
     raw[0] = "daft remove".to_string();
-    let remove_args = RemoveArgs::parse_from(raw);
+    let mut remove_args = RemoveArgs::parse_from(raw);
 
     init_logging(remove_args.verbose);
 
+    // When invoked outside a git repository, allow operating on worktree paths
+    // by discovering the owning repo from the first existing path argument and
+    // chdir-ing to its project root. All path arguments are canonicalized first
+    // so the subsequent chdir doesn't break their resolution.
     if !is_git_repository()? {
-        anyhow::bail!("Not inside a Git repository");
+        prepare_out_of_repo_remove(&mut remove_args.branches)?;
     }
 
     let settings = DaftSettings::load()?;
@@ -217,6 +221,74 @@ pub fn run_remove() -> Result<()> {
         &mut output,
         &settings,
     )
+}
+
+/// Prepare `daft remove` to run when the user's current directory is not inside
+/// any git repository. Resolves path arguments to absolute canonical paths,
+/// discovers the owning repository from the first one, ensures all paths share
+/// the same repository, and `chdir`s into the project root so the cwd-based
+/// branch_delete pipeline can take over unchanged.
+fn prepare_out_of_repo_remove(args: &mut Vec<String>) -> Result<()> {
+    // clap enforces `required = true` on `branches`, so an empty `args` here
+    // would have already been rejected before this function runs.
+    let cwd = std::env::current_dir()
+        .map_err(|e| anyhow::anyhow!("failed to read current working directory: {e}"))?;
+    let mut absolute_paths: Vec<std::path::PathBuf> = Vec::with_capacity(args.len());
+    for arg in args.iter() {
+        let raw = std::path::PathBuf::from(arg);
+        let candidate = if raw.is_absolute() {
+            raw
+        } else {
+            cwd.join(&raw)
+        };
+        let canonical = std::fs::canonicalize(&candidate).map_err(|_| {
+            anyhow::anyhow!(
+                "Not inside a Git repository, and '{}' is not an existing path. \
+                 Run `daft remove` inside a repository, or pass an existing worktree path.",
+                arg
+            )
+        })?;
+        absolute_paths.push(canonical);
+    }
+
+    let mut common_dir: Option<std::path::PathBuf> = None;
+    for (path, original) in absolute_paths.iter().zip(args.iter()) {
+        let repo = gix::discover(path).map_err(|_| {
+            anyhow::anyhow!(
+                "'{}' is not inside a Git repository. \
+                 Run `daft remove` inside a repository, or pass a worktree path.",
+                original
+            )
+        })?;
+        let canonical_common = std::fs::canonicalize(repo.common_dir())
+            .unwrap_or_else(|_| repo.common_dir().to_path_buf());
+        match common_dir {
+            None => common_dir = Some(canonical_common),
+            Some(ref existing) if existing == &canonical_common => {}
+            Some(_) => anyhow::bail!(
+                "all paths must belong to the same repository when running outside a worktree"
+            ),
+        }
+    }
+
+    let common_dir = common_dir.expect("at least one path was processed");
+    let project_root = common_dir
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("could not determine project root for repository"))?;
+
+    std::env::set_current_dir(project_root).map_err(|e| {
+        anyhow::anyhow!(
+            "failed to enter project root '{}': {e}",
+            project_root.display()
+        )
+    })?;
+
+    *args = absolute_paths
+        .into_iter()
+        .map(|p| p.to_string_lossy().into_owned())
+        .collect();
+
+    Ok(())
 }
 
 /// Daft-style args for `daft rename`. Separate from `Args` so that `-h`/`--help`

--- a/tests/manual/scenarios/branch-delete/daft-remove-cross-repo-rejected.yml
+++ b/tests/manual/scenarios/branch-delete/daft-remove-cross-repo-rejected.yml
@@ -1,0 +1,41 @@
+name: Daft remove rejects paths from different repositories
+description:
+  When invoked outside any worktree, daft-remove must refuse a single invocation
+  that mixes paths from two unrelated repositories so the user doesn't
+  accidentally chdir into the wrong one.
+
+repos:
+  - name: test-repo-a
+    use_fixture: standard-remote
+  - name: test-repo-b
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone both repositories with worktrees
+    run: |
+      cd $WORK_DIR
+      git-worktree-clone --layout contained $REMOTE_TEST_REPO_A
+      cd $WORK_DIR/test-repo-a
+      git-worktree-checkout -b feature/in-a
+      cd $WORK_DIR
+      git-worktree-clone --layout contained $REMOTE_TEST_REPO_B
+      cd $WORK_DIR/test-repo-b
+      git-worktree-checkout -b feature/in-b
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-repo-a/feature/in-a"
+        - "$WORK_DIR/test-repo-b/feature/in-b"
+
+  - name: Mixing paths from two repos is rejected with a clear message
+    run:
+      daft-remove "$WORK_DIR/test-repo-a/feature/in-a"
+      "$WORK_DIR/test-repo-b/feature/in-b" 2>&1
+    cwd: "$WORK_DIR"
+    expect:
+      exit_code: 1
+      output_contains:
+        - "same repository"
+      dirs_exist:
+        - "$WORK_DIR/test-repo-a/feature/in-a"
+        - "$WORK_DIR/test-repo-b/feature/in-b"

--- a/tests/manual/scenarios/branch-delete/daft-remove-outside-repo-by-path.yml
+++ b/tests/manual/scenarios/branch-delete/daft-remove-outside-repo-by-path.yml
@@ -1,0 +1,56 @@
+name: Daft remove by path from outside any repository
+description:
+  daft-remove with an absolute worktree path works when cwd is outside any git
+  repository. The owning repo is discovered from the path argument.
+
+repos:
+  - name: test-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone and create a feature branch
+    run: |
+      git-worktree-clone --layout contained $REMOTE_TEST_REPO
+      cd $WORK_DIR/test-repo
+      git-worktree-checkout -b feature/standalone
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-repo/feature/standalone"
+
+  - name: Merge into main and push so safe-delete passes
+    run: |
+      cd $WORK_DIR/test-repo/feature/standalone
+      echo "work" > work.txt
+      git add work.txt
+      git commit -m "Add work"
+      git push origin feature/standalone
+      cd $WORK_DIR/test-repo/main
+      git merge feature/standalone
+      git push origin main
+    expect:
+      exit_code: 0
+
+  - name: Delete worktree by absolute path from outside the repo
+    run: daft-remove "$WORK_DIR/test-repo/feature/standalone"
+    cwd: "$WORK_DIR"
+    expect:
+      exit_code: 0
+      files_not_exist:
+        - "$WORK_DIR/test-repo/feature/standalone"
+
+  - name: Bare branch name from outside still errors
+    run: daft-remove some-branch 2>&1
+    cwd: "$WORK_DIR"
+    expect:
+      exit_code: 1
+      output_contains:
+        - "Not inside a Git repository"
+
+  - name: Non-existent path from outside reports a usable error
+    run: daft-remove "$WORK_DIR/does-not-exist" 2>&1
+    cwd: "$WORK_DIR"
+    expect:
+      exit_code: 1
+      output_contains:
+        - "is not an existing path"

--- a/tests/manual/scenarios/branch-delete/daft-remove-outside-repo-sibling-layout.yml
+++ b/tests/manual/scenarios/branch-delete/daft-remove-outside-repo-sibling-layout.yml
@@ -1,0 +1,41 @@
+name: Daft remove by path from outside (sibling layout)
+description:
+  daft-remove with an absolute worktree path also works for the sibling layout
+  when invoked outside the main worktree.
+
+repos:
+  - name: test-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone with sibling layout and create a feature worktree
+    run: |
+      git-worktree-clone --layout sibling $REMOTE_TEST_REPO
+      cd $WORK_DIR/test-repo
+      git-worktree-checkout -b feature/sib-cleanup
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-repo"
+        - "$WORK_DIR/test-repo.feature-sib-cleanup"
+
+  - name: Merge into main and push
+    run: |
+      cd $WORK_DIR/test-repo.feature-sib-cleanup
+      echo "work" > work.txt
+      git add work.txt
+      git commit -m "Add work"
+      git push origin feature/sib-cleanup
+      cd $WORK_DIR/test-repo
+      git merge feature/sib-cleanup
+      git push origin main
+    expect:
+      exit_code: 0
+
+  - name: Delete feature worktree by path from $WORK_DIR (outside any worktree)
+    run: daft-remove "$WORK_DIR/test-repo.feature-sib-cleanup"
+    cwd: "$WORK_DIR"
+    expect:
+      exit_code: 0
+      files_not_exist:
+        - "$WORK_DIR/test-repo.feature-sib-cleanup"

--- a/tests/manual/scenarios/rename/outside-repo-by-path.yml
+++ b/tests/manual/scenarios/rename/outside-repo-by-path.yml
@@ -1,0 +1,39 @@
+name: Daft rename by path from outside any repository
+description:
+  daft-rename with an absolute worktree path works when cwd is outside any git
+  repository. Mirrors the daft-remove behaviour so completion-suggested paths
+  are usable from any cwd.
+
+repos:
+  - name: test-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone and create a feature worktree
+    run: |
+      git-worktree-clone --layout contained $REMOTE_TEST_REPO
+      cd $WORK_DIR/test-repo
+      git-worktree-checkout -b feature/old-name
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-repo/feature/old-name"
+
+  - name: Rename worktree by absolute path from $WORK_DIR (outside the repo)
+    run:
+      daft-rename "$WORK_DIR/test-repo/feature/old-name" feature/new-name 2>&1
+    cwd: "$WORK_DIR"
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-repo/feature/new-name"
+      files_not_exist:
+        - "$WORK_DIR/test-repo/feature/old-name"
+
+  - name: Bare branch name from outside still errors
+    run: daft-rename feature/missing feature/whatever 2>&1
+    cwd: "$WORK_DIR"
+    expect:
+      exit_code: 1
+      output_contains:
+        - "Not inside a Git repository"


### PR DESCRIPTION
## Summary

- `daft remove` and `daft rename` document worktree paths as a valid input form, but Tab on `./`, `../`, `/`, or `~/` produced no candidates.
- Running `daft remove <abs-path>` from outside any git repo bailed with `Not inside a Git repository`, even when the path argument unambiguously named a worktree.
- Per-shell rich-completion stubs now offer directory completion alongside (or short-circuited from) the dynamic branch source for the path-accepting commands; `run_remove` discovers the owning repo from a path arg when cwd is outside any repo and `chdir`s to its project root before delegating to the existing branch-delete pipeline.

Fixes #450

## Test plan

- [x] `mise run fmt:check` and `mise run clippy` clean
- [x] `mise run test:unit` (1498 lib tests + new completion-stub tests) all green
- [x] `tests/manual/scenarios/branch-delete/daft-remove-outside-repo-by-path.yml` passes (contained layout: success + bare-branch error + non-existent-path error)
- [x] `tests/manual/scenarios/branch-delete/daft-remove-outside-repo-sibling-layout.yml` passes (sibling layout end-to-end)
- [x] Existing `branch-delete:basic`, `:by-absolute-path`, `:by-relative-path`, `:by-dot`, and `:daft-remove-force` scenarios still pass — no regressions in inside-repo path resolution
- [ ] Spot-check Tab completion in zsh for `daft remove ./`, `daft remove /tmp/`, and `daft remove <branch-prefix>` from inside and outside a daft-managed repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)