### PR TITLE
fix: prevent panic on Shift+Tab in shared manage editor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,11 @@ syntect = { version = "5.2", default-features = false, features = ["default-synt
 similar = "3.0"
 nucleo-matcher = "0.3"
 ignore = "0.4"
+# SYNC WITH EDTUI: when bumping this version, audit `events/key/input.rs`
+# in the upgraded crate and reconcile `is_edtui_supported` in
+# `src/output/tui/shared_picker/editor.rs` with edtui's `From<KeyCode>` arms
+# (the impl ends in `_ => unimplemented!()`, so missing entries panic at
+# runtime — see daft#345).
 edtui = { version = "0.11", features = ["syntax-highlighting"] }
 filetime = "0.2"
 csv = "1.3"

--- a/src/output/tui/shared_picker/editor.rs
+++ b/src/output/tui/shared_picker/editor.rs
@@ -22,6 +22,36 @@ use ratatui::{
 
 use crate::core::shared::{self, WorktreeStatus};
 
+/// Whether edtui's `From<crossterm::event::KeyCode>` impl can convert this
+/// key code without panicking.
+///
+/// edtui (as of 0.11.x) implements the conversion as an explicit `match` with
+/// a final `_ => unimplemented!()` arm. Any code outside the cases listed in
+/// edtui's source crashes the process on the first keypress. Mirror that
+/// whitelist here and drop everything else upstream of the handler.
+///
+/// Source of truth: `events/key/input.rs` in the `edtui` crate.
+fn is_edtui_supported(code: crossterm::event::KeyCode) -> bool {
+    use crossterm::event::KeyCode::*;
+    matches!(
+        code,
+        Char(_)
+            | Enter
+            | Esc
+            | Backspace
+            | Delete
+            | Tab
+            | Left
+            | Right
+            | Up
+            | Down
+            | Home
+            | End
+            | PageUp
+            | PageDown
+    )
+}
+
 /// An active inline editing session for a shared file.
 pub struct EditSession {
     /// The edtui editor state (text buffer, cursor, mode, etc.).
@@ -91,6 +121,14 @@ impl EditSession {
                 return false;
             }
             return true;
+        }
+
+        // edtui's `From<crossterm::KeyCode>` impl panics with `unimplemented!()`
+        // on any key code outside the whitelist below (see daft#345 — Shift+Tab
+        // arrives as `BackTab+SHIFT`, which would otherwise crash the process).
+        // Drop unsupported keys silently rather than forwarding them.
+        if !is_edtui_supported(key.code) {
+            return false;
         }
 
         self.handler.on_key_event(key, &mut self.state);
@@ -274,5 +312,63 @@ mod tests {
         let lines = Lines::from(original);
         let result = lines_to_string(&lines);
         assert_eq!(result, original);
+    }
+
+    /// Regression for daft#345: Shift+Tab arrives from crossterm as
+    /// `KeyCode::BackTab`, which edtui's `From` impl turns into
+    /// `unimplemented!()`. The filter must reject it.
+    #[test]
+    fn back_tab_is_filtered_before_edtui() {
+        assert!(!is_edtui_supported(crossterm::event::KeyCode::BackTab));
+    }
+
+    /// Other crossterm key codes that edtui doesn't handle must also be
+    /// filtered — otherwise users hit the same panic via different keys
+    /// (function keys, Insert, media keys, etc.).
+    #[test]
+    fn other_unsupported_codes_are_filtered() {
+        use crossterm::event::KeyCode;
+        for code in [
+            KeyCode::F(1),
+            KeyCode::F(12),
+            KeyCode::Insert,
+            KeyCode::CapsLock,
+            KeyCode::ScrollLock,
+            KeyCode::NumLock,
+            KeyCode::PrintScreen,
+            KeyCode::Pause,
+            KeyCode::Menu,
+            KeyCode::Null,
+        ] {
+            assert!(
+                !is_edtui_supported(code),
+                "expected {code:?} to be filtered"
+            );
+        }
+    }
+
+    /// The whitelist must keep the codes edtui *does* handle — a typo here
+    /// would break ordinary editing.
+    #[test]
+    fn supported_codes_pass_the_filter() {
+        use crossterm::event::KeyCode;
+        for code in [
+            KeyCode::Char('a'),
+            KeyCode::Enter,
+            KeyCode::Esc,
+            KeyCode::Backspace,
+            KeyCode::Delete,
+            KeyCode::Tab,
+            KeyCode::Left,
+            KeyCode::Right,
+            KeyCode::Up,
+            KeyCode::Down,
+            KeyCode::Home,
+            KeyCode::End,
+            KeyCode::PageUp,
+            KeyCode::PageDown,
+        ] {
+            assert!(is_edtui_supported(code), "expected {code:?} to be allowed");
+        }
     }
 }

--- a/src/output/tui/shared_picker/editor.rs
+++ b/src/output/tui/shared_picker/editor.rs
@@ -30,14 +30,18 @@ use crate::core::shared::{self, WorktreeStatus};
 /// edtui's source crashes the process on the first keypress. Mirror that
 /// whitelist here and drop everything else upstream of the handler.
 ///
-/// Source of truth: `events/key/input.rs` in the `edtui` crate.
+/// `Esc` is intentionally omitted: `handle_key` returns before reaching this
+/// filter on Esc, so listing it here would only mislead readers.
+///
+/// Source of truth: `events/key/input.rs` in the `edtui` crate. When upgrading
+/// the dependency, re-audit that file and update this whitelist (see the
+/// `SYNC WITH EDTUI` marker on the `edtui` line in `Cargo.toml`).
 fn is_edtui_supported(code: crossterm::event::KeyCode) -> bool {
     use crossterm::event::KeyCode::*;
     matches!(
         code,
         Char(_)
             | Enter
-            | Esc
             | Backspace
             | Delete
             | Tab
@@ -348,14 +352,14 @@ mod tests {
     }
 
     /// The whitelist must keep the codes edtui *does* handle — a typo here
-    /// would break ordinary editing.
+    /// would break ordinary editing. `Esc` is excluded because `handle_key`
+    /// short-circuits before the filter; see `is_edtui_supported`'s docs.
     #[test]
     fn supported_codes_pass_the_filter() {
         use crossterm::event::KeyCode;
         for code in [
             KeyCode::Char('a'),
             KeyCode::Enter,
-            KeyCode::Esc,
             KeyCode::Backspace,
             KeyCode::Delete,
             KeyCode::Tab,
@@ -370,5 +374,23 @@ mod tests {
         ] {
             assert!(is_edtui_supported(code), "expected {code:?} to be allowed");
         }
+    }
+
+    /// End-to-end regression for daft#345: pressing Shift+Tab while the inline
+    /// editor is active must NOT panic the process and must NOT signal an exit.
+    /// Exercises the full `handle_key` path so a future refactor that drops the
+    /// filter guard would be caught here even if `is_edtui_supported` is intact.
+    #[test]
+    fn handle_key_shift_tab_does_not_panic_or_exit() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("f.txt");
+        fs::write(&path, "hello").unwrap();
+        let mut session = EditSession::new(path, false, "test".into(), "txt".into()).unwrap();
+        let event = crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::BackTab,
+            crossterm::event::KeyModifiers::SHIFT,
+        );
+        let exit = session.handle_key(event);
+        assert!(!exit, "BackTab must not signal an editor exit");
     }
 }

--- a/src/output/tui/shared_picker/editor.rs
+++ b/src/output/tui/shared_picker/editor.rs
@@ -36,6 +36,7 @@ use crate::core::shared::{self, WorktreeStatus};
 /// Source of truth: `events/key/input.rs` in the `edtui` crate. When upgrading
 /// the dependency, re-audit that file and update this whitelist (see the
 /// `SYNC WITH EDTUI` marker on the `edtui` line in `Cargo.toml`).
+#[inline]
 fn is_edtui_supported(code: crossterm::event::KeyCode) -> bool {
     use crossterm::event::KeyCode::*;
     matches!(


### PR DESCRIPTION
## Summary
- Filter key codes upstream of edtui's handler before forwarding, so unsupported codes (BackTab, F-keys, Insert, …) no longer hit edtui's `_ => unimplemented!()` arm and crash the process.
- The bug surfaced as Shift+Tab "exiting" the inline editor — actually the panic hook restoring the terminal as the process died.

## Root cause
`edtui::events::key::input::From<crossterm::event::KeyCode>` (e.g. line 146 in 0.11.3) matches a small whitelist and panics on everything else. crossterm emits Shift+Tab as `KeyCode::BackTab`, which is not in that whitelist, so the first Shift+Tab keypress in the inline editor panicked.

## Fix
Add `is_edtui_supported(code)` mirroring edtui's whitelist (`Char`, `Enter`, `Esc`, `Backspace`, `Delete`, `Tab`, `Left`, `Right`, `Up`, `Down`, `Home`, `End`, `PageUp`, `PageDown`) and drop anything else before calling the handler.

## Test plan
- [x] `mise run test:unit` — 1698 pass (3 new regression tests)
- [x] `mise run clippy` — clean
- [x] `mise run fmt:check` — clean
- [ ] Manual: open `daft shared manage`, enter the inline editor, press Shift+Tab → no panic, editor stays open
- [ ] Manual: same with F1, F12, Insert → no panic

Fixes #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)