### PR TITLE
fix(coordinator): honor needs: between background jobs (#454)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -373,6 +373,11 @@ Key behaviors:
 
 - Background jobs participate in the DAG. If a foreground job depends on a
   background job, the background job is promoted to foreground automatically.
+- `needs:` between background jobs is honored at runtime — the coordinator
+  schedules them in topological wave order. A background job with
+  `needs: [other-bg-job]` does not start until `other-bg-job` has terminated.
+- If a `needs:` dependency fails or is cancelled, the dependent background job
+  does not run; it is recorded as `Skipped` in `daft hooks jobs` listings.
 - `background: true` can be set at the hook level as a default for all jobs.
 - `DAFT_NO_BACKGROUND_JOBS=1` promotes all background jobs to foreground (useful
   in CI or for debugging).

--- a/docs/superpowers/plans/2026-05-02-bg-jobs-honor-needs.md
+++ b/docs/superpowers/plans/2026-05-02-bg-jobs-honor-needs.md
@@ -10,11 +10,15 @@ jobs, so that bg→bg dependencies are scheduled in topological order with
 parallel waves, matching the contract foreground jobs already enjoy.
 
 **Architecture:** Replace the coordinator's unconditional fan-out loop in
-`src/coordinator/process.rs::run_all_with_cancel` with a
-`DagGraph::run_parallel` call (the same scheduler primitive
-`runner.rs::run_dag_execution` uses). The existing per-job logic
-(`run_single_background_job`) becomes the closure body; its only required change
-is to return `NodeStatus` so the DAG can cascade failures and cancellations to
+`src/coordinator/process.rs::run_all_with_cancel` with a wave-based scheduler
+that uses `DagGraph` (in `src/executor/dag.rs`) for graph queries (cycle and
+missing-dep detection, dependent lookups) but executes each wave with bare
+`std::thread::spawn`/`JoinHandle::join` rather than `DagGraph::run_parallel`.
+`run_parallel` uses `std::thread::scope` internally, which can deadlock
+post-`libc::fork()` on macOS due to malloc-arena state inherited from the
+parent. The bare-spawn pattern matches what the pre-fix coordinator used and is
+known to work post-fork. The per-job logic (`run_single_background_job`) returns
+`NodeStatus` so the wave scheduler can cascade failures and cancellations to
 dependents.
 
 **Tech Stack:** Rust, existing `DagGraph` primitive (`src/executor/dag.rs`),

--- a/docs/superpowers/plans/2026-05-02-bg-jobs-honor-needs.md
+++ b/docs/superpowers/plans/2026-05-02-bg-jobs-honor-needs.md
@@ -1,0 +1,1018 @@
+# Background Jobs Honor `needs:` — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the background coordinator honor `needs:` between background
+jobs, so that bg→bg dependencies are scheduled in topological order with
+parallel waves, matching the contract foreground jobs already enjoy.
+
+**Architecture:** Replace the coordinator's unconditional fan-out loop in
+`src/coordinator/process.rs::run_all_with_cancel` with a
+`DagGraph::run_parallel` call (the same scheduler primitive
+`runner.rs::run_dag_execution` uses). The existing per-job logic
+(`run_single_background_job`) becomes the closure body; its only required change
+is to return `NodeStatus` so the DAG can cascade failures and cancellations to
+dependents.
+
+**Tech Stack:** Rust, existing `DagGraph` primitive (`src/executor/dag.rs`),
+existing coordinator infrastructure.
+
+**Reference issue:** [daft#454](https://github.com/avihut/daft/issues/454).
+
+---
+
+## File Structure
+
+### Modified files
+
+| File                                                               | Change                                                                                             |
+| ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------- |
+| `src/coordinator/process.rs`                                       | Replace fan-out loop with `DagGraph::run_parallel`; change `run_single_background_job` return type |
+| `src/coordinator/mod.rs`                                           | (No change expected — verify exports if tests need new visibility)                                 |
+| `tests/manual/scenarios/hooks/bg-needs-ordering.yml`               | New YAML scenario asserting bg→bg ordering via timestamp comparison                                |
+| `docs/superpowers/specs/2026-03-27-background-hook-jobs-design.md` | Already updated in the spec section that ships with this plan                                      |
+
+### Files NOT changed
+
+- `src/executor/dag.rs` — used as-is.
+- `src/executor/runner.rs` — foreground path unchanged.
+- `src/hooks/yaml_executor/partition.rs` — partition logic correct, no changes
+  needed.
+- `docs/guide/hooks.md` — user-facing behavior already documented; the bug was
+  purely an implementation drift.
+- `SKILL.md` — same reason.
+
+---
+
+## Task 1: Update spec doc to nail down the runtime contract
+
+**Files:**
+
+- Verify already-applied:
+  `docs/superpowers/specs/2026-03-27-background-hook-jobs-design.md`
+
+This update was applied alongside this plan. It adds a "Runtime contract for
+`needs:` (binding)" subsection under "DAG Integration" that:
+
+1. States bg jobs MUST wait for `needs:` deps to terminate.
+2. Pins down satisfied = `JobStatus::Completed`.
+3. Pins down `Failed`/`Cancelled`/`Skipped` deps cascade to `DepFailed`
+   dependents.
+4. Mandates cycle/missing-dep detection.
+5. Describes the closure status-mapping table (`Completed → Succeeded`; anything
+   else → `Failed`).
+
+- [ ] **Step 1: Confirm the spec section exists**
+
+```bash
+rg -n "Runtime contract for" docs/superpowers/specs/2026-03-27-background-hook-jobs-design.md
+```
+
+Expected: matches the heading line. If missing, re-apply the edit from the plan
+PR description.
+
+- [ ] **Step 2: Commit (if uncommitted)**
+
+```bash
+git add docs/superpowers/specs/2026-03-27-background-hook-jobs-design.md
+git commit -m "docs(spec): pin down bg-coordinator runtime contract for needs:"
+```
+
+---
+
+## Task 2: Write a failing ordering regression test
+
+**Files:**
+
+- Modify: `src/coordinator/process.rs` (inside `mod tests`)
+
+This test reproduces the issue ticket directly: B `needs: [A]` where A sleeps
+200ms; assert `B.started_at >= A.finished_at` from the on-disk `meta.json`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add at the bottom of `mod tests` in `src/coordinator/process.rs`:
+
+```rust
+#[test]
+fn bg_dependent_waits_for_dep_to_finish() {
+    // Regression test for daft#454: B `needs: [A]` must not start until A
+    // has terminated.
+    let (_tmp, store, child_pids, cancel_all, cancelled_jobs, _results) =
+        make_test_state();
+
+    let mut state = CoordinatorState::new("test-repo", "inv-needs-1")
+        .with_metadata("worktree-post-create", "worktree-post-create", "feat/x");
+
+    state.add_job(JobSpec {
+        name: "dep-a".to_string(),
+        command: "sleep 0.2 && echo done".to_string(),
+        working_dir: std::env::temp_dir(),
+        background: true,
+        ..Default::default()
+    });
+    state.add_job(JobSpec {
+        name: "dep-b".to_string(),
+        command: "echo b".to_string(),
+        working_dir: std::env::temp_dir(),
+        background: true,
+        needs: vec!["dep-a".to_string()],
+        ..Default::default()
+    });
+
+    state
+        .run_all_with_cancel(&store, &child_pids, &cancel_all, &cancelled_jobs)
+        .unwrap();
+
+    let dir_a = store.base_dir.join("inv-needs-1").join("dep-a");
+    let dir_b = store.base_dir.join("inv-needs-1").join("dep-b");
+    let meta_a = store.read_meta(&dir_a).expect("meta-a");
+    let meta_b = store.read_meta(&dir_b).expect("meta-b");
+
+    let a_finished = meta_a.finished_at.expect("a finished_at");
+    let b_started = meta_b.started_at;
+
+    assert!(
+        b_started >= a_finished,
+        "dep-b started ({b_started}) before dep-a finished ({a_finished})"
+    );
+    assert!(matches!(meta_a.status, JobStatus::Completed));
+    assert!(matches!(meta_b.status, JobStatus::Completed));
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cargo test --lib -p daft coordinator::process::tests::bg_dependent_waits_for_dep_to_finish
+```
+
+Expected: FAIL — `dep-b started ... before dep-a finished ...` (the bug).
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+git add src/coordinator/process.rs
+git commit -m "test(coordinator): add failing regression test for bg needs: ordering"
+```
+
+---
+
+## Task 3: Make `run_single_background_job` return `NodeStatus`
+
+**Files:**
+
+- Modify: `src/coordinator/process.rs` (the `run_single_background_job` fn,
+  lines 152-363)
+
+This change is a precondition for plugging the function into
+`DagGraph::run_parallel`. The DAG closure must return `NodeStatus`. Today the
+function returns `()` and pushes the result to a shared vec; we keep the push
+side-effect (used by tests and the `JobResult` collector) and add the return
+value on top.
+
+- [ ] **Step 1: Change the function signature and add the return statement**
+
+In `src/coordinator/process.rs`, edit the function declaration on line 152:
+
+```rust
+fn run_single_background_job(
+    job: &JobSpec,
+    ctx: &JobInvocationContext<'_>,
+    store: &LogStore,
+    results: &Arc<Mutex<Vec<JobResult>>>,
+    child_pids: &ChildPidMap,
+    cancel_all: &Arc<AtomicBool>,
+    cancelled_jobs: &CancelledJobs,
+) -> NodeStatus {
+```
+
+In the early-return cancel_all check (around line 169), change `return;` to
+`return NodeStatus::Failed;`:
+
+```rust
+if cancel_all.load(Ordering::Relaxed) {
+    results.lock().unwrap().push(JobResult {
+        name: job.name.clone(),
+        status: NodeStatus::Skipped,
+        duration: start.elapsed(),
+        exit_code: None,
+        stdout: String::new(),
+        stderr: "Cancelled before start".to_string(),
+    });
+    return NodeStatus::Failed;
+}
+```
+
+In the create-job-dir error path (around line 184), change `return;` to
+`return NodeStatus::Failed;`:
+
+```rust
+let job_dir = match store.create_job_dir(ctx.invocation_id, &job.name) {
+    Ok(dir) => dir,
+    Err(e) => {
+        eprintln!("daft: failed to create log dir for '{}': {e}", job.name);
+        results.lock().unwrap().push(JobResult {
+            name: job.name.clone(),
+            status: NodeStatus::Failed,
+            duration: start.elapsed(),
+            exit_code: None,
+            stdout: String::new(),
+            stderr: format!("Failed to create log dir: {e}"),
+        });
+        return NodeStatus::Failed;
+    }
+};
+```
+
+At the bottom of the function (after the existing
+`results.lock().unwrap().push(JobResult { ... })` call near the end of the fn),
+add the final return:
+
+```rust
+    results.lock().unwrap().push(JobResult {
+        name: job.name.clone(),
+        status: node_status,
+        duration,
+        exit_code,
+        stdout,
+        stderr,
+    });
+
+    // Map outcome to a DAG-cascade-friendly status. Cancelled and Skipped
+    // collapse to Failed because the dep did not produce its work product,
+    // so dependents must DepFailed via cascade. JobMeta on disk preserves
+    // the Completed/Failed/Cancelled distinction for `daft hooks jobs`.
+    if matches!(node_status, NodeStatus::Succeeded) {
+        NodeStatus::Succeeded
+    } else {
+        NodeStatus::Failed
+    }
+}
+```
+
+- [ ] **Step 2: Update existing test call sites**
+
+The standalone tests `run_single_background_job_registers_and_deregisters_pid`
+(line 1062), `per_job_cancel_marks_status_cancelled_not_failed` (line 1101),
+`silent_bg_output_deletes_log_on_success` (line 1148),
+`silent_bg_output_keeps_log_on_failure` (line 1181),
+`non_silent_bg_output_always_writes_log` (line 1216), and
+`silent_bg_output_keeps_log_when_status_is_cancelled` (line 1245) call
+`run_single_background_job` and discard the return value. Update each call to
+discard explicitly with `let _ =`:
+
+```rust
+let _ = run_single_background_job(
+    &job,
+    &ctx,
+    &store,
+    &results,
+    &child_pids,
+    &cancel_all,
+    &cancelled_jobs,
+);
+```
+
+This is needed because Rust will warn about unused `NodeStatus` Result-like
+values if not handled (and because clippy enforces `#![warn(unused_must_use)]`
+in the project).
+
+- [ ] **Step 3: Build to confirm the signature change compiles**
+
+```bash
+cargo build -p daft
+```
+
+Expected: clean build. If errors complain about callers, those are caught
+already in step 2 — the only callers are the tests.
+
+- [ ] **Step 4: Run all coordinator tests**
+
+```bash
+cargo test --lib -p daft coordinator::process::tests
+```
+
+Expected: all existing tests still pass (PID registration, cancel, silent
+output, etc.). The new ordering test (`bg_dependent_waits_for_dep_to_finish`)
+still fails — it depends on Task 4.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/coordinator/process.rs
+git commit -m "refactor(coordinator): return NodeStatus from run_single_background_job"
+```
+
+---
+
+## Task 4: Replace fan-out loop with `DagGraph::run_parallel`
+
+**Files:**
+
+- Modify: `src/coordinator/process.rs`, the body of `run_all_with_cancel` (lines
+  88-139)
+
+This is the core fix.
+
+- [ ] **Step 1: Add the new imports**
+
+At the top of `src/coordinator/process.rs`, alongside the existing executor
+imports (currently `use crate::executor::command::run_command;` and
+`use crate::executor::{JobResult, JobSpec, NodeStatus};`), extend the executor
+import to bring `DagGraph`:
+
+```rust
+use crate::executor::command::run_command;
+use crate::executor::dag::DagGraph;
+use crate::executor::{JobResult, JobSpec, NodeStatus};
+```
+
+- [ ] **Step 2: Replace the fan-out loop body**
+
+Replace the body of `run_all_with_cancel` (lines 88-139). The new body:
+
+```rust
+fn run_all_with_cancel(
+    &self,
+    store: &LogStore,
+    child_pids: &ChildPidMap,
+    cancel_all: &Arc<AtomicBool>,
+    cancelled_jobs: &CancelledJobs,
+) -> Result<Vec<JobResult>> {
+    if self.jobs.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Build the DAG from `needs:`. Reusing the same scheduler the foreground
+    // runner uses so foreground and background share one ordering contract.
+    let nodes: Vec<(String, Vec<String>)> = self
+        .jobs
+        .iter()
+        .map(|j| (j.name.clone(), j.needs.clone()))
+        .collect();
+    let graph = DagGraph::new(nodes)
+        .map_err(|e| anyhow::anyhow!("invalid background job DAG: {e}"))?;
+
+    let job_map: HashMap<&str, &JobSpec> = self
+        .jobs
+        .iter()
+        .map(|j| (j.name.as_str(), j))
+        .collect();
+
+    let results = Arc::new(Mutex::new(Vec::<JobResult>::new()));
+    let max_workers = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(4);
+
+    graph.run_parallel(
+        |_idx, name| {
+            let Some(job) = job_map.get(name).copied() else {
+                return NodeStatus::Failed;
+            };
+            let ctx = JobInvocationContext {
+                invocation_id: &self.invocation_id,
+                hook_type: &self.hook_type,
+                worktree: &self.worktree,
+            };
+            run_single_background_job(
+                job,
+                &ctx,
+                store,
+                &results,
+                child_pids,
+                cancel_all,
+                cancelled_jobs,
+            )
+        },
+        max_workers,
+    );
+
+    let results = match Arc::try_unwrap(results) {
+        Ok(mutex) => mutex.into_inner().unwrap_or_default(),
+        Err(arc) => arc.lock().unwrap().clone(),
+    };
+
+    Ok(results)
+}
+```
+
+Notes for the implementer:
+
+- The closure captures `self`, `store`, `child_pids`, `cancel_all`,
+  `cancelled_jobs`, `results`, and `job_map` by reference. Each is `Sync`
+  (Arc/Mutex/AtomicBool/&LogStore/HashMap-of-refs), so the resulting closure is
+  `Fn + Send + Sync` as required by `DagGraph::run_parallel`.
+- The previous code constructed a fresh `LogStore::new(store_base)` per thread;
+  this is unnecessary because `LogStore` is `{ base_dir: PathBuf }` and
+  trivially `Sync`. Pass `store` directly.
+- `Arc::try_unwrap` succeeds because `run_parallel` joins all workers before
+  returning, so no Arc clones survive.
+- `DagGraph::new` validates the graph: cycles and missing dependencies are
+  reported via `DagError`, which we wrap in `anyhow::Error` for the
+  `Result<Vec<JobResult>>` return.
+
+- [ ] **Step 3: Build**
+
+```bash
+cargo build -p daft
+```
+
+Expected: clean build.
+
+- [ ] **Step 4: Run the regression test**
+
+```bash
+cargo test --lib -p daft coordinator::process::tests::bg_dependent_waits_for_dep_to_finish
+```
+
+Expected: PASS — `dep-b` now waits for `dep-a` to finish.
+
+- [ ] **Step 5: Run all coordinator tests**
+
+```bash
+cargo test --lib -p daft coordinator
+```
+
+Expected: all pass, including the existing
+`test_run_all_with_cancel_skips_when_cancelled` (which has one job and no deps —
+closure runs once, sees cancel_all, pushes `Skipped` JobResult, returns Failed;
+results vec has one Skipped entry — same as before).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/coordinator/process.rs
+git commit -m "fix(coordinator): honor needs: between background jobs
+
+Closes #454.
+
+The coordinator's run_all_with_cancel previously spawned every background
+job as a thread immediately and joined them at the end, ignoring needs:.
+Reuses DagGraph from the foreground runner so foreground and background
+share the same scheduler primitive."
+```
+
+---
+
+## Task 5: Add a failure-cascade unit test
+
+**Files:**
+
+- Modify: `src/coordinator/process.rs` (inside `mod tests`)
+
+Verifies that when A fails, B `needs: [A]` is not spawned.
+
+- [ ] **Step 1: Write the test**
+
+Append to `mod tests`:
+
+```rust
+#[test]
+fn bg_dependent_skipped_when_dep_fails() {
+    let (_tmp, store, child_pids, cancel_all, cancelled_jobs, _results) =
+        make_test_state();
+
+    let mut state = CoordinatorState::new("test-repo", "inv-needs-fail-1")
+        .with_metadata("worktree-post-create", "worktree-post-create", "feat/x");
+
+    state.add_job(JobSpec {
+        name: "fails".to_string(),
+        command: "exit 7".to_string(),
+        working_dir: std::env::temp_dir(),
+        background: true,
+        ..Default::default()
+    });
+    state.add_job(JobSpec {
+        name: "dependent".to_string(),
+        command: "touch /tmp/should-never-exist-bg-needs-fail".to_string(),
+        working_dir: std::env::temp_dir(),
+        background: true,
+        needs: vec!["fails".to_string()],
+        ..Default::default()
+    });
+
+    // Make sure the marker file isn't lying around from a prior run.
+    let _ = std::fs::remove_file("/tmp/should-never-exist-bg-needs-fail");
+
+    state
+        .run_all_with_cancel(&store, &child_pids, &cancel_all, &cancelled_jobs)
+        .unwrap();
+
+    let meta_fails = store
+        .read_meta(&store.base_dir.join("inv-needs-fail-1").join("fails"))
+        .expect("meta fails");
+    assert!(matches!(meta_fails.status, JobStatus::Failed));
+
+    // The dependent's closure was never invoked, so no meta exists.
+    let dep_dir = store.base_dir.join("inv-needs-fail-1").join("dependent");
+    assert!(
+        !dep_dir.exists(),
+        "dependent should not have a job dir — its closure must not have run"
+    );
+
+    // Cleanup safety check.
+    assert!(
+        !std::path::Path::new("/tmp/should-never-exist-bg-needs-fail").exists(),
+        "dependent ran its command despite dep failing"
+    );
+}
+```
+
+- [ ] **Step 2: Run it**
+
+```bash
+cargo test --lib -p daft coordinator::process::tests::bg_dependent_skipped_when_dep_fails
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/coordinator/process.rs
+git commit -m "test(coordinator): assert failed bg dep cascades skip to dependents"
+```
+
+---
+
+## Task 6: Add a cancellation-cascade unit test
+
+**Files:**
+
+- Modify: `src/coordinator/process.rs` (inside `mod tests`)
+
+Verifies that when A is per-job-cancelled mid-run, B `needs: [A]` is not
+spawned.
+
+- [ ] **Step 1: Write the test**
+
+Append to `mod tests`:
+
+```rust
+#[test]
+fn bg_dependent_skipped_when_dep_cancelled() {
+    let (_tmp, store, child_pids, cancel_all, cancelled_jobs, _results) =
+        make_test_state();
+
+    let mut state = CoordinatorState::new("test-repo", "inv-needs-cancel-1")
+        .with_metadata("worktree-post-create", "worktree-post-create", "feat/x");
+
+    state.add_job(JobSpec {
+        name: "long".to_string(),
+        command: "sleep 5".to_string(),
+        working_dir: std::env::temp_dir(),
+        timeout: std::time::Duration::from_secs(30),
+        background: true,
+        ..Default::default()
+    });
+    state.add_job(JobSpec {
+        name: "after".to_string(),
+        command: "touch /tmp/should-never-exist-bg-needs-cancel".to_string(),
+        working_dir: std::env::temp_dir(),
+        background: true,
+        needs: vec!["long".to_string()],
+        ..Default::default()
+    });
+
+    let _ = std::fs::remove_file("/tmp/should-never-exist-bg-needs-cancel");
+
+    let pids = Arc::clone(&child_pids);
+    let cancelled = Arc::clone(&cancelled_jobs);
+    let store_for_killer = store.clone();
+    let killer = std::thread::spawn(move || {
+        std::thread::sleep(std::time::Duration::from_millis(200));
+        let _ = cancel_single_job("long", &pids, &cancelled, &store_for_killer);
+    });
+
+    state
+        .run_all_with_cancel(&store, &child_pids, &cancel_all, &cancelled_jobs)
+        .unwrap();
+    killer.join().unwrap();
+
+    let meta_long = store
+        .read_meta(&store.base_dir.join("inv-needs-cancel-1").join("long"))
+        .expect("meta long");
+    assert!(
+        matches!(meta_long.status, JobStatus::Cancelled),
+        "long should be Cancelled, got {:?}",
+        meta_long.status
+    );
+
+    let after_dir = store.base_dir.join("inv-needs-cancel-1").join("after");
+    assert!(
+        !after_dir.exists(),
+        "after's closure ran even though its dep was cancelled"
+    );
+    assert!(
+        !std::path::Path::new("/tmp/should-never-exist-bg-needs-cancel").exists(),
+        "after ran its command despite dep being cancelled"
+    );
+}
+```
+
+- [ ] **Step 2: Run it**
+
+```bash
+cargo test --lib -p daft coordinator::process::tests::bg_dependent_skipped_when_dep_cancelled
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/coordinator/process.rs
+git commit -m "test(coordinator): assert cancelled bg dep cascades skip to dependents"
+```
+
+---
+
+## Task 7: Add cycle / missing-dep error tests
+
+**Files:**
+
+- Modify: `src/coordinator/process.rs` (inside `mod tests`)
+
+Verifies that cycles and missing-dep references in the bg bucket are surfaced as
+errors rather than silently fanning out (per the Runtime Contract, clause 4).
+
+- [ ] **Step 1: Write the tests**
+
+Append to `mod tests`:
+
+```rust
+#[test]
+fn bg_cycle_in_needs_returns_error() {
+    let (_tmp, store, child_pids, cancel_all, cancelled_jobs, _results) =
+        make_test_state();
+
+    let mut state = CoordinatorState::new("test-repo", "inv-cycle-1")
+        .with_metadata("worktree-post-create", "worktree-post-create", "feat/x");
+
+    state.add_job(JobSpec {
+        name: "a".to_string(),
+        command: "echo a".to_string(),
+        background: true,
+        needs: vec!["b".to_string()],
+        ..Default::default()
+    });
+    state.add_job(JobSpec {
+        name: "b".to_string(),
+        command: "echo b".to_string(),
+        background: true,
+        needs: vec!["a".to_string()],
+        ..Default::default()
+    });
+
+    let result =
+        state.run_all_with_cancel(&store, &child_pids, &cancel_all, &cancelled_jobs);
+    assert!(result.is_err(), "cycle should be reported as an error");
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("invalid background job DAG"),
+        "error should mention invalid DAG, got: {msg}"
+    );
+}
+
+#[test]
+fn bg_missing_dep_in_needs_returns_error() {
+    let (_tmp, store, child_pids, cancel_all, cancelled_jobs, _results) =
+        make_test_state();
+
+    let mut state = CoordinatorState::new("test-repo", "inv-missing-1")
+        .with_metadata("worktree-post-create", "worktree-post-create", "feat/x");
+
+    state.add_job(JobSpec {
+        name: "only".to_string(),
+        command: "echo only".to_string(),
+        background: true,
+        needs: vec!["does-not-exist".to_string()],
+        ..Default::default()
+    });
+
+    let result =
+        state.run_all_with_cancel(&store, &child_pids, &cancel_all, &cancelled_jobs);
+    assert!(
+        result.is_err(),
+        "missing dep should be reported as an error"
+    );
+}
+```
+
+- [ ] **Step 2: Run them**
+
+```bash
+cargo test --lib -p daft coordinator::process::tests::bg_cycle_in_needs_returns_error coordinator::process::tests::bg_missing_dep_in_needs_returns_error
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/coordinator/process.rs
+git commit -m "test(coordinator): bg DAG errors on cycles and missing deps"
+```
+
+---
+
+## Task 8: Add a YAML scenario for end-to-end ordering
+
+**Files:**
+
+- Create: `tests/manual/scenarios/hooks/bg-needs-ordering.yml`
+
+End-to-end test: two background jobs, second `needs:` first; assert ordering via
+timestamps in the recorded `meta.json`.
+
+- [ ] **Step 1: Write the scenario**
+
+Create `tests/manual/scenarios/hooks/bg-needs-ordering.yml`:
+
+```yaml
+name: Background bg→bg ordering honors needs
+description:
+  "Two background jobs where the second `needs:` the first. The second job's
+  meta.json must record started_at >= the first's finished_at — i.e., the
+  coordinator must not race them. Regression test for daft#454."
+
+repos:
+  - name: test-bg-needs
+    default_branch: main
+    branches:
+      - name: main
+        files:
+          - path: README.md
+            content: "# bg needs ordering"
+        commits:
+          - message: "Initial commit"
+      - name: feature/bg-needs
+        from: main
+    daft_yml: |
+      hooks:
+        worktree-post-create:
+          jobs:
+            - name: dep-a
+              background: true
+              run: |
+                sleep 0.5
+                date -u +%s%N > "$DAFT_WORKTREE_PATH/.a-finished-ns"
+            - name: dep-b
+              background: true
+              needs: [dep-a]
+              run: |
+                date -u +%s%N > "$DAFT_WORKTREE_PATH/.b-started-ns"
+
+steps:
+  - name: Clone the repository
+    run: git-worktree-clone --layout contained $REMOTE_TEST_BG_NEEDS
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-bg-needs/main"
+
+  - name: Trust the repository
+    run: daft hooks trust --force 2>&1
+    cwd: "$WORK_DIR/test-bg-needs/main"
+    expect:
+      exit_code: 0
+
+  - name: Checkout feature branch (triggers worktree-post-create hooks)
+    run: git-worktree-checkout feature/bg-needs 2>&1
+    cwd: "$WORK_DIR/test-bg-needs/main"
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-bg-needs/feature/bg-needs"
+
+  - name: Wait for both background jobs to finish (poll for B's marker)
+    run: |
+      for i in $(seq 1 40); do
+        if [ -f "$WORK_DIR/test-bg-needs/feature/bg-needs/.b-started-ns" ]; then
+          echo "BOTH_MARKERS_PRESENT"
+          exit 0
+        fi
+        sleep 0.5
+      done
+      echo "BG_NEEDS_TIMEOUT"
+      exit 1
+    expect:
+      exit_code: 0
+      output_contains:
+        - "BOTH_MARKERS_PRESENT"
+
+  - name: Assert dep-b started AFTER dep-a finished
+    run: |
+      A_FINISHED=$(cat "$WORK_DIR/test-bg-needs/feature/bg-needs/.a-finished-ns")
+      B_STARTED=$(cat "$WORK_DIR/test-bg-needs/feature/bg-needs/.b-started-ns")
+      echo "a_finished_ns=$A_FINISHED"
+      echo "b_started_ns=$B_STARTED"
+      if [ "$B_STARTED" -lt "$A_FINISHED" ]; then
+        echo "ORDERING_VIOLATION: dep-b started before dep-a finished"
+        exit 1
+      fi
+      echo "ORDERING_OK"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "ORDERING_OK"
+```
+
+Notes:
+
+- macOS `date` does not support `+%s%N` as nanoseconds; on Linux it does. GitHub
+  CI runs on both. The CI matrix runs `mise run test:integration` which executes
+  scenarios via the YAML harness. If `%N` proves unportable, swap to a
+  `python -c "import time; print(time.time_ns())"` invocation in step 4.
+  **Implementer: verify on macOS first** — run
+  `mise run test:manual -- --ci hooks/bg-needs-ordering` locally and check
+  whether `%N` produces nanoseconds or a literal `N`. If the latter, fall back
+  to `python -c 'import time; print(time.time_ns())'`.
+
+- [ ] **Step 2: Run the scenario locally**
+
+```bash
+mise run test:manual -- --ci hooks/bg-needs-ordering
+```
+
+Expected: PASS. If `%N` returns a literal `N` on macOS, edit the scenario to use
+`python -c 'import time; print(time.time_ns())'` for both timestamps, re-run,
+and re-check.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/manual/scenarios/hooks/bg-needs-ordering.yml
+git commit -m "test(hooks): YAML scenario for bg→bg needs: ordering (regresses #454)"
+```
+
+---
+
+## Task 9: Run the full test suite, lint, format
+
+**Files:**
+
+- None — verification only.
+
+- [ ] **Step 1: Format**
+
+```bash
+mise run fmt
+```
+
+Expected: no diffs (or all generated diffs are intentional).
+
+- [ ] **Step 2: Format check**
+
+```bash
+mise run fmt:check
+```
+
+Expected: clean.
+
+- [ ] **Step 3: Clippy**
+
+```bash
+mise run clippy
+```
+
+Expected: zero warnings. If clippy complains about the `Fn` closure captures,
+prefer adjusting the closure body rather than `#[allow]`-ing.
+
+- [ ] **Step 4: Unit tests**
+
+```bash
+mise run test:unit
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Integration tests**
+
+```bash
+mise run test:integration
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit any fmt/clippy fixups**
+
+```bash
+git status
+# If fmt/clippy made changes:
+git add -p
+git commit -m "chore: fmt/clippy fixups for bg coordinator scheduler"
+```
+
+(If no changes, skip.)
+
+---
+
+## Task 10: Push and open the PR
+
+**Files:**
+
+- None.
+
+- [ ] **Step 1: Push**
+
+```bash
+git push -u origin daft-454/fix/background-job-coordinator-ignores-needs
+```
+
+- [ ] **Step 2: Open PR**
+
+PR title (conventional commit, ≤70 chars):
+
+> `fix(coordinator): honor needs: between background jobs (#454)`
+
+PR body — copy-paste:
+
+```markdown
+## Summary
+
+- Reuse the foreground `DagGraph` scheduler in the background coordinator so
+  bg→bg `needs:` is honored at runtime, not just on paper.
+- `run_single_background_job` now returns `NodeStatus`; the closure passed to
+  `DagGraph::run_parallel` carries the existing per-job logic (PID registration,
+  log streaming, `meta.json` lifecycle) unchanged.
+- Cancelled / failed deps cascade `DepFailed` to dependents (no spawn).
+
+Fixes #454.
+
+## Test plan
+
+- [x] Unit: `bg_dependent_waits_for_dep_to_finish` (regression for #454)
+- [x] Unit: `bg_dependent_skipped_when_dep_fails`
+- [x] Unit: `bg_dependent_skipped_when_dep_cancelled`
+- [x] Unit: `bg_cycle_in_needs_returns_error`,
+      `bg_missing_dep_in_needs_returns_error`
+- [x] YAML scenario: `tests/manual/scenarios/hooks/bg-needs-ordering.yml`
+- [x] All existing coordinator tests still pass
+- [x] `mise run fmt:check`, `mise run clippy`, `mise run test:unit`,
+      `mise run test:integration`
+```
+
+PR tags (per `CLAUDE.md`):
+
+- Assignee: `avihut`
+- Label: `fix`
+- Milestone: `Public Launch`
+
+```bash
+gh pr create \
+  --title "fix(coordinator): honor needs: between background jobs (#454)" \
+  --assignee avihut \
+  --label fix \
+  --milestone "Public Launch" \
+  --body-file <(cat <<'EOF'
+## Summary
+
+- Reuse the foreground `DagGraph` scheduler in the background coordinator so
+  bg→bg `needs:` is honored at runtime, not just on paper.
+- `run_single_background_job` now returns `NodeStatus`; the closure passed
+  to `DagGraph::run_parallel` carries the existing per-job logic unchanged.
+- Cancelled / failed deps cascade `DepFailed` to dependents (no spawn).
+
+Fixes #454.
+
+## Test plan
+
+- [x] Unit: `bg_dependent_waits_for_dep_to_finish` (regression for #454)
+- [x] Unit: `bg_dependent_skipped_when_dep_fails`
+- [x] Unit: `bg_dependent_skipped_when_dep_cancelled`
+- [x] Unit: `bg_cycle_in_needs_returns_error`, `bg_missing_dep_in_needs_returns_error`
+- [x] YAML scenario: `tests/manual/scenarios/hooks/bg-needs-ordering.yml`
+- [x] All existing coordinator tests still pass
+- [x] `mise run fmt:check`, `mise run clippy`, `mise run test:unit`, `mise run test:integration`
+EOF
+)
+```
+
+- [ ] **Step 3: Confirm PR is open and tagged**
+
+```bash
+gh pr view --json title,labels,assignees,milestone
+```
+
+Expected: title matches, label `fix`, assignee `avihut`, milestone
+`Public Launch`.
+
+---
+
+## Self-review checklist
+
+- [x] Spec coverage: each requirement in the Runtime Contract section maps to at
+      least one task (1–7).
+- [x] No placeholders: every step contains the actual code or command.
+- [x] Type consistency: `NodeStatus`, `JobStatus`, `JobSpec`, `JobMeta`,
+      `LogStore`, `DagGraph` names are used identically across tasks; the
+      `run_single_background_job` signature change is propagated to all caller
+      sites in Task 3.
+- [x] All file paths are absolute-from-repo-root.
+- [x] All commands include the daft `mise` task or `cargo` invocation as used by
+      `CLAUDE.md`.

--- a/docs/superpowers/specs/2026-03-27-background-hook-jobs-design.md
+++ b/docs/superpowers/specs/2026-03-27-background-hook-jobs-design.md
@@ -156,6 +156,56 @@ The `background` flag is orthogonal to `needs`. It only affects whether a job
 blocks the daft command from returning — it does not change dependency
 resolution.
 
+### Runtime contract for `needs:` (binding)
+
+The background coordinator is bound by the same dependency-ordering contract the
+foreground runner provides. Stating it explicitly so the binary can be audited
+against the spec:
+
+1. A background job whose `needs:` list is non-empty MUST NOT begin executing
+   its command until every listed dependency has reached a terminal state.
+2. A dependency is **satisfied** only when it terminates with
+   `JobStatus::Completed`.
+3. If a dependency terminates `Failed`, `Cancelled`, or `Skipped` (e.g. routed
+   through a `cancel_all` at-start gate), every transitive dependent MUST be
+   marked as not-run (`NodeStatus::DepFailed`) and MUST NOT spawn a child
+   process.
+4. The scheduler MUST detect cycles and missing-dependency references in the
+   background bucket and surface them as errors rather than silently fanning
+   out.
+
+The runtime SHOULD share the foreground scheduler primitive (`DagGraph` in
+`src/executor/dag.rs`) so foreground and background share one source of truth
+for ordering, parallelism, and failure cascading. Coordinator-specific behavior
+(PID registration for `daft hooks jobs cancel`, log streaming to `output.log`,
+`meta.json` lifecycle, silent-mode log deletion) lives in the per-job closure
+passed to the scheduler — not in the scheduler itself.
+
+### Status mapping for cascade decisions
+
+The bg per-job closure maps execution outcome to `NodeStatus` for the DAG
+scheduler:
+
+| Outcome                                              | `JobMeta.status` | `NodeStatus` returned to DAG |
+| ---------------------------------------------------- | ---------------- | ---------------------------- |
+| Command exited 0                                     | `Completed`      | `Succeeded`                  |
+| Command exited non-zero                              | `Failed`         | `Failed`                     |
+| Per-job cancel (`daft hooks jobs cancel <name>`)     | `Cancelled`      | `Failed`                     |
+| `cancel_all` flipped before the closure ran          | `Cancelled`      | `Failed`                     |
+| `cancel_all` flipped while the closure was executing | `Cancelled`      | `Failed`                     |
+
+`Cancelled` and `Skipped` are mapped to `NodeStatus::Failed` for cascade
+purposes because the dependency did not produce its work product, and any job
+that declared `needs: [<dep>]` cannot be assumed to be safe to run. The on-disk
+`JobMeta.status` (read by `daft hooks jobs`) preserves the precise distinction
+between `Failed` and `Cancelled`; only the DAG cascade collapses them.
+
+This intentionally diverges from the foreground rule that "skipped deps are
+considered satisfied" (which exists because foreground `Skipped` is normally
+caused by an `if:` condition voluntarily declining to run). In the bg
+coordinator, `Skipped`/`Cancelled` always means "did not actually run" and must
+propagate.
+
 ### Partitioning Algorithm
 
 1. Build the full DAG as today (all jobs, foreground and background).

