### PR TITLE
fix(tui): keep size column TOTAL summary intact when wider than data cells

### DIFF
--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -27,7 +27,11 @@ use clap::Parser;
 use std::collections::HashSet;
 use tabled::{
     builder::Builder,
-    settings::{Padding, Style, Width, object::Columns, peaker::Priority},
+    settings::{
+        Padding, Style, Width,
+        object::Columns,
+        peaker::{Peaker, Priority},
+    },
 };
 use terminal_size::{Width as TermWidth, terminal_size};
 
@@ -631,6 +635,42 @@ fn build_emit_table(
     table
 }
 
+/// Like `Priority::max(true)` but never picks the excluded column indices.
+///
+/// `Priority::max(true)` shrinks the widest column first when `Width::truncate`
+/// runs. That's fine for descriptive columns (Branch/Path/LastCommit) but the
+/// Size column's TOTAL summary cell (`"10.2G"`, `"127.4G"`) gets truncated mid-
+/// suffix when it becomes a shrink candidate (#501). `Width::increase`/MinWidth
+/// doesn't help — `Width::truncate` derives its per-column floors from
+/// `EmptyRecords` (padding only), so MinWidth pads cells but doesn't pin a
+/// shrink floor. Excluding the column from the candidate set is the only
+/// surgical fix.
+///
+/// Honors `mins` so the shrink loop terminates cleanly when every non-excluded
+/// column has hit its floor.
+///
+/// Note: the other fixed-width metric columns (`Hash`, `Changes`, `Base`,
+/// `Remote`, `Age`, `Owner`) have the same class of bug under `Priority::max`
+/// in very narrow terminals — the TUI's `fit_widths_to_available` only
+/// shrinks `{Branch, Path, LastCommit}`. Excluding more columns here would
+/// be a separate scope.
+struct PriorityMaxExcept {
+    excluded: Vec<usize>,
+}
+
+impl Peaker for PriorityMaxExcept {
+    fn peak(&mut self, mins: &[usize], values: &[usize]) -> Option<usize> {
+        values
+            .iter()
+            .zip(mins.iter())
+            .enumerate()
+            .filter(|(i, _)| !self.excluded.contains(i))
+            .filter(|(_, (w, m))| **w > **m)
+            .max_by_key(|(_, (w, _))| **w)
+            .map(|(i, _)| i)
+    }
+}
+
 fn print_table(
     infos: &[crate::core::worktree::list::WorktreeInfo],
     project_root: &std::path::Path,
@@ -1024,14 +1064,36 @@ fn print_table(
     table.modify(Columns::first(), Padding::new(1, 0, 0, 0));
 
     if let Some((TermWidth(width), _)) = terminal_size() {
-        table.with(
-            Width::truncate(width as usize)
-                .suffix("...")
-                .priority(Priority::max(true)),
-        );
+        let width = width as usize;
+        // When the Size column is shown, exclude it from the shrink candidate
+        // set — its TOTAL summary cell can be wider than any data cell and
+        // gets truncated otherwise (#501). See `PriorityMaxExcept`.
+        match size_column_index(selected_columns, show_annotations) {
+            Some(idx) => table.with(Width::truncate(width).suffix("...").priority(
+                PriorityMaxExcept {
+                    excluded: vec![idx],
+                },
+            )),
+            None => table.with(
+                Width::truncate(width)
+                    .suffix("...")
+                    .priority(Priority::max(true)),
+            ),
+        };
     }
 
     println!("{table}");
+}
+
+/// The visible column index of `Size` in the rendered blocking table, or `None`
+/// if the user didn't select it. Accounts for the leading annotation column
+/// when annotations are shown.
+fn size_column_index(selected_columns: &[ListColumn], show_annotations: bool) -> Option<usize> {
+    let pos = selected_columns
+        .iter()
+        .filter(|c| **c != ListColumn::Annotation)
+        .position(|c| *c == ListColumn::Size)?;
+    Some(if show_annotations { pos + 1 } else { pos })
 }
 
 #[cfg(test)]
@@ -1121,6 +1183,80 @@ mod tests {
             .position(|h| h == "size_bytes")
             .unwrap();
         assert_eq!(total_row[size_bytes_idx], Cell::Int(1024));
+    }
+
+    #[test]
+    fn size_column_index_returns_position_among_visible_columns() {
+        // Annotation is filtered out before col_headers, so the index for Size
+        // is computed against the post-filter column list, then offset by 1
+        // when the annotation column is shown.
+        let cols = &[
+            ListColumn::Branch,
+            ListColumn::Path,
+            ListColumn::Size,
+            ListColumn::Age,
+        ];
+        assert_eq!(size_column_index(cols, false), Some(2));
+        assert_eq!(size_column_index(cols, true), Some(3));
+    }
+
+    #[test]
+    fn size_column_index_is_none_when_size_unselected() {
+        let cols = &[ListColumn::Branch, ListColumn::Path];
+        assert_eq!(size_column_index(cols, false), None);
+        assert_eq!(size_column_index(cols, true), None);
+    }
+
+    #[test]
+    fn size_column_index_skips_annotation_in_position_count() {
+        // Annotation in selected_columns is filtered out before col_headers
+        // is built, so the visible position of Size shifts down by one when
+        // Annotation appears earlier in the list.
+        let cols = &[ListColumn::Annotation, ListColumn::Branch, ListColumn::Size];
+        // show_annotations=false: annotation column not shown, Size is at 1.
+        assert_eq!(size_column_index(cols, false), Some(1));
+        // show_annotations=true: leading annotation column adds 1.
+        assert_eq!(size_column_index(cols, true), Some(2));
+    }
+
+    /// `PriorityMaxExcept` underpins the #501 fix: pick the widest column to
+    /// shrink, but skip excluded indices and stop when every non-excluded
+    /// column has hit its floor.
+    #[test]
+    fn priority_max_except_picks_widest_non_excluded() {
+        let mut p = PriorityMaxExcept { excluded: vec![1] };
+        // values=[10, 20, 15], col 1 (widest) is excluded → pick col 2 (15).
+        assert_eq!(p.peak(&[0, 0, 0], &[10, 20, 15]), Some(2));
+    }
+
+    #[test]
+    fn priority_max_except_returns_none_when_all_at_min() {
+        let mut p = PriorityMaxExcept { excluded: vec![1] };
+        // Non-excluded columns 0,2 are at their mins → terminate.
+        assert_eq!(p.peak(&[5, 0, 5], &[5, 30, 5]), None);
+    }
+
+    #[test]
+    fn priority_max_except_skips_excluded_even_when_widest() {
+        let mut p = PriorityMaxExcept { excluded: vec![0] };
+        // Excluded col 0 is by far the widest; must still pick col 2.
+        assert_eq!(p.peak(&[0, 0, 0], &[100, 5, 8]), Some(2));
+    }
+
+    /// The TUI's natural-width computation passes
+    /// `format_human_size(total).chars().count()` as the Size column's extra
+    /// width (#501). Internal whitespace would split the cell across the
+    /// column boundary, so pin the contract: the formatted total has no
+    /// spaces.
+    #[test]
+    fn format_human_size_has_no_internal_whitespace() {
+        for bytes in [0, 1024, 1024u64.pow(2), 11 * 1024u64.pow(3)] {
+            let s = format_human_size(bytes);
+            assert!(
+                !s.contains(char::is_whitespace),
+                "format_human_size({bytes}) = {s:?} must not contain whitespace"
+            );
+        }
     }
 
     #[test]

--- a/src/output/tui/columns.rs
+++ b/src/output/tui/columns.rs
@@ -142,11 +142,16 @@ pub(super) fn status_display_width(status: &WorktreeStatus) -> u16 {
 }
 
 /// Compute the maximum content width a column needs across all rows.
+///
+/// `extra_width` lets callers contribute a non-row width that must also fit —
+/// today it's the TOTAL summary cell for the Size column (#501). Callers that
+/// don't have a summary pass `0`.
 pub(super) fn column_content_width(
     col: Column,
     worktrees: &[WorktreeRow],
     vals: &[ColumnValues],
     sort_spec: Option<&SortSpec>,
+    extra_width: u16,
 ) -> u16 {
     // Account for sort indicator (" ↓" / " ↑" = 2 visible chars) in header width.
     let sort_extra: u16 = col
@@ -157,8 +162,8 @@ pub(super) fn column_content_width(
     let header_width = col.label().len() as u16 + sort_extra;
     if worktrees.is_empty() {
         return match col {
-            Column::Status => header_width.max(STATUS_MAX_WIDTH),
-            _ => header_width,
+            Column::Status => header_width.max(STATUS_MAX_WIDTH).max(extra_width),
+            _ => header_width.max(extra_width),
         };
     }
     let max_data = worktrees
@@ -194,7 +199,7 @@ pub(super) fn column_content_width(
         })
         .max()
         .unwrap_or(0);
-    header_width.max(max_data)
+    header_width.max(max_data).max(extra_width)
 }
 
 /// Minimum widths for shrinkable columns. Below these the column would lose
@@ -286,6 +291,34 @@ mod tests {
             !ALL_COLUMNS.contains(&Column::Size),
             "Size requires --columns +size; it must not appear in the default set"
         );
+    }
+
+    /// `extra_width` lets the caller inject a baseline (e.g. the TOTAL summary
+    /// cell width for the Size column, which isn't represented in `worktrees`).
+    /// Regression: #501 — without this, the size column was sized to data only
+    /// and the TOTAL cell got truncated.
+    #[test]
+    fn column_content_width_honors_extra_width_when_wider() {
+        let w = column_content_width(Column::Size, &[], &[], None, /* extra_width */ 6);
+        assert_eq!(
+            w, 6,
+            "extra_width must dominate when wider than header/data"
+        );
+    }
+
+    #[test]
+    fn column_content_width_ignores_extra_width_when_narrower() {
+        // "Size" header is 4 chars; extra_width=2 should not shrink the column.
+        let w = column_content_width(Column::Size, &[], &[], None, 2);
+        assert_eq!(w, 4, "extra_width must not shrink below header width");
+    }
+
+    #[test]
+    fn column_content_width_status_keeps_minimum_with_extra_width() {
+        // Status has a hard floor (STATUS_MAX_WIDTH); extra_width below it
+        // shouldn't shrink the column.
+        let w = column_content_width(Column::Status, &[], &[], None, 3);
+        assert_eq!(w, STATUS_MAX_WIDTH);
     }
 
     #[test]

