### PR TITLE
fix(hooks): stop yaml_executor unit tests from leaking into ~/.local/state/daft

### DIFF
--- a/src/coordinator/log_store.rs
+++ b/src/coordinator/log_store.rs
@@ -135,9 +135,18 @@ impl LogStore {
         Self { base_dir }
     }
 
-    /// Returns the log store for a specific repository.
+    /// Returns the log store for a specific repository, rooted under the
+    /// daft state directory.
     pub fn for_repo(repo_hash: &str) -> Result<Self> {
-        let base = crate::daft_state_dir()?.join("jobs").join(repo_hash);
+        Self::for_repo_in(repo_hash, &crate::daft_state_dir()?)
+    }
+
+    /// Returns the log store for a specific repository, rooted under an
+    /// explicit state directory base. Tests use this to redirect writes to a
+    /// tempdir; production callers go through `for_repo`. The on-disk shape
+    /// (`<state_base>/jobs/<repo_hash>/...`) is identical either way.
+    pub fn for_repo_in(repo_hash: &str, state_base: &Path) -> Result<Self> {
+        let base = state_base.join("jobs").join(repo_hash);
         Ok(Self::new(base))
     }
 

--- a/src/hooks/environment.rs
+++ b/src/hooks/environment.rs
@@ -68,6 +68,13 @@ pub struct HookContext {
     /// command injects `DAFT_MERGE_*` here). Ordering is kept stable
     /// (`BTreeMap`) so overriding/appending is deterministic in tests.
     pub extra_env: BTreeMap<String, String>,
+
+    /// Override for the daft state directory used when writing hook
+    /// invocation/job records. `None` (the production default) routes through
+    /// `daft_state_dir()` (XDG state home, modulo `DAFT_STATE_DIR` in dev
+    /// builds). Tests set this to a tempdir so their LogStore writes never
+    /// touch the user's real `~/.local/state/daft`.
+    pub state_dir: Option<PathBuf>,
 }
 
 /// Reason why a worktree is being removed.
@@ -124,6 +131,7 @@ impl HookContext {
             old_branch_name: None,
             changed_attributes: None,
             extra_env: BTreeMap::new(),
+            state_dir: None,
         }
     }
 
