### PR TITLE
ci: add manual bypass for mise upgrade cooldown

### DIFF
--- a/.github/workflows/mise-tool-updates.yml
+++ b/.github/workflows/mise-tool-updates.yml
@@ -11,7 +11,14 @@ on:
     # schedule. Most days this is a no-op (nothing has aged into the gate);
     # the action only opens a PR when there's an actual diff.
     - cron: "0 6 * * *"
-  workflow_dispatch: {} # manual trigger from the Actions UI
+  workflow_dispatch: # manual trigger from the Actions UI
+    inputs:
+      bypass_cooldown:
+        description:
+          "Ignore the 7d minimum_release_age (pick the newest available version,
+          including fresh releases)"
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -30,19 +37,27 @@ jobs:
         # Stays within the constraints already in mise.toml (e.g. `bun = "1.3"`
         # → newest 1.3.x). Use `mise upgrade --bump` manually when you want to
         # advance the constraint itself.
+        env:
+          # Per-invocation override for the [settings] minimum_release_age in
+          # mise.toml. Empty string falls through to the file-level setting
+          # (the safe default for cron + unchecked manual runs); "0" disables
+          # the cooldown for this single run when manually requested.
+          MISE_MINIMUM_RELEASE_AGE: ${{ inputs.bypass_cooldown && '0' || '' }}
         run: mise upgrade
 
       - name: Open PR
         uses: peter-evans/create-pull-request@v8
         with:
           commit-message: "deps: bump mise tools"
-          title: "deps: bump mise tools"
+          title:
+            "${{ inputs.bypass_cooldown && 'deps: bump mise tools (cooldown
+            bypassed)' || 'deps: bump mise tools' }}"
           body: |
             Automated `mise upgrade` run.
 
-            Versions selected are subject to the 7-day cooldown set in
-            `mise.toml` `[settings] minimum_release_age = "7d"`. To advance a
-            constraint (e.g. `bun = "1.3"` -> `"1.4"`), run
+            ${{ inputs.bypass_cooldown && '**Cooldown bypassed.** Triggered manually with `bypass_cooldown=true` — `MISE_MINIMUM_RELEASE_AGE=0` was exported for this run, so the 7-day cooldown in `mise.toml` was disabled and the newest available versions (including fresh releases) were picked.' || 'Versions selected are subject to the 7-day cooldown set in `mise.toml` `[settings] minimum_release_age = "7d"`.' }}
+
+            To advance a constraint (e.g. `bun = "1.3"` -> `"1.4"`), run
             `mise upgrade --bump` locally and commit instead.
 
             Note: PRs opened by the default GITHUB_TOKEN do not trigger other


### PR DESCRIPTION
## Summary

- Add a `bypass_cooldown` boolean input to `workflow_dispatch` on `.github/workflows/mise-tool-updates.yml`.
- When checked, export `MISE_MINIMUM_RELEASE_AGE=0` for the `mise upgrade` step so it picks the newest available versions, including fresh releases that haven't aged past the 7d gate yet.
- When unchecked (and on every cron run), the env var is empty and `mise upgrade` falls through to `[settings] minimum_release_age = "7d"` in `mise.toml` — i.e. behavior is unchanged.
- The auto-PR title and body branch on the same flag so reviewers can tell at a glance whether a bump came from the cooldown-respecting path or the bypassed one.

## Why

Per #488, the workflow already exposes a manual trigger but offered no way to push past the 7d cooldown — so a fresh upstream release (e.g. a new pnpm/bun point release) couldn't be landed via the Actions UI without locally editing `mise.toml` or running `mise upgrade` with the cooldown disabled. The env var `MISE_MINIMUM_RELEASE_AGE` is the documented per-invocation override (https://mise.jdx.dev/configuration/settings.html#minimum_release_age), which scopes the change to a single run.

## Test plan

- [x] `prettier --check` passes on the workflow file (also via `mise run fmt:docs:check`).
- [x] `actionlint` accepts the workflow.
- [x] `python3 -c yaml.safe_load(...)` parses the YAML and confirms `inputs: ['bypass_cooldown']` is registered under `workflow_dispatch`.
- [ ] Trigger the workflow from the Actions UI with `bypass_cooldown` unchecked → confirm `MISE_MINIMUM_RELEASE_AGE` resolves to empty and the resulting PR keeps the original title/body.
- [ ] Trigger with `bypass_cooldown` checked → confirm `MISE_MINIMUM_RELEASE_AGE=0` is exported, the resulting PR title is `deps: bump mise tools (cooldown bypassed)`, and the body calls out the bypass.

Fixes #488