--- a/src/output/tui/render.rs
+++ b/src/output/tui/render.rs
@@ -201,13 +201,45 @@ pub fn render_table(state: &TuiState, frame: &mut Frame, area: Rect) {
         }
     };
 
+    // Pre-compute the Size column's formatted TOTAL once and reuse for both
+    // (a) the natural-width hint passed to `column_content_width` (so the
+    // column is sized to fit the summary cell that's appended later) and
+    // (b) the summary footer row build below. The summary row otherwise
+    // doesn't participate in width sizing — regression: #501.
+    // If a future column also gets a summary row, thread its width through
+    // the same way; `column_content_width`'s `extra_width` is single-valued.
+    let total_size: Option<String> = if columns.contains(&Column::Size) {
+        let total_bytes: u64 = state
+            .live
+            .rows
+            .iter()
+            .filter(|wt| wt.info.kind == EntryKind::Worktree)
+            .filter(|wt| !matches!(wt.status, WorktreeStatus::Done(FinalStatus::Pruned)))
+            .filter_map(|wt| wt.info.size_bytes)
+            .sum();
+        Some(format_human_size(total_bytes))
+    } else {
+        None
+    };
+    let size_total_width: u16 = total_size
+        .as_ref()
+        .map(|s| s.chars().count() as u16)
+        .unwrap_or(0);
+
     // Compute natural column widths, then shrink Branch/Path so the table fits
     // in the available area. Without this step a single long path or branch
     // name in `live.rows` (often off-screen) blows out those columns and
     // squeezes `LastCommit` (Fill(1)) down to nearly zero width.
     let natural_widths: Vec<u16> = columns
         .iter()