@@ -133,6 +141,13 @@ impl HookContext {
     /// `new()` starts with an empty map.
     pub fn with_extra_env(mut self, extra: BTreeMap<String, String>) -> Self {
         self.extra_env = extra;
+        self
+    }
+
+    /// Override the daft state directory used for LogStore writes. Test-only
+    /// in practice: production hooks always go through `daft_state_dir()`.
+    pub fn with_state_dir(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.state_dir = Some(dir.into());
         self
     }
 
@@ -470,6 +485,7 @@ mod tests {
             old_branch_name: Some("feat/old-name".to_string()),
             changed_attributes: None,
             extra_env: BTreeMap::new(),
+            state_dir: None,
         };
         let env = HookEnvironment::from_context(&ctx);
         assert_eq!(env.vars.get("DAFT_IS_MOVE").unwrap(), "true");
@@ -504,6 +520,7 @@ mod tests {
             old_branch_name: None,
             changed_attributes: None,
             extra_env: BTreeMap::new(),
+            state_dir: None,
         };
         let env = HookEnvironment::from_context(&ctx);
         assert!(!env.vars.contains_key("DAFT_IS_MOVE"));

--- a/src/hooks/template.rs
+++ b/src/hooks/template.rs
@@ -145,6 +145,7 @@ mod tests {
             old_branch_name: Some("feat/old".to_string()),
             changed_attributes: None,
             extra_env: std::collections::BTreeMap::new(),
+            state_dir: None,
         };
         let result = substitute(
             "from {old_worktree_path} to {worktree_path} branch {old_branch}",
@@ -179,6 +180,7 @@ mod tests {
             old_branch_name: None,
             changed_attributes: None,
             extra_env: std::collections::BTreeMap::new(),
+            state_dir: None,
         };
         let result = substitute("old={old_worktree_path} branch={old_branch}", &ctx, None);
         assert_eq!(result, "old= branch=");

--- a/src/hooks/yaml_executor/mod.rs
+++ b/src/hooks/yaml_executor/mod.rs
@@ -157,8 +157,16 @@ pub fn execute_yaml_hook_with_rc(
     // for daft.yml-only repos), and the hook silently never fires.
     let repo_hash = crate::core::repo_identity::compute_repo_id_from_common_dir(&ctx.git_dir)?;
     let invocation_id = crate::coordinator::log_store::generate_invocation_id();
-    let store = std::sync::Arc::new(crate::coordinator::log_store::LogStore::for_repo(
+    // Honor `ctx.state_dir` so unit tests route LogStore writes into a
+    // tempdir; production callers leave it `None` and fall through to
+    // `daft_state_dir()` (XDG state home).
+    let state_base = match &ctx.state_dir {
+        Some(p) => p.clone(),
+        None => crate::daft_state_dir()?,
+    };
+    let store = std::sync::Arc::new(crate::coordinator::log_store::LogStore::for_repo_in(
         &repo_hash,
+        &state_base,
     )?);
 
     let trigger_command = if ctx.command == "hooks-run" {
@@ -516,14 +524,19 @@ mod tests {
     use std::collections::HashMap;
     use tempfile::TempDir;
 
-    /// Build a `HookContext` whose `git_dir` is a real temp directory.
+    /// Build a `HookContext` whose `git_dir` is a real temp directory and
+    /// whose `state_dir` is the same temp directory.
     ///
     /// `execute_yaml_hook_with_rc` writes a `daft-id` file into `ctx.git_dir`
-    /// to compute the repo hash; pre-fix it called `compute_repo_id()`
+    /// to compute the repo hash; pre-fix (#448) it called `compute_repo_id()`
     /// (cwd-based) and silently picked up whatever git repo the test runner
-    /// was sitting in. The fix moves that to `ctx.git_dir`, so tests need a
-    /// real directory there or they trip on `try_create_new` failing on
-    /// `/project/.git`.
+    /// was sitting in. The fix moved that to `ctx.git_dir`, so tests need a
+    /// real directory there.
+    ///
+    /// Setting `state_dir` to the same tempdir routes the LogStore writes for
+    /// the resulting invocation/job records into the tempdir as well — pre
+    /// `#478` they fell through to `daft_state_dir()` and accumulated as
+    /// orphan UUID directories under the user's `~/.local/state/daft/jobs/`.
     ///
     /// Tests that need the context together with the keep-alive guard call
     /// `make_ctx_with_dir`. Tests that only need the context (and don't mind
@@ -540,7 +553,8 @@ mod tests {
             "/project/main",
             "/project/feature/new",
             "feature/new",
-        );
+        )
+        .with_state_dir(dir.path());
         (ctx, dir)
     }
 
@@ -639,6 +653,57 @@ mod tests {
         .unwrap();
 
         assert!(result.skipped);
+    }
+
+    /// Regression for #478: `execute_yaml_hook_with_rc` must honor
+    /// `ctx.state_dir` and route LogStore writes into the supplied base, not
+    /// fall through to `daft_state_dir()` and leak orphan UUID directories
+    /// into the user's real `~/.local/state/daft/jobs/`.
+    #[test]
+    fn test_execute_yaml_hook_honors_state_dir_override() {
+        let hook_def = HookDef {
+            jobs: Some(vec![JobDef {
+                name: Some("noop".to_string()),
+                run: Some(RunCommand::Simple("true".to_string())),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        };
+        let (ctx, dir) = make_ctx_with_dir();
+        let mut output = TestOutput::default();
+
+        execute_yaml_hook(
+            "test-hook",
+            &hook_def,
+            &ctx,
+            &mut output,
+            ".daft",
+            Path::new("/tmp"),
+            &HookOutputConfig::default(),
+        )
+        .unwrap();
+
+        // The executor stamps a `daft-id` UUID into `ctx.git_dir` and then
+        // writes invocation/job records under `<state_dir>/jobs/<uuid>/`. Read
+        // the UUID it picked, then verify both halves of the contract: writes
+        // landed under our tempdir, and nothing leaked into the real state
+        // dir. The latter is the actual regression: pre-fix every test run
+        // created a fresh orphan there.
+        let repo_hash = crate::core::repo_identity::compute_repo_id_from_common_dir(dir.path())
+            .expect("daft-id should have been written into ctx.git_dir");
+        assert!(
+            dir.path().join("jobs").join(&repo_hash).exists(),
+            "LogStore writes should have landed under the tempdir state base"
+        );
+        let leaked = crate::daft_state_dir()
+            .expect("daft_state_dir resolves")
+            .join("jobs")
+            .join(&repo_hash);
+        assert!(
+            !leaked.exists(),
+            "must not leak a UUID dir into the real state dir: {}",
+            leaked.display()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `LogStore::for_repo_in(repo_hash, base)` parameterizes the state-dir base. Existing `for_repo` keeps its production behavior by delegating with `daft_state_dir()`.
- `HookContext` gains an optional `state_dir` (set via `with_state_dir`) that `execute_yaml_hook_with_rc` consults before falling back to the global state dir.
- `make_ctx_with_dir` now sets `state_dir` to the same tempdir it already uses as `git_dir`, so yaml_executor unit tests no longer write under `~/.local/state/daft/jobs/`.

Pre-#448 the leak was visible: cwd-based `compute_repo_id()` made unit tests pollute the *current* repo's UUID dir under whatever repo the test runner sat in. #448 fixed the cwd issue but left a quieter leak — every `cargo test` of yaml_executor still wrote a fresh orphan UUID directory into the user's real state dir. This PR closes that.

Out of scope:
- Cleaning up the existing pre-#448 `feature/new` residue. Use `daft hooks jobs prune --older-than 1d` to clear stale entries.
- The UX gaps around large `daft hooks jobs --all` output (no aggregate view, no `prune --worktree`/`--hook` filter). Tracked separately.

Fixes #478

## Test plan

- [x] `mise run test:unit` — full suite green
- [x] `mise run clippy` — zero warnings
- [x] `mise run fmt:check` — clean
- [x] New regression test `test_execute_yaml_hook_honors_state_dir_override` passes after the fix
- [x] Same test fails (`LogStore writes should have landed under the tempdir state base`) when the `for_repo_in` redirect is reverted, confirming it actually catches the regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)
