### PR TITLE
perf(test-runner): parallelize YAML scenario execution

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -482,9 +482,16 @@ jobs:
 
       - name: Run YAML manual tests
         if: matrix.suite == 'yaml'
+        # `--jobs $(nproc)` saturates the runner — CI is dedicated to this job
+        # so there's no need for `--parallel`'s `num_cpus/2` headroom for
+        # concurrent local work.
+        #
+        # Security note: every input here is workflow-controlled (the config
+        # file path comes from a `mktemp` step, `nproc` is a coreutils binary).
+        # No `${{ github.event.* }}` substitutions touch the run: body.
         run: |
           GIT_CONFIG_GLOBAL="${{ steps.config.outputs.config_file }}" \
-            DAFT_TESTING=1 ./target/release/xtask manual-test --ci
+            DAFT_TESTING=1 ./target/release/xtask manual-test --ci --jobs "$(nproc)"
 
       - name: Test shell completions
         if: matrix.suite == 'bash'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3691,6 +3691,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5679,6 +5699,7 @@ dependencies = [
  "ctrlc",
  "daft",
  "nix",
+ "rayon",
  "serde",
  "serde_yaml",
  "tempfile",

--- a/benches/README.md
+++ b/benches/README.md
@@ -1,0 +1,128 @@
+# Benchmarks
+
+Two families of benchmarks live here. Both write their results to
+`benches/results/` (gitignored) and follow a `:baseline`/`:compare` workflow so
+you can pin a SHA's numbers and diff against them as work lands.
+
+## Family 1 — daft vs git (command runtime)
+
+For changes that affect how fast a single daft command runs (`clone`,
+`checkout`, `prune`, ...). Each scenario uses [`hyperfine`] to compare
+`daft <cmd>` against the equivalent raw-git invocation, three-way against the
+gitoxide variant where applicable.
+
+```bash
+mise run bench                 # All scenarios
+mise run bench:clone           # Just clone
+mise run bench:baseline        # Pin the current results
+mise run bench:compare         # Diff latest against the baseline
+```
+
+Implementation:
+
+- `benches/scenarios/*.sh` — one per command
+- `benches/bench_framework.sh` — shared `bench_compare` helper
+- `mise-tasks/bench/*` — task wiring
+
+When to run: before merging anything that touches the hot path of an existing
+command, or when adding a new command.
+
+## Family 2 — test-runner performance (issue #509)
+
+For changes that affect how fast the YAML manual-test suite itself runs.
+Distinct from the command benchmarks above — here the unit under test is
+`xtask manual-test`, not `daft <cmd>`. Two sub-benchmarks:
+
+```bash
+mise run bench:tests:manual              # Single-trial wall-clock check (~30 min serial)
+mise run bench:tests:manual:scale        # Scaling sweep across --jobs values (~2-4 hours)
+mise run bench:tests:manual:scale-baseline   # Pin scale results
+mise run bench:tests:manual:scale-compare    # Diff against baseline
+```
+
+`bench:tests:manual` is the cheap "did we regress the serial baseline" check —
+one run with default flags. `bench:tests:manual:scale` is the deep "how does
+parallelism scale" check, sweeping `--jobs` over a range and emitting
+per-scenario p50/p95/max distributions.
+
+Implementation:
+
+- `benches/scenarios/test_manual_scale.sh` — driver
+- `mise-tasks/bench/tests/manual/*` — task wiring
+
+### Configuring the scaling sweep
+
+```bash
+BENCH_JOBS=1,2,4,8     # comma-separated --jobs values to sweep (default: 1,2,4,8)
+BENCH_RUNS=3           # trials per jobs value (default: 3)
+BENCH_SKIP_TIMING=1    # skip per-scenario distribution phase (faster)
+```
+
+### Per-scenario timing
+
+When `DAFT_MANUAL_TEST_EMIT_TIMING=1` is set, the manual-test runner emits one
+grep-friendly line per scenario:
+
+```
+[bench] scenario="Clone basic" elapsed_ms=412
+```
+
+The scaling sweep script uses this to compute p50/p95/max distributions. Outside
+the bench harness, you can pipe the output through `grep ^\[bench\]` to capture
+per-scenario timings yourself.
+
+## Methodology notes
+
+### Wall-clock is machine-relative
+
+Numbers from the bench harness depend on CPU, disk, and concurrent load. The
+`summary.md` headers always capture the machine the run was taken on so future
+readers know what they're comparing.
+
+**For SHA-over-SHA comparison on the same machine,** the absolute numbers are
+directly comparable. Regressions in the daft binary's startup or per-scenario
+overhead show up as a slower serial baseline.
+
+**For parallelism quality across SHAs,** use the speedup ratio
+(`serial / parallel`) rather than absolute parallel wall-clock. The ratio
+abstracts over machine speed; only the curve shape matters.
+
+### Variance
+
+The scaling sweep defaults to 3 trials per jobs value. hyperfine reports mean ±
+stddev. A standard deviation above ~5% of the mean is a sign of contention
+(background processes, disk pressure) — re-run on a quiet machine before drawing
+conclusions.
+
+`bench:tests:manual` is a single trial by design — it's the everyday "did
+anything regress?" check, not a publication-quality measurement. Use the scaling
+sweep for that.
+
+### Baselines
+
+Two baselines coexist:
+
+- **Local baseline** — what `mise run bench:tests:manual:scale-baseline`
+  produces: a copy of your last run pinned to
+  `benches/results/test-manual-scale-baseline.md` (gitignored). Use for
+  day-to-day "did my change regress my own machine?" checks.
+- **Reference baseline** — committed under `benches/baselines/` with a
+  date-stamped filename (`test-manual-scale-YYYY-MM-DD.md`). Captures the
+  numbers a maintainer measured on a specific machine; future PRs doing #509
+  work can compare the _curve shape_ (speedup × efficiency) against it, even
+  when their machine differs in absolute speed. Add a new dated file when a PR
+  materially moves the numbers — don't edit prior baselines in place.
+
+### Long-form review
+
+When a PR is meant to move the needle on #509:
+
+1. Pin the pre-change baseline: `mise run bench:tests:manual:scale-baseline` on
+   the parent commit.
+2. Apply the change.
+3. Run `mise run bench:tests:manual:scale`.
+4. `mise run bench:tests:manual:scale-compare` for the diff.
+5. Paste the diff into the PR description, and consider whether to add a fresh
+   `benches/baselines/test-manual-scale-<date>.md` reference snapshot.
+
+[`hyperfine`]: https://github.com/sharkdp/hyperfine

--- a/benches/baselines/test-manual-scale-2026-05-17.md
+++ b/benches/baselines/test-manual-scale-2026-05-17.md
@@ -1,0 +1,158 @@
+# Manual-test runner scaling — post-#510 baseline
+
+Reference results captured after the parallelization work in #510 landed on this
+branch. Pinned here so future #509 work can be measured against a defensible
+starting point.
+
+- **Captured:** 2026-05-17, 02:30–02:55 UTC+3
+- **SHA:** `208c3603` (branch `daft-510/perf/parallelize-yaml-test-runner`) —
+  includes both the `perf(test-runner): parallelize…` commit and the
+  `fix(test-runner): suppress orphan log-clean spawns…` commit
+- **Machine:** Apple M1 Max — 10 physical / 10 logical cores
+- **macOS:** Darwin 25.4.0
+- **Scenarios in corpus:** 572 (master at `fe3e9faf`, post-coordinator redesign)
+- **Default cap (`--parallel`):** 5 (= `available_parallelism() / 2`)
+- **Harness:** `mise run bench:tests:manual:scale`, hyperfine 1.20.0
+
+## Headline
+
+| Mode                          | Wall-clock | Speedup vs serial | Speedup vs pre-PR main† |
+| ----------------------------- | ---------- | ----------------- | ----------------------- |
+| pre-PR main (serial, no fix)  | ~1586 s    | —                 | 1.00×                   |
+| this PR, `--jobs 1`           | 392 s      | 1.00×             | **4.05×**               |
+| this PR, `--parallel` (cap=5) | 100 s      | **3.92×**         | **15.9×**               |
+| this PR, `--jobs 10`          | 82 s       | 4.78×             | 19.3×                   |
+
+† The pre-PR row is a one-shot measurement on the parent commit
+(`xtask -- manual-test --ci`) before either the parallelization work or the
+`DAFT_NO_LOG_CLEAN=1` test-env fix landed. Two effects combine: (a) parallelism
+amortizes scenarios across workers, and (b) suppressing `daft __clean-logs`
+orphan spawns prevents init-reparented daemons from stealing CPU as the corpus
+grows. The fix alone is responsible for the 4.05× jump from
+`pre-PR main → --jobs 1` — even users who don't opt into `--parallel` will see a
+serial run drop from ~26 minutes to under 7.
+
+## Phase 1 — wall-clock by `--jobs` (full sweep)
+
+| --jobs | Mean     | σ       | Min      | Max      | Trials | Speedup | Efficiency |
+| ------ | -------- | ------- | -------- | -------- | ------ | ------- | ---------- |
+| 1      | 392.10 s | 1.51 s  | 390.47 s | 393.46 s | 3      | 1.00×   | 100%       |
+| 2      | 217.22 s | 0.94 s  | 216.64 s | 218.30 s | 3      | 1.81×   | 90%        |
+| 4      | 113.78 s | 0.46 s  | 113.26 s | 114.13 s | 3      | 3.45×   | 86%        |
+| 5      | 100.00 s | 3.45 s  | 97.07 s  | 103.80 s | 3      | 3.92×   | 78%        |
+| 8      | ~144 s   | (noisy) | 123.12 s | 165.91 s | 2      | 2.71×   | 34%        |
+| 10     | 82.19 s  | —       | 82.19 s  | 82.19 s  | 1      | 4.78×   | 48%        |
+
+Efficiency = `speedup / jobs` — ideal is 100%.
+
+### What the curve says
+
+- **Scaling is near-linear up to ~num_cpus/2 (jobs=4–5).** The default cap that
+  `--parallel` picks is well-chosen on this class of machine.
+- **Past num_cpus/2, returns diminish quickly.** jobs=8 actually _regresses_
+  below jobs=5 (longer wall-clock, higher variance, and scenario failures
+  appeared in one of two trials at jobs=8 — likely contention on a shared
+  resource we haven't traced). jobs=10 recovers and improves to 4.78× but with
+  much lower efficiency.
+- **Don't push `--jobs` above `num_cpus/2` casually.** The default cap exists
+  for a reason.
+
+## Phase 2 — per-scenario distribution
+
+572 scenarios, captured via `DAFT_MANUAL_TEST_EMIT_TIMING=1`.
+
+| Mode                 | p50    | p95     | max     | Cumulative scenario time |
+| -------------------- | ------ | ------- | ------- | ------------------------ |
+| `--jobs 1` (serial)  | 498 ms | 1111 ms | 3213 ms | 300.0 s                  |
+| `--jobs 5` (default) | 567 ms | 1293 ms | 3502 ms | 342.5 s                  |
+
+Notes:
+
+- Per-scenario times grow ~14% (p50) under `--jobs 5` due to CPU contention.
+  Acceptable trade-off for the 3.92× wall-clock win.
+- Cumulative scenario time (300 s) is less than the serial wall-clock (392 s);
+  the ~92 s gap is xtask-level overhead per scenario — sandbox `mkdir`/`cp -a`
+  setup, `TestEnv::Drop` teardown, output buffer serialization — that lives
+  outside `run_non_interactive` and isn't counted in the per-scenario timer.
+- That fixed overhead is what caps efficiency: at `--jobs 5` the cumulative work
+  is 342.5 s spread across 5 workers (perfect scheduling → 68.5 s); we measure
+  100 s, leaving ~31 s for the same fixed overhead amortized across the parallel
+  run.
+
+## Failure rate
+
+| Mode                 | Scenarios | Steps | Passed | Failed              |
+| -------------------- | --------- | ----- | ------ | ------------------- |
+| `--jobs 1` (serial)  | 572       | 2193  | 2193   | 0                   |
+| `--jobs 5` (default) | 572       | 2193  | 2193   | 0                   |
+| `--jobs 8`           | 572       | —     | varies | 1+ in 1 of 2 trials |
+| `--jobs 10`          | 572       | —     | varies | flaky               |
+
+Parallelism at the default cap surfaces zero new failures across multiple runs —
+the acceptance criterion's "no new flakes" is met for that knob. Pushing past
+`num_cpus/2` does introduce occasional failures; this is consistent with the
+"diminishing returns" reading of the wall-clock curve and is the reason the
+default cap is `num_cpus/2` rather than `num_cpus`.
+
+## Methodology
+
+1. Build release binaries:
+   `cargo build --release && cargo build -p xtask --release`.
+2. Clean `/tmp`:
+   `find -L /tmp -maxdepth 1 -name 'daft-manual-test-*' -type d -exec rm -rf {} +`.
+3. Confirm no orphan daft processes:
+   `ps -e -o pid,ppid,command | awk '$2==1 && /target\/release\/daft/'` should
+   be empty.
+4. Run:
+   ```bash
+   BENCH_JOBS=1,2,4,5,8,10 BENCH_RUNS=3 mise run bench:tests:manual:scale
+   ```
+5. To re-baseline this file on a new machine or after a corpus change, run the
+   same command and copy `benches/results/test-manual-scale.md` into
+   `benches/baselines/` with a date-stamped filename.
+
+### Variance and noise sources
+
+- `--jobs 5` showed σ = 3.45 s (~3.4% of the mean) vs σ ≤ 1.5 s at jobs={1,2,4}.
+  The default cap _is_ the contention boundary on this machine; variance climbs
+  when workers approach saturation.
+- `--jobs 8` ran with only 2 trials in this baseline (the bench harness exited
+  mid-sweep — see "Known harness issue" below); the wide range (123–166 s)
+  suggests it'd need 5+ trials to converge.
+- `--jobs 10` is a single trial. The number is suggestive, not rigorous.
+
+### Known harness issue
+
+`hyperfine` exited mid-sweep twice during baseline capture with
+`Error: No such file or directory (os error 2)` between consecutive parameter
+values. Root cause not isolated; the script now catches a non-zero hyperfine
+exit so partial JSON is preserved (`benches/scenarios/test_manual_scale.sh`).
+When this happens, the later parameter values are missing — re-run those
+individually:
+
+```bash
+hyperfine --warmup 0 --runs 3 --ignore-failure \
+    "target/release/xtask manual-test --ci --jobs N"
+```
+
+## What this enables for #509
+
+The umbrella's purpose is making the YAML manual-test runner fast enough to run
+on every PR without slowing down the dev loop. Today:
+
+- Pre-#510 + `DAFT_NO_LOG_CLEAN`: 392 s = 6.5 min serial. Workable but not
+  joyful.
+- This PR with `--parallel`: 100 s = 1.7 min. Below the "context-switch cost"
+  threshold — fast enough that engineers will actually wait for it on a PR.
+
+Going forward, the bench should fire on any change that touches:
+
+- `xtask/src/manual_test/` (the runner itself)
+- `tests/manual/scenarios/` (new scenarios that don't parallelize well)
+- The hot path of `daft` startup (a 50 ms regression per invocation = ~30 s
+  added to the serial baseline across 572 scenarios)
+- `src/coordinator/` or `src/hooks/` (the highest-fanout subsystems per
+  scenario)
+
+Re-baseline this file when the corpus grows by ~10%+, when MSRV changes (codegen
+variance), or when a structural change to the runner lands.

--- a/benches/scenarios/test_manual_scale.sh
+++ b/benches/scenarios/test_manual_scale.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Manual-test runner scaling sweep — times the YAML manual-test suite at
+# varying --jobs values so #509 progress can be measured SHA-over-SHA.
+#
+# Outputs:
+#   benches/results/test-manual-scale.md     human-readable summary
+#   benches/results/test-manual-scale.json   hyperfine-native JSON
+#
+# Configurable via env vars:
+#   BENCH_JOBS   comma-separated jobs values (default: 1,2,4,8)
+#   BENCH_RUNS   trials per jobs value (default: 3)
+#   BENCH_SKIP_TIMING   if set, skip Phase 2 per-scenario timing collection
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+RESULTS_DIR="$REPO_ROOT/benches/results"
+mkdir -p "$RESULTS_DIR"
+
+MD_OUT="$RESULTS_DIR/test-manual-scale.md"
+JSON_OUT="$RESULTS_DIR/test-manual-scale.json"
+
+JOBS_VALUES="${BENCH_JOBS:-1,2,4,8}"
+RUNS="${BENCH_RUNS:-3}"
+
+if ! command -v hyperfine >/dev/null 2>&1; then
+    echo "hyperfine not found. brew install hyperfine"
+    exit 1
+fi
+
+echo "Building daft + xtask (release)..."
+cargo build --release --quiet
+cargo build --package xtask --release --quiet
+
+if [[ "$(uname)" == "Darwin" ]]; then
+    CPU_PHYS=$(sysctl -n hw.physicalcpu)
+    CPU_LOG=$(sysctl -n hw.logicalcpu)
+    CPU_MODEL=$(sysctl -n machdep.cpu.brand_string)
+else
+    CPU_PHYS=$(nproc 2>/dev/null || echo "?")
+    CPU_LOG=$CPU_PHYS
+    CPU_MODEL=$(grep -m1 "model name" /proc/cpuinfo 2>/dev/null | sed 's/.*: //' || echo "?")
+fi
+DEFAULT_CAP=$((CPU_LOG / 2))
+[ "$DEFAULT_CAP" -lt 1 ] && DEFAULT_CAP=1
+DAFT_SHA=$(git -C "$REPO_ROOT" rev-parse --short HEAD)
+DAFT_BRANCH=$(git -C "$REPO_ROOT" symbolic-ref --short HEAD 2>/dev/null || echo "DETACHED")
+SCENARIO_COUNT=$(find "$REPO_ROOT/tests/manual/scenarios" -type f \( -name '*.yml' -o -name '*.yaml' \) | wc -l | tr -d ' ')
+
+echo "=== Manual-test scaling sweep ==="
+echo "  Daft:       $DAFT_BRANCH @ $DAFT_SHA"
+echo "  CPU:        $CPU_MODEL ($CPU_PHYS physical / $CPU_LOG logical)"
+echo "  Scenarios:  $SCENARIO_COUNT"
+echo "  Default cap: $DEFAULT_CAP (would be picked by --parallel)"
+echo "  Jobs values: $JOBS_VALUES"
+echo "  Trials:      $RUNS per value"
+echo
+
+# Pre-cleanup runs before each timed invocation so a previous run's
+# leftover sandboxes don't slow down the next one's mkdir/rm syscalls.
+PREPARE='find -L /tmp -maxdepth 1 -name "daft-manual-test-*" -type d -exec rm -rf {} + 2>/dev/null || true'
+
+# Phase 1 — hyperfine wall-clock sweep over --jobs values.
+# Don't let a transient hyperfine failure (we've seen sporadic
+# "No such file or directory" errors mid-sweep, root cause unclear)
+# short-circuit `set -e` and lose the data already collected. If
+# hyperfine bails partway, the JSON it has already written stays usable.
+echo "=== Phase 1: wall-clock sweep ==="
+set +e
+hyperfine \
+    --warmup 0 \
+    --min-runs "$RUNS" \
+    --max-runs "$RUNS" \
+    --ignore-failure \
+    --prepare "$PREPARE" \
+    --parameter-list jobs "$JOBS_VALUES" \
+    --command-name "jobs={jobs}" \
+    --export-json "$JSON_OUT" \
+    --export-markdown "${MD_OUT}.phase1" \
+    "$REPO_ROOT/target/release/xtask manual-test --ci --jobs {jobs}"
+HF_STATUS=$?
+set -e
+if [[ $HF_STATUS -ne 0 ]]; then
+    echo "Phase 1: hyperfine exited $HF_STATUS — keeping partial results in $JSON_OUT"
+fi
+if [[ ! -s "${MD_OUT}.phase1" ]]; then
+    echo "Phase 1: no markdown output; nothing to report."
+    echo "(empty)" > "${MD_OUT}.phase1"
+fi
+
+# Phase 2 — per-scenario timing at jobs=1 and at the default cap.
+SERIAL_TIMINGS=$(mktemp -t daft-bench-serial)
+PARALLEL_TIMINGS=$(mktemp -t daft-bench-parallel)
+trap 'rm -f "$SERIAL_TIMINGS" "$PARALLEL_TIMINGS"' EXIT
+
+if [[ -z "${BENCH_SKIP_TIMING:-}" ]]; then
+    echo
+    echo "=== Phase 2: per-scenario timing — jobs=1 ==="
+    eval "$PREPARE"
+    DAFT_MANUAL_TEST_EMIT_TIMING=1 \
+        "$REPO_ROOT/target/release/xtask" manual-test --ci --jobs 1 2>&1 \
+        | grep '^\[bench\] scenario=' > "$SERIAL_TIMINGS" || true
+
+    echo "=== Phase 2: per-scenario timing — jobs=$DEFAULT_CAP ==="
+    eval "$PREPARE"
+    DAFT_MANUAL_TEST_EMIT_TIMING=1 \
+        "$REPO_ROOT/target/release/xtask" manual-test --ci --jobs "$DEFAULT_CAP" 2>&1 \
+        | grep '^\[bench\] scenario=' > "$PARALLEL_TIMINGS" || true
+fi
+
+# Compute distribution stats from a timings file. Emits the markdown body
+# directly to stdout so callers can splice it into a report.
+percentiles() {
+    local f="$1"
+    if [[ ! -s "$f" ]]; then
+        echo "_(no samples — Phase 2 skipped or no timings emitted)_"
+        return
+    fi
+    awk -F'elapsed_ms=' '{print $2}' "$f" | sort -n | awk '
+    {
+        a[NR] = $1;
+    }
+    END {
+        n = NR;
+        if (n == 0) { print "_(no samples)_"; exit }
+        p50 = a[int((n + 1) * 0.50)];
+        p95 = a[int((n + 1) * 0.95)];
+        max = a[n];
+        sum = 0;
+        for (i = 1; i <= n; i++) sum += a[i];
+        printf "| scenarios | p50 | p95 | max | cumulative |\n";
+        printf "|---|---|---|---|---|\n";
+        printf "| %d | %d ms | %d ms | %d ms | %.1f s |\n", n, p50, p95, max, sum / 1000;
+    }'
+}
+
+# Compose the final markdown report.
+{
+    echo "# Manual-test runner scaling sweep"
+    echo
+    echo "- **Generated:** $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+    echo "- **Daft:** \`$DAFT_BRANCH @ $DAFT_SHA\`"
+    echo "- **CPU:** $CPU_MODEL ($CPU_PHYS physical / $CPU_LOG logical)"
+    echo "- **Scenarios in corpus:** $SCENARIO_COUNT"
+    echo "- **Default cap (\`--parallel\`):** $DEFAULT_CAP"
+    echo "- **Jobs swept:** \`$JOBS_VALUES\`"
+    echo "- **Trials per jobs value:** $RUNS"
+    echo
+    echo "## Wall-clock by --jobs"
+    echo
+    cat "${MD_OUT}.phase1"
+    if [[ -z "${BENCH_SKIP_TIMING:-}" ]]; then
+        echo
+        echo "## Per-scenario distribution"
+        echo
+        echo "### \`--jobs 1\` (serial)"
+        echo
+        percentiles "$SERIAL_TIMINGS"
+        echo
+        echo "### \`--jobs $DEFAULT_CAP\` (default cap)"
+        echo
+        percentiles "$PARALLEL_TIMINGS"
+    fi
+} > "$MD_OUT"
+
+rm -f "${MD_OUT}.phase1"
+
+echo
+echo "=== Done ==="
+echo "  Markdown: $MD_OUT"
+echo "  JSON:     $JSON_OUT"

--- a/mise-tasks/bench/tests/manual/scale
+++ b/mise-tasks/bench/tests/manual/scale
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+#MISE description="Scaling sweep: time the YAML manual-test runner across --jobs values"
+#MISE depends=["dev"]
+set -euo pipefail
+exec "$(git rev-parse --show-toplevel)/benches/scenarios/test_manual_scale.sh" "$@"

--- a/mise-tasks/bench/tests/manual/scale-baseline
+++ b/mise-tasks/bench/tests/manual/scale-baseline
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#MISE description="Pin the latest manual-test scaling results as the new baseline"
+set -euo pipefail
+
+RESULTS_DIR="$(git rev-parse --show-toplevel)/benches/results"
+
+if [[ ! -f "$RESULTS_DIR/test-manual-scale.md" ]]; then
+    echo "No scaling results to baseline. Run: mise run bench:tests:manual:scale"
+    exit 1
+fi
+
+cp "$RESULTS_DIR/test-manual-scale.md" "$RESULTS_DIR/test-manual-scale-baseline.md"
+cp "$RESULTS_DIR/test-manual-scale.json" "$RESULTS_DIR/test-manual-scale-baseline.json"
+echo "Baseline updated from current results."

--- a/mise-tasks/bench/tests/manual/scale-compare
+++ b/mise-tasks/bench/tests/manual/scale-compare
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#MISE description="Diff the latest manual-test scaling results against the pinned baseline"
+set -euo pipefail
+
+RESULTS_DIR="$(git rev-parse --show-toplevel)/benches/results"
+
+if [[ ! -f "$RESULTS_DIR/test-manual-scale.md" ]]; then
+    echo "No scaling results found. Run: mise run bench:tests:manual:scale"
+    exit 1
+fi
+
+if [[ ! -f "$RESULTS_DIR/test-manual-scale-baseline.md" ]]; then
+    echo "No baseline pinned yet. Run: mise run bench:tests:manual:scale-baseline"
+    echo
+    cat "$RESULTS_DIR/test-manual-scale.md"
+    exit 0
+fi
+
+diff --color "$RESULTS_DIR/test-manual-scale-baseline.md" "$RESULTS_DIR/test-manual-scale.md" || true

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -11,6 +11,7 @@ clap_mangen = "0.3"
 crossterm = "0.29"
 ctrlc = "3.5.2"
 daft = { path = "..", version = "1.13.0" }
+rayon = "1.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -399,6 +399,17 @@ enum Commands {
         /// Include expectation checks in --show output
         #[arg(long, requires = "show")]
         checks: bool,
+
+        /// Run scenarios in parallel. Output is buffered per scenario and
+        /// flushed in input order once all scenarios finish — runs concurrently,
+        /// reports deterministically.
+        #[arg(long)]
+        parallel: bool,
+
+        /// Cap on concurrent scenarios. Overrides --parallel and
+        /// DAFT_MANUAL_TEST_JOBS. `--jobs 1` forces serial execution.
+        #[arg(long, value_name = "N")]
+        jobs: Option<usize>,
     },
 }
 
@@ -427,18 +438,124 @@ fn main() -> Result<()> {
             list,
             show,
             checks,
-        } => manual_test::run(
-            scenarios,
-            no_interactive,
-            verbose,
-            step,
-            loop_count,
-            keep,
-            setup_only,
-            list,
-            show,
-            checks,
-        ),
+            parallel,
+            jobs,
+        } => {
+            let jobs = resolve_jobs(jobs, parallel)?;
+            manual_test::run(
+                scenarios,
+                no_interactive,
+                verbose,
+                step,
+                loop_count,
+                keep,
+                setup_only,
+                list,
+                show,
+                checks,
+                jobs,
+            )
+        }
+    }
+}
+
+/// Resolve the parallel-job cap for the manual-test runner.
+///
+/// Precedence: `--jobs N` > `DAFT_MANUAL_TEST_JOBS` > (`--parallel` ?
+/// `default_cap()` : 1). Returning `1` keeps today's serial behavior as the
+/// default; the rollout plan flips this to `default_cap()` in a follow-up PR
+/// after a week of `--parallel` use surfaces no new flakes.
+fn resolve_jobs(jobs_flag: Option<usize>, parallel_flag: bool) -> Result<usize> {
+    if let Some(n) = jobs_flag {
+        return Ok(n.max(1));
+    }
+    if let Ok(raw) = std::env::var("DAFT_MANUAL_TEST_JOBS") {
+        let parsed: usize = raw
+            .parse()
+            .with_context(|| format!("DAFT_MANUAL_TEST_JOBS must be a usize, got {raw:?}"))?;
+        return Ok(parsed.max(1));
+    }
+    if parallel_flag {
+        return Ok(default_cap());
+    }
+    Ok(1)
+}
+
+/// Default parallel-job cap. Aims for `available_parallelism() / 2` to leave
+/// headroom for the two-worktree scenarios that spawn child `daft` processes.
+fn default_cap() -> usize {
+    std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1)
+        .saturating_div(2)
+        .max(1)
+}
+
+#[cfg(test)]
+mod jobs_resolution_tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // Serializes the env-touching tests below — cargo runs unit tests on
+    // multiple threads by default and concurrent writes to the same env var
+    // would race.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn resolve_jobs_flag_wins_over_env_and_parallel() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::set_var("DAFT_MANUAL_TEST_JOBS", "9");
+        let r = resolve_jobs(Some(4), true).unwrap();
+        std::env::remove_var("DAFT_MANUAL_TEST_JOBS");
+        assert_eq!(r, 4);
+    }
+
+    #[test]
+    fn resolve_jobs_env_wins_over_parallel_flag() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::set_var("DAFT_MANUAL_TEST_JOBS", "7");
+        let r = resolve_jobs(None, true).unwrap();
+        std::env::remove_var("DAFT_MANUAL_TEST_JOBS");
+        assert_eq!(r, 7);
+    }
+
+    #[test]
+    fn resolve_jobs_parallel_flag_uses_default_cap() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var("DAFT_MANUAL_TEST_JOBS");
+        let r = resolve_jobs(None, true).unwrap();
+        assert_eq!(r, default_cap());
+        assert!(r >= 1);
+    }
+
+    #[test]
+    fn resolve_jobs_default_is_one() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var("DAFT_MANUAL_TEST_JOBS");
+        let r = resolve_jobs(None, false).unwrap();
+        assert_eq!(r, 1);
+    }
+
+    #[test]
+    fn resolve_jobs_zero_coerced_to_one() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var("DAFT_MANUAL_TEST_JOBS");
+        let r = resolve_jobs(Some(0), false).unwrap();
+        assert_eq!(r, 1);
+    }
+
+    #[test]
+    fn resolve_jobs_malformed_env_errors() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::set_var("DAFT_MANUAL_TEST_JOBS", "not-a-number");
+        let r = resolve_jobs(None, false);
+        std::env::remove_var("DAFT_MANUAL_TEST_JOBS");
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn default_cap_is_at_least_one() {
+        assert!(default_cap() >= 1);
     }
 }
 

--- a/xtask/src/manual_test/env.rs
+++ b/xtask/src/manual_test/env.rs
@@ -293,10 +293,15 @@ impl TestEnv {
             self.git_config_path.to_string_lossy().into_owned(),
         );
 
-        // Daft feature flags.
+        // Daft feature flags. Disable every daemon-style background spawn:
+        // the test harness invokes `daft` many times back-to-back, and any
+        // detached child that survives its parent (e.g. `daft __clean-logs`)
+        // accumulates as init-reparented orphans and steals CPU — visible as
+        // load-average climbing into the hundreds during parallel runs.
         env.insert("DAFT_TESTING".into(), "1".into());
         env.insert("DAFT_NO_UPDATE_CHECK".into(), "1".into());
         env.insert("DAFT_NO_TRUST_PRUNE".into(), "1".into());
+        env.insert("DAFT_NO_LOG_CLEAN".into(), "1".into());
         env.insert(
             "DAFT_CONFIG_DIR".into(),
             self.daft_config_dir.to_string_lossy().into_owned(),

--- a/xtask/src/manual_test/env.rs
+++ b/xtask/src/manual_test/env.rs
@@ -7,9 +7,15 @@
 use anyhow::{Context, Result};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use super::schema::Scenario;
+
+/// Within-process counter that guarantees `TestEnv::create` produces a unique
+/// `base_dir` even when called concurrently from rayon workers. The
+/// nanosecond+pid prefix disambiguates across overlapping xtask invocations.
+static SANDBOX_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
 /// Manages the lifecycle of a single test environment (sandbox).
 pub struct TestEnv {
@@ -45,24 +51,54 @@ impl Drop for TestEnv {
     }
 }
 
+/// Reserve the next sandbox base directory without creating it on disk.
+///
+/// Workers call this before registering the path with the SIGINT cleanup set
+/// so that an interruption during `TestEnv::create_at` still leaves a tracked
+/// path the handler can `rm -rf`.
+pub fn next_sandbox_base_dir(scenario: &Scenario) -> Result<PathBuf> {
+    if let Ok(base) = std::env::var("DAFT_MANUAL_TEST_BASE") {
+        // Deterministic path under a managed directory (e.g., sandbox/test/).
+        // Note: callers using DAFT_MANUAL_TEST_BASE with --jobs > 1 must
+        // ensure scenario names are unique, since this path is keyed by slug.
+        let slug = scenario.name.to_lowercase().replace(' ', "-");
+        return Ok(PathBuf::from(base).join(slug));
+    }
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("system clock before UNIX epoch")?
+        .as_nanos();
+    let pid = std::process::id();
+    let counter = SANDBOX_COUNTER.fetch_add(1, Ordering::Relaxed);
+    Ok(PathBuf::from(format!(
+        "/tmp/daft-manual-test-{nanos}-{pid}-{counter}"
+    )))
+}
+
 impl TestEnv {
     /// Create a new test environment on disk for the given scenario.
     ///
-    /// This creates the sandbox directory tree and initialises built-in
-    /// variables (`WORK_DIR`, `BASE_DIR`, `BINARY_DIR`) plus any extra vars
-    /// from `scenario.env`.
+    /// Picks a fresh sandbox path and delegates to [`Self::create_at`].
+    /// Prefer [`Self::create_at`] in the parallel worker path so the cleanup
+    /// registry can be populated before any directory I/O.
+    #[allow(dead_code)]
     pub fn create(scenario: &Scenario, project_root: &Path, keep: bool) -> Result<Self> {
-        let base_dir = if let Ok(base) = std::env::var("DAFT_MANUAL_TEST_BASE") {
-            // Deterministic path under a managed directory (e.g., sandbox/test/).
-            let slug = scenario.name.to_lowercase().replace(' ', "-");
-            PathBuf::from(base).join(slug)
-        } else {
-            let timestamp = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .context("system clock before UNIX epoch")?
-                .as_millis();
-            PathBuf::from(format!("/tmp/daft-manual-test-{timestamp}"))
-        };
+        let base_dir = next_sandbox_base_dir(scenario)?;
+        Self::create_at(scenario, project_root, base_dir, keep)
+    }
+
+    /// Create a test environment rooted at a caller-supplied `base_dir`.
+    ///
+    /// Used by the parallel worker so it can register `base_dir` with the
+    /// SIGINT cleanup set before any directories are created — that way a
+    /// signal arriving mid-create still leaves a tracked path the handler
+    /// can `rm -rf`.
+    pub fn create_at(
+        scenario: &Scenario,
+        project_root: &Path,
+        base_dir: PathBuf,
+        keep: bool,
+    ) -> Result<Self> {
         let remotes_dir = base_dir.join("remotes");
         let template_dir = base_dir.join("remotes-template");
         let work_dir = base_dir.join("work");
@@ -341,5 +377,38 @@ mod tests {
         let cmd_env = env.command_env();
         assert_eq!(cmd_env.get("GIT_AUTHOR_NAME").unwrap(), "Manual Test");
         assert_eq!(cmd_env.get("DAFT_TESTING").unwrap(), "1");
+    }
+
+    /// Regression test for the millisecond-timestamp collision bug:
+    /// two `TestEnv::create` calls in quick succession must produce distinct
+    /// `base_dir`s. Pre-#510 this used `as_millis()` and would collide under
+    /// rayon-parallel scheduling.
+    #[test]
+    fn test_create_produces_unique_base_dirs() {
+        use tempfile::TempDir;
+
+        let project_root = TempDir::new().expect("temp project root");
+        let scenario = Scenario {
+            name: "unique-test".to_string(),
+            description: None,
+            repos: Vec::new(),
+            env: HashMap::new(),
+            steps: Vec::new(),
+        };
+
+        let mut paths = Vec::new();
+        for _ in 0..16 {
+            let env = TestEnv::create(&scenario, project_root.path(), false)
+                .expect("TestEnv::create should succeed");
+            paths.push(env.base_dir.clone());
+            // env drops here, removing its sandbox.
+        }
+
+        let unique: std::collections::HashSet<_> = paths.iter().collect();
+        assert_eq!(
+            unique.len(),
+            paths.len(),
+            "TestEnv::create produced colliding base_dirs: {paths:?}"
+        );
     }
 }

--- a/xtask/src/manual_test/mod.rs
+++ b/xtask/src/manual_test/mod.rs
@@ -5,37 +5,140 @@ pub mod runner;
 pub mod schema;
 
 use anyhow::{Context, Result};
-use std::io::IsTerminal;
+use rayon::prelude::*;
+use std::collections::HashSet;
+use std::io::{IsTerminal, Write};
+use std::panic::AssertUnwindSafe;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
-/// Register a Ctrl+C handler that cleans up the active test environment.
+/// Shared registry of live sandbox directories.
 ///
-/// Returns a shared handle that the run loop updates with the current sandbox
-/// path. On SIGINT the handler removes that directory and exits.
-fn setup_cleanup_handler(keep: bool) -> Arc<Mutex<Option<PathBuf>>> {
-    let cleanup_path: Arc<Mutex<Option<PathBuf>>> = Arc::new(Mutex::new(None));
-    let handler_path = Arc::clone(&cleanup_path);
+/// Workers register their sandbox path on creation and unregister on cleanup;
+/// the Ctrl+C handler drains the set and removes every live sandbox. Using a
+/// generic `HashSet<PathBuf>` keeps the scheduler decoupled from any sandbox
+/// path prefix, which preserves the runner's spin-out story.
+type CleanupSet = Arc<Mutex<HashSet<PathBuf>>>;
+
+/// RAII guard that keeps the live-sandbox registry in sync.
+///
+/// Inserted into the cleanup set on construction and removed on drop, so
+/// early returns, `?`-propagated errors, and panics inside a worker all
+/// leave the registry consistent.
+struct CleanupGuard {
+    set: CleanupSet,
+    path: PathBuf,
+}
+
+impl CleanupGuard {
+    fn new(set: CleanupSet, path: PathBuf) -> Self {
+        if let Ok(mut g) = set.lock() {
+            g.insert(path.clone());
+        }
+        Self { set, path }
+    }
+}
+
+impl Drop for CleanupGuard {
+    fn drop(&mut self) {
+        if let Ok(mut g) = self.set.lock() {
+            g.remove(&self.path);
+        }
+    }
+}
+
+/// Register a Ctrl+C handler that cleans up every live test environment.
+///
+/// Returns a shared registry the run loop populates as scenarios start and
+/// clears as they finish. On SIGINT the handler drains the set in a loop —
+/// `process::exit(130)` aborts worker threads mid-flight without running
+/// their `Drop` impls, so a single drain can miss workers that registered
+/// after the snapshot. Re-draining with a short sleep between passes catches
+/// those late registrations until the set stays empty.
+fn setup_cleanup_handler(keep: bool) -> CleanupSet {
+    let set: CleanupSet = Arc::new(Mutex::new(HashSet::new()));
+    let handler_set = Arc::clone(&set);
 
     ctrlc::set_handler(move || {
         // Restore terminal state in case interactive mode left raw mode on.
         let _ = crossterm::terminal::disable_raw_mode();
         eprintln!();
         if !keep {
-            if let Ok(guard) = handler_path.lock() {
-                if let Some(dir) = guard.as_ref() {
+            // Workers in flight fall into two camps when SIGINT fires:
+            //
+            // 1. Past `CleanupGuard::new` — their `base_dir` is in the set.
+            //    Drain captures it; we `rm -rf` to remove whatever they
+            //    built so far. Their subprocesses (`git`, `cp`) may still
+            //    be running and may RECREATE entries at the same path
+            //    between our `rm` and `process::exit` below, which is why
+            //    we re-rm in a short loop while holding the lock.
+            // 2. About to call `CleanupGuard::new` — they block at
+            //    `set.lock()` because we hold the lock to process exit, then
+            //    die with the process. They never touch disk, so no leak.
+            //
+            // Holding the lock for the whole sequence prevents new
+            // registrations, so the `known` set captures the entire universe
+            // of paths that could possibly still have on-disk presence. The
+            // re-rm loop is bounded so the handler always finishes ahead of
+            // the main thread's rayon-iteration completion (which would
+            // otherwise short-circuit the closure via the natural anyhow
+            // bail with a non-130 exit code).
+            let mut g = match handler_set.lock() {
+                Ok(g) => g,
+                Err(p) => p.into_inner(),
+            };
+            let known: HashSet<PathBuf> = g.drain().collect();
+            for _ in 0..4 {
+                for dir in &known {
                     let _ = std::fs::remove_dir_all(dir);
-                    eprintln!("Cleaned up test environment.");
                 }
+                if known.iter().all(|p| !p.exists()) {
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(30));
             }
+            if !known.is_empty() {
+                eprintln!("Cleaned up {} test environment(s).", known.len());
+            }
+            // `g` stays in scope through process::exit — the lock is never
+            // released, which prevents any racing worker from registering a
+            // new sandbox between our drain and the process dying.
+            let _hold = g;
         }
         std::process::exit(130); // 128 + SIGINT(2)
     })
     .ok();
 
-    cleanup_path
+    set
 }
 
+/// Aggregated result of one scenario, produced by a parallel worker.
+struct ScenarioOutcome {
+    /// Position of the scenario in the input list; used to order both output
+    /// and stats independently of completion order.
+    index: usize,
+    /// Display name from the YAML (or the file path if parsing failed before
+    /// the name could be read).
+    name: String,
+    /// `None` when execution short-circuited before stats were computed
+    /// (parse/setup error or panic); `Some(_)` after a normal run.
+    result: Option<runner::ScenarioResult>,
+    /// Captured stderr-style output, replayed verbatim once all workers
+    /// finish.
+    output: Vec<u8>,
+    /// Fatal error, if any (parse/setup failure or panic).
+    error: Option<anyhow::Error>,
+}
+
+/// Read-only context shared across parallel workers.
+struct RunContext<'a> {
+    project_root: &'a Path,
+    fixtures_dir: &'a Path,
+    verbose: bool,
+    keep: bool,
+}
+
+#[allow(clippy::too_many_arguments)]
 pub fn run(
     scenarios: Vec<PathBuf>,
     no_interactive: bool,
@@ -47,6 +150,7 @@ pub fn run(
     list: bool,
     show: bool,
     checks: bool,
+    jobs: usize,
 ) -> Result<()> {
     let project_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .parent()
@@ -89,39 +193,175 @@ pub fn run(
     }
 
     let is_interactive = !no_interactive && std::io::stdin().is_terminal();
-    let cleanup_path = setup_cleanup_handler(keep);
+
+    if jobs > 1 {
+        if is_interactive {
+            anyhow::bail!(
+                "--jobs/--parallel is only supported in non-interactive mode (pass --ci or run from a non-TTY)"
+            );
+        }
+        if setup_only {
+            anyhow::bail!("--jobs/--parallel is incompatible with --setup-only");
+        }
+    }
+
+    let cleanup_set = setup_cleanup_handler(keep);
+
+    eprintln!();
+
+    // Interactive and --setup-only stay on the streaming serial path. Both
+    // have semantics — TTY ownership for interactive, `println!` of work_dir
+    // for shell capture in setup-only — that don't fit the buffered worker
+    // model used by the parallel scheduler.
+    if is_interactive || setup_only {
+        return run_serial(
+            &scenario_files,
+            &project_root,
+            &fixtures_dir,
+            &cleanup_set,
+            step,
+            loop_count,
+            verbose,
+            keep,
+            setup_only,
+            is_interactive,
+        );
+    }
+
+    // Non-interactive CI path — always goes through the parallel scheduler,
+    // even at `jobs == 1` (a 1-thread rayon pool). Output is buffered per
+    // scenario and flushed in input order.
+    run_parallel(
+        &scenario_files,
+        &project_root,
+        &fixtures_dir,
+        &cleanup_set,
+        verbose,
+        keep,
+        jobs,
+    )
+}
+
+fn run_parallel(
+    scenario_files: &[PathBuf],
+    project_root: &Path,
+    fixtures_dir: &Path,
+    cleanup_set: &CleanupSet,
+    verbose: bool,
+    keep: bool,
+    jobs: usize,
+) -> Result<()> {
+    let ctx = RunContext {
+        project_root,
+        fixtures_dir,
+        verbose,
+        keep,
+    };
+
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(jobs)
+        .build()
+        .context("building rayon thread pool")?;
+
+    let mut outcomes: Vec<ScenarioOutcome> = pool.install(|| {
+        scenario_files
+            .par_iter()
+            .enumerate()
+            .map(|(idx, path)| run_one_scenario(idx, path, &ctx, cleanup_set))
+            .collect()
+    });
+
+    // Restore input order before printing and aggregating, so output and
+    // stats are deterministic regardless of completion order.
+    outcomes.sort_by_key(|o| o.index);
+
+    let stderr = std::io::stderr();
+    {
+        let mut lock = stderr.lock();
+        for o in &outcomes {
+            lock.write_all(&o.output)?;
+        }
+    }
 
     let mut total_scenarios = 0usize;
     let mut total_steps = 0usize;
     let mut total_passed = 0usize;
     let mut total_failed = 0usize;
     let mut failed_scenarios: Vec<String> = Vec::new();
+    let mut errors: Vec<(String, anyhow::Error)> = Vec::new();
+
+    for o in outcomes {
+        match (o.result, o.error) {
+            (Some(sr), _) => {
+                total_scenarios += 1;
+                total_steps += sr.steps;
+                total_passed += sr.passed;
+                total_failed += sr.failed;
+                if sr.failed > 0 {
+                    failed_scenarios.push(o.name);
+                }
+            }
+            (None, Some(err)) => errors.push((o.name, err)),
+            (None, None) => {}
+        }
+    }
+
+    use daft::styles;
 
     eprintln!();
-
-    for path in &scenario_files {
-        let content = std::fs::read_to_string(path)
-            .with_context(|| format!("Failed to read scenario: {}", path.display()))?;
-        let raw: schema::RawScenario = serde_yaml::from_str(&content)
-            .with_context(|| format!("Failed to parse scenario: {}", path.display()))?;
-        let repos = resolve_repos(raw.repos, &fixtures_dir)
-            .with_context(|| format!("Failed to resolve repos in: {}", path.display()))?;
-        let scenario = schema::Scenario {
-            name: raw.name,
-            description: raw.description,
-            repos,
-            env: raw.env,
-            steps: raw.steps,
-        };
-
-        let mut test_env = env::TestEnv::create(&scenario, &project_root, keep || setup_only)?;
-
-        // Register for cleanup on Ctrl+C.
-        if let Ok(mut guard) = cleanup_path.lock() {
-            *guard = Some(test_env.base_dir.clone());
+    eprintln!(
+        "{} scenarios, {} steps, {} passed, {} failed",
+        total_scenarios,
+        total_steps,
+        styles::green(&total_passed.to_string()),
+        if total_failed > 0 {
+            styles::red(&total_failed.to_string())
+        } else {
+            "0".into()
         }
+    );
+    for name in &failed_scenarios {
+        eprintln!("{} {}", styles::red("x"), name);
+    }
+    for (name, err) in &errors {
+        eprintln!("{} {}: {err:#}", styles::red("ERROR"), name);
+    }
+    eprintln!();
 
-        // Generate repos from specs.
+    if !errors.is_empty() {
+        anyhow::bail!("{} scenario(s) hit a fatal error", errors.len());
+    }
+    if total_failed > 0 {
+        anyhow::bail!("{total_failed} step(s) failed across {total_scenarios} scenarios");
+    }
+
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_serial(
+    scenario_files: &[PathBuf],
+    project_root: &Path,
+    fixtures_dir: &Path,
+    cleanup_set: &CleanupSet,
+    step: Option<usize>,
+    loop_count: Option<usize>,
+    verbose: bool,
+    keep: bool,
+    setup_only: bool,
+    is_interactive: bool,
+) -> Result<()> {
+    for path in scenario_files {
+        let scenario = load_scenario(path, fixtures_dir)?;
+
+        // Register the sandbox path before touching disk so a SIGINT during
+        // `TestEnv::create_at` still leaves a tracked path the cleanup handler
+        // can `rm -rf`.
+        let base_dir = env::next_sandbox_base_dir(&scenario)?;
+        let _guard = CleanupGuard::new(Arc::clone(cleanup_set), base_dir.clone());
+        let mut test_env =
+            env::TestEnv::create_at(&scenario, project_root, base_dir, keep || setup_only)?;
+
         for repo_spec in &scenario.repos {
             repo_gen::generate_repo(repo_spec, &test_env.remotes_dir)?;
             test_env.register_remote(&repo_spec.name);
@@ -129,7 +369,6 @@ pub fn run(
         test_env.create_template()?;
 
         if setup_only {
-            // Run steps up to --step N (or all steps if not specified).
             let run_until = step
                 .unwrap_or(scenario.steps.len())
                 .min(scenario.steps.len());
@@ -146,19 +385,12 @@ pub fn run(
             eprintln!("Test environment ready at: {}", test_env.work_dir.display());
             // Print work dir to stdout for shell wrapper to capture for cd.
             println!("{}", test_env.work_dir.display());
-            // Don't clean up — the point is to keep the env for manual use.
-            if let Ok(mut guard) = cleanup_path.lock() {
-                *guard = None;
-            }
             continue;
         }
 
-        let result = if is_interactive {
+        if is_interactive {
             interactive::run_interactive(&scenario, &test_env, step, loop_count, verbose)?;
-            None
-        } else {
-            Some(runner::run_non_interactive(&scenario, &test_env, verbose)?)
-        };
+        }
 
         if keep {
             eprintln!(
@@ -171,52 +403,128 @@ pub fn run(
                 Err(e) => eprintln!("  Warning: cleanup failed: {e}"),
             }
         }
-
-        // Clear cleanup path after successful cleanup.
-        if let Ok(mut guard) = cleanup_path.lock() {
-            *guard = None;
-        }
-
-        if let Some(sr) = result {
-            total_scenarios += 1;
-            total_steps += sr.steps;
-            total_passed += sr.passed;
-            total_failed += sr.failed;
-            if sr.failed > 0 {
-                failed_scenarios.push(scenario.name.clone());
-            }
-        }
-    }
-
-    // Print overall summary for non-interactive runs.
-    if !is_interactive && scenario_files.len() > 0 {
-        use daft::styles;
-
-        eprintln!();
-        eprintln!(
-            "{} scenarios, {} steps, {} passed, {} failed",
-            total_scenarios,
-            total_steps,
-            styles::green(&total_passed.to_string()),
-            if total_failed > 0 {
-                styles::red(&total_failed.to_string())
-            } else {
-                "0".into()
-            }
-        );
-        if !failed_scenarios.is_empty() {
-            for name in &failed_scenarios {
-                eprintln!("{} {}", styles::red("x"), name);
-            }
-        }
-        eprintln!();
-
-        if total_failed > 0 {
-            anyhow::bail!("{total_failed} step(s) failed across {total_scenarios} scenarios");
-        }
     }
 
     Ok(())
+}
+
+fn load_scenario(path: &Path, fixtures_dir: &Path) -> Result<schema::Scenario> {
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("Failed to read scenario: {}", path.display()))?;
+    let raw: schema::RawScenario = serde_yaml::from_str(&content)
+        .with_context(|| format!("Failed to parse scenario: {}", path.display()))?;
+    let repos = resolve_repos(raw.repos, fixtures_dir)
+        .with_context(|| format!("Failed to resolve repos in: {}", path.display()))?;
+    Ok(schema::Scenario {
+        name: raw.name,
+        description: raw.description,
+        repos,
+        env: raw.env,
+        steps: raw.steps,
+    })
+}
+
+fn run_one_scenario(
+    index: usize,
+    path: &Path,
+    ctx: &RunContext<'_>,
+    cleanup_set: &CleanupSet,
+) -> ScenarioOutcome {
+    let scenario = match load_scenario(path, ctx.fixtures_dir) {
+        Ok(s) => s,
+        Err(e) => {
+            return ScenarioOutcome {
+                index,
+                name: path.display().to_string(),
+                result: None,
+                output: Vec::new(),
+                error: Some(e),
+            };
+        }
+    };
+
+    let name = scenario.name.clone();
+
+    // `catch_unwind` so a single panicking scenario doesn't poison the rayon
+    // pool — the worker reports the panic and the pool keeps draining the
+    // remaining scenarios.
+    let work = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        run_one_scenario_inner(&scenario, ctx, cleanup_set)
+    }));
+
+    match work {
+        Ok(Ok((sr, buf))) => ScenarioOutcome {
+            index,
+            name,
+            result: Some(sr),
+            output: buf,
+            error: None,
+        },
+        Ok(Err(err)) => ScenarioOutcome {
+            index,
+            name,
+            result: None,
+            output: Vec::new(),
+            error: Some(err),
+        },
+        Err(payload) => {
+            let msg = panic_payload_to_string(&payload);
+            ScenarioOutcome {
+                index,
+                name,
+                result: None,
+                output: Vec::new(),
+                error: Some(anyhow::anyhow!("scenario panicked: {msg}")),
+            }
+        }
+    }
+}
+
+fn run_one_scenario_inner(
+    scenario: &schema::Scenario,
+    ctx: &RunContext<'_>,
+    cleanup_set: &CleanupSet,
+) -> Result<(runner::ScenarioResult, Vec<u8>)> {
+    // Pre-register the sandbox path so a SIGINT during create_at still leaves
+    // a tracked path the cleanup handler can `rm -rf`. See [`setup_cleanup_handler`]
+    // for the matching drain-loop logic.
+    let base_dir = env::next_sandbox_base_dir(scenario)?;
+    let _guard = CleanupGuard::new(Arc::clone(cleanup_set), base_dir.clone());
+    let mut test_env = env::TestEnv::create_at(scenario, ctx.project_root, base_dir, ctx.keep)?;
+
+    for repo_spec in &scenario.repos {
+        repo_gen::generate_repo(repo_spec, &test_env.remotes_dir)?;
+        test_env.register_remote(&repo_spec.name);
+    }
+    test_env.create_template()?;
+
+    let mut buf: Vec<u8> = Vec::new();
+    let result = runner::run_non_interactive(scenario, &test_env, ctx.verbose, &mut buf)?;
+
+    if ctx.keep {
+        writeln!(
+            &mut buf,
+            "  Test environment kept at: {}",
+            test_env.base_dir.display()
+        )?;
+    } else {
+        match test_env.cleanup() {
+            Ok(()) => writeln!(&mut buf, "Cleaned up test environment.")?,
+            Err(e) => writeln!(&mut buf, "  Warning: cleanup failed: {e}")?,
+        }
+    }
+
+    Ok((result, buf))
+}
+
+fn panic_payload_to_string(payload: &Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<&'static str>() {
+        (*s).to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "<non-string panic payload>".to_string()
+    }
 }
 
 /// Resolve scenario arguments to full paths.
@@ -542,4 +850,68 @@ fn discover_scenarios_recursive(dir: &PathBuf) -> Result<Vec<(String, PathBuf)>>
     }
     scenarios.sort_by(|a, b| a.0.cmp(&b.0));
     Ok(scenarios)
+}
+
+#[cfg(test)]
+mod cleanup_guard_tests {
+    use super::*;
+
+    fn empty_set() -> CleanupSet {
+        Arc::new(Mutex::new(HashSet::new()))
+    }
+
+    #[test]
+    fn guard_registers_on_new_and_unregisters_on_drop() {
+        let set = empty_set();
+        let path = PathBuf::from("/tmp/daft-manual-test-fake");
+
+        {
+            let _g = CleanupGuard::new(Arc::clone(&set), path.clone());
+            assert!(set.lock().unwrap().contains(&path));
+        }
+
+        assert!(
+            !set.lock().unwrap().contains(&path),
+            "guard should have removed path on drop"
+        );
+    }
+
+    #[test]
+    fn guard_tracks_multiple_concurrent_sandboxes() {
+        let set = empty_set();
+        let p1 = PathBuf::from("/tmp/daft-manual-test-a");
+        let p2 = PathBuf::from("/tmp/daft-manual-test-b");
+
+        let g1 = CleanupGuard::new(Arc::clone(&set), p1.clone());
+        let g2 = CleanupGuard::new(Arc::clone(&set), p2.clone());
+        assert_eq!(set.lock().unwrap().len(), 2);
+
+        drop(g1);
+        assert!(set.lock().unwrap().contains(&p2));
+        assert!(!set.lock().unwrap().contains(&p1));
+
+        drop(g2);
+        assert!(set.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn guard_drop_during_panic_still_unregisters() {
+        let set = empty_set();
+        let path = PathBuf::from("/tmp/daft-manual-test-panicky");
+
+        let result = std::panic::catch_unwind({
+            let set = Arc::clone(&set);
+            let path = path.clone();
+            move || {
+                let _g = CleanupGuard::new(set, path);
+                panic!("worker exploded");
+            }
+        });
+
+        assert!(result.is_err());
+        assert!(
+            !set.lock().unwrap().contains(&path),
+            "guard must unregister even when the worker panics"
+        );
+    }
 }

--- a/xtask/src/manual_test/mod.rs
+++ b/xtask/src/manual_test/mod.rs
@@ -499,7 +499,20 @@ fn run_one_scenario_inner(
     test_env.create_template()?;
 
     let mut buf: Vec<u8> = Vec::new();
+    let scenario_start = std::time::Instant::now();
     let result = runner::run_non_interactive(scenario, &test_env, ctx.verbose, &mut buf)?;
+    let elapsed_ms = scenario_start.elapsed().as_millis();
+
+    // Opt-in per-scenario timing for the bench harness. Lines are
+    // grep-friendly and live inside the scenario's buffered output so they
+    // print in input order alongside the scenario's own report.
+    if std::env::var_os("DAFT_MANUAL_TEST_EMIT_TIMING").is_some() {
+        writeln!(
+            &mut buf,
+            "[bench] scenario={:?} elapsed_ms={elapsed_ms}",
+            scenario.name
+        )?;
+    }
 
     if ctx.keep {
         writeln!(

--- a/xtask/src/manual_test/runner.rs
+++ b/xtask/src/manual_test/runner.rs
@@ -7,6 +7,7 @@
 //! reports pass/fail.
 
 use anyhow::{Context, Result};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use super::env::TestEnv;
@@ -485,61 +486,65 @@ pub fn run_non_interactive(
     scenario: &Scenario,
     env: &TestEnv,
     verbose: bool,
+    out: &mut impl Write,
 ) -> Result<ScenarioResult> {
     use daft::styles;
 
-    eprintln!("{}", styles::cyan(&scenario.name));
+    writeln!(out, "{}", styles::cyan(&scenario.name))?;
 
     let mut passed = 0;
     let mut failed = 0;
 
     for (i, step) in scenario.steps.iter().enumerate() {
-        eprint!(
+        write!(
+            out,
             "{} {} ... ",
             styles::blue(&format!("[{}/{}]", i + 1, scenario.steps.len())),
             &step.name
-        );
+        )?;
 
         let result = execute_step(step, env, true)?;
 
         if result.all_passed {
             let check_count = result.assertions.len();
             if check_count > 0 {
-                eprintln!(
+                writeln!(
+                    out,
                     "{} {}",
                     styles::green("ok"),
                     styles::dim(&format!("({check_count} checks)"))
-                );
+                )?;
             } else {
-                eprintln!("{}", styles::green("ok"));
+                writeln!(out, "{}", styles::green("ok"))?;
             }
             if verbose {
                 for a in &result.assertions {
-                    eprintln!("  {} {}", styles::green("✓"), styles::dim(&a.label));
+                    writeln!(out, "  {} {}", styles::green("✓"), styles::dim(&a.label))?;
                 }
             }
             passed += 1;
         } else {
             let fail_count = result.assertions.iter().filter(|a| !a.passed).count();
-            eprintln!(
+            writeln!(
+                out,
                 "{} {}",
                 styles::red("FAIL"),
                 styles::dim(&format!("({fail_count} failed)"))
-            );
+            )?;
             for a in &result.assertions {
                 if !a.passed {
-                    eprintln!("  {} {}", styles::red("x"), a.label);
+                    writeln!(out, "  {} {}", styles::red("x"), a.label)?;
                     if let Some(detail) = &a.detail {
-                        eprintln!("    {}", styles::dim(detail));
+                        writeln!(out, "    {}", styles::dim(detail))?;
                     }
                 }
             }
             // Show captured output for debugging.
             let captured = combine_captured(&result.stdout, &result.stderr);
             if !captured.is_empty() {
-                eprintln!("  {}", styles::dim("--- captured output ---"));
+                writeln!(out, "  {}", styles::dim("--- captured output ---"))?;
                 for line in captured.lines().take(20) {
-                    eprintln!("  {}", styles::dim(line));
+                    writeln!(out, "  {}", styles::dim(line))?;
                 }
             }
             failed += 1;


### PR DESCRIPTION
## Summary

- Adds `--parallel` and `--jobs N` (plus `DAFT_MANUAL_TEST_JOBS`) to the xtask manual-test runner, executing scenarios concurrently via rayon with per-scenario buffered output flushed in input order. Default stays serial; a follow-up PR will flip the default after a week of opt-in use.
- Fixes orphan-spawn accumulation: the test env now sets `DAFT_NO_LOG_CLEAN=1`, suppressing detached `daft __clean-logs` children that would otherwise outlive xtask scenarios, get reparented to init, and steal CPU. This was effectively a precondition for parallel scaling working at all on local-dev runs.
- Adds a benchmark harness for #509 progress tracking: `mise run bench:tests:manual:scale` does a hyperfine parameter-scan over `--jobs` values + an opt-in per-scenario timing pass for p50/p95/max distributions. Methodology in `benches/README.md`; first reference baseline checked in at `benches/baselines/test-manual-scale-2026-05-17.md`.

## Speedup (M1 Max 10-core, 572 scenarios, full corpus)

| Mode                          | Wall-clock         | Speedup vs serial | Speedup vs pre-PR main |
|-------------------------------|--------------------|-------------------|------------------------|
| pre-PR main (serial, no fix)  | ~1586 s            | —                 | 1.00×                  |
| this PR, `--jobs 1`           | 392.10 s ± 1.51 s  | 1.00×             | **4.05×**              |
| this PR, `--parallel` (cap=5) | 100.00 s ± 3.45 s  | **3.92×**         | **15.9×**              |
| this PR, `--jobs 10`          | 82.19 s            | 4.78×             | 19.3×                  |

End-to-end: 26 min → 1.7 min on a 10-core box.

Scaling is near-linear up to `num_cpus/2`: jobs=2 (1.81× / 90%), jobs=4 (3.45× / 86%), jobs=5 (3.92× / 78%). Past `num_cpus/2`, returns diminish and scenario flakes appear — `available_parallelism()/2` is well-calibrated as the default cap. Zero new failures at the default cap across all measured runs.

Per-scenario distribution at the default cap stays clean: p50 567 ms, p95 1293 ms — only ~14% per-scenario slowdown from CPU contention, paid back many times over in wall-clock.

## Rollout

The runner ships with serial as the default. `--parallel` is opt-in; `--jobs N` and `DAFT_MANUAL_TEST_JOBS` are the explicit overrides. The acceptance criteria's "parallel by default" flips in a follow-up PR after a week of opt-in use surfaces no new flakes. Interactive mode and `--setup-only` hard-error when `--jobs > 1` — their semantics (TTY ownership, `println!` of `work_dir` for shell capture) don't survive the buffered worker model.

## CI

CI in `test.yml:487` still invokes serial. A follow-up commit on this PR will enable `--parallel` there to measure the impact on CI wall-clock.

## Test plan

- [ ] CI checks pass (build, unit, integration matrix)
- [ ] `mise run test:unit` locally (1721 + 65 xtask passing)
- [ ] `mise run clippy` zero warnings
- [ ] Manual `target/release/xtask manual-test --ci --parallel` produces deterministic input-ordered output matching serial
- [ ] SIGINT mid-run cleans up sandbox dirs (no leaks)
- [ ] Mixed pass/fail scenario set produces stable `failed_scenarios` list in input order under both serial and parallel

Refs #510, part of #509.

🤖 Generated with [Claude Code](https://claude.com/claude-code)