### PR TITLE
docs(about): rename third pillar from Networking to Graph

### DIFF
--- a/docs/about/why-daft.md
+++ b/docs/about/why-daft.md
@@ -9,8 +9,8 @@ description:
 
 daft is built on one thesis:
 
-> **Parallelize development through isolation; coordinate across repos via
-> networking.**
+> **Parallelize development through isolation; coordinate across the repo
+> graph.**
 
 The first half — parallelize through isolation — is what daft does today. The
 second half — coordinate across repos — is in design
@@ -41,8 +41,8 @@ Three pillars, each idempotent — you can adopt one without the others.
 - **[Hooks](/hooks/)**: declarative automation at every code-evolution boundary.
   Local equivalent of GitHub Actions, but enforced before code leaves your
   machine.
-- **Networking** ([#357](https://github.com/avihut/daft/issues/357)): coordinate
-  changes across repos. A repo catalog plus a manifest of cross-repo
+- **Graph** ([#357](https://github.com/avihut/daft/issues/357)): coordinate
+  changes across the repo graph. A repo catalog plus a manifest of cross-repo
   relationships, so a change that touches three services can be propagated
   coherently.
 


### PR DESCRIPTION
## Summary

Renames the third pillar from "Networking" to "Graph" everywhere in the live `docs/` content.

The pillar's job is to model relations between repos as a graph (catalog + relations manifest). "Networking" implied live communication; "Graph" is descriptive of what the pillar actually is.

## What changed

- `docs/about/why-daft.md` — thesis line and pillars list bullet renamed.
- Issues #357 (Repo Catalog) and #466 (Networking pillar docs, closed) updated separately via the API; their bodies now use Graph terminology and explain the rename.

## What did not change (intentional)

- **`docs/superpowers/plans/2026-05-03-docs-ia-restructure.md`** and **`docs/superpowers/specs/2026-05-03-docs-ia-restructure-design.md`** — these are non-published archive docs (`superpowers/**` is in `srcExclude`) describing the IA work at a point in time. Updating them would rewrite snapshots; the terminology shift is documented in the issue updates.
- **`docs/public/_redirects`** — `/about/networking-roadmap` → `/about/why-daft` stays as a 301 redirect for backward compatibility (legacy URL nobody types in any more, but cheap to keep).
- **The "Networking" placeholder file `docs/about/networking-roadmap.md`** — already removed in #485; only the redirect remains.

When the Graph pillar pages land via #357, the file paths will be `docs/graph/index.md` etc. (already reflected in #357's body).

## Test plan

- [ ] Build the docs site locally (`mise run docs:site:build`) and verify no broken internal links
- [ ] Open `/about/why-daft` and confirm both the thesis line and the pillars list show "Graph" not "Networking"
- [ ] Visit `/about/networking-roadmap` (or curl with -I) and confirm the 301 redirect still works