### PR TITLE
chore: enforce dependency license allowlist via cargo-deny

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,7 @@ jobs:
           if echo "$files" | grep -qE '^(man/|docs/cli/)'; then
             man=true
           fi
-          if echo "$files" | grep -qxE '(Cargo\.lock|bun\.lock|\.dep-age-allowlist|cooldown\.toml|bunfig\.toml)'; then
+          if echo "$files" | grep -qxE '(Cargo\.lock|bun\.lock|\.dep-age-allowlist|cooldown\.toml|bunfig\.toml|deny\.toml)'; then
             lockfile=true
           fi
 
@@ -105,6 +105,30 @@ jobs:
           # interpolating it into the shell command directly.
           PR_BASE_REF: ${{ github.base_ref }}
         run: BASE_REF="origin/${PR_BASE_REF}" scripts/check-lockfile-age.sh
+
+  # Supply-chain gate: enforce the dependency license/advisory/source policy
+  # in deny.toml. Fails the PR if a transitive crate carries an unapproved
+  # license, an open RustSec advisory, or comes from an unexpected source.
+  dep-license-check:
+    needs: changes
+    if:
+      needs.changes.outputs.self == 'true' || needs.changes.outputs.rust ==
+      'true' || needs.changes.outputs.lockfile == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install mise
+        uses: jdx/mise-action@v4
+
+      - name: Run cargo-deny
+        run: mise run deny
 
   # Fast feedback: formatting, linting, unit tests (debug mode only - no release build needed)
   lint:

--- a/deny.toml
+++ b/deny.toml
@@ -18,6 +18,10 @@ targets = [
     "aarch64-apple-darwin",
     "x86_64-pc-windows-msvc",
 ]
+# daft has no [features] table today, so all-features = false is a no-op
+# (nothing to gate). If a [features] table is ever added, revisit: any
+# optional dep pulled in by a feature flag is invisible to this check
+# unless this is flipped to true or run separately with --all-features.
 all-features = false
 no-default-features = false
 
@@ -62,14 +66,19 @@ allow = [
     "Unicode-3.0",
     "CC0-1.0",
     "0BSD",
-    "MPL-2.0",
 ]
 confidence-threshold = 0.93
 exceptions = [
-    # Example:
-    # { name = "ring", allow = ["OpenSSL"] },
-    # # why: ring's OpenSSL-derived BoringSSL code is statically embedded;
-    # #      the OpenSSL clause covers that subtree only.
+    # MPL-2.0 is file-level copyleft — modifications to MPL files must be
+    # shared. That's a materially different posture from the permissive
+    # licenses above, so each MPL-2.0 dep is named here rather than carried
+    # in the global allow list. Drop the entry when the dep is gone.
+    # why: transitive through ratatui's fuzzy-matcher; MPL applies only to
+    #      nucleo-matcher's own source, which we link but don't modify.
+    { name = "nucleo-matcher", allow = ["MPL-2.0"] },
+    # why: transitive through `dirs`; MPL applies only to option-ext's own
+    #      source, which we link but don't modify.
+    { name = "option-ext", allow = ["MPL-2.0"] },
 ]
 
 [sources]

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,83 @@
+# cargo-deny policy. See https://embarkstudios.github.io/cargo-deny/
+#
+# Run locally: `mise run deny`
+# Gated in CI:  .github/workflows/test.yml (dep-license-check job)
+#
+# Exceptions require a `# why:` comment with a rationale and, ideally, an
+# expiration condition. Entries here weaken the policy and should be
+# temporary unless the why explains otherwise.
+
+[graph]
+# Check every release target, not just the host. Mirrors dist-workspace.toml.
+# Without this, Windows-only and macOS-only transitive crates are silently
+# skipped.
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "aarch64-apple-darwin",
+    "x86_64-pc-windows-msvc",
+]
+all-features = false
+no-default-features = false
+
+[advisories]
+# Fail on any RustSec advisory not explicitly ignored. Complements Dependabot
+# security alerts (broader coverage, gated in CI).
+version = 2
+yanked = "deny"
+ignore = [
+    # why: `unmaintained` advisory, not a security CVE. bincode 1.x reached
+    #      an explicit "feature-complete, no further releases" state after
+    #      the maintainers stepped down. Reaches us transitively through
+    #      syntect (https://github.com/trishume/syntect). No safe upgrade
+    #      exists; revisit once syntect publishes a release that drops the
+    #      bincode 1.x dependency.
+    "RUSTSEC-2025-0141",
+    # why: `unmaintained` advisory, not a security CVE. yaml-rust 0.4 has
+    #      had no upstream activity in years; the maintained successor is
+    #      yaml-rust2. Reaches us transitively through syntect. Revisit
+    #      once syntect migrates to yaml-rust2.
+    "RUSTSEC-2024-0320",
+]
+
+[licenses]
+version = 2
+# Skip workspace members marked `publish = false` (xtask is internal-only and
+# never published). Without this, the check trips on missing/internal license
+# metadata for in-tree crates.
+private = { ignore = true }
+# Permissive licenses standard in the Rust ecosystem. Any license not on this
+# list fails the check; add via `exceptions` with a why.
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "ISC",
+    "Zlib",
+    "Unicode-DFS-2016",
+    "Unicode-3.0",
+    "CC0-1.0",
+    "0BSD",
+    "MPL-2.0",
+]
+confidence-threshold = 0.93
+exceptions = [
+    # Example:
+    # { name = "ring", allow = ["OpenSSL"] },
+    # # why: ring's OpenSSL-derived BoringSSL code is statically embedded;
+    # #      the OpenSSL clause covers that subtree only.
+]
+
+[sources]
+# Restrict crates to crates.io plus any git sources explicitly allowed below.
+# Catches accidental private-registry deps and unexpected forks.
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []
+
+# [bans] intentionally omitted — sub-task 4 follow-up (see #477).

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -203,3 +203,17 @@ match Rust-ecosystem norms (Apache-2.0 carries an explicit patent grant).
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the project by you, as defined in the Apache-2.0 license, shall
 be dual licensed as above, without any additional terms or conditions.
