### PR TITLE
fix(tui): always render selected columns; stop dropping by terminal width

### DIFF
--- a/src/output/tui/columns.rs
+++ b/src/output/tui/columns.rs
@@ -33,24 +33,6 @@ pub enum Column {
 }
 
 impl Column {
-    /// Display priority (lower = higher priority, always shown first).
-    pub(super) fn priority(self) -> u8 {
-        match self {
-            Self::Status => 0,
-            Self::Annotation => 1,
-            Self::Branch => 2,
-            Self::Path => 3,
-            Self::Size => 4,
-            Self::Base => 5,
-            Self::Changes => 6,
-            Self::Remote => 7,
-            Self::Age => 8,
-            Self::Owner => 9,
-            Self::Hash => 10,
-            Self::LastCommit => 11,
-        }
-    }
-
     /// Column header label.
     pub(super) fn label(self) -> &'static str {
         match self {
@@ -214,38 +196,6 @@ pub(super) fn column_content_width(
     header_width.max(max_data)
 }
 
-/// Select which columns fit in the given terminal width using content-based widths.
-///
-/// Always keeps columns with priority <= 2 (Status, Annotation, Branch).
-/// Drops lowest-priority columns first when the terminal is too narrow.
-pub fn select_columns(
-    width: u16,
-    worktrees: &[WorktreeRow],
-    vals: &[ColumnValues],
-    sort_spec: Option<&SortSpec>,
-) -> Vec<Column> {
-    let mut cols: Vec<Column> = ALL_COLUMNS.to_vec();
-
-    loop {
-        // Total = sum of content widths + inter-column spacing (1 char each gap).
-        let content: u16 = cols
-            .iter()
-            .map(|c| column_content_width(*c, worktrees, vals, sort_spec))
-            .sum();
-        let spacing = cols.len().saturating_sub(1) as u16 * 2;
-        if content + spacing <= width {
-            break;
-        }
-        if let Some(pos) = cols.iter().rposition(|c| c.priority() > 2) {
-            cols.remove(pos);
-        } else {
-            break;
-        }
-    }
-
-    cols
-}
-
 /// Minimum widths for shrinkable columns. Below these the column would lose
 /// most of its meaning, so we stop shrinking and accept overflow instead.
 const BRANCH_MIN_WIDTH: u16 = 12;
@@ -325,36 +275,6 @@ pub(super) fn truncate_with_ellipsis(s: &str, width: u16) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn column_selection_wide_terminal() {
-        let cols = select_columns(200, &[], &[], None);
-        assert_eq!(cols.len(), ALL_COLUMNS.len());
-    }
-
-    #[test]
-    fn column_selection_narrow_drops_last_commit() {
-        let cols = select_columns(60, &[], &[], None);
-        assert!(!cols.iter().any(|c| matches!(c, Column::LastCommit)));
-    }
-
-    #[test]
-    fn column_selection_very_narrow_keeps_essentials() {
-        let cols = select_columns(30, &[], &[], None);
-        assert!(cols.iter().any(|c| matches!(c, Column::Status)));
-        assert!(cols.iter().any(|c| matches!(c, Column::Branch)));
-    }
-
-    /// Regression: Size must never appear in the default responsive set.
-    /// It is an opt-in column that requires `--columns +size`.
-    #[test]
-    fn size_excluded_from_default_responsive_columns() {
-        let cols = select_columns(500, &[], &[], None);
-        assert!(
-            !cols.iter().any(|c| matches!(c, Column::Size)),
-            "Size should not appear in responsive defaults even on a wide terminal"
-        );
-    }
 
     #[test]
     fn fit_widths_passthrough_when_total_fits() {

--- a/src/output/tui/columns.rs
+++ b/src/output/tui/columns.rs
@@ -3,32 +3,33 @@ use crate::core::columns::ListColumn;
 use crate::core::sort::SortSpec;
 use crate::output::format::ColumnValues;
 
-/// Columns available in the worktree table, ordered by display priority.
+/// Columns available in the worktree table, in canonical display order.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Column {
-    /// Sync/prune status indicator. Priority 0 (always shown).
+    /// Sync/prune status indicator.
     Status,
-    /// Current/default branch annotation. Priority 1 (always shown).
+    /// Current/default branch annotation.
     Annotation,
-    /// Branch name. Priority 2 (always shown).
+    /// Branch name.
     Branch,
-    /// Worktree path. Priority 3.
+    /// Worktree path.
     Path,
-    /// Disk size of worktree. Priority 4.
+    /// Disk size of worktree. Opt-in only (requires `--columns +size`); not in
+    /// `ALL_COLUMNS` because the size computation triggers a filesystem walk.
     Size,
-    /// Commits ahead/behind base branch. Priority 5.
+    /// Commits ahead/behind base branch.
     Base,
-    /// Commits ahead/behind remote. Priority 5.
+    /// Commits ahead/behind remote.
     Remote,
-    /// Local changes (staged/unstaged/untracked). Priority 6.
+    /// Local changes (staged/unstaged/untracked).
     Changes,
-    /// Branch age. Priority 7.
+    /// Branch age.
     Age,
-    /// Branch owner (from git author email). Priority 8.
+    /// Branch owner (from git author email).
     Owner,
-    /// Abbreviated commit hash (7 chars). Priority 9.
+    /// Abbreviated commit hash (7 chars).
     Hash,
-    /// Last commit subject. Priority 10.
+    /// Last commit subject.
     LastCommit,
 }
 
@@ -275,6 +276,17 @@ pub(super) fn truncate_with_ellipsis(s: &str, width: u16) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `Column::Size` triggers a filesystem walk to total bytes on disk and
+    /// is opt-in only via `--columns +size`. Pin that it never sneaks into
+    /// the default set.
+    #[test]
+    fn all_columns_never_includes_size() {
+        assert!(
+            !ALL_COLUMNS.contains(&Column::Size),
+            "Size requires --columns +size; it must not appear in the default set"
+        );
+    }
 
     #[test]
     fn fit_widths_passthrough_when_total_fits() {

--- a/src/output/tui/live_table.rs
+++ b/src/output/tui/live_table.rs
@@ -23,6 +23,7 @@ use super::state::WorktreeRow;
 pub struct LiveTableConfig {
     pub stat: Stat,
     pub columns: Option<Vec<Column>>,
+    // Unused by render after #494; pending removal in a follow-up.
     pub columns_explicit: bool,
     pub sort_spec: Option<SortSpec>,
     /// `true` for prune/sync, `false` for `daft list`.

--- a/src/output/tui/mod.rs
+++ b/src/output/tui/mod.rs
@@ -12,7 +12,7 @@ mod render;
 pub mod shared_picker;
 mod state;
 
-pub use columns::{Column, select_columns};
+pub use columns::Column;
 pub use driver::TuiRenderer;
 pub use live_table::{LiveTable, LiveTableConfig};
 pub use operation_table::{CompletedTable, OperationTable, TableConfig};

--- a/src/output/tui/operation_table.rs
+++ b/src/output/tui/operation_table.rs
@@ -20,10 +20,9 @@ use std::{path::PathBuf, sync::mpsc};
 
 /// Configuration for a TUI table operation.
 pub struct TableConfig {
-    /// User-selected columns (`None` = use responsive selection).
+    /// User-selected columns (`None` = use `ALL_COLUMNS` defaults).
     pub columns: Option<Vec<Column>>,
-    /// If `true`, the user explicitly chose columns (replace mode) — disables
-    /// responsive dropping.
+    // Unused by render after #494; pending removal in a follow-up.
     pub columns_explicit: bool,
     /// User-specified sort order (`None` = default alphabetical).
     pub sort_spec: Option<SortSpec>,

--- a/src/output/tui/render.rs
+++ b/src/output/tui/render.rs
@@ -1,6 +1,5 @@
 use super::columns::{
-    ALL_COLUMNS, Column, column_content_width, fit_widths_to_available, select_columns,
-    truncate_with_ellipsis,
+    ALL_COLUMNS, Column, column_content_width, fit_widths_to_available, truncate_with_ellipsis,
 };
 use super::state::{FinalStatus, PhaseStatus, TuiState, WorktreeStatus};
 use crate::core::sort::SortSpec;
@@ -176,36 +175,29 @@ pub fn render_table(state: &TuiState, frame: &mut Frame, area: Rect) {
                 .collect()
         })
     } else {
-        let columns = match (&state.live.cfg.columns, state.live.cfg.columns_explicit) {
-            // Replace mode: user explicitly chose columns, don't responsively drop.
-            (Some(user_cols), true) => user_cols.clone(),
-            // Modifier mode: user tweaked defaults, responsive dropping still applies.
-            // Opt-in columns (not in ALL_COLUMNS, e.g. Size) that the user explicitly
-            // added are always included — they bypass responsive dropping.
-            (Some(user_cols), false) => {
-                let responsive =
-                    select_columns(table_area.width, &state.live.rows, &row_vals, sort_ref);
-                let mut cols: Vec<Column> = responsive
-                    .into_iter()
-                    .filter(|c| matches!(c, Column::Status) || user_cols.contains(c))
-                    .collect();
-                for col in user_cols {
-                    if !ALL_COLUMNS.contains(col) && !cols.contains(col) {
-                        cols.push(*col);
-                    }
-                }
-                cols
-            }
-            // No column selection: fully responsive.
-            (None, _) => select_columns(table_area.width, &state.live.rows, &row_vals, sort_ref),
-        };
+        // Phased commands: render the user's columns (already resolved by
+        // ColumnSelection::parse — replace mode is the user's list verbatim,
+        // modifier mode is defaults +/- the user's adjustments) or fall back
+        // to ALL_COLUMNS. No width-based dropping: fit_widths_to_available
+        // shrinks Branch/Path/LastCommit for narrow terminals, then accepts
+        // overflow rather than removing data columns. See #494.
+        //
+        // Asymmetry preserved: the no-flag fallback is ALL_COLUMNS (includes
+        // Hash), while modifier mode's base set comes from
+        // ListColumn::tui_defaults() (no Hash). A follow-up may reconcile.
+        let columns = state
+            .live
+            .cfg
+            .columns
+            .clone()
+            .unwrap_or_else(|| ALL_COLUMNS.to_vec());
         // Status is always prepended for TUI commands with phases.
-        if !columns.contains(&Column::Status) {
+        if columns.contains(&Column::Status) {
+            columns
+        } else {
             let mut with_status = vec![Column::Status];
             with_status.extend(columns);
             with_status
-        } else {
-            columns
         }
     };
 
@@ -1485,5 +1477,97 @@ mod tests {
             .map(|x| buffer[(x, 0)].symbol().to_string())
             .collect();
         assert!(!row.contains("cancelled"), "row was: {row:?}");
+    }
+
+    /// Regression for #494: phased commands (sync/clone/prune/repo-remove)
+    /// must render the full default column set at any terminal width that
+    /// admits the minimum shrunk widths. A long branch name pushes the
+    /// natural total over the constrained width — pre-fix, `select_columns`
+    /// would have dropped LastCommit / Hash / Owner here; post-fix,
+    /// `fit_widths_to_available` shrinks Branch instead and every column
+    /// header is visible.
+    #[test]
+    fn render_table_phased_keeps_all_default_columns_at_constrained_width() {
+        let state = TuiState::new(
+            vec![OperationPhase::Fetch],
+            vec![WorktreeInfo::empty(
+                "feature/long-branch-name-to-force-shrinking",
+            )],
+            PathBuf::from("/tmp/test"),
+            PathBuf::from("/tmp/test"),
+            Stat::Summary,
+            0,
+            None,
+            false,
+            None,
+            None::<SortSpec>,
+            true,
+            false,
+            crate::core::worktree::info_field::FieldSet::EMPTY,
+        );
+        let backend = TestBackend::new(100, 5);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render_table(&state, frame, frame.area());
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+        let header: String = (0..buffer.area.width)
+            .map(|x| buffer[(x, 0)].symbol().to_string())
+            .collect();
+        for label in [
+            "Status", "Branch", "Path", "Base", "Changes", "Remote", "Age", "Owner", "Hash",
+            "Commit",
+        ] {
+            assert!(
+                header.contains(label),
+                "header at width 100 should contain {label:?}; got: {header:?}"
+            );
+        }
+    }
+
+    /// Contract for #494: phaseless (`daft list`) was never affected by
+    /// `select_columns`, but pin the behavior. With `columns: None` the
+    /// `ListColumn::list_defaults()` fallback should yield every default
+    /// header — Branch through Commit — at a constrained width.
+    #[test]
+    fn render_table_phaseless_keeps_all_default_columns_at_constrained_width() {
+        let state = TuiState::new(
+            Vec::<OperationPhase>::new(),
+            vec![WorktreeInfo::empty(
+                "feature/long-branch-name-to-force-shrinking",
+            )],
+            PathBuf::from("/tmp/test"),
+            PathBuf::from("/tmp/test"),
+            Stat::Summary,
+            0,
+            None,
+            false,
+            None,
+            None::<SortSpec>,
+            true,
+            false,
+            crate::core::worktree::info_field::FieldSet::EMPTY,
+        );
+        let backend = TestBackend::new(100, 5);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render_table(&state, frame, frame.area());
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+        let header: String = (0..buffer.area.width)
+            .map(|x| buffer[(x, 0)].symbol().to_string())
+            .collect();
+        for label in [
+            "Branch", "Path", "Base", "Changes", "Remote", "Age", "Owner", "Commit",
+        ] {
+            assert!(
+                header.contains(label),
+                "header at width 100 should contain {label:?}; got: {header:?}"
+            );
+        }
     }
 }

--- a/src/output/tui/render.rs
+++ b/src/output/tui/render.rs
@@ -1486,6 +1486,11 @@ mod tests {
     /// would have dropped LastCommit / Hash / Owner here; post-fix,
     /// `fit_widths_to_available` shrinks Branch instead and every column
     /// header is visible.
+    ///
+    /// At width=100 with all 11 columns at their minimum widths the table
+    /// technically overflows by a few characters. That is the spec
+    /// ("accept overflow rather than dropping data"). We verify header
+    /// *presence* via substring match, not pixel-level fit.
     #[test]
     fn render_table_phased_keeps_all_default_columns_at_constrained_width() {
         let state = TuiState::new(

--- a/test-plans/render-all-columns.md
+++ b/test-plans/render-all-columns.md
@@ -1,0 +1,51 @@
+---
+branch: daft-494/fix/render-all-columns
+---
+
+# Render All Columns — Manual Smoke
+
+Fix #494: TUI no longer drops columns by terminal width. Verify across three
+widths (narrow / typical / wide) and two commands (`daft list`, `daft sync`).
+
+## How to constrain width
+
+In a real terminal: `resize -s 5 60`, `printf '\e[8;5;60t'`, or `stty cols 60`
+on platforms that support it. Easier path: resize the terminal window manually.
+
+For TUI commands (`sync`), confirm by reading the rendered header. The full
+default column header set is:
+
+- Phased (`sync`, `clone`, `prune`, `repo remove`):
+  `Status   Branch  Path  Base  Changes  Remote  Age  Owner  Hash  Commit`
+  (Annotation column has an empty label — sits between Status and Branch as
+  blank space.)
+- Phaseless (`daft list`):
+  `Branch  Path  Base  Changes  Remote  Age  Owner  Commit`
+
+## 60 cols
+
+- [ ] `daft list` — full default header set rendered. Branch / Path / Commit
+      show ellipsis truncation as needed. **No column missing.** (Ratatui may
+      clip the rightmost columns at the buffer edge — that is the spec's "accept
+      overflow rather than dropping data" behavior. Confirm the column **set**
+      is intact, even if pixels off-screen.)
+- [ ] `daft sync` — same as above; Status column on the left, Hash and Commit on
+      the right.
+
+## 100 cols
+
+- [ ] `daft list` — full default header set. Light Branch / Path / Commit
+      truncation possible if branch names are long; no missing columns.
+- [ ] `daft sync` — same.
+
+## 160 cols
+
+- [ ] `daft list` — full default header set, no truncation.
+- [ ] `daft sync` — same.
+
+## Mid-`sync` resize regression
+
+- [ ] Start `daft sync` in a 100-col terminal. Mid-run, resize the terminal to
+      60 cols. Confirm: no columns appear or disappear during the resize; only
+      the widths of Branch / Path / Commit shift. (Pre-fix this was the worst
+      symptom — columns popped in and out as data streamed in.)


### PR DESCRIPTION
## Summary

Stops the TUI from silently dropping low-priority columns (LastCommit, Hash, Owner, Age, ...) when the natural table width exceeds the terminal. The full intended column set now renders every time; `fit_widths_to_available` shrinks Branch / Path / LastCommit with ellipses and accepts overflow, mirroring the blocking-list renderer's `tabled::Width::truncate(...).priority(Priority::max(true))`.

Affects `daft list` (LiveTable), `daft sync`, `daft clone`, `daft prune`, `daft repo remove`. All five flow through `src/output/tui/render.rs::render_table` so the fix is centralized to one match-expression collapse.

## Behavior change worth surfacing

For phased commands (`sync`, `clone`, `prune`, `repo remove`) with **no `--columns` flag**, the **Hash** column is now always visible. Pre-fix it was the first column dropped on most realistic terminal widths, so most users have never seen it by default. Consistent with the spec — flagging here in case reviewers want to push back.

A pre-existing asymmetry is preserved: `daft sync` with no flag falls back to `ALL_COLUMNS` (includes Hash); `daft sync --columns +size` uses the modifier-mode base `ListColumn::tui_defaults()` which doesn't include Hash. Out of scope for this PR; can be reconciled in a follow-up.

## AC deviation

Issue acceptance criterion #4 asked for a YAML regression scenario verifying narrow-terminal behavior. YAML can't exercise this path: `xtask/src/manual_test/runner.rs` runs commands via `Command::new("bash").output()` with piped stdio, so `terminal_size` returns `None` and the renderer's narrow-width branches never fire. Setting `COLUMNS=60` in scenario `env:` doesn't help — `terminal_size` reads ioctl, not env. Replaced with two `TestBackend` tests in `render.rs::tests` that exercise `render_table` directly at a constrained width with a long branch name (forcing `fit_widths_to_available` to shrink Branch from natural to min while keeping all 11 columns).

## Cleanup deferred

`columns_explicit: bool` is threaded through `live_table.rs`, `operation_table.rs`, `state.rs`, `list_live.rs`, `prune.rs`, `clone.rs`, `sync.rs`, `repo/remove.rs`. After this fix no render-layer logic branches on it. Marked with `// Unused by render after #494; pending removal in a follow-up.` comments on the two config-struct fields; full rip is a separate PR.

## Test plan

- [x] `mise run fmt` clean
- [x] `mise run clippy` clean (zero warnings)
- [x] `mise run test:unit` — 1701 pass, 0 fail (4 deleted `column_selection_*` tests replaced by 2 TestBackend regression tests in `render.rs`)
- [ ] Manual smoke per `test-plans/render-all-columns.md`: 3 widths (60/100/160) × 2 commands (`daft list`, `daft sync`), plus mid-`sync` resize regression check

Fixes #494

🤖 Generated with [Claude Code](https://claude.com/claude-code)