### PR TITLE
chore: reduce test.yml flake — pin mise tools, skip cargo-cooldown on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,6 +114,17 @@ jobs:
       'true' || needs.changes.outputs.tests == 'true' ||
       needs.changes.outputs.xtask == 'true'
     runs-on: ubuntu-latest
+    env:
+      # cargo-cooldown is a local-dev supply-chain guard that wraps `cargo
+      # build|check|test|run|update` against cooldown.toml. CI enforces the
+      # same policy at PR boundary via scripts/check-lockfile-age.sh, so
+      # installing it here only adds a from-source cargo build (~2 min, ~125
+      # transitive crates from crates.io) with no behavioral payoff — and a
+      # crates.io network-flake surface that the policy doesn't require.
+      # Disabled for this job only; mise.toml stays the source of truth for
+      # local dev. Backend prefix (`cargo:`) is required — mise matches the
+      # full short name and bare `cargo-cooldown` silently no-ops.
+      MISE_DISABLE_TOOLS: cargo:cargo-cooldown
     steps:
       - uses: actions/checkout@v6
 

--- a/mise.toml
+++ b/mise.toml
@@ -12,16 +12,21 @@ minimum_release_age = "7d"
 
 [tools]
 rust = "1.93"
-lefthook = "latest"
-cocogitto = "latest"
-bun = "latest"
-bat = "latest"
+lefthook = "2.1.6"
+cocogitto = "7.0.0"
+bun = "1.3.13"
+bat = "0.26.1"
+# neovim: the vfox:mise-plugins/vfox-neovim backend does not record a
+# concrete version in mise.lock — it stays "stable". Leave the tag-based
+# selector. Weekly mise-tool-updates.yml refreshes the install.
 neovim = "stable"
 # cargo-cooldown: optional supply-chain guard. Wraps `cargo
 # build|check|test|run|update` to refuse package versions younger than the
 # window in cooldown.toml. Doesn't gate `cargo add` directly — pair it with
-# the lockfile-age CI check (scripts/check-lockfile-age.sh).
-"cargo:cargo-cooldown" = "latest"
+# the lockfile-age CI check (scripts/check-lockfile-age.sh). Disabled in CI
+# (see MISE_DISABLE_TOOLS in .github/workflows/test.yml lint job) because
+# scripts/check-lockfile-age.sh enforces the same policy at PR boundary.
+"cargo:cargo-cooldown" = "0.3.0"
 
 [env]
 _.path = ["./target/release"]


### PR DESCRIPTION
## Summary

Two changes from #484 that reduce `test.yml`'s flake surface. The third
ticket-suggested change (explicit `actions/cache@v4` step) is intentionally
deferred — `jdx/mise-action@v4` already caches `~/.local/share/mise` keyed
on `mise.toml` + `mise.lock`, verified on run [`25909874748`][r1]
(`cache restored from key: mise-v1-linux-x64-69f084f...`, install completed
in ~3s). The cache amplifier diagnosis in the ticket body was wrong; ship
the two changes that do still help and gate the explicit cache step behind
post-merge observation (V4 below).

[r1]: https://github.com/avihut/daft/actions/runs/25909874748

### Commit 1 — `chore(mise): pin tool versions to lockfile values`

Replace `latest` with exact `mise.lock` values for `lefthook`, `cocogitto`,
`bun`, `bat`, and `cargo:cargo-cooldown`. Zero-behavior-change tightening
— each pin matches what these tools resolve to today. The win is removing
per-install version-resolution lookups against backend registries (aqua,
cargo); those round-trips happen even on cache HIT and are a flake surface
of their own.

`neovim` intentionally stays at `"stable"` — the
`vfox:mise-plugins/vfox-neovim` backend does not record concrete versions
in `mise.lock`, so there's nothing valid to substitute. Inline comment
explains.

Weekly `mise-tool-updates.yml` runs `mise upgrade` (respects
`minimum_release_age = "7d"`) and will keep these current, auto-opening
PRs that update `mise.toml` + `mise.lock` together.

### Commit 2 — `ci(test): skip cargo-cooldown install in lint job`

Set `MISE_DISABLE_TOOLS: cargo:cargo-cooldown` at the `lint` job level in
`test.yml`. Removes a ~2 min from-source cargo build (~125 transitive
crates from crates.io) on every cold-cache run — the exact flake surface
the cocogitto-style CDN 5xx came through.

`scripts/check-lockfile-age.sh` already enforces the same supply-chain
cooldown policy at PR boundary on `Cargo.lock` and `bun.lock`. The
`cargo-cooldown` tool wraps `cargo build|check|test|run|update`, which CI
doesn't exercise interactively, so the CI install covers nothing
`scripts/check-lockfile-age.sh` doesn't. Local devs still get the wrap —
`mise.toml` keeps the pin.

Job-level scope (not step-level) is deliberate: subsequent `mise run
clippy` and `mise run test:unit` steps need the same disable to stay
consistent.

## Verification

- **V1 — baseline (pre-merge)**: 5 most recent successful `lint` jobs
  inspected for `Restoring mise cache` outcome. Run `25909874748`
  confirmed cache HIT.
- **V2 — pin lands cleanly**: `mise run clippy`, `mise run test:unit`,
  `mise run fmt:check` all pass locally. CI on this PR will confirm
  `Install mise` log no longer shows `latest` for the 5 pinned tools.
- **V3 — `cargo:cargo-cooldown` skip works on CI**: this PR's `lint` job
  log should not list `cargo:cargo-cooldown` in the mise install
  tool-list. (Backend-prefix matching is required — bare names silently
  no-op.)
- **V4 — full caches hit (post-merge)**: watch the next 5 PRs that don't
  touch `mise.toml`/`mise.lock`. Pass if ≥4/5 show `cache restored from
  key:` and `Install mise` finishes in <5s. If <4/5, open a follow-up to
  add the explicit `actions/cache@v4` step.
- **V5 — weekly `mise-tool-updates.yml`**: next daily `mise upgrade` run
  should auto-PR pinned-version bumps (not `latest` reverts).

## Test plan

- [ ] CI lint job on this PR passes
- [ ] CI lint job's `Install mise` log shows `lefthook 2.1.6`, `cocogitto
      7.0.0`, `bun 1.3.13`, `bat 0.26.1`, `cargo:cargo-cooldown 0.3.0`
      resolved (not `latest`)
- [ ] CI lint job's `Install mise` log does not list
      `cargo:cargo-cooldown` as an install target
- [ ] No regression in `lint` job wall-clock vs pre-merge baseline
- [ ] Local: `unset MISE_DISABLE_TOOLS; mise install --dry-run` still
      lists `cargo:cargo-cooldown` (local dev unaffected)

## Pitfalls noted

- `MISE_DISABLE_TOOLS` value must include the `cargo:` backend prefix.
  Bare `cargo-cooldown` silently no-ops; V3 will catch.
- First `lint` run post-merge incurs one cold cache miss because
  `mise.toml` content changes the file-hash key segment.
- Scope is narrow to `test.yml`. `bench.yml` and `mise-tool-updates.yml`
  also use `mise-action` but were left alone to match ticket scope —
  separate ticket if their flake matters.

Fixes #484

🤖 Generated with [Claude Code](https://claude.com/claude-code)