--- a/docs/superpowers/specs/2026-03-27-background-hook-jobs-design.md
+++ b/docs/superpowers/specs/2026-03-27-background-hook-jobs-design.md
@@ -178,8 +178,20 @@ The runtime SHOULD share the foreground scheduler primitive (`DagGraph` in
 `src/executor/dag.rs`) so foreground and background share one source of truth
 for ordering, parallelism, and failure cascading. Coordinator-specific behavior
 (PID registration for `daft hooks jobs cancel`, log streaming to `output.log`,
-`meta.json` lifecycle, silent-mode log deletion) lives in the per-job closure
-passed to the scheduler — not in the scheduler itself.
+`meta.json` lifecycle, silent-mode log deletion) lives in the per-job thread
+body — not in the scheduler itself.
+
+**Constraint — `std::thread::scope` post-`fork()`:** The coordinator runs in a
+forked child (`libc::fork()` in `fork_coordinator`). On macOS, executing
+`std::thread::scope` after `fork()` can deadlock because the malloc arenas
+inherited from the parent are in an inconsistent state — the second
+`format!`/allocation inside a scoped worker can hang. Therefore the bg scheduler
+MUST NOT use `DagGraph::run_parallel` (which is built on `thread::scope`). The
+coordinator instead uses `DagGraph` only for graph queries (`new`, `len`,
+`dependencies_of`, `dependents_of`) and executes each wave with bare
+`std::thread::spawn`/`JoinHandle::join` — the same primitive the pre-fix
+coordinator used. The foreground runner is unaffected because it runs in the
+parent process, not post-fork.
 
 ### Status mapping for cascade decisions
 

