### PR TITLE
fix(hooks): honor user git-config in commands that fire hooks

### DIFF
--- a/src/commands/branch_delete.rs
+++ b/src/commands/branch_delete.rs
@@ -1,7 +1,7 @@
 use crate::{
     core::{worktree::branch_delete, CommandBridge},
     git::should_show_gitoxide_notice,
-    hooks::{HookExecutor, HooksConfig},
+    hooks::HookExecutor,
     is_git_repository,
     logging::init_logging,
     output::{CliOutput, Output, OutputConfig},
@@ -102,7 +102,7 @@ fn run_branch_delete(args: &Args, output: &mut dyn Output, settings: &DaftSettin
         prune_cd_target: settings.prune_cd_target,
     };
 
-    let hooks_config = HooksConfig::default();
+    let hooks_config = crate::core::settings::load_hooks_config()?;
     let executor = HookExecutor::new(hooks_config)?;
 
     if should_show_gitoxide_notice(settings.use_gitoxide) {

--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -11,7 +11,7 @@ use crate::{
     get_current_worktree_path, get_git_common_dir, get_project_root,
     git::{should_show_gitoxide_notice, GitCommand},
     hints::maybe_show_shell_hint,
-    hooks::{yaml_config_loader, HookExecutor, HooksConfig, TrustDatabase},
+    hooks::{yaml_config_loader, HookExecutor, TrustDatabase},
     is_git_repository,
     logging::init_logging,
     output::{CliOutput, Output, OutputConfig},
@@ -722,7 +722,7 @@ fn run_checkout(
         at_path: args.at.clone(),
     };
 
-    let hooks_config = HooksConfig::default();
+    let hooks_config = crate::core::settings::load_hooks_config()?;
     let executor = HookExecutor::new(hooks_config)?;
 
     if should_show_gitoxide_notice(settings.use_gitoxide) {
@@ -804,7 +804,7 @@ fn run_create_branch(args: &Args, settings: &DaftSettings, output: &mut dyn Outp
         at_path: args.at.clone(),
     };
 
-    let hooks_config = HooksConfig::default();
+    let hooks_config = crate::core::settings::load_hooks_config()?;
     let executor = HookExecutor::new(hooks_config)?;
 
     if should_show_gitoxide_notice(settings.use_gitoxide) {

--- a/src/commands/clone.rs
+++ b/src/commands/clone.rs
@@ -22,7 +22,7 @@ use crate::{
     hints::{maybe_prompt_layout_choice, maybe_show_shell_hint, LayoutPromptResult},
     hooks::{
         get_remote_url_for_git_dir, yaml_config_loader, HookContext, HookExecutor, HookType,
-        HooksConfig, TrustDatabase, TrustLevel,
+        TrustDatabase, TrustLevel,
     },
     logging::init_logging,
     output::{
@@ -546,6 +546,15 @@ fn create_satellite_worktrees(
         change_directory(&repo_path)?;
     }
 
+    // Load once, clone per-iteration. Loader hits global git-config files,
+    // which are stable for the life of this command — no need to re-read
+    // per branch.
+    let shared_hooks_config = if !no_hooks {
+        Some(crate::core::settings::load_hooks_config_global()?)
+    } else {
+        None
+    };
+
     let mut created_count = 0;
     for branch in satellites {
         let worktree_path = if layout.needs_bare() {
@@ -579,9 +588,8 @@ fn create_satellite_worktrees(
         };
 
         // Run worktree-pre-create hook
-        if !no_hooks {
-            let hooks_config = HooksConfig::default();
-            if let Ok(mut executor) = HookExecutor::new(hooks_config) {
+        if let Some(ref hooks_config) = shared_hooks_config {
+            if let Ok(mut executor) = HookExecutor::new(hooks_config.clone()) {
                 if trust_hooks {
                     if let Some(fp) = get_remote_url_for_git_dir(&base_result.git_dir) {
                         let _ = executor.trust_repository_with_fingerprint(
@@ -640,7 +648,7 @@ fn create_satellite_worktrees(
                 created_count += 1;
 
                 // Run worktree-post-create hook
-                if !no_hooks {
+                if let Some(ref hooks_config) = shared_hooks_config {
                     // Link shared files before post-create hooks
                     crate::core::shared::link_shared_files_on_create(
                         &abs_worktree_path,
@@ -648,8 +656,7 @@ fn create_satellite_worktrees(
                         &base_result.parent_dir,
                     );
 
-                    let hooks_config = HooksConfig::default();
-                    if let Ok(mut executor) = HookExecutor::new(hooks_config) {
+                    if let Ok(mut executor) = HookExecutor::new(hooks_config.clone()) {
                         if trust_hooks {
                             if let Some(fp) = get_remote_url_for_git_dir(&base_result.git_dir) {
                                 let _ = executor.trust_repository_with_fingerprint(
@@ -859,8 +866,17 @@ fn create_satellite_worktrees_tui(
     let shared_git_dir = Arc::new(base_result.git_dir.clone());
     let shared_parent_dir = Arc::new(base_result.parent_dir.clone());
     let shared_remote_name_for_hooks = Arc::new(base_result.remote_name.clone());
-    let shared_no_hooks = no_hooks;
     let shared_trust_hooks = trust_hooks;
+    // Load once for the orchestrator thread; the base-post-create site and the
+    // per-satellite loop each clone from this. Loader hits global git-config
+    // files which are stable for the life of this command. `Option<None>`
+    // when --no-hooks was passed — the gates below (`if let Some`) replace
+    // the previous `if !no_hooks` checks.
+    let shared_hooks_config = if no_hooks {
+        None
+    } else {
+        Some(crate::core::settings::load_hooks_config_global()?)
+    };
     let shared_base_branch = base_branch.map(|s| s.to_string());
     let shared_base_path: Option<std::path::PathBuf> =
         worktree_infos.first().and_then(|info| info.path.clone());
@@ -887,9 +903,8 @@ fn create_satellite_worktrees_tui(
             });
 
             // Run worktree-post-create hook for the base worktree via TuiBridge
-            if !shared_no_hooks {
-                let hooks_cfg = HooksConfig::default();
-                if let Ok(mut executor) = HookExecutor::new(hooks_cfg) {
+            if let Some(ref hooks_cfg) = shared_hooks_config {
+                if let Ok(mut executor) = HookExecutor::new(hooks_cfg.clone()) {
                     if shared_trust_hooks {
                         if let Some(fp) = get_remote_url_for_git_dir(&shared_git_dir) {
                             let _ = executor.trust_repository_with_fingerprint(
@@ -955,11 +970,7 @@ fn create_satellite_worktrees_tui(
         }
 
         // Prepare hooks config for per-satellite executor creation
-        let hooks_config = if !shared_no_hooks {
-            Some(HooksConfig::default())
-        } else {
-            None
-        };
+        let hooks_config = shared_hooks_config.clone();
 
         // Process each satellite branch
         for (branch, worktree_path) in shared_satellite_paths.iter() {
@@ -1304,7 +1315,7 @@ fn run_post_clone_hook(
         return Ok(());
     }
 
-    let hooks_config = HooksConfig::default();
+    let hooks_config = crate::core::settings::load_hooks_config_global()?;
     let mut executor = HookExecutor::new(hooks_config)?;
 
     if args.trust_hooks {
@@ -1355,7 +1366,7 @@ fn run_post_create_hook(
         return Ok(());
     }
 
-    let hooks_config = HooksConfig::default();
+    let hooks_config = crate::core::settings::load_hooks_config_global()?;
     let mut executor = HookExecutor::new(hooks_config)?;
 
     if args.trust_hooks {

--- a/src/commands/clone.rs
+++ b/src/commands/clone.rs
@@ -546,9 +546,12 @@ fn create_satellite_worktrees(
         change_directory(&repo_path)?;
     }
 
-    // Load once, clone per-iteration. Loader hits global git-config files,
-    // which are stable for the life of this command — no need to re-read
-    // per branch.
+    // Load once, clone per-iteration — loader is stable for the life of
+    // this command, no need to re-read per branch. `_global` rather than
+    // local even though `change_directory(&repo_path)` above puts us inside
+    // the new repo: a freshly-cloned repo's `.git/config` is unlikely to
+    // hold daft-specific keys yet, and `_global` keeps this consistent
+    // with the orchestrator-thread site below — both pre-clone paths.
     let shared_hooks_config = if !no_hooks {
         Some(crate::core::settings::load_hooks_config_global()?)
     } else {
@@ -1315,6 +1318,13 @@ fn run_post_clone_hook(
         return Ok(());
     }
 
+    // `_global` rather than `load_hooks_config()`: cwd at this point is
+    // path-dependent (single-branch clone leaves cwd at the user's invocation
+    // dir; multi-branch sequential leaves it inside the new repo via
+    // `create_satellite_worktrees`). The local loader requires being inside a
+    // repo and would error in the former case. Repo-local overrides on a
+    // freshly-cloned repo are vanishingly rare in practice — a deliberate
+    // tradeoff for cwd-tolerance.
     let hooks_config = crate::core::settings::load_hooks_config_global()?;
     let mut executor = HookExecutor::new(hooks_config)?;
 
@@ -1366,6 +1376,8 @@ fn run_post_create_hook(
         return Ok(());
     }
 
+    // `_global` for the same cwd-tolerance reason as `run_post_clone_hook` —
+    // see the comment there.
     let hooks_config = crate::core::settings::load_hooks_config_global()?;
     let mut executor = HookExecutor::new(hooks_config)?;
 

--- a/src/commands/flow_adopt.rs
+++ b/src/commands/flow_adopt.rs
@@ -4,8 +4,7 @@ use crate::{
     get_git_common_dir,
     git::should_show_gitoxide_notice,
     hooks::{
-        get_remote_url_for_git_dir, HookContext, HookExecutor, HookType, HooksConfig,
-        TrustDatabase, TrustLevel,
+        get_remote_url_for_git_dir, HookContext, HookExecutor, HookType, TrustDatabase, TrustLevel,
     },
     logging::init_logging,
     output::{CliOutput, Output, OutputConfig},
@@ -152,7 +151,7 @@ fn run_adopt(args: &Args, settings: &DaftSettings, output: &mut dyn Output) -> R
     if !params.dry_run {
         output.start_spinner("Converting to worktree layout...");
     }
-    let hooks_config = HooksConfig::default();
+    let hooks_config = crate::core::settings::load_hooks_config()?;
     let executor = HookExecutor::new(hooks_config)?;
     let exec_result = {
         let mut bridge = CommandBridge::new(output, executor);
@@ -205,7 +204,7 @@ fn run_post_adopt_hook(
         return Ok(());
     }
 
-    let hooks_config = HooksConfig::default();
+    let hooks_config = crate::core::settings::load_hooks_config()?;
     let mut executor = HookExecutor::new(hooks_config)?;
 
     if args.trust_hooks {

--- a/src/commands/flow_eject.rs
+++ b/src/commands/flow_eject.rs
@@ -2,7 +2,7 @@ use crate::{
     core::{worktree::flow_eject, CommandBridge},
     get_git_common_dir,
     git::should_show_gitoxide_notice,
-    hooks::{HookExecutor, HooksConfig, TrustDatabase},
+    hooks::{HookExecutor, TrustDatabase},
     logging::init_logging,
     output::{CliOutput, Output, OutputConfig},
     settings::DaftSettings,
@@ -122,7 +122,7 @@ fn run_eject(args: &Args, settings: &DaftSettings, output: &mut dyn Output) -> R
         remote_name: settings.remote.clone(),
     };
 
-    let hooks_config = HooksConfig::default();
+    let hooks_config = crate::core::settings::load_hooks_config()?;
     let executor = HookExecutor::new(hooks_config)?;
 
     if should_show_gitoxide_notice(settings.use_gitoxide) {

--- a/src/commands/hooks/run_cmd.rs
+++ b/src/commands/hooks/run_cmd.rs
@@ -2,7 +2,7 @@ use super::{styled_trust_level, HooksRunArgs};
 use crate::executor::cli_presenter::CliPresenter;
 use crate::hooks::yaml_executor::JobFilter;
 use crate::hooks::{
-    yaml_config, yaml_config_loader, HookExecutor, HookType, HooksConfig, TrustDatabase, TrustLevel,
+    yaml_config, yaml_config_loader, HookExecutor, HookType, TrustDatabase, TrustLevel,
 };
 use crate::output::emit::{self, Cell, EmitArgs, EmitPayload, Section, Table};
 use crate::output::Output;
@@ -214,7 +214,7 @@ pub(super) fn cmd_run(args: &HooksRunArgs, output: &mut dyn Output) -> Result<()
         &branch_name,
     );
 
-    let mut hooks_config = HooksConfig::default();
+    let mut hooks_config = crate::core::settings::load_hooks_config()?;
     if args.verbose {
         hooks_config.output.verbose = true;
     }

--- a/src/commands/layout.rs
+++ b/src/commands/layout.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     get_current_worktree_path, get_git_common_dir,
     git::GitCommand,
-    hooks::{yaml_config_loader, HookExecutor, HooksConfig, TrustDatabase},
+    hooks::{yaml_config_loader, HookExecutor, TrustDatabase},
     is_git_repository,
     output::{
         emit::{self, Cell, EmitArgs, EmitPayload, Table},
@@ -693,7 +693,7 @@ fn cmd_transform(args: &TransformArgs, output: &mut dyn Output) -> Result<()> {
         remote: settings.remote.clone(),
         source_worktree: source.project_root.clone(),
     };
-    let mut hooks_config = HooksConfig::default();
+    let mut hooks_config = crate::core::settings::load_hooks_config()?;
     if args.verbose {
         hooks_config.output.verbose = true;
     }

--- a/src/commands/prune.rs
+++ b/src/commands/prune.rs
@@ -16,7 +16,7 @@ use crate::{
     },
     get_git_common_dir, get_project_root,
     git::{should_show_gitoxide_notice, GitCommand},
-    hooks::{HookExecutor, HooksConfig},
+    hooks::HookExecutor,
     is_git_repository,
     logging::init_logging,
     output::{
@@ -142,7 +142,7 @@ fn run_prune_inner(output: &mut dyn Output, settings: &DaftSettings, force: bool
         prune_cd_target: settings.prune_cd_target,
     };
 
-    let hooks_config = HooksConfig::default();
+    let hooks_config = crate::core::settings::load_hooks_config()?;
     let executor = HookExecutor::new(hooks_config)?;
 
     if should_show_gitoxide_notice(settings.use_gitoxide) {
@@ -326,7 +326,7 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
     // Capture count before worktree_infos is moved into OperationTable.
     let worktree_count = worktree_infos.len();
 
-    let hooks_config = HooksConfig::default();
+    let hooks_config = crate::core::settings::load_hooks_config()?;
 
     // ── Create channel and spawn orchestrator ──────────────────────────
     let (tx, rx) = std::sync::mpsc::channel();

--- a/src/commands/repo/remove.rs
+++ b/src/commands/repo/remove.rs
@@ -87,16 +87,7 @@ pub(crate) fn run_with_args(args: &Args) -> Result<()> {
     // Honor user-configured hook settings (timeout, output verbosity,
     // per-hook trust defaults). Loading from global mirrors the
     // `load_global()` call above — same rationale, same failure-mode
-    // tolerance for cwd-outside-any-repo invocations. Without this, long-
-    // running cleanup hooks (e.g. docker teardown, db dump) silently time
-    // out at the 300s default even when the user configured a larger
-    // budget. See finding #1 in <PR #448 review> for context.
-    //
-    // The codebase-wide pattern is `HooksConfig::default()` for nearly
-    // every command (clone, sync, flow_eject, worktree_branch, ...) —
-    // this site is intentionally inconsistent because the user-visible
-    // impact is sharpest here (long docker-teardown hooks). Tracking
-    // codebase-wide propagation in #456.
+    // tolerance for cwd-outside-any-repo invocations.
     let hooks_config = crate::core::settings::load_hooks_config_global()?;
 
     let target = resolve_repo(args.path.as_deref(), use_gitoxide)?;

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -27,7 +27,7 @@ use crate::{
     },
     get_git_common_dir, get_project_root,
     git::{should_show_gitoxide_notice, GitCommand},
-    hooks::{HookExecutor, HooksConfig},
+    hooks::HookExecutor,
     is_git_repository,
     logging::init_logging,
     output::{
@@ -483,7 +483,7 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
     if args.push {
         phases.push(sync_dag::OperationPhase::Push);
     }
-    let hooks_config = HooksConfig::default();
+    let hooks_config = crate::core::settings::load_hooks_config()?;
     let shared_hooks_config = Arc::new(hooks_config.clone());
 
     use crate::core::columns::{ColumnSelection, CommandKind};
@@ -1296,7 +1296,7 @@ fn run_prune_phase(
         prune_cd_target: settings.prune_cd_target,
     };
 
-    let hooks_config = HooksConfig::default();
+    let hooks_config = crate::core::settings::load_hooks_config()?;
     let executor = HookExecutor::new(hooks_config)?;
 
     output.start_spinner("Pruning stale branches...");

--- a/src/commands/worktree_branch.rs
+++ b/src/commands/worktree_branch.rs
@@ -4,7 +4,7 @@ use crate::{
         CommandBridge,
     },
     git::should_show_gitoxide_notice,
-    hooks::{HookExecutor, HooksConfig},
+    hooks::HookExecutor,
     is_git_repository,
     logging::init_logging,
     output::{CliOutput, Output, OutputConfig},
@@ -464,7 +464,7 @@ fn run_branch_delete(
         prune_cd_target: settings.prune_cd_target,
     };
 
-    let hooks_config = HooksConfig::default();
+    let hooks_config = crate::core::settings::load_hooks_config()?;
     let executor = HookExecutor::new(hooks_config)?;
 
     if should_show_gitoxide_notice(settings.use_gitoxide) {
@@ -558,7 +558,7 @@ fn run_rename_inner(
         output.warning("[experimental] Using gitoxide backend for git operations");
     }
 
-    let mut hooks_config = HooksConfig::default();
+    let mut hooks_config = crate::core::settings::load_hooks_config()?;
     if verbose {
         hooks_config.output.verbose = true;
     }

--- a/tests/manual/scenarios/hooks/config-disabled-respected.yml
+++ b/tests/manual/scenarios/hooks/config-disabled-respected.yml
@@ -1,0 +1,62 @@
+name: daft.hooks.enabled=false in git config disables hook execution
+description: >
+  Regression test for #456 — every hook-firing command used to construct a
+  `HooksConfig::default()` (enabled=true) instead of calling the loader, so
+  `daft.hooks.enabled=false` in user git config was silently ignored. With the
+  loader wired up, setting that key locally must skip hook execution. We
+  exercise the checkout path (worktree_branch.rs) as a representative site —
+  same loader call shape as every other command this PR touches.
+
+repos:
+  - name: test-hooks-config-disabled
+    default_branch: main
+    branches:
+      - name: main
+        files:
+          - path: README.md
+            content: "# Hook config test"
+        commits:
+          - message: "Initial commit"
+      - name: feature/skipped-hook
+        from: main
+    daft_yml: |
+      hooks:
+        worktree-post-create:
+          jobs:
+            - name: marker
+              run: |
+                touch "$DAFT_WORKTREE_PATH/.hook-fired"
+
+steps:
+  - name: Clone the repository
+    run:
+      git-worktree-clone --layout contained $REMOTE_TEST_HOOKS_CONFIG_DISABLED
+    expect:
+      exit_code: 0
+      files_exist:
+        - "$WORK_DIR/test-hooks-config-disabled/main/daft.yml"
+
+  - name: Trust the repository
+    run: daft hooks trust --force 2>&1
+    cwd: "$WORK_DIR/test-hooks-config-disabled/main"
+    expect:
+      exit_code: 0
+
+  - name: Set daft.hooks.enabled=false in repo-local config
+    run: git config --local daft.hooks.enabled false
+    cwd: "$WORK_DIR/test-hooks-config-disabled/main"
+    expect:
+      exit_code: 0
+
+  - name: Checkout feature branch — hooks must be skipped per config
+    run: git-worktree-checkout feature/skipped-hook 2>&1
+    cwd: "$WORK_DIR/test-hooks-config-disabled/main"
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-hooks-config-disabled/feature/skipped-hook"
+      # The marker file would exist if `daft.hooks.enabled=false` was
+      # ignored (the pre-fix behavior). Its absence proves the loader
+      # wired the user-set value through to the executor.
+      files_not_exist:
+        - "$WORK_DIR/test-hooks-config-disabled/feature/skipped-hook/.hook-fired"


### PR DESCRIPTION
## Summary

- Replace 21 `HooksConfig::default()` call sites across 11 command modules with `load_hooks_config[_global]()`. Every `daft.hooks.*` setting users wrote in their git config (`enabled`, `timeout`, `userDirectory`, `output.quiet`, ...) was previously ignored — the loaders existed but were never called outside `repo remove`.
- Pre-clone sites in `clone.rs` use `_global` (cwd may not be inside any repo). All in-repo commands use `load_hooks_config()` to pick up repo-local overrides too.
- Hoist the loader call out of `create_satellite_worktrees`'s per-branch loop and out of the `--all-branches` orchestrator's two construction sites — load once, clone per-iteration. Multi-branch clones no longer re-read global git config N times.

Fixes #456

## Test plan

- [x] `mise run fmt` clean
- [x] `mise run clippy` zero warnings
- [x] New regression test `tests/manual/scenarios/hooks/config-disabled-respected.yml` verified to **fail on master** (marker file created because `enabled=true` default ignored the user's `daft.hooks.enabled=false`) and **pass with the fix**
- [x] `clone/all-branches-hooks.yml` still passes (validates the loader-hoist refactor in `clone.rs`)
- [x] All other hook scenarios continue passing