-        .map(|col| column_content_width(*col, &state.live.rows, &row_vals, sort_ref))
+        .map(|col| {
+            let extra = if matches!(col, Column::Size) {
+                size_total_width
+            } else {
+                0
+            };
+            column_content_width(*col, &state.live.rows, &row_vals, sort_ref, extra)
+        })
         .collect();
     let assigned_widths = fit_widths_to_available(&columns, &natural_widths, table_area.width);
 
@@ -410,23 +442,13 @@ pub fn render_table(state: &TuiState, frame: &mut Frame, area: Rect) {
         }
     }
 
-    // Summary footer row for the Size column
-    let has_size_column = columns.contains(&Column::Size);
-    if has_size_column {
+    // Summary footer row for the Size column. `total_size` is computed once
+    // above so the natural-width hint and the rendered cell stay in lockstep.
+    if let Some(total_size) = &total_size {
         // Empty separator row
         let empty_cells: Vec<Cell> = (0..num_columns).map(|_| Cell::from("")).collect();
         all_rows.push(Row::new(empty_cells));
 
-        // Summary row with total size (excludes pruned worktrees)
-        let total_bytes: u64 = state
-            .live
-            .rows
-            .iter()
-            .filter(|wt| wt.info.kind == EntryKind::Worktree)
-            .filter(|wt| !matches!(wt.status, WorktreeStatus::Done(FinalStatus::Pruned)))
-            .filter_map(|wt| wt.info.size_bytes)
-            .sum();
-        let total_size = format_human_size(total_bytes);
         let summary_cells: Vec<Cell> = columns
             .iter()
             .map(|col| {
@@ -1574,5 +1596,70 @@ mod tests {
                 "header at width 100 should contain {label:?}; got: {header:?}"
             );
         }
+    }
+
+    /// Regression for #501. Three worktrees of 5 GiB each give a TOTAL of
+    /// 15 GiB → "15.0G" (5 chars), wider than each per-row "5.0G" (4 chars).
+    /// Pre-fix, `column_content_width` only saw data rows, so the column was
+    /// allocated 4 chars and the TOTAL summary cell rendered as "15.0" — the
+    /// unit suffix was silently truncated. This test pins that the full
+    /// "15.0G" string appears in the rendered buffer.
+    #[test]
+    fn render_table_size_column_total_fits_when_wider_than_data() {
+        let mut wts: Vec<WorktreeInfo> = (0..3)
+            .map(|i| {
+                let mut info = WorktreeInfo::empty(&format!("feat/branch{i}"));
+                info.size_bytes = Some(5 * 1024 * 1024 * 1024); // 5 GiB
+                info
+            })
+            .collect();
+        // First worktree is the current one (so it gets a path).
+        wts[0].path = Some(PathBuf::from("/tmp/test/feat/branch0"));
+
+        let state = TuiState::new(
+            Vec::<OperationPhase>::new(),
+            wts,
+            PathBuf::from("/tmp/test"),
+            PathBuf::from("/tmp/test"),
+            Stat::Summary,
+            0,
+            Some(vec![Column::Branch, Column::Path, Column::Size]),
+            true,
+            None,
+            None::<SortSpec>,
+            true,
+            false,
+            crate::core::worktree::info_field::FieldSet::EMPTY,
+        );
+
+        // 80 cols is plenty wide — no shrinking forced. The bug being tested
+        // is about natural-width sizing, not about narrow-terminal behavior.
+        let backend = TestBackend::new(80, 8);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render_table(&state, frame, frame.area());
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+
+        // Sweep all rows for "15.0G" — the summary row position depends on
+        // header + 3 data rows + separator, but pinning the row index would
+        // be brittle. The full string only ever appears in the TOTAL cell.
+        let full_buffer: String = (0..buffer.area.height)
+            .flat_map(|y| {
+                (0..buffer.area.width)
+                    .map(move |x| buffer[(x, y)].symbol().to_string())
+                    .chain(std::iter::once("\n".to_string()))
+            })
+            .collect();
+        assert!(
+            full_buffer.contains("15.0G"),
+            "TOTAL summary should render full \"15.0G\" — got buffer:\n{full_buffer}"
+        );
+        assert!(
+            !full_buffer.contains("15.0 ") && !full_buffer.contains("15.0\n"),
+            "TOTAL must not render as truncated \"15.0\" — got buffer:\n{full_buffer}"
+        );
     }
 }

--- a/tests/manual/scenarios/list/size-total.yml
+++ b/tests/manual/scenarios/list/size-total.yml
@@ -1,0 +1,46 @@
+name: List size column with TOTAL summary
+description: |
+  --columns +size renders the Size column and a summary row with the total
+  size in a unit suffix (K/M/G/T). The blocking renderer leaves the summary
+  row's other cells blank — there is no literal "TOTAL" label (that's only
+  in the structured-emit path's `path` cell). Smoke coverage for the
+  wire-up touched by #501. The runner pipes stdio so terminal_size() returns
+  None, meaning Width::truncate doesn't fire — true truncation regression
+  coverage lives in unit + TestBackend tests (PriorityMaxExcept tests in
+  src/commands/list.rs and render_table_size_column_total_fits_when_wider_than_data
+  in src/output/tui/render.rs).
+
+repos:
+  - name: test-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone the repository
+    run: git-worktree-clone --layout contained $REMOTE_TEST_REPO
+    expect:
+      exit_code: 0
+
+  - name: Checkout develop
+    run: git-worktree-checkout develop
+    cwd: "$WORK_DIR/test-repo"
+    expect:
+      exit_code: 0
+
+  - name: Checkout feature branch
+    run: git-worktree-checkout feature/test-feature
+    cwd: "$WORK_DIR/test-repo"
+    expect:
+      exit_code: 0
+
+  - name: List with --columns +size shows Size column
+    run: NO_COLOR=1 git-worktree-list --columns +size 2>&1
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "Size"
+        # Standard fixture worktrees are tiny — the per-row and TOTAL cells
+        # all render as "<1K". The string appearing N+1 times (N data rows
+        # plus the summary row) is implicit since `output_contains` only
+        # checks substring presence; the TestBackend test covers the bug.
+        - "<1K"


### PR DESCRIPTION
## Summary

- The `daft list --columns +size` TOTAL summary cell silently truncated when wider than per-row cells (`10.2G` → `10.2`, losing the unit suffix).
- Two render paths, two distinct mechanisms: TUI sizes columns from data rows only; blocking shrinks the size column under `Width::truncate` + `Priority::max(true)` once Branch/Path hit their floor.
- Fix threads the formatted TOTAL width into `column_content_width` (TUI) and replaces `Priority::max(true)` with a custom `PriorityMaxExcept` Peaker that excludes the size column (blocking).

## Why not `MinWidth`

`Width::truncate` derives per-column floors from `EmptyRecords` (padding only), not from `MinWidth` settings — verified empirically with a standalone repro. `MinWidth`/`Width::increase` pads cells but doesn't pin a shrink floor. Excluding the column from the candidate set is the only surgical fix.

## Out of scope

The other fixed-width metric columns (`Hash`, `Changes`, `Base`, `Remote`, `Age`, `Owner`) have the same class of bug under `Priority::max(true)` in very narrow terminals — the TUI's `fit_widths_to_available` only shrinks `{Branch, Path, LastCommit}`. Noted in `PriorityMaxExcept`'s docstring; can be a follow-up.

## Test plan

- [x] `mise run fmt:check` — clean
- [x] `mise run clippy` — clean
- [x] `mise run test:unit` — 1713 tests pass
- [x] `mise run test:manual -- --ci tests/manual/scenarios/list/` — 53 scenarios / 167 steps pass
- [x] New `TestBackend` regression test fails pre-fix (renders `15.0`), passes post-fix (renders `15.0G`) — verified by temporarily reverting `column_content_width`'s `.max(extra_width)`
- [x] Standalone tabled repro confirms blocking-path fix at terminal widths 18, 20, 25, 30, 120
- [ ] Manual TTY check in a scratch repo with multi-GB worktrees (CI cannot exercise this — `terminal_size()` returns `None` under piped stdio)

Fixes #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)