--- a/src/coordinator/process.rs
+++ b/src/coordinator/process.rs
@@ -115,7 +115,7 @@ impl CoordinatorState {
             .map(|n| n.get())
             .unwrap_or(4);
 
-        graph.run_parallel(
+        let statuses = graph.run_parallel(
             |_idx, name| {
                 let Some(job) = job_map.get(name).copied() else {
                     return NodeStatus::Failed;
@@ -137,6 +137,47 @@ impl CoordinatorState {
             },
             max_workers,
         );
+
+        // Synthesize meta + JobResult for jobs the DAG marked DepFailed (the
+        // closure is not invoked for them, so they would otherwise be invisible
+        // to `daft hooks jobs`).
+        for (idx, status) in statuses.iter().enumerate() {
+            if *status != NodeStatus::DepFailed {
+                continue;
+            }
+            let Some(job) = self.jobs.get(idx) else {
+                continue;
+            };
+            if let Ok(job_dir) = store.create_job_dir(&self.invocation_id, &job.name) {
+                let meta = JobMeta::skipped(
+                    &job.name,
+                    &self.hook_type,
+                    &self.worktree,
+                    &job.command,
+                    job.background,
+                    job.needs.clone(),
+                );
+                if let Err(e) = store.write_meta(&job_dir, &meta) {
+                    eprintln!(
+                        "daft: failed to write dep-failed meta for '{}': {e}",
+                        job.name
+                    );
+                }
+            } else {
+                eprintln!(
+                    "daft: failed to create dep-failed log dir for '{}'",
+                    job.name
+                );
+            }
+            results.lock().unwrap().push(JobResult {
+                name: job.name.clone(),
+                status: NodeStatus::DepFailed,
+                duration: std::time::Duration::ZERO,
+                exit_code: None,
+                stdout: String::new(),
+                stderr: "Dependency failed; job did not run".to_string(),
+            });
+        }
 
         let results = match Arc::try_unwrap(results) {
             Ok(mutex) => mutex.into_inner().unwrap_or_default(),
@@ -682,8 +723,27 @@ pub fn fork_coordinator(
             .ok();
 
             // Run all jobs (blocking).
-            let _results =
-                state.run_all_with_cancel(&store, &child_pids, &cancel_all, &cancelled_jobs)?;
+            let _results = match state.run_all_with_cancel(
+                &store,
+                &child_pids,
+                &cancel_all,
+                &cancelled_jobs,
+            ) {
+                Ok(r) => r,
+                Err(e) => {
+                    eprintln!("daft: coordinator error: {e}");
+                    // Best-effort cleanup of the listener and PID file before exiting.
+                    shutdown.store(true, Ordering::Relaxed);
+                    if let Some((handle, socket_path)) = listener_handle {
+                        std::fs::remove_file(&socket_path).ok();
+                        handle.join().ok();
+                    }
+                    if let Some(path) = pid_path {
+                        std::fs::remove_file(&path).ok();
+                    }
+                    process::exit(1);
+                }
+            };
 
             // Signal the listener to stop and wait for it.
             shutdown.store(true, Ordering::Relaxed);

--- a/src/coordinator/process.rs
+++ b/src/coordinator/process.rs
@@ -113,7 +113,9 @@ impl CoordinatorState {
                     hook_type: &hook_type,
                     worktree: &worktree,
                 };
-                run_single_background_job(
+                // TODO(daft#454, Task 4): plug this into DagGraph::run_parallel and
+                // propagate the NodeStatus instead of discarding it.
+                let _ = run_single_background_job(
                     &job,
                     &ctx,
                     &local_store,

--- a/src/coordinator/process.rs
+++ b/src/coordinator/process.rs
@@ -1545,4 +1545,63 @@ mod tests {
             "after ran its command despite dep being cancelled"
         );
     }
+
+    #[test]
+    fn bg_cycle_in_needs_returns_error() {
+        let (_tmp, store, child_pids, cancel_all, cancelled_jobs, _results) = make_test_state();
+
+        let mut state = CoordinatorState::new("test-repo", "inv-cycle-1").with_metadata(
+            "worktree-post-create",
+            "worktree-post-create",
+            "feat/x",
+        );
+
+        state.add_job(JobSpec {
+            name: "a".to_string(),
+            command: "echo a".to_string(),
+            background: true,
+            needs: vec!["b".to_string()],
+            ..Default::default()
+        });
+        state.add_job(JobSpec {
+            name: "b".to_string(),
+            command: "echo b".to_string(),
+            background: true,
+            needs: vec!["a".to_string()],
+            ..Default::default()
+        });
+
+        let result = state.run_all_with_cancel(&store, &child_pids, &cancel_all, &cancelled_jobs);
+        assert!(result.is_err(), "cycle should be reported as an error");
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("invalid background job DAG"),
+            "error should mention invalid DAG, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn bg_missing_dep_in_needs_returns_error() {
+        let (_tmp, store, child_pids, cancel_all, cancelled_jobs, _results) = make_test_state();
+
+        let mut state = CoordinatorState::new("test-repo", "inv-missing-1").with_metadata(
+            "worktree-post-create",
+            "worktree-post-create",
+            "feat/x",
+        );
+
+        state.add_job(JobSpec {
+            name: "only".to_string(),
+            command: "echo only".to_string(),
+            background: true,
+            needs: vec!["does-not-exist".to_string()],
+            ..Default::default()
+        });
+
+        let result = state.run_all_with_cancel(&store, &child_pids, &cancel_all, &cancelled_jobs);
+        assert!(
+            result.is_err(),
+            "missing dep should be reported as an error"
+        );
+    }
 }

--- a/src/coordinator/process.rs
+++ b/src/coordinator/process.rs
@@ -107,39 +107,100 @@ impl CoordinatorState {
         let graph =
             DagGraph::new(nodes).map_err(|e| anyhow::anyhow!("invalid background job DAG: {e}"))?;
 
-        let job_map: HashMap<&str, &JobSpec> =
-            self.jobs.iter().map(|j| (j.name.as_str(), j)).collect();
-
         let results = Arc::new(Mutex::new(Vec::<JobResult>::new()));
-        let max_workers = std::thread::available_parallelism()
-            .map(|n| n.get())
-            .unwrap_or(4);
 
-        let statuses = graph.run_parallel(
-            |_idx, name| {
-                let Some(job) = job_map.get(name).copied() else {
-                    return NodeStatus::Failed;
-                };
-                let ctx = JobInvocationContext {
-                    invocation_id: &self.invocation_id,
-                    hook_type: &self.hook_type,
-                    worktree: &self.worktree,
-                };
-                run_single_background_job(
-                    job,
-                    &ctx,
-                    store,
-                    &results,
-                    child_pids,
-                    cancel_all,
-                    cancelled_jobs,
-                )
-            },
-            max_workers,
-        );
+        // Wave-based scheduler. We use DagGraph for cycle/missing-dep
+        // detection and dependent lookups, but execute each wave with bare
+        // `std::thread::spawn` (matching master's per-job spawn pattern)
+        // rather than `DagGraph::run_parallel`. The reason is platform-
+        // specific: `run_parallel` uses `std::thread::scope`, which can
+        // deadlock post-`libc::fork()` on macOS due to malloc-arena state
+        // inherited from the parent. Bare `thread::spawn` does not exhibit
+        // this — the buggy pre-fix coordinator used the same primitive.
+        let n = graph.len();
+        let mut statuses = vec![NodeStatus::Pending; n];
+        let mut in_degree: Vec<usize> = (0..n).map(|i| graph.dependencies_of(i).len()).collect();
+        let mut ready: Vec<usize> = (0..n).filter(|&i| in_degree[i] == 0).collect();
 
-        // Synthesize meta + JobResult for jobs the DAG marked DepFailed (the
-        // closure is not invoked for them, so they would otherwise be invisible
+        while !ready.is_empty() {
+            // Spawn one worker per ready node. Inputs are cloned per-spawn,
+            // matching the pre-fix per-thread cloning pattern.
+            let mut handles: Vec<(usize, std::thread::JoinHandle<NodeStatus>)> = Vec::new();
+            for &idx in &ready {
+                statuses[idx] = NodeStatus::Running;
+
+                let job = self.jobs[idx].clone();
+                let inv_id = self.invocation_id.clone();
+                let store_base = store.base_dir.clone();
+                let hook_type = self.hook_type.clone();
+                let worktree = self.worktree.clone();
+                let results_clone = Arc::clone(&results);
+                let child_pids_clone = Arc::clone(child_pids);
+                let cancel_all_clone = Arc::clone(cancel_all);
+                let cancelled_jobs_clone = Arc::clone(cancelled_jobs);
+
+                let handle = std::thread::spawn(move || {
+                    let local_store = LogStore::new(store_base);
+                    let ctx = JobInvocationContext {
+                        invocation_id: &inv_id,
+                        hook_type: &hook_type,
+                        worktree: &worktree,
+                    };
+                    run_single_background_job(
+                        &job,
+                        &ctx,
+                        &local_store,
+                        &results_clone,
+                        &child_pids_clone,
+                        &cancel_all_clone,
+                        &cancelled_jobs_clone,
+                    )
+                });
+                handles.push((idx, handle));
+            }
+
+            // Wait for the wave to finish. A panicked worker is treated as a
+            // Failed outcome so the cascade still fires.
+            let wave_outcomes: Vec<(usize, NodeStatus)> = handles
+                .into_iter()
+                .map(|(idx, handle)| (idx, handle.join().unwrap_or(NodeStatus::Failed)))
+                .collect();
+
+            // Apply outcomes and compute the next wave.
+            let mut next_ready: Vec<usize> = Vec::new();
+            for (idx, status) in wave_outcomes {
+                statuses[idx] = status;
+                match status {
+                    NodeStatus::Succeeded | NodeStatus::Skipped => {
+                        for &dep_idx in graph.dependents_of(idx) {
+                            if statuses[dep_idx] == NodeStatus::Pending {
+                                in_degree[dep_idx] -= 1;
+                                if in_degree[dep_idx] == 0 {
+                                    next_ready.push(dep_idx);
+                                }
+                            }
+                        }
+                    }
+                    NodeStatus::Failed => {
+                        // Cascade DepFailed to all transitive Pending dependents.
+                        let mut stack = vec![idx];
+                        while let Some(i) = stack.pop() {
+                            for &d in graph.dependents_of(i) {
+                                if statuses[d] == NodeStatus::Pending {
+                                    statuses[d] = NodeStatus::DepFailed;
+                                    stack.push(d);
+                                }
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            ready = next_ready;
+        }
+
+        // Synthesize meta + JobResult for jobs the scheduler marked DepFailed
+        // (their closure was not invoked, so they would otherwise be invisible
         // to `daft hooks jobs`).
         for (idx, status) in statuses.iter().enumerate() {
             if *status != NodeStatus::DepFailed {

--- a/src/coordinator/process.rs
+++ b/src/coordinator/process.rs
@@ -157,7 +157,7 @@ fn run_single_background_job(
     child_pids: &ChildPidMap,
     cancel_all: &Arc<AtomicBool>,
     cancelled_jobs: &CancelledJobs,
-) {
+) -> NodeStatus {
     let start = Instant::now();
 
     let is_silent = matches!(
@@ -175,7 +175,7 @@ fn run_single_background_job(
             stdout: String::new(),
             stderr: "Cancelled before start".to_string(),
         });
-        return;
+        return NodeStatus::Failed;
     }
 
     // 1. Create the job log directory.
@@ -191,7 +191,7 @@ fn run_single_background_job(
                 stdout: String::new(),
                 stderr: format!("Failed to create log dir: {e}"),
             });
-            return;
+            return NodeStatus::Failed;
         }
     };
 
@@ -360,6 +360,16 @@ fn run_single_background_job(
         stdout,
         stderr,
     });
+
+    // Map outcome to a DAG-cascade-friendly status. Cancelled and Skipped
+    // collapse to Failed because the dep did not produce its work product,
+    // so dependents must DepFailed via cascade. JobMeta on disk preserves
+    // the Completed/Failed/Cancelled distinction for `daft hooks jobs`.
+    if matches!(node_status, NodeStatus::Succeeded) {
+        NodeStatus::Succeeded
+    } else {
+        NodeStatus::Failed
+    }
 }
 
 /// Start a Unix socket listener that handles IPC requests from CLI clients.
@@ -1076,7 +1086,7 @@ mod tests {
             pids_probe.lock().unwrap().clone()
         });
 
-        run_single_background_job(
+        let _ = run_single_background_job(
             &job,
             &ctx,
             &store,
@@ -1124,7 +1134,7 @@ mod tests {
             })
         };
 
-        run_single_background_job(
+        let _ = run_single_background_job(
             &job,
             &ctx,
             &store,
@@ -1159,7 +1169,7 @@ mod tests {
         let inv_id = "00000000-0000-0000-0000-000000000003".to_string();
         let ctx = make_ctx(&inv_id);
 
-        run_single_background_job(
+        let _ = run_single_background_job(
             &job,
             &ctx,
             &store,
@@ -1192,7 +1202,7 @@ mod tests {
         let inv_id = "00000000-0000-0000-0000-000000000004".to_string();
         let ctx = make_ctx(&inv_id);
 
-        run_single_background_job(
+        let _ = run_single_background_job(
             &job,
             &ctx,
             &store,
@@ -1226,7 +1236,7 @@ mod tests {
         let inv_id = "00000000-0000-0000-0000-000000000005".to_string();
         let ctx = make_ctx(&inv_id);
 
-        run_single_background_job(
+        let _ = run_single_background_job(
             &job,
             &ctx,
             &store,
@@ -1265,7 +1275,7 @@ mod tests {
         let inv_id = "00000000-0000-0000-0000-000000000006".to_string();
         let ctx = make_ctx(&inv_id);
 
-        run_single_background_job(
+        let _ = run_single_background_job(
             &job,
             &ctx,
             &store,

--- a/src/coordinator/process.rs
+++ b/src/coordinator/process.rs
@@ -122,6 +122,15 @@ impl CoordinatorState {
         let mut in_degree: Vec<usize> = (0..n).map(|i| graph.dependencies_of(i).len()).collect();
         let mut ready: Vec<usize> = (0..n).filter(|&i| in_degree[i] == 0).collect();
 
+        // Each iteration of this loop is one wave: every ready node is spawned
+        // in parallel and the loop blocks until ALL of them finish before
+        // computing the next wave. This is intentionally less concurrent than
+        // a free-running scheduler — an independent fast chain can be held up
+        // behind a slow one in the same wave — but it is the simplest shape
+        // that is provably safe across `libc::fork()` on macOS without
+        // touching `std::thread::scope`. Do not "optimize" this into per-node
+        // free-running advancement without re-checking the post-fork
+        // constraint described above.
         while !ready.is_empty() {
             // Spawn one worker per ready node. Inputs are cloned per-spawn,
             // matching the pre-fix per-thread cloning pattern.
@@ -171,6 +180,12 @@ impl CoordinatorState {
             for (idx, status) in wave_outcomes {
                 statuses[idx] = status;
                 match status {
+                    // `Skipped` is treated like `Succeeded` for cascade
+                    // purposes — both unblock dependents. Today
+                    // `run_single_background_job` only ever returns
+                    // `Succeeded` or `Failed`, so the `Skipped` arm is
+                    // reserved for future closure variants (e.g. an `if:`
+                    // conditional skip path).
                     NodeStatus::Succeeded | NodeStatus::Skipped => {
                         for &dep_idx in graph.dependents_of(idx) {
                             if statuses[dep_idx] == NodeStatus::Pending {
@@ -285,6 +300,11 @@ fn run_single_background_job(
             stdout: String::new(),
             stderr: "Cancelled before start".to_string(),
         });
+        // Note the deliberate split: the in-memory `JobResult.status` is
+        // `Skipped` (the user cancelled), but the value returned to the
+        // wave scheduler is `Failed` so dependents cascade to `DepFailed`.
+        // Same rationale as the final-return mapping at the bottom of this
+        // function — the dependency did not produce its work product.
         return NodeStatus::Failed;
     }
 
@@ -1481,6 +1501,10 @@ mod tests {
     fn bg_dependent_skipped_when_dep_fails() {
         let (_tmp, store, child_pids, cancel_all, cancelled_jobs, _results) = make_test_state();
 
+        // Use a marker path scoped to this test's TempDir so parallel test
+        // runs cannot race on a global `/tmp` path.
+        let marker = _tmp.path().join("dep-failed-side-effect");
+
         let mut state = CoordinatorState::new("test-repo", "inv-needs-fail-1").with_metadata(
             "worktree-post-create",
             "worktree-post-create",
@@ -1496,15 +1520,12 @@ mod tests {
         });
         state.add_job(JobSpec {
             name: "dependent".to_string(),
-            command: "touch /tmp/should-never-exist-bg-needs-fail".to_string(),
+            command: format!("touch {}", marker.display()),
             working_dir: std::env::temp_dir(),
             background: true,
             needs: vec!["fails".to_string()],
             ..Default::default()
         });
-
-        // Make sure the marker file isn't lying around from a prior run.
-        let _ = std::fs::remove_file("/tmp/should-never-exist-bg-needs-fail");
 
         state
             .run_all_with_cancel(&store, &child_pids, &cancel_all, &cancelled_jobs)
@@ -1531,7 +1552,7 @@ mod tests {
         );
         assert_eq!(meta_dependent.needs, vec!["fails".to_string()]);
         assert!(
-            !std::path::Path::new("/tmp/should-never-exist-bg-needs-fail").exists(),
+            !marker.exists(),
             "dependent ran its command despite dep failing"
         );
     }
@@ -1539,6 +1560,10 @@ mod tests {
     #[test]
     fn bg_dependent_skipped_when_dep_cancelled() {
         let (_tmp, store, child_pids, cancel_all, cancelled_jobs, _results) = make_test_state();
+
+        // Marker path is scoped to this test's TempDir to avoid races with
+        // parallel test runs.
+        let marker = _tmp.path().join("dep-cancelled-side-effect");
 
         let mut state = CoordinatorState::new("test-repo", "inv-needs-cancel-1").with_metadata(
             "worktree-post-create",
@@ -1556,14 +1581,12 @@ mod tests {
         });
         state.add_job(JobSpec {
             name: "after".to_string(),
-            command: "touch /tmp/should-never-exist-bg-needs-cancel".to_string(),
+            command: format!("touch {}", marker.display()),
             working_dir: std::env::temp_dir(),
             background: true,
             needs: vec!["long".to_string()],
             ..Default::default()
         });
-
-        let _ = std::fs::remove_file("/tmp/should-never-exist-bg-needs-cancel");
 
         let pids = Arc::clone(&child_pids);
         let cancelled = Arc::clone(&cancelled_jobs);
@@ -1602,7 +1625,7 @@ mod tests {
         );
         assert_eq!(meta_after.needs, vec!["long".to_string()]);
         assert!(
-            !std::path::Path::new("/tmp/should-never-exist-bg-needs-cancel").exists(),
+            !marker.exists(),
             "after ran its command despite dep being cancelled"
         );
     }

--- a/src/coordinator/process.rs
+++ b/src/coordinator/process.rs
@@ -1289,4 +1289,52 @@ mod tests {
             meta.status
         );
     }
+
+    #[test]
+    fn bg_dependent_waits_for_dep_to_finish() {
+        // Regression test for daft#454: B `needs: [A]` must not start until A
+        // has terminated.
+        let (_tmp, store, child_pids, cancel_all, cancelled_jobs, _results) = make_test_state();
+
+        let mut state = CoordinatorState::new("test-repo", "inv-needs-1").with_metadata(
+            "worktree-post-create",
+            "worktree-post-create",
+            "feat/x",
+        );
+
+        state.add_job(JobSpec {
+            name: "dep-a".to_string(),
+            command: "sleep 0.2 && echo done".to_string(),
+            working_dir: std::env::temp_dir(),
+            background: true,
+            ..Default::default()
+        });
+        state.add_job(JobSpec {
+            name: "dep-b".to_string(),
+            command: "echo b".to_string(),
+            working_dir: std::env::temp_dir(),
+            background: true,
+            needs: vec!["dep-a".to_string()],
+            ..Default::default()
+        });
+
+        state
+            .run_all_with_cancel(&store, &child_pids, &cancel_all, &cancelled_jobs)
+            .unwrap();
+
+        let dir_a = store.base_dir.join("inv-needs-1").join("dep-a");
+        let dir_b = store.base_dir.join("inv-needs-1").join("dep-b");
+        let meta_a = store.read_meta(&dir_a).expect("meta-a");
+        let meta_b = store.read_meta(&dir_b).expect("meta-b");
+
+        let a_finished = meta_a.finished_at.expect("a finished_at");
+        let b_started = meta_b.started_at;
+
+        assert!(
+            b_started >= a_finished,
+            "dep-b started ({b_started}) before dep-a finished ({a_finished})"
+        );
+        assert!(matches!(meta_a.status, JobStatus::Completed));
+        assert!(matches!(meta_b.status, JobStatus::Completed));
+    }
 }

--- a/src/coordinator/process.rs
+++ b/src/coordinator/process.rs
@@ -1474,4 +1474,75 @@ mod tests {
             "dependent ran its command despite dep failing"
         );
     }
+
+    #[test]
+    fn bg_dependent_skipped_when_dep_cancelled() {
+        let (_tmp, store, child_pids, cancel_all, cancelled_jobs, _results) = make_test_state();
+
+        let mut state = CoordinatorState::new("test-repo", "inv-needs-cancel-1").with_metadata(
+            "worktree-post-create",
+            "worktree-post-create",
+            "feat/x",
+        );
+
+        state.add_job(JobSpec {
+            name: "long".to_string(),
+            command: "sleep 5".to_string(),
+            working_dir: std::env::temp_dir(),
+            timeout: std::time::Duration::from_secs(30),
+            background: true,
+            ..Default::default()
+        });
+        state.add_job(JobSpec {
+            name: "after".to_string(),
+            command: "touch /tmp/should-never-exist-bg-needs-cancel".to_string(),
+            working_dir: std::env::temp_dir(),
+            background: true,
+            needs: vec!["long".to_string()],
+            ..Default::default()
+        });
+
+        let _ = std::fs::remove_file("/tmp/should-never-exist-bg-needs-cancel");
+
+        let pids = Arc::clone(&child_pids);
+        let cancelled = Arc::clone(&cancelled_jobs);
+        let store_for_killer = store.clone();
+        let killer = std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(200));
+            let _ = cancel_single_job("long", &pids, &cancelled, &store_for_killer);
+        });
+
+        state
+            .run_all_with_cancel(&store, &child_pids, &cancel_all, &cancelled_jobs)
+            .unwrap();
+        killer.join().unwrap();
+
+        let meta_long = store
+            .read_meta(&store.base_dir.join("inv-needs-cancel-1").join("long"))
+            .expect("meta long");
+        assert!(
+            matches!(meta_long.status, JobStatus::Cancelled),
+            "long should be Cancelled, got {:?}",
+            meta_long.status
+        );
+
+        // After the DAG returns, the coordinator synthesizes a meta record
+        // for the dep-failed dependent so it remains visible to
+        // `daft hooks jobs`. Disk status is `Skipped` (no `DepFailed` variant
+        // exists in `JobStatus`). The job's command must NOT have run.
+        let after_dir = store.base_dir.join("inv-needs-cancel-1").join("after");
+        let meta_after = store
+            .read_meta(&after_dir)
+            .expect("after should have a synthesized dep-failed meta");
+        assert!(
+            matches!(meta_after.status, JobStatus::Skipped),
+            "after should be Skipped on disk (dep cancelled), got {:?}",
+            meta_after.status
+        );
+        assert_eq!(meta_after.needs, vec!["long".to_string()]);
+        assert!(
+            !std::path::Path::new("/tmp/should-never-exist-bg-needs-cancel").exists(),
+            "after ran its command despite dep being cancelled"
+        );
+    }
 }

--- a/src/coordinator/process.rs
+++ b/src/coordinator/process.rs
@@ -1415,4 +1415,63 @@ mod tests {
         assert!(matches!(meta_a.status, JobStatus::Completed));
         assert!(matches!(meta_b.status, JobStatus::Completed));
     }
+
+    #[test]
+    fn bg_dependent_skipped_when_dep_fails() {
+        let (_tmp, store, child_pids, cancel_all, cancelled_jobs, _results) = make_test_state();
+
+        let mut state = CoordinatorState::new("test-repo", "inv-needs-fail-1").with_metadata(
+            "worktree-post-create",
+            "worktree-post-create",
+            "feat/x",
+        );
+
+        state.add_job(JobSpec {
+            name: "fails".to_string(),
+            command: "exit 7".to_string(),
+            working_dir: std::env::temp_dir(),
+            background: true,
+            ..Default::default()
+        });
+        state.add_job(JobSpec {
+            name: "dependent".to_string(),
+            command: "touch /tmp/should-never-exist-bg-needs-fail".to_string(),
+            working_dir: std::env::temp_dir(),
+            background: true,
+            needs: vec!["fails".to_string()],
+            ..Default::default()
+        });
+
+        // Make sure the marker file isn't lying around from a prior run.
+        let _ = std::fs::remove_file("/tmp/should-never-exist-bg-needs-fail");
+
+        state
+            .run_all_with_cancel(&store, &child_pids, &cancel_all, &cancelled_jobs)
+            .unwrap();
+
+        let meta_fails = store
+            .read_meta(&store.base_dir.join("inv-needs-fail-1").join("fails"))
+            .expect("meta fails");
+        assert!(matches!(meta_fails.status, JobStatus::Failed));
+
+        // The dependent's closure was NOT invoked (no spawn) — but the
+        // coordinator synthesizes a `meta.json` after the DAG returns so the
+        // job remains visible to `daft hooks jobs`. Disk status is `Skipped`
+        // (the closest available variant). The job's command must NOT have
+        // produced its side-effect.
+        let dep_dir = store.base_dir.join("inv-needs-fail-1").join("dependent");
+        let meta_dependent = store
+            .read_meta(&dep_dir)
+            .expect("dependent should have a synthesized dep-failed meta");
+        assert!(
+            matches!(meta_dependent.status, JobStatus::Skipped),
+            "dep-failed dependent should be Skipped on disk, got {:?}",
+            meta_dependent.status
+        );
+        assert_eq!(meta_dependent.needs, vec!["fails".to_string()]);
+        assert!(
+            !std::path::Path::new("/tmp/should-never-exist-bg-needs-fail").exists(),
+            "dependent ran its command despite dep failing"
+        );
+    }
 }

--- a/src/coordinator/process.rs
+++ b/src/coordinator/process.rs
@@ -14,6 +14,7 @@ use super::{
     coordinator_pid_path, coordinator_socket_path, CoordinatorRequest, CoordinatorResponse, JobInfo,
 };
 use crate::executor::command::run_command;
+use crate::executor::dag::DagGraph;
 use crate::executor::{JobResult, JobSpec, NodeStatus};
 use anyhow::Result;
 use std::collections::{HashMap, HashSet};
@@ -92,45 +93,50 @@ impl CoordinatorState {
         cancel_all: &Arc<AtomicBool>,
         cancelled_jobs: &CancelledJobs,
     ) -> Result<Vec<JobResult>> {
-        let mut handles = Vec::new();
-        let results = Arc::new(Mutex::new(Vec::new()));
+        if self.jobs.is_empty() {
+            return Ok(Vec::new());
+        }
 
-        for job in &self.jobs {
-            let job = job.clone();
-            let inv_id = self.invocation_id.clone();
-            let store_base = store.base_dir.clone();
-            let results = Arc::clone(&results);
-            let child_pids = Arc::clone(child_pids);
-            let cancel_all = Arc::clone(cancel_all);
-            let cancelled_jobs = Arc::clone(cancelled_jobs);
-            let hook_type = self.hook_type.clone();
-            let worktree = self.worktree.clone();
+        // Build the DAG from `needs:`. Reusing the same scheduler the foreground
+        // runner uses so foreground and background share one ordering contract.
+        let nodes: Vec<(String, Vec<String>)> = self
+            .jobs
+            .iter()
+            .map(|j| (j.name.clone(), j.needs.clone()))
+            .collect();
+        let graph =
+            DagGraph::new(nodes).map_err(|e| anyhow::anyhow!("invalid background job DAG: {e}"))?;
 
-            let handle = std::thread::spawn(move || {
-                let local_store = LogStore::new(store_base);
-                let ctx = JobInvocationContext {
-                    invocation_id: &inv_id,
-                    hook_type: &hook_type,
-                    worktree: &worktree,
+        let job_map: HashMap<&str, &JobSpec> =
+            self.jobs.iter().map(|j| (j.name.as_str(), j)).collect();
+
+        let results = Arc::new(Mutex::new(Vec::<JobResult>::new()));
+        let max_workers = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(4);
+
+        graph.run_parallel(
+            |_idx, name| {
+                let Some(job) = job_map.get(name).copied() else {
+                    return NodeStatus::Failed;
                 };
-                // TODO(daft#454, Task 4): plug this into DagGraph::run_parallel and
-                // propagate the NodeStatus instead of discarding it.
-                let _ = run_single_background_job(
-                    &job,
+                let ctx = JobInvocationContext {
+                    invocation_id: &self.invocation_id,
+                    hook_type: &self.hook_type,
+                    worktree: &self.worktree,
+                };
+                run_single_background_job(
+                    job,
                     &ctx,
-                    &local_store,
+                    store,
                     &results,
-                    &child_pids,
-                    &cancel_all,
-                    &cancelled_jobs,
-                );
-            });
-            handles.push(handle);
-        }
-
-        for handle in handles {
-            handle.join().ok();
-        }
+                    child_pids,
+                    cancel_all,
+                    cancelled_jobs,
+                )
+            },
+            max_workers,
+        );
 
         let results = match Arc::try_unwrap(results) {
             Ok(mutex) => mutex.into_inner().unwrap_or_default(),

--- a/tests/manual/scenarios/hooks/bg-needs-ordering.yml
+++ b/tests/manual/scenarios/hooks/bg-needs-ordering.yml
@@ -1,0 +1,86 @@
+name: Background bg→bg ordering honors needs
+description:
+  "Two background jobs where the second `needs:` the first. The second job's
+  meta.json must record started_at >= the first's finished_at — i.e., the
+  coordinator must not race them. Regression test for daft#454."
+
+repos:
+  - name: test-bg-needs
+    default_branch: main
+    branches:
+      - name: main
+        files:
+          - path: README.md
+            content: "# bg needs ordering"
+        commits:
+          - message: "Initial commit"
+      - name: feature/bg-needs
+        from: main
+    daft_yml: |
+      hooks:
+        worktree-post-create:
+          jobs:
+            - name: dep-a
+              background: true
+              run: |
+                sleep 0.5
+                python3 -c 'import time; print(time.time_ns())' > "$DAFT_WORKTREE_PATH/.a-finished-ns"
+            - name: dep-b
+              background: true
+              needs: [dep-a]
+              run: |
+                python3 -c 'import time; print(time.time_ns())' > "$DAFT_WORKTREE_PATH/.b-started-ns"
+
+steps:
+  - name: Clone the repository
+    run: git-worktree-clone --layout contained $REMOTE_TEST_BG_NEEDS
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-bg-needs/main"
+
+  - name: Trust the repository
+    run: daft hooks trust --force 2>&1
+    cwd: "$WORK_DIR/test-bg-needs/main"
+    expect:
+      exit_code: 0
+
+  - name: Checkout feature branch (triggers worktree-post-create hooks)
+    run: git-worktree-checkout feature/bg-needs 2>&1
+    cwd: "$WORK_DIR/test-bg-needs/main"
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-bg-needs/feature/bg-needs"
+
+  - name: Wait for both background jobs to finish (poll for B's marker)
+    run: |
+      for i in $(seq 1 40); do
+        if [ -f "$WORK_DIR/test-bg-needs/feature/bg-needs/.b-started-ns" ]; then
+          echo "BOTH_MARKERS_PRESENT"
+          exit 0
+        fi
+        sleep 0.5
+      done
+      echo "BG_NEEDS_TIMEOUT"
+      exit 1
+    expect:
+      exit_code: 0
+      output_contains:
+        - "BOTH_MARKERS_PRESENT"
+
+  - name: Assert dep-b started AFTER dep-a finished
+    run: |
+      A_FINISHED=$(cat "$WORK_DIR/test-bg-needs/feature/bg-needs/.a-finished-ns")
+      B_STARTED=$(cat "$WORK_DIR/test-bg-needs/feature/bg-needs/.b-started-ns")
+      echo "a_finished_ns=$A_FINISHED"
+      echo "b_started_ns=$B_STARTED"
+      if [ "$B_STARTED" -lt "$A_FINISHED" ]; then
+        echo "ORDERING_VIOLATION: dep-b started before dep-a finished"
+        exit 1
+      fi
+      echo "ORDERING_OK"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "ORDERING_OK"


### PR DESCRIPTION
## Summary

- Reuse the foreground `DagGraph` machinery in the background coordinator so
  bg→bg `needs:` is honored at runtime, not just on paper.
- `run_single_background_job` now returns `NodeStatus`; a hand-rolled
  wave scheduler in `run_all_with_cancel` spawns one `std::thread::spawn`
  per ready node, joins each wave, and cascades `DepFailed` to dependents.
- `DagGraph` is reused for cycle / missing-dep detection and dependent
  lookups but **not** for execution: `DagGraph::run_parallel` builds on
  `std::thread::scope`, which can deadlock post-`libc::fork()` on macOS due
  to inherited malloc-arena state. The wave scheduler avoids that by using
  the same bare-spawn primitive the pre-fix coordinator used.
- Cancelled / failed deps cascade `DepFailed` to dependents; dep-failed bg
  jobs synthesize a `JobStatus::Skipped` `meta.json` so they remain visible
  to `daft hooks jobs`.

Fixes #454.

## Test plan

- [x] Unit: `bg_dependent_waits_for_dep_to_finish` (regression for #454)
- [x] Unit: `bg_dependent_skipped_when_dep_fails`
- [x] Unit: `bg_dependent_skipped_when_dep_cancelled`
- [x] Unit: `bg_cycle_in_needs_returns_error`, `bg_missing_dep_in_needs_returns_error`
- [x] YAML scenario: `tests/manual/scenarios/hooks/bg-needs-ordering.yml`
- [x] All existing coordinator unit tests still pass (85/85 in coordinator module)
- [x] Full integration matrix (default+gitoxide, bash+yaml): 504 scenarios, 1872 steps, all pass
- [x] `mise run fmt:check`, `mise run clippy`, `mise run test:unit`, `mise run test:integration`