+
+### Dependency licenses
+
+daft enforces a permissive-license allowlist on every transitive crate via
+[`cargo-deny`](https://github.com/EmbarkStudios/cargo-deny). The policy lives in
+[`deny.toml`](https://github.com/avihut/daft/blob/master/deny.toml) at the repo
+root and is gated in CI (`.github/workflows/test.yml`) on every PR that touches
+`Cargo.toml`, `Cargo.lock`, or `deny.toml`. The same check also fails the PR on
+any open RustSec advisory or a dep sourced from an unexpected registry.
+
+If a new dependency carries a license not on the allowlist (or you need to
+ignore an advisory), add a `[licenses.exceptions]` or `advisories.ignore` entry
+to `deny.toml` with a `# why:` comment explaining the rationale. Run
+`mise run deny` locally to verify before pushing.

--- a/mise-tasks/ci
+++ b/mise-tasks/ci
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #MISE description="Run CI simulation"
-#MISE depends=["setup", "validate", "test"]
+#MISE depends=["setup", "validate", "test", "deny"]
 set -euo pipefail
 
 echo "CI simulation completed successfully"

--- a/mise-tasks/deny
+++ b/mise-tasks/deny
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+#MISE description="Run cargo-deny license/advisory/source policy check"
+set -euo pipefail
+
+cargo deny check

--- a/mise.lock
+++ b/mise.lock
@@ -100,6 +100,10 @@ url = "https://github.com/oven-sh/bun/releases/download/bun-v1.3.13/bun-windows-
 version = "0.3.0"
 backend = "cargo:cargo-cooldown"
 
+[[tools."cargo:cargo-deny"]]
+version = "0.19.4"
+backend = "cargo:cargo-deny"
+
 [[tools.cocogitto]]
 version = "7.0.0"
 backend = "aqua:cocogitto/cocogitto"

--- a/mise.toml
+++ b/mise.toml
@@ -27,6 +27,12 @@ neovim = "stable"
 # (see MISE_DISABLE_TOOLS in .github/workflows/test.yml lint job) because
 # scripts/check-lockfile-age.sh enforces the same policy at PR boundary.
 "cargo:cargo-cooldown" = "0.3.0"
+# cargo-deny: license / advisory / source policy gate. Run via `mise run
+# deny`; enforced in CI on every PR that touches Cargo.toml, Cargo.lock, or
+# deny.toml. Pinned to lockfile version (matches the post-#498 convention
+# of pinning over "latest" to avoid per-install registry resolution and
+# trim a CI flake surface).
+"cargo:cargo-deny" = "0.19.4"
 
 [env]
 _.path = ["./target/release"]


### PR DESCRIPTION
## Summary

- Adds `cargo-deny` pinned through mise with a permissive license allowlist, RustSec advisory gating, and source-registry restriction. Enforced in CI on every PR that touches `Cargo.toml`, `Cargo.lock`, or `deny.toml`.
- Mirrors the existing `cargo-cooldown` / `.dep-age-allowlist` supply-chain pattern: small dedicated tool + CI gate + allowlist with `# why:` rationale.
- `[bans]` (duplicate-version detection) deferred to a follow-up — daft has natural duplicate transitive versions today (`winnow`, `windows_*`) that need curation before that gate can land cleanly.

## Baseline curation

The initial run surfaced three real findings, all triaged in this PR:

- **`BSL-1.0`** (Boost Software License 1.0) on `clipboard-win` / `error-code`, transitive through `arboard` → `edtui`. Added to the allowlist — permissive, OSI-approved, FSF Free.
- **`RUSTSEC-2025-0141`** (bincode `unmaintained`) — transitive through `syntect`. No safe upgrade exists; added to `advisories.ignore` with rationale. Revisit when syntect drops bincode 1.x.
- **`RUSTSEC-2024-0320`** (yaml-rust `unmaintained`) — same dependency chain. Revisit when syntect migrates to yaml-rust2.

## Test plan

- [x] `mise install` fetches `cargo-deny` 0.19.4 through the cargo backend (covered by the existing 7-day `minimum_release_age` gate)
- [x] `mise run deny` passes locally: `advisories ok, bans ok, licenses ok, sources ok`
- [x] `mise run fmt:check` clean
- [x] `mise run clippy` zero warnings
- [x] `mise run test:unit` 1703 passed, 0 failed
- [ ] CI: `dep-license-check` job appears and passes on this PR
- [ ] CI: docs-only follow-up commit (if any) skips the new job via the `lockfile` path gate

Closes #477.