### PR TITLE
feat: add top-level -C <path> flag (git -C semantics)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -160,6 +160,36 @@ but agent shells typically don't have that wrapper installed, so follow-up
 commands will fail with `chdir: no such file or directory` until the agent's cwd
 is fixed.
 
+## Global Flags
+
+All daft commands and `git-worktree-*` symlinked entries accept a top-level
+`-C <path>` flag that changes the effective working directory before resolving
+any path-dependent state (repo discovery, layout, hooks, `daft.yml`). Semantics
+match `git -C`.
+
+```bash
+daft -C /path/to/repo list             # equivalent to: cd /path/to/repo && daft list
+daft -C /path/to/repo go feature/x     # creates worktree inside /path/to/repo
+git-worktree-list -C /path/to/repo     # works for symlink entries too
+```
+
+**This is the recommended pattern for agents** operating across multiple daft
+worktrees in a session. It eliminates the need to `cd` between invocations and
+makes each command self-contained ("do X in path Y"). Prefer `-C` over spawning
+a subshell with `cd && daft …`.
+
+Rules:
+
+- Composes like `git -C`: `daft -C /a -C b list` is equivalent to
+  `daft -C /a/b list`. Each subsequent non-absolute `-C` resolves relative to
+  the previous applied cwd. **Not** "last wins".
+- `-C ""` is a no-op (cwd unchanged).
+- Missing/non-directory path: terse error, exit code 2.
+- Relative paths in subcommand arguments resolve against the post-`-C` cwd.
+- `-C` is parsed only at the very front of the argv (before the subcommand
+  name), so a subcommand-local `-C` (e.g. an inner shell command in `daft exec`)
+  is preserved.
+
 ## Command Reference
 
 All commands below use the `daft` binary form for agent execution. Users know

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -252,6 +252,10 @@ export default defineConfig({
             text: "Running commands across worktrees",
             link: "/worktrees/running-commands",
           },
+          {
+            text: "Running daft from anywhere (-C)",
+            link: "/worktrees/from-anywhere",
+          },
           { text: "Merging across worktrees", link: "/worktrees/merging" },
           { text: "Shortcuts", link: "/worktrees/shortcuts" },
         ],
@@ -392,6 +396,7 @@ export default defineConfig({
             text: "CLI",
             collapsed: true,
             items: [
+              { text: "daft (top-level)", link: "/reference/cli/daft" },
               {
                 text: "Setup",
                 items: [

--- a/docs/cli/daft.md
+++ b/docs/cli/daft.md
@@ -1,0 +1,95 @@
+---
+title: daft
+description: Top-level daft binary and global options
+---
+
+# daft
+
+The top-level `daft` binary dispatches to subcommands (`daft list`, `daft go`,
+`daft checkout`, …) and equivalent `git worktree-*` symlinks. Run `daft` with
+no arguments for a categorized overview, or `daft <command> --help` for help
+on a specific subcommand.
+
+## Global options
+
+These options are parsed before subcommand dispatch and apply to every daft
+subcommand and `git-worktree-*` symlinked entry.
+
+### `-C <path>`
+
+Run as if `daft` had been started in `<path>` instead of the current working
+directory. The chdir happens before repo discovery, layout resolution, hook
+lookup, and `daft.yml` reading — so the entire invocation behaves as if you
+had `cd`-ed into `<path>` first.
+
+```bash
+daft -C ~/repos/foo list         # equivalent to:  cd ~/repos/foo && daft list
+daft -C ~/repos/foo go feat/x    # creates the worktree inside ~/repos/foo
+git-worktree-list -C ~/repos/foo # works for symlinked entries too
+```
+
+#### Composition
+
+Multiple `-C` flags **compose**, matching `git -C`. Each subsequent
+non-absolute `-C <path>` is interpreted relative to the previously applied
+cwd:
+
+```bash
+daft -C ~/repos -C foo list      # equivalent to:  daft -C ~/repos/foo list
+daft -C /tmp -C a -C b list      # lands in /tmp/a/b
+```
+
+The first relative `-C` is resolved against the cwd at invocation time;
+subsequent ones compose against the prior `-C`.
+
+#### Empty argument
+
+`-C ""` is a no-op (cwd unchanged), matching `git -C ""`.
+
+#### Errors
+
+If `<path>` doesn't exist or isn't a directory, daft prints a terse error and
+exits with status 2 (clap usage-error convention):
+
+```
+daft: -C: '/missing/path': not a directory
+```
+
+#### Why it exists
+
+Agent-driven workflows: an agent operating across multiple worktrees in a
+single session often can't reliably `cd`, so each invocation needs to be
+self-contained. `-C <path>` turns every daft call into "do X in path Y",
+matching the pattern users already know from `git -C`, `make -C`, and
+`pnpm -C`.
+
+Humans get a quality-of-life win too: `daft -C ~/repos/foo list` is shorter
+than `cd ~/repos/foo && daft list`.
+
+#### Interactions
+
+- **Shell-integration cd redirect** (`DAFT_CD_FILE`) works through `-C`. The
+  wrapper strips `-C <path>` from the front of args before dispatching to the
+  verb, then reattaches them so the binary applies the chdir. `daft -C
+  ~/repo go newbranch` leaves your shell inside the new worktree under
+  `~/repo`.
+- **Hooks** run from the post-`-C` cwd. The `.daft/hooks/` directory and
+  `daft.yml` are resolved from the new working directory's repo root.
+- **XDG state directories** (`DAFT_CONFIG_DIR` / `DAFT_DATA_DIR`) are
+  environment-based, not cwd-based, and are unaffected by `-C`.
+- **Relative path arguments** to the subcommand are resolved against the
+  post-`-C` cwd. `daft -C ~/repos exec ./script.sh` runs `~/repos/script.sh`.
+
+### `--version`, `-V`
+
+Print the daft version and exit.
+
+### `--help`, `-h`
+
+Print the top-level command overview.
+
+## See also
+
+- [Configuration reference](/reference/configuration)
+- [Shell integration](/getting-started/shell-integration)
+- `daft <command> --help` for per-subcommand documentation.

--- a/docs/worktrees/from-anywhere.md
+++ b/docs/worktrees/from-anywhere.md
@@ -1,0 +1,87 @@
+---
+title: Running daft from anywhere with -C
+description:
+  Use the top-level -C <path> flag to operate on a worktree or repo without
+  cd-ing into it. Primary use case is agentic workflows; humans benefit too.
+---
+
+# Running daft from anywhere with `-C`
+
+`daft -C <path> <subcommand>` runs the subcommand as if you had `cd`-ed into
+`<path>` first. The chdir happens before repo discovery, layout resolution, hook
+lookup, and `daft.yml` reading — so the entire invocation behaves as if you had
+been there from the start.
+
+Same semantics as `git -C`, `make -C`, and `pnpm -C`.
+
+```bash
+daft -C ~/repos/foo list             # equivalent to:  cd ~/repos/foo && daft list
+daft -C ~/repos/foo go feat/x        # creates worktree inside ~/repos/foo
+git-worktree-list -C ~/repos/foo     # works via the symlink entry too
+```
+
+## When to reach for it
+
+### Coding agents
+
+The motivating use case. When an agent works across multiple daft worktrees in
+one session, it often can't reliably `cd` — the tool surface either doesn't
+expose `cd` or expects each command to be self-contained. `-C` turns every
+invocation into "do X in path Y":
+
+```bash
+# Agent batch-running tests across three feature worktrees:
+daft -C ~/repos/api/feat/auth   exec --all -- cargo test
+daft -C ~/repos/api/feat/billing exec --all -- cargo test
+daft -C ~/repos/api/feat/search  exec --all -- cargo test
+```
+
+Without `-C`, the agent would need to spawn a shell for each command
+(`bash -c 'cd … && daft …'`), or fight daft's repo-discovery walk-up.
+
+### Humans
+
+`daft -C ~/repos/foo list` is shorter than `cd ~/repos/foo && daft list`, and
+keeps your shell wherever it was.
+
+## Composition (matches git)
+
+Multiple `-C` flags compose. Each subsequent non-absolute path is interpreted
+relative to the previously applied cwd:
+
+```bash
+daft -C ~/repos -C foo list          # = daft -C ~/repos/foo list
+daft -C /tmp -C a -C b list          # lands in /tmp/a/b
+```
+
+This is **not** "last wins" — that would silently break scripts that build up
+`-C` arguments incrementally.
+
+## With the shell integration
+
+`-C` cooperates with `DAFT_CD_FILE` redirection. If you have the shell wrapper
+installed (`eval "$(daft shell-init bash)"`), running:
+
+```bash
+daft -C ~/repos/foo go feat/x
+```
+
+leaves your shell inside `~/repos/foo/feat/x`, not in `~/repos/foo` and not in
+your previous cwd. The wrapper strips `-C <path>` from the front of the args
+before dispatching to the verb, then reattaches them so the binary applies the
+chdir — so the cd-redirect path is preserved.
+
+## Edge cases
+
+- `-C ""` is a no-op (cwd unchanged), matching `git -C ""`.
+- Missing/non-directory path: terse error and exit 2.
+- Relative paths in subcommand arguments are resolved against the post-`-C` cwd.
+  `daft -C ~/repos exec ./script.sh` runs `~/repos/script.sh`.
+- `-C` is parsed before subcommand dispatch, so a subcommand-local `-C` flag
+  (e.g. an inner shell command's `-C`) is not consumed: only the leading
+  `-C <path>` pairs (those appearing before the verb) are processed.
+
+## See also
+
+- [`daft` CLI reference — global options](/reference/cli/daft#global-options)
+- [Shell integration](/getting-started/shell-integration)

--- a/man/daft.1
+++ b/man/daft.1
@@ -4,7 +4,7 @@
 .SH NAME
 daft \- A Git extensions toolkit for worktree\-based development
 .SH SYNOPSIS
-\fBdaft\fR [\fB\-h\fR|\fB\-\-help\fR] [\fIsubcommands\fR]
+\fBdaft\fR [\fB\-C \fR] [\fB\-h\fR|\fB\-\-help\fR] [\fIsubcommands\fR]
 .SH DESCRIPTION
 daft is a comprehensive Git extensions toolkit that enhances developer workflows with powerful worktree management. It provides both git\-style subcommands (git worktree\-clone, git worktree\-checkout, ...) and short verb aliases (daft clone, daft go, daft start, ...).
 .PP
@@ -16,6 +16,9 @@ To enable automatic cd into new worktrees, add the shell integration:
 .PP
 See daft\-shell\-init(1) for details.
 .SH OPTIONS
+.TP
+\fB\-C\fR \fI<path>\fR
+Run as if started in <path> instead of the current working directory. Applied before subcommand dispatch, layout resolution, and hook discovery. Multiple `\-C` flags compose, matching `git \-C` semantics.
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help (see a summary with \*(Aq\-h\*(Aq)

--- a/src/cli/argv.rs
+++ b/src/cli/argv.rs
@@ -1,0 +1,174 @@
+//! Pure parser for top-level CLI flags that must be handled before clap dispatch.
+//!
+//! Currently handles `-C <path>` with `git -C` semantics (multiple flags compose,
+//! empty path is a no-op). The imperative shell that applies the chdir and
+//! installs the stripped argv lives in `super`.
+
+use std::path::PathBuf;
+
+use thiserror::Error;
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct ParseResult {
+    /// Paths to chdir into, in argv order. Each is applied as a separate
+    /// `set_current_dir` call so relative paths compose (matching git).
+    /// Empty paths (from `-C ""`) are retained so the caller can choose how to
+    /// handle them; the standard git behavior is no-op.
+    pub chdir_paths: Vec<PathBuf>,
+    /// argv with the consumed `-C <path>` pairs removed. argv[0] (program name)
+    /// is always preserved.
+    pub stripped: Vec<String>,
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum ParseError {
+    #[error("option requires an argument")]
+    MissingPathAfterC,
+}
+
+/// Parse top-level options off the front of argv.
+///
+/// Stops at the first non-option token (the subcommand name) so that
+/// subcommand-local flags with the same name are preserved untouched.
+/// `-C "" ` is preserved as an empty `PathBuf` so the caller can implement
+/// git's "no-op" semantic without losing the fact that the flag was used.
+pub fn parse_top_level_cwd(argv: &[String]) -> Result<ParseResult, ParseError> {
+    let mut chdir_paths = Vec::new();
+    let mut stripped = Vec::with_capacity(argv.len());
+
+    let Some((program, rest)) = argv.split_first() else {
+        return Ok(ParseResult {
+            chdir_paths,
+            stripped,
+        });
+    };
+    stripped.push(program.clone());
+
+    let mut iter = rest.iter();
+    while let Some(tok) = iter.next() {
+        if tok == "-C" {
+            let path = iter.next().ok_or(ParseError::MissingPathAfterC)?;
+            chdir_paths.push(PathBuf::from(path));
+            continue;
+        }
+        // First non-option token (or unknown option) stops the scan. Push it
+        // and the rest verbatim — those belong to the subcommand.
+        stripped.push(tok.clone());
+        stripped.extend(iter.cloned());
+        break;
+    }
+
+    Ok(ParseResult {
+        chdir_paths,
+        stripped,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn s(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    fn paths(items: &[&str]) -> Vec<PathBuf> {
+        items.iter().map(PathBuf::from).collect()
+    }
+
+    #[test]
+    fn empty_argv() {
+        let r = parse_top_level_cwd(&[]).unwrap();
+        assert!(r.chdir_paths.is_empty());
+        assert!(r.stripped.is_empty());
+    }
+
+    #[test]
+    fn no_flags() {
+        let r = parse_top_level_cwd(&s(&["daft", "list"])).unwrap();
+        assert!(r.chdir_paths.is_empty());
+        assert_eq!(r.stripped, s(&["daft", "list"]));
+    }
+
+    #[test]
+    fn single_c_flag() {
+        let r = parse_top_level_cwd(&s(&["daft", "-C", "/tmp", "list"])).unwrap();
+        assert_eq!(r.chdir_paths, paths(&["/tmp"]));
+        assert_eq!(r.stripped, s(&["daft", "list"]));
+    }
+
+    #[test]
+    fn compose_two_c_flags() {
+        let r = parse_top_level_cwd(&s(&["daft", "-C", "/tmp", "-C", "foo", "list"])).unwrap();
+        assert_eq!(r.chdir_paths, paths(&["/tmp", "foo"]));
+        assert_eq!(r.stripped, s(&["daft", "list"]));
+    }
+
+    #[test]
+    fn stops_at_subcommand_preserves_inner_c() {
+        // Once `bar` is hit (non-option), the scan stops. The inner `-C baz`
+        // belongs to the subcommand and must be preserved verbatim.
+        let r = parse_top_level_cwd(&s(&[
+            "daft", "-C", "/tmp", "-C", "foo", "bar", "list", "-C", "baz",
+        ]))
+        .unwrap();
+        assert_eq!(r.chdir_paths, paths(&["/tmp", "foo"]));
+        assert_eq!(r.stripped, s(&["daft", "bar", "list", "-C", "baz"]));
+    }
+
+    #[test]
+    fn empty_path_preserved() {
+        // git's `-C ""` semantic: the flag was used, but it's a no-op. The
+        // imperative shell decides how to handle the empty path; the parser
+        // just preserves it.
+        let r = parse_top_level_cwd(&s(&["daft", "-C", "", "list"])).unwrap();
+        assert_eq!(r.chdir_paths, paths(&[""]));
+        assert_eq!(r.stripped, s(&["daft", "list"]));
+    }
+
+    #[test]
+    fn trailing_c_missing_path() {
+        let err = parse_top_level_cwd(&s(&["daft", "-C"])).unwrap_err();
+        assert_eq!(err, ParseError::MissingPathAfterC);
+    }
+
+    #[test]
+    fn unknown_long_option_stops_scan() {
+        // Any token that isn't `-C` stops the scan. `--version` belongs to
+        // the dispatch layer in main.rs (or to a subcommand) — the parser
+        // doesn't know about it and must not consume it.
+        let r = parse_top_level_cwd(&s(&["daft", "--version"])).unwrap();
+        assert!(r.chdir_paths.is_empty());
+        assert_eq!(r.stripped, s(&["daft", "--version"]));
+    }
+
+    #[test]
+    fn symlink_entry_with_c() {
+        // Invocation via a symlinked entry: argv[0] is the symlink name, not
+        // "daft". Behavior must be identical.
+        let r = parse_top_level_cwd(&s(&[
+            "git-worktree-checkout",
+            "-C",
+            "/tmp/repo",
+            "newbranch",
+        ]))
+        .unwrap();
+        assert_eq!(r.chdir_paths, paths(&["/tmp/repo"]));
+        assert_eq!(r.stripped, s(&["git-worktree-checkout", "newbranch"]));
+    }
+
+    #[test]
+    fn program_name_only() {
+        let r = parse_top_level_cwd(&s(&["daft"])).unwrap();
+        assert!(r.chdir_paths.is_empty());
+        assert_eq!(r.stripped, s(&["daft"]));
+    }
+
+    #[test]
+    fn relative_paths_passed_through() {
+        // Resolution happens in the imperative shell (`set_current_dir`); the
+        // parser just records the strings.
+        let r = parse_top_level_cwd(&s(&["daft", "-C", "../sibling", "list"])).unwrap();
+        assert_eq!(r.chdir_paths, paths(&["../sibling"]));
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -27,11 +27,17 @@ static ARGV: OnceLock<Vec<String>> = OnceLock::new();
 /// Exits with code 2 (clap usage-error convention) on `-C` paths that don't
 /// exist or aren't directories, matching `git -C`'s terse error style.
 pub fn install_and_apply(raw: Vec<String>) -> Result<()> {
-    let parsed = argv::parse_top_level_cwd(&raw).map_err(|e| match e {
-        argv::ParseError::MissingPathAfterC => {
-            anyhow::anyhow!("daft: -C: option requires an argument")
+    let parsed = match argv::parse_top_level_cwd(&raw) {
+        Ok(p) => p,
+        Err(argv::ParseError::MissingPathAfterC) => {
+            // Exit 2 to match the directory-not-found branch and the clap
+            // usage-error convention. Returning anyhow::Err would propagate
+            // through main's `?` and exit 1 instead — inconsistent with the
+            // rest of the flag's error surface.
+            eprintln!("daft: -C: option requires an argument");
+            std::process::exit(2);
         }
-    })?;
+    };
 
     for path in &parsed.chdir_paths {
         if path.as_os_str().is_empty() {
@@ -66,17 +72,4 @@ fn apply_chdir(path: &Path) {
 pub fn argv() -> &'static [String] {
     ARGV.get()
         .expect("cli::install_and_apply must be called before cli::argv()")
-}
-
-/// Test-only: install a known argv vector, bypassing the parser.
-///
-/// Panics if the slot was already set in the same process. Each test must run
-/// in a fresh process, so use `#[cfg(test)]` `serial_test::serial` and prefer
-/// `#[test]` functions that don't share state with this slot. For tests that
-/// truly need to exercise [`argv()`], the recommended pattern is to do so once
-/// per integration-test binary rather than across unit tests.
-#[cfg(test)]
-pub fn install_for_tests(argv: Vec<String>) {
-    ARGV.set(argv)
-        .expect("ARGV already set in this test process");
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,0 +1,82 @@
+//! CLI-layer concerns that wrap the multicall dispatch in `main.rs`.
+//!
+//! Owns the program's "effective argv" — the original `std::env::args()` after
+//! top-level flags (currently just `-C <path>`) have been stripped off.
+//! Subcommands and helpers read from [`argv()`] instead of [`std::env::args`]
+//! so the strip is universally visible.
+//!
+//! Split: [`argv`] holds the pure parser (unit-tested in-module). This file is
+//! the imperative shell — chdir, OnceLock install, process exit on bad `-C`.
+//! Functional core, imperative shell.
+
+use std::path::Path;
+use std::sync::OnceLock;
+
+use anyhow::{Context, Result};
+
+pub mod argv;
+
+static ARGV: OnceLock<Vec<String>> = OnceLock::new();
+
+/// Parse top-level flags off `raw`, apply their side effects (`-C` chdir), and
+/// install the stripped argv into the process-wide [`ARGV`] slot.
+///
+/// Must be called exactly once, at the top of `main()`, before any other code
+/// reads argv or relies on the working directory.
+///
+/// Exits with code 2 (clap usage-error convention) on `-C` paths that don't
+/// exist or aren't directories, matching `git -C`'s terse error style.
+pub fn install_and_apply(raw: Vec<String>) -> Result<()> {
+    let parsed = argv::parse_top_level_cwd(&raw).map_err(|e| match e {
+        argv::ParseError::MissingPathAfterC => {
+            anyhow::anyhow!("daft: -C: option requires an argument")
+        }
+    })?;
+
+    for path in &parsed.chdir_paths {
+        if path.as_os_str().is_empty() {
+            // git's `-C ""` semantic: no-op.
+            continue;
+        }
+        apply_chdir(path);
+    }
+
+    ARGV.set(parsed.stripped)
+        .map_err(|_| anyhow::anyhow!("cli::install_and_apply called more than once"))?;
+    Ok(())
+}
+
+fn apply_chdir(path: &Path) {
+    if !path.is_dir() {
+        eprintln!("daft: -C: '{}': not a directory", path.display());
+        std::process::exit(2);
+    }
+    if let Err(e) =
+        std::env::set_current_dir(path).with_context(|| format!("daft: -C: '{}'", path.display()))
+    {
+        eprintln!("{e:#}");
+        std::process::exit(2);
+    }
+}
+
+/// The stripped argv as installed by [`install_and_apply`].
+///
+/// Panics if called before [`install_and_apply`] — that would mean a code path
+/// is bypassing the install, which is a programming error.
+pub fn argv() -> &'static [String] {
+    ARGV.get()
+        .expect("cli::install_and_apply must be called before cli::argv()")
+}
+
+/// Test-only: install a known argv vector, bypassing the parser.
+///
+/// Panics if the slot was already set in the same process. Each test must run
+/// in a fresh process, so use `#[cfg(test)]` `serial_test::serial` and prefer
+/// `#[test]` functions that don't share state with this slot. For tests that
+/// truly need to exercise [`argv()`], the recommended pattern is to do so once
+/// per integration-test binary rather than across unit tests.
+#[cfg(test)]
+pub fn install_for_tests(argv: Vec<String>) {
+    ARGV.set(argv)
+        .expect("ARGV already set in this test process");
+}

--- a/src/commands/complete.rs
+++ b/src/commands/complete.rs
@@ -41,7 +41,7 @@ struct Args {
 
 pub fn run() -> Result<()> {
     // When called as a subcommand, skip "daft" and "__complete" from args
-    let mut args_vec: Vec<String> = std::env::args().collect();
+    let mut args_vec: Vec<String> = crate::cli::argv().to_vec();
 
     // If args start with [daft, __complete, ...], keep only [daft, ...]
     // to make clap parse correctly

--- a/src/commands/completions/bash.rs
+++ b/src/commands/completions/bash.rs
@@ -252,6 +252,27 @@ _daft() {
     local cur prev words cword
     _init_completion || return
 
+    # `-C <path>` is a top-level option (issue #519). If the previous token is
+    # `-C`, complete directories for its value and stop.
+    if [[ "$prev" == "-C" ]]; then
+        COMPREPLY=( $(compgen -d -- "$cur") )
+        return 0
+    fi
+
+    # Strip leading `-C <path>` pairs from words/cword so the rest of the
+    # completion logic sees argv as if `-C` weren't there. This keeps every
+    # subsequent `${words[1]}` / `cword -eq N` branch correct regardless of
+    # how many `-C` flags precede the subcommand.
+    local __daft_skip=1
+    while [[ "${words[$__daft_skip]}" == "-C" && $((__daft_skip + 1)) -le ${#words[@]} ]]; do
+        __daft_skip=$((__daft_skip + 2))
+    done
+    if [[ $__daft_skip -gt 1 ]]; then
+        words=("${words[0]}" "${words[@]:$__daft_skip}")
+        cword=$((cword - (__daft_skip - 1)))
+        if [[ $cword -lt 1 ]]; then cword=1; fi
+    fi
+
     # --format value completion (emit-enabled subcommand paths)
     if [[ "$prev" == "--format" ]]; then
         local _fmt_path="" _fmt_i _fmt_w
@@ -677,7 +698,7 @@ _daft() {
     # top-level: complete daft subcommands and flags
     if [[ $cword -eq 1 ]]; then
         if [[ "$cur" == -* ]]; then
-            COMPREPLY=( $(compgen -W "--version -V --help -h" -- "$cur") )
+            COMPREPLY=( $(compgen -W "--version -V --help -h -C" -- "$cur") )
         else
             COMPREPLY=( $(compgen -W "hooks shell-init setup multi-remote release-notes doctor layout shared config repo clone init go start carry exec update list prune rename sync remove merge worktree-merge adopt eject" -- "$cur") )
         fi

--- a/src/commands/completions/fig.rs
+++ b/src/commands/completions/fig.rs
@@ -57,6 +57,10 @@ struct FigOption {
 struct FigOptionArg {
     #[serde(skip_serializing_if = "Option::is_none")]
     suggestions: Option<Vec<FigSuggestion>>,
+    /// Fig built-in completion source (e.g. "folders", "filepaths"). Set this
+    /// to let Fig's filesystem completion fill in the argument value.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    template: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -221,6 +225,7 @@ pub(super) fn generate_fig_completion_string(command_name: &str) -> Result<Strin
                 }
                 Some(FigOptionArg {
                     suggestions: Some(suggestions),
+                    template: None,
                 })
             } else if has_columns && long == "--sort" {
                 let sort_defs = [
@@ -256,6 +261,7 @@ pub(super) fn generate_fig_completion_string(command_name: &str) -> Result<Strin
                 }
                 Some(FigOptionArg {
                     suggestions: Some(suggestions),
+                    template: None,
                 })
             } else if long == "--format" {
                 emit_formats_for(command_name).map(|formats| {
@@ -268,6 +274,7 @@ pub(super) fn generate_fig_completion_string(command_name: &str) -> Result<Strin
                         .collect();
                     FigOptionArg {
                         suggestions: Some(suggestions),
+                        template: None,
                     }
                 })
             } else {
@@ -347,6 +354,7 @@ fn build_emit_options(command_path: &str) -> Vec<FigOption> {
             description: "Output format. Mutually exclusive with --template.".into(),
             args: Some(FigOptionArg {
                 suggestions: Some(suggestions),
+                template: None,
             }),
         },
         FigOption {
@@ -426,17 +434,26 @@ fn build_fig_hooks_subcommand() -> FigSubcommand {
                 FigOption {
                     name: FigName::Single("--worktree".into()),
                     description: "Filter to a specific worktree".into(),
-                    args: Some(FigOptionArg { suggestions: None }),
+                    args: Some(FigOptionArg {
+                        suggestions: None,
+                        template: None,
+                    }),
                 },
                 FigOption {
                     name: FigName::Single("--status".into()),
                     description: "Filter by job status".into(),
-                    args: Some(FigOptionArg { suggestions: None }),
+                    args: Some(FigOptionArg {
+                        suggestions: None,
+                        template: None,
+                    }),
                 },
                 FigOption {
                     name: FigName::Single("--hook".into()),
                     description: "Filter to invocations of this hook type".into(),
-                    args: Some(FigOptionArg { suggestions: None }),
+                    args: Some(FigOptionArg {
+                        suggestions: None,
+                        template: None,
+                    }),
                 },
             ];
             opts.extend(build_emit_options("hooks jobs"));
@@ -560,7 +577,10 @@ fn build_fig_layout_subcommand() -> FigSubcommand {
             FigOption {
                 name: FigName::Single("--include".into()),
                 description: "Also relocate non-conforming worktree".into(),
-                args: Some(FigOptionArg { suggestions: None }),
+                args: Some(FigOptionArg {
+                    suggestions: None,
+                    template: None,
+                }),
             },
             FigOption {
                 name: FigName::Single("--include-all".into()),
@@ -645,6 +665,7 @@ fn build_fig_merge_subcommand(name: &str) -> FigSubcommand {
                 description: "Strip trailing whitespace only".into(),
             },
         ]),
+        template: None,
     });
 
     let strategy_suggestions = Some(FigOptionArg {
@@ -657,9 +678,13 @@ fn build_fig_merge_subcommand(name: &str) -> FigSubcommand {
                 })
                 .collect(),
         ),
+        template: None,
     });
 
-    let into_suggestions = Some(FigOptionArg { suggestions: None });
+    let into_suggestions = Some(FigOptionArg {
+        suggestions: None,
+        template: None,
+    });
     let branch_arg_option = FigOption {
         name: FigName::Single("--into".into()),
         description: "Target worktree/branch for the merge".into(),
@@ -716,12 +741,18 @@ fn build_fig_merge_subcommand(name: &str) -> FigSubcommand {
         FigOption {
             name: FigName::Single("-m".into()),
             description: "Commit message for the merge commit".into(),
-            args: Some(FigOptionArg { suggestions: None }),
+            args: Some(FigOptionArg {
+                suggestions: None,
+                template: None,
+            }),
         },
         FigOption {
             name: FigName::Multiple(vec!["-F".into(), "--file".into()]),
             description: "Read the commit message from FILE".into(),
-            args: Some(FigOptionArg { suggestions: None }),
+            args: Some(FigOptionArg {
+                suggestions: None,
+                template: None,
+            }),
         },
         FigOption {
             name: FigName::Single("--edit".into()),
@@ -786,12 +817,18 @@ fn build_fig_merge_subcommand(name: &str) -> FigSubcommand {
         FigOption {
             name: FigName::Multiple(vec!["-X".into(), "--strategy-option".into()]),
             description: "Strategy-specific option".into(),
-            args: Some(FigOptionArg { suggestions: None }),
+            args: Some(FigOptionArg {
+                suggestions: None,
+                template: None,
+            }),
         },
         FigOption {
             name: FigName::Multiple(vec!["-S".into(), "--gpg-sign".into()]),
             description: "GPG-sign the merge commit (optional KEYID)".into(),
-            args: Some(FigOptionArg { suggestions: None }),
+            args: Some(FigOptionArg {
+                suggestions: None,
+                template: None,
+            }),
         },
         FigOption {
             name: FigName::Single("--no-gpg-sign".into()),
@@ -889,6 +926,16 @@ pub(super) fn generate_fig_daft_spec() -> Result<String> {
                 name: FigName::Multiple(vec!["--help".to_string(), "-h".to_string()]),
                 description: "Print help".to_string(),
                 args: None,
+            },
+            // Top-level `-C <path>` (issue #519). `template: "folders"` makes
+            // Fig fill in directory completions for the value.
+            FigOption {
+                name: FigName::Single("-C".to_string()),
+                description: "Run as if started in <path>".to_string(),
+                args: Some(FigOptionArg {
+                    suggestions: None,
+                    template: Some("folders".to_string()),
+                }),
             },
         ]),
         subcommands: Some(subcommands),

--- a/src/commands/completions/fish.rs
+++ b/src/commands/completions/fish.rs
@@ -323,6 +323,11 @@ fn generate_fish_rich_completion(command_name: &str) -> Result<String> {
 
 const DAFT_FISH_COMPLETIONS: &str = r#"# daft subcommand completions
 complete -c daft -f
+# `-C <path>` is a top-level option (issue #519). Fish completes by short
+# letter regardless of position, so a single -c registration with -xa for
+# directory value completion is enough — no need to thread it through every
+# __fish_seen_subcommand_from condition below.
+complete -c daft -s C -d 'Run as if started in <path>' -xa '(__fish_complete_directories)'
 complete -c daft -n '__fish_use_subcommand' -s V -l version -d 'Print version information'
 complete -c daft -n '__fish_use_subcommand' -s h -l help -d 'Print help'
 complete -c daft -n '__fish_use_subcommand' -a 'hooks' -d 'Manage lifecycle hooks'

--- a/src/commands/completions/mod.rs
+++ b/src/commands/completions/mod.rs
@@ -350,7 +350,7 @@ pub fn generate_all_completions(shell_name: &str) -> Result<String> {
 
 pub fn run() -> Result<()> {
     // When called as a subcommand, skip "daft" and "completions" from args
-    let mut args_vec: Vec<String> = std::env::args().collect();
+    let mut args_vec: Vec<String> = crate::cli::argv().to_vec();
 
     // If args start with [daft, completions, ...], keep only [daft, ...]
     // to make clap parse correctly

--- a/src/commands/completions/zsh.rs
+++ b/src/commands/completions/zsh.rs
@@ -410,6 +410,27 @@ pub(super) const DAFT_ZSH_COMPLETIONS: &str = r#"# daft subcommand completions
 _daft() {
     local curword="${words[$CURRENT]}"
 
+    # `-C <path>` is a top-level option (issue #519). If the previous token is
+    # `-C`, complete directories for its value and stop.
+    local __daft_prev="${words[$((CURRENT-1))]}"
+    if [[ "$__daft_prev" == "-C" ]]; then
+        _files -/
+        return
+    fi
+
+    # Strip leading `-C <path>` pairs from words/CURRENT so the rest of the
+    # completion logic sees argv as if `-C` weren't there.
+    local __daft_skip=2
+    while [[ "${words[$__daft_skip]}" == "-C" ]] && (( __daft_skip + 1 <= ${#words} )); do
+        __daft_skip=$((__daft_skip + 2))
+    done
+    if (( __daft_skip > 2 )); then
+        words=("${words[1]}" "${(@)words[$__daft_skip,-1]}")
+        CURRENT=$((CURRENT - (__daft_skip - 2)))
+        if (( CURRENT < 2 )); then CURRENT=2; fi
+        curword="${words[$CURRENT]}"
+    fi
+
     # --format value completion (emit-enabled subcommand paths)
     local _fmt_prev="${words[$((CURRENT-1))]}"
     if [[ "$_fmt_prev" == "--format" ]]; then
@@ -864,7 +885,7 @@ _daft() {
     # top-level: complete daft subcommands and flags
     if (( CURRENT == 2 )); then
         if [[ "$curword" == -* ]]; then
-            compadd -- --version -V --help -h
+            compadd -- --version -V --help -h -C
         else
             compadd hooks shell-init setup multi-remote release-notes doctor layout shared \
                     config repo clone init go start carry exec update list prune rename sync remove \

--- a/src/commands/config/mod.rs
+++ b/src/commands/config/mod.rs
@@ -3,7 +3,7 @@ pub mod remote_sync;
 use anyhow::Result;
 
 pub fn run() -> Result<()> {
-    let args: Vec<String> = std::env::args().collect();
+    let args: Vec<String> = crate::cli::argv().to_vec();
     // Find the "config" arg and route to subcommands after it
     let config_idx = args.iter().position(|a| a == "config").unwrap_or(1);
     let sub_args: Vec<String> = args[(config_idx + 1)..].to_vec();

--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -371,8 +371,9 @@ fn bold(text: &str, use_color: bool) -> String {
 
 pub fn run() -> Result<()> {
     // Detect how we were invoked
-    let program_path = std::env::args()
-        .next()
+    let program_path = crate::cli::argv()
+        .first()
+        .cloned()
         .unwrap_or_else(|| "daft".to_string());
     let program_name = Path::new(&program_path)
         .file_name()

--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -434,6 +434,13 @@ fn render_daft() -> Result<()> {
     }
 
     println!();
+    println!("{}", bold_underline("Global options", use_color));
+    println!(
+        "   {}      Run as if started in <path>. Composes like git -C.",
+        bold("-C <path>", use_color)
+    );
+
+    println!();
     println!(
         "'daft {} --help' to read about a specific command.",
         bold("<command>", use_color)
@@ -487,6 +494,10 @@ fn render_git_daft() -> Result<()> {
     println!(
         "   clone, init, carry, merge, update, list, prune, rename, sync, remove, adopt, eject"
     );
+
+    println!();
+    println!("Global options");
+    println!("   -C <path>            Run as if started in <path>. Composes like git -C.");
 
     println!();
     println!("'git worktree-<command> --help' to read about a specific command.");

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -64,7 +64,7 @@ pub struct Args {
 }
 
 pub fn run() -> Result<()> {
-    let args: Vec<String> = std::env::args().skip(1).collect();
+    let args: Vec<String> = crate::cli::argv().iter().skip(1).cloned().collect();
     let args = Args::parse_from(args);
     // Doctor manages its own quiet/verbose filtering; Output is just the print sink.
     let mut output = CliOutput::new(OutputConfig::new(false, false));

--- a/src/commands/dump_store.rs
+++ b/src/commands/dump_store.rs
@@ -18,7 +18,7 @@
 use anyhow::{Context, Result, bail};
 
 pub fn run() -> Result<()> {
-    let args: Vec<String> = std::env::args().collect();
+    let args: Vec<String> = crate::cli::argv().to_vec();
     let Some(table) = args.get(2) else {
         bail!("usage: daft __dump-store <table>\n  tables: repo-policy");
     };

--- a/src/commands/hooks/mod.rs
+++ b/src/commands/hooks/mod.rs
@@ -480,7 +480,7 @@ mod trust_cmd {
 }
 
 pub fn run() -> Result<()> {
-    let args: Vec<String> = std::env::args().skip(1).collect();
+    let args: Vec<String> = crate::cli::argv().iter().skip(1).cloned().collect();
     let args = Args::parse_from(args);
     let mut output = CliOutput::new(OutputConfig::new(false, false));
 

--- a/src/commands/layout.rs
+++ b/src/commands/layout.rs
@@ -124,7 +124,7 @@ struct DefaultArgs {
 }
 
 pub fn run() -> Result<()> {
-    let args: Vec<String> = std::env::args().skip(1).collect();
+    let args: Vec<String> = crate::cli::argv().iter().skip(1).cloned().collect();
     let layout_args = LayoutArgs::parse_from(args);
     let mut output = CliOutput::new(OutputConfig::new(false, false));
 

--- a/src/commands/multi_remote.rs
+++ b/src/commands/multi_remote.rs
@@ -154,7 +154,7 @@ to match the new remote organization.
 
 pub fn run() -> Result<()> {
     // Skip "daft" and "multi-remote" from args
-    let args: Vec<String> = std::env::args().skip(1).collect();
+    let args: Vec<String> = crate::cli::argv().iter().skip(1).cloned().collect();
     let args = Args::parse_from(args);
 
     match args.command {

--- a/src/commands/release_notes.rs
+++ b/src/commands/release_notes.rs
@@ -68,7 +68,7 @@ pub struct Args {
 
 pub fn run() -> Result<()> {
     // When called as a subcommand, skip "daft" and "release-notes" from args
-    let mut args_vec: Vec<String> = std::env::args().collect();
+    let mut args_vec: Vec<String> = crate::cli::argv().to_vec();
 
     // If args start with [daft, release-notes, ...], remove "release-notes"
     // to make clap parse correctly (keep "daft" as program name)

--- a/src/commands/repo/mod.rs
+++ b/src/commands/repo/mod.rs
@@ -9,7 +9,7 @@ pub mod remove;
 
 /// Dispatch entry from the top-level main.
 pub fn run() -> Result<()> {
-    let args: Vec<String> = std::env::args().collect();
+    let args: Vec<String> = crate::cli::argv().to_vec();
     let sub = args.get(2).map(String::as_str).unwrap_or("");
     match sub {
         "remove" => remove::run(),

--- a/src/commands/repo/remove.rs
+++ b/src/commands/repo/remove.rs
@@ -55,7 +55,7 @@ pub fn run() -> Result<()> {
     // in debug builds — if a future shortcut alias or alternative entry path
     // dispatches here without that argv shape, we want a loud failure rather
     // than silently dropping or shifting positional arguments.
-    let raw_args: Vec<String> = std::env::args().collect();
+    let raw_args: Vec<String> = crate::cli::argv().to_vec();
     debug_assert!(
         raw_args.len() >= 3 && raw_args[1] == "repo" && raw_args[2] == "remove",
         "repo::remove::run() invoked with unexpected argv: {raw_args:?} \

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -92,7 +92,7 @@ pub struct Args {
 }
 
 pub fn run() -> Result<()> {
-    let args: Vec<String> = std::env::args().skip(1).collect();
+    let args: Vec<String> = crate::cli::argv().iter().skip(1).cloned().collect();
     let args = Args::parse_from(args);
     let mut output = CliOutput::new(OutputConfig::new(false, false));
 

--- a/src/commands/shared.rs
+++ b/src/commands/shared.rs
@@ -114,7 +114,7 @@ pub fn run() -> Result<()> {
     // Skip argv[0] (binary name). When invoked as `daft shared <sub> <args>`,
     // env::args() is ["daft", "shared", ...] and skip(1) gives ["shared", ...]
     // so clap sees "shared" as the program name and parses the rest correctly.
-    let args_raw: Vec<String> = std::env::args().skip(1).collect();
+    let args_raw: Vec<String> = crate::cli::argv().iter().skip(1).cloned().collect();
     let args = Args::parse_from(args_raw);
     let mut output = CliOutput::default_output();
 

--- a/src/commands/shell_init.rs
+++ b/src/commands/shell_init.rs
@@ -187,7 +187,15 @@ daft() {
     while [ "$#" -gt 0 ]; do
         case "$1" in
             -C)
-                __daft_pre+=("$1" "$2"); shift 2 || return 2 ;;
+                # Trailing `-C` with no path: surface the same error the binary
+                # would print, then exit 2. Without this echo the wrapper's
+                # `return 2` is silent and the user sees no clue what went
+                # wrong (the binary never runs to print its own error).
+                if [ "$#" -lt 2 ]; then
+                    echo "daft: -C: option requires an argument" >&2
+                    return 2
+                fi
+                __daft_pre+=("$1" "$2"); shift 2 ;;
             *) break ;;
         esac
     done

--- a/src/commands/shell_init.rs
+++ b/src/commands/shell_init.rs
@@ -177,37 +177,52 @@ git() {
 
 # daft wrapper to intercept "daft worktree-*" and "daft <verb>" subcommands
 daft() {
+    # Strip top-level options (currently just `-C <path>`) so the dispatch
+    # below sees the verb in $1. The stripped options are re-attached as
+    # arguments to the binary so the binary's cli::install_and_apply applies
+    # the chdir. Without this, `daft -C /path go branch` would fall through
+    # to `*) command daft "$@"`, skipping DAFT_CD_FILE setup — the shell
+    # wouldn't follow the binary into the newly-created worktree.
+    local __daft_pre=()
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            -C)
+                __daft_pre+=("$1" "$2"); shift 2 || return 2 ;;
+            *) break ;;
+        esac
+    done
+
     case "$1" in
         worktree-clone|clone)
-            shift; __daft_wrapper git-worktree-clone "$@" ;;
+            shift; __daft_wrapper git-worktree-clone "${__daft_pre[@]}" "$@" ;;
         worktree-init|init)
-            shift; __daft_wrapper git-worktree-init "$@" ;;
+            shift; __daft_wrapper git-worktree-init "${__daft_pre[@]}" "$@" ;;
         worktree-checkout)
-            shift; __daft_wrapper git-worktree-checkout "$@" ;;
+            shift; __daft_wrapper git-worktree-checkout "${__daft_pre[@]}" "$@" ;;
         go)
-            shift; __daft_wrapper daft-go "$@" ;;
+            shift; __daft_wrapper daft-go "${__daft_pre[@]}" "$@" ;;
         start)
-            shift; __daft_wrapper daft-start "$@" ;;
+            shift; __daft_wrapper daft-start "${__daft_pre[@]}" "$@" ;;
         worktree-carry|carry)
-            shift; __daft_wrapper git-worktree-carry "$@" ;;
+            shift; __daft_wrapper git-worktree-carry "${__daft_pre[@]}" "$@" ;;
         worktree-prune|prune)
-            shift; __daft_wrapper git-worktree-prune "$@" ;;
+            shift; __daft_wrapper git-worktree-prune "${__daft_pre[@]}" "$@" ;;
         worktree-branch)
-            shift; __daft_wrapper git-worktree-branch "$@" ;;
+            shift; __daft_wrapper git-worktree-branch "${__daft_pre[@]}" "$@" ;;
         remove)
-            shift; __daft_wrapper daft-remove "$@" ;;
+            shift; __daft_wrapper daft-remove "${__daft_pre[@]}" "$@" ;;
         worktree-branch-delete)
-            shift; __daft_wrapper git-worktree-branch-delete "$@" ;;
+            shift; __daft_wrapper git-worktree-branch-delete "${__daft_pre[@]}" "$@" ;;
         rename)
-            shift; __daft_wrapper daft-rename "$@" ;;
+            shift; __daft_wrapper daft-rename "${__daft_pre[@]}" "$@" ;;
         worktree-fetch|update)
-            shift; __daft_wrapper git-worktree-fetch "$@" ;;
+            shift; __daft_wrapper git-worktree-fetch "${__daft_pre[@]}" "$@" ;;
         worktree-flow-adopt|adopt)
-            shift; __daft_wrapper git-worktree-flow-adopt "$@" ;;
+            shift; __daft_wrapper git-worktree-flow-adopt "${__daft_pre[@]}" "$@" ;;
         worktree-flow-eject|eject)
-            shift; __daft_wrapper git-worktree-flow-eject "$@" ;;
+            shift; __daft_wrapper git-worktree-flow-eject "${__daft_pre[@]}" "$@" ;;
         worktree-sync|sync)
-            shift; __daft_wrapper git-worktree-sync "$@" ;;
+            shift; __daft_wrapper git-worktree-sync "${__daft_pre[@]}" "$@" ;;
         layout|repo)
             # `daft layout` (transform) and `daft repo remove` both need cd
             # support — repo-remove writes DAFT_CD_FILE when the user invoked
@@ -218,7 +233,7 @@ daft() {
             local __cd_file
             __cd_file=$(mktemp "${TMPDIR:-/tmp}/daft-cd.XXXXXX" 2>/dev/null)
             if [ -n "$__cd_file" ]; then
-                DAFT_CD_FILE="$__cd_file" command daft "$@"
+                DAFT_CD_FILE="$__cd_file" command daft "${__daft_pre[@]}" "$@"
                 local __exit=$?
                 if [ -s "$__cd_file" ]; then
                     local __target
@@ -228,11 +243,11 @@ daft() {
                 rm -f "$__cd_file"
                 return $__exit
             else
-                command daft "$@"
+                command daft "${__daft_pre[@]}" "$@"
             fi
             ;;
         *)
-            command daft "$@" ;;
+            command daft "${__daft_pre[@]}" "$@" ;;
     esac
 }
 
@@ -428,37 +443,56 @@ end
 
 # daft wrapper to intercept "daft worktree-*" and "daft <verb>" subcommands
 function daft --wraps daft
+    # Strip top-level options (currently just `-C <path>`) so the switch
+    # below sees the verb in $argv[1]. The stripped options are re-attached
+    # as arguments to the binary so cli::install_and_apply applies the chdir.
+    # See the bash/zsh wrapper for the matching rationale.
+    set -l pre
+    while test (count $argv) -gt 0
+        switch $argv[1]
+            case -C
+                set pre $pre $argv[1] $argv[2]
+                if test (count $argv) -ge 3
+                    set argv $argv[3..-1]
+                else
+                    set argv
+                end
+            case '*'
+                break
+        end
+    end
+
     switch $argv[1]
         case worktree-clone clone
-            __daft_wrapper git-worktree-clone $argv[2..-1]
+            __daft_wrapper git-worktree-clone $pre $argv[2..-1]
         case worktree-init init
-            __daft_wrapper git-worktree-init $argv[2..-1]
+            __daft_wrapper git-worktree-init $pre $argv[2..-1]
         case worktree-checkout
-            __daft_wrapper git-worktree-checkout $argv[2..-1]
+            __daft_wrapper git-worktree-checkout $pre $argv[2..-1]
         case go
-            __daft_wrapper daft-go $argv[2..-1]
+            __daft_wrapper daft-go $pre $argv[2..-1]
         case start
-            __daft_wrapper daft-start $argv[2..-1]
+            __daft_wrapper daft-start $pre $argv[2..-1]
         case worktree-carry carry
-            __daft_wrapper git-worktree-carry $argv[2..-1]
+            __daft_wrapper git-worktree-carry $pre $argv[2..-1]
         case worktree-prune prune
-            __daft_wrapper git-worktree-prune $argv[2..-1]
+            __daft_wrapper git-worktree-prune $pre $argv[2..-1]
         case worktree-branch
-            __daft_wrapper git-worktree-branch $argv[2..-1]
+            __daft_wrapper git-worktree-branch $pre $argv[2..-1]
         case remove
-            __daft_wrapper daft-remove $argv[2..-1]
+            __daft_wrapper daft-remove $pre $argv[2..-1]
         case worktree-branch-delete
-            __daft_wrapper git-worktree-branch-delete $argv[2..-1]
+            __daft_wrapper git-worktree-branch-delete $pre $argv[2..-1]
         case rename
-            __daft_wrapper daft-rename $argv[2..-1]
+            __daft_wrapper daft-rename $pre $argv[2..-1]
         case worktree-fetch update
-            __daft_wrapper git-worktree-fetch $argv[2..-1]
+            __daft_wrapper git-worktree-fetch $pre $argv[2..-1]
         case worktree-flow-adopt adopt
-            __daft_wrapper git-worktree-flow-adopt $argv[2..-1]
+            __daft_wrapper git-worktree-flow-adopt $pre $argv[2..-1]
         case worktree-flow-eject eject
-            __daft_wrapper git-worktree-flow-eject $argv[2..-1]
+            __daft_wrapper git-worktree-flow-eject $pre $argv[2..-1]
         case worktree-sync sync
-            __daft_wrapper git-worktree-sync $argv[2..-1]
+            __daft_wrapper git-worktree-sync $pre $argv[2..-1]
         case layout repo
             # `daft layout` (transform) and `daft repo remove` both need cd
             # support — repo-remove writes DAFT_CD_FILE when the user invoked
@@ -468,7 +502,7 @@ function daft --wraps daft
             # `exec -a`; mirror the per-subcommand pattern used for layout.
             set -l cd_file (mktemp (set -q TMPDIR; and echo $TMPDIR; or echo /tmp)/daft-cd.XXXXXX 2>/dev/null)
             if test -n "$cd_file"
-                DAFT_CD_FILE=$cd_file command daft $argv
+                DAFT_CD_FILE=$cd_file command daft $pre $argv
                 set -l exit_code $status
                 if test -s "$cd_file"
                     builtin cd (cat "$cd_file") 2>/dev/null
@@ -476,10 +510,10 @@ function daft --wraps daft
                 rm -f "$cd_file"
                 return $exit_code
             else
-                command daft $argv
+                command daft $pre $argv
             end
         case '*'
-            command daft $argv
+            command daft $pre $argv
     end
 end
 

--- a/src/commands/shell_init.rs
+++ b/src/commands/shell_init.rs
@@ -36,7 +36,7 @@ pub struct Args {
 
 pub fn run() -> Result<()> {
     // Skip the first two args ("daft" and "shell-init") to let clap parse from "shell-init"
-    let args: Vec<String> = std::env::args().skip(1).collect();
+    let args: Vec<String> = crate::cli::argv().iter().skip(1).cloned().collect();
     let args = Args::parse_from(args);
 
     let shell_name = match args.shell {

--- a/src/commands/shortcuts.rs
+++ b/src/commands/shortcuts.rs
@@ -80,7 +80,7 @@ enum ShortcutsCommand {
 
 pub fn run() -> Result<()> {
     // Skip "daft", "setup", and "shortcuts" from args
-    let args: Vec<String> = std::env::args().skip(3).collect();
+    let args: Vec<String> = crate::cli::argv().iter().skip(3).cloned().collect();
     let args = Args::parse_from(std::iter::once("shortcuts".to_string()).chain(args));
     let mut output = CliOutput::new(OutputConfig::new(false, false));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,7 @@ const DAFT_VERBS: &[&str] = &[
 /// # Arguments
 /// * `expected_cmd` - The expected command name (e.g., "git-worktree-clone")
 pub fn get_clap_args(expected_cmd: &str) -> Vec<String> {
-    let args: Vec<String> = env::args().collect();
+    let args = cli::argv();
 
     // Check if invoked as `daft worktree-*` or `daft <verb>`
     if args.len() >= 2 {
@@ -147,13 +147,13 @@ pub fn get_clap_args(expected_cmd: &str) -> Vec<String> {
         {
             // Reconstruct args with the expected command name
             let mut new_args = vec![expected_cmd.to_string()];
-            new_args.extend(args.into_iter().skip(2));
+            new_args.extend(args.iter().skip(2).cloned());
             return new_args;
         }
     }
 
     // Default: return args as-is (symlink invocation)
-    args
+    args.to_vec()
 }
 
 /// Returns `true` if the given argv corresponds to an invocation that should
@@ -180,6 +180,7 @@ pub fn skip_startup_tasks_for(args: &[String]) -> bool {
     sub.starts_with("__") || matches!(sub, "shell-init" | "completions")
 }
 
+pub mod cli;
 pub mod commands;
 pub mod completion_spinner;
 pub mod coordinator;

--- a/src/log_clean.rs
+++ b/src/log_clean.rs
@@ -40,7 +40,7 @@ pub fn maybe_clean_logs() {
 }
 
 fn maybe_clean_logs_inner() {
-    if env::args().any(|a| a.starts_with("__")) {
+    if crate::cli::argv().iter().any(|a| a.starts_with("__")) {
         return;
     }
     if is_disabled() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,10 +11,17 @@ use daft::shortcuts;
 use std::path::Path;
 
 fn main() -> Result<()> {
+    // Parse and apply top-level flags (currently just `-C <path>`) before any
+    // other work. This MUST happen before `skip_startup_tasks_for` below — that
+    // gate inspects argv[1] to detect `shell-init`/`__*` invocations that must
+    // skip background spawns, and if `-C` is still in argv at that point the
+    // gate fails open (see the fork-bomb warning further down).
+    let raw_argv: Vec<String> = std::env::args().collect();
+    daft::cli::install_and_apply(raw_argv)?;
+    let argv = daft::cli::argv();
+
     // Detect how we were invoked by checking argv[0]
-    let program_path = std::env::args()
-        .next()
-        .unwrap_or_else(|| "daft".to_string());
+    let program_path = argv.first().cloned().unwrap_or_else(|| "daft".to_string());
     let program_name = Path::new(&program_path)
         .file_name()
         .and_then(|n| n.to_str())
@@ -24,12 +31,12 @@ fn main() -> Result<()> {
     let resolved = shortcuts::resolve(program_name);
 
     // Handle --version/-V flag for the main daft/git-daft command
-    if resolved == "daft" || resolved == "git-daft" {
-        let args: Vec<String> = std::env::args().collect();
-        if args.len() == 2 && (args[1] == "--version" || args[1] == "-V") {
-            println!("daft {}", daft::VERSION_DISPLAY);
-            return Ok(());
-        }
+    if (resolved == "daft" || resolved == "git-daft")
+        && argv.len() == 2
+        && (argv[1] == "--version" || argv[1] == "-V")
+    {
+        println!("daft {}", daft::VERSION_DISPLAY);
+        return Ok(());
     }
 
     // Skip startup-time background work for invocations that must stay lean:
@@ -48,8 +55,7 @@ fn main() -> Result<()> {
     // Or more broadly:
     //   pkill -9 -f "<worktree-path>/target/release"
     // Repeat until `ps aux | grep __check-update | wc -l` returns 0.
-    let argv: Vec<String> = std::env::args().collect();
-    let skip_startup_tasks = daft::skip_startup_tasks_for(&argv);
+    let skip_startup_tasks = daft::skip_startup_tasks_for(argv);
 
     // Also skip background spawning if we're inside a coordinator process
     let is_coordinator = std::env::var("DAFT_IS_COORDINATOR").is_ok();
@@ -117,7 +123,7 @@ fn main() -> Result<()> {
                 "daft"
             };
             // Check if a subcommand was provided
-            let args: Vec<String> = std::env::args().collect();
+            let args = argv;
             if args.len() > 1 {
                 match args[1].as_str() {
                     "--help" | "-h" => commands::docs::run(),

--- a/src/trust_prune.rs
+++ b/src/trust_prune.rs
@@ -79,7 +79,7 @@ pub fn run_prune_trust() -> Result<()> {
 fn maybe_prune_trust_inner() {
     // Don't run inside any background task process — otherwise __prune-trust
     // spawns __check-update which spawns __prune-trust, creating a fork bomb.
-    if env::args().any(|a| a.starts_with("__")) {
+    if crate::cli::argv().iter().any(|a| a.starts_with("__")) {
         return;
     }
 

--- a/src/update_check.rs
+++ b/src/update_check.rs
@@ -146,7 +146,7 @@ pub fn print_notification(notification: &UpdateNotification) {
 fn maybe_check_for_update_inner() -> Option<UpdateNotification> {
     // Don't run inside any background task process — otherwise __check-update
     // spawns __prune-trust which spawns __check-update, creating a fork bomb.
-    if env::args().any(|a| a.starts_with("__")) {
+    if crate::cli::argv().iter().any(|a| a.starts_with("__")) {
         return None;
     }
 

--- a/tests/integration/test_shell_init.sh
+++ b/tests/integration/test_shell_init.sh
@@ -536,6 +536,83 @@ test_daft_repo_wrapper_writes_cd_file() {
     return 0
 }
 
+# Regression for issue #519: the `-C <path>` global flag must work end-to-end
+# through the shell wrapper. Two failure modes the wrapper could introduce:
+#  1. Binary writes DAFT_CD_FILE relative to its post-`-C` cwd correctly, but
+#     the wrapper's `cd` happens before the binary runs and points at the
+#     wrong place. (Wrapper doesn't touch DAFT_CD_FILE between
+#     binary-exit and `cd`, so this should be fine — but assert it.)
+#  2. Binary's `cli::install_and_apply` doesn't trigger for the multicall arm
+#     and the chdir never happens — wrapper would then land in the wrong repo.
+test_c_flag_cd_redirect_through_wrapper() {
+    log "Testing: daft -C <other-repo> checkout through wrapper lands shell in other-repo's worktree"
+
+    local remote_a remote_b
+    remote_a=$(create_test_remote "test-c-flag-wrapper-a" "main")
+    remote_b=$(create_test_remote "test-c-flag-wrapper-b" "main")
+
+    git-worktree-clone --layout contained "$remote_a" >/dev/null 2>&1
+    git-worktree-clone --layout contained "$remote_b" >/dev/null 2>&1
+    local repo_a="$PWD/test-c-flag-wrapper-a"
+    local repo_b="$PWD/test-c-flag-wrapper-b"
+
+    # From inside repo_a/main, invoke `daft -C <repo_b/main> go develop`.
+    # Expected: the wrapper cd's us into repo_b's new worktree, NOT into
+    # repo_b/main directly and NOT staying in repo_a.
+    local out
+    out=$(REPO_A_MAIN="$repo_a/main" REPO_B_MAIN="$repo_b/main" REPO_B="$repo_b" bash -c '
+        eval "$(daft shell-init bash)"
+        builtin cd "$REPO_A_MAIN" || exit 11
+        daft -C "$REPO_B_MAIN" go develop >/dev/null 2>&1 || true
+        builtin pwd
+    ' 2>&1) || true
+
+    # Resolve symlinks: /tmp -> /private/tmp on macOS, where daft canonicalizes
+    # paths in DAFT_CD_FILE but $repo_b stays un-resolved.
+    local resolved_repo_b
+    resolved_repo_b=$(python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$repo_b")
+
+    if [[ "$out" != "$resolved_repo_b/develop"* ]]; then
+        log_error "wrapper did not cd into the -C target's new worktree"
+        log_error "  expected prefix: $resolved_repo_b/develop"
+        log_error "  actual pwd:      $out"
+        return 1
+    fi
+
+    log_success "daft -C through wrapper lands shell at: $out"
+    return 0
+}
+
+# Regression for issue #519: -C must work for symlinked-entry invocations
+# (git-worktree-*, daft-go, etc.) just like for the multicall `daft` arm.
+# The argv-strip is in the SAME place for both paths, so this is mostly a
+# smoke test that nothing in the symlink dispatch path bypassed it.
+test_c_flag_symlink_entry() {
+    log "Testing: git-worktree-list -C <other-repo> succeeds"
+
+    local remote
+    remote=$(create_test_remote "test-c-flag-symlink" "main")
+    git-worktree-clone --layout contained "$remote" >/dev/null 2>&1
+    local repo="$PWD/test-c-flag-symlink"
+
+    # From an unrelated cwd, list via the symlink entry against the repo.
+    local out
+    out=$(builtin cd "$TEMP_BASE_DIR" && NO_COLOR=1 git-worktree-list -C "$repo/main" 2>&1) || {
+        log_error "git-worktree-list -C exited non-zero"
+        log_error "output: $out"
+        return 1
+    }
+
+    if [[ "$out" != *"main"* ]]; then
+        log_error "git-worktree-list -C did not list the target repo"
+        log_error "output: $out"
+        return 1
+    fi
+
+    log_success "git-worktree-list -C succeeds: lists target repo's worktrees"
+    return 0
+}
+
 # --- Main Test Runner ---
 
 main() {
@@ -566,6 +643,8 @@ main() {
     run_test "daft_wrapper_intercepts_subcommand" test_daft_wrapper_intercepts_subcommand
     run_test "wrapper_resolves_binary_live" test_wrapper_resolves_binary_live
     run_test "daft_repo_wrapper_writes_cd_file" test_daft_repo_wrapper_writes_cd_file
+    run_test "c_flag_cd_redirect_through_wrapper" test_c_flag_cd_redirect_through_wrapper
+    run_test "c_flag_symlink_entry" test_c_flag_symlink_entry
 
     print_summary
 }

--- a/tests/integration/test_shell_init.sh
+++ b/tests/integration/test_shell_init.sh
@@ -374,13 +374,12 @@ test_daft_wrapper_function_exists() {
         return 1
     fi
 
-    # Check that it has passthrough for other commands
-    if grep -q 'command daft "\$@"' <<< "$output"; then
-        log_success "daft() wrapper passes through other commands"
-    else
-        log_error "daft() wrapper missing passthrough"
-        return 1
-    fi
+    # Passthrough behavior is exercised end-to-end by
+    # test_daft_wrapper_passthrough. A grep for `command daft "$@"` here
+    # is unreliable because the wrapper now strips top-level `-C <path>`
+    # pairs and emits `command daft "${__daft_pre[@]}" "$@"` — and
+    # explanatory comments in the wrapper can match a literal-pattern grep
+    # by accident.
 
     return 0
 }
@@ -583,6 +582,34 @@ test_c_flag_cd_redirect_through_wrapper() {
     return 0
 }
 
+# Regression: trailing `daft -C` (no path argument) through the wrapper must
+# emit the same `option requires an argument` error the binary would print,
+# and exit 2. Previously the wrapper's `shift 2 || return 2` short-circuited
+# silently — exit code was right but the user got no message because the
+# binary never ran.
+test_c_flag_no_arg_through_wrapper_errors_cleanly() {
+    log "Testing: daft -C (no arg) through wrapper exits 2 with error message"
+
+    local output
+    output=$(bash -c 'eval "$(daft shell-init bash)"; daft -C' 2>&1)
+    local exit_code=$?
+
+    if [[ $exit_code -ne 2 ]]; then
+        log_error "Expected exit code 2, got $exit_code"
+        log_error "Output: $output"
+        return 1
+    fi
+
+    if [[ "$output" != *"requires an argument"* ]]; then
+        log_error "Expected error message containing 'requires an argument'"
+        log_error "Got: $output"
+        return 1
+    fi
+
+    log_success "daft -C through wrapper: exit 2 with clear error message"
+    return 0
+}
+
 # Regression for issue #519: -C must work for symlinked-entry invocations
 # (git-worktree-*, daft-go, etc.) just like for the multicall `daft` arm.
 # The argv-strip is in the SAME place for both paths, so this is mostly a
@@ -644,6 +671,7 @@ main() {
     run_test "wrapper_resolves_binary_live" test_wrapper_resolves_binary_live
     run_test "daft_repo_wrapper_writes_cd_file" test_daft_repo_wrapper_writes_cd_file
     run_test "c_flag_cd_redirect_through_wrapper" test_c_flag_cd_redirect_through_wrapper
+    run_test "c_flag_no_arg_through_wrapper_errors_cleanly" test_c_flag_no_arg_through_wrapper_errors_cleanly
     run_test "c_flag_symlink_entry" test_c_flag_symlink_entry
 
     print_summary

--- a/tests/manual/scenarios/global-flags/c-basic.yml
+++ b/tests/manual/scenarios/global-flags/c-basic.yml
@@ -1,0 +1,38 @@
+name: -C basic chdir
+description:
+  -C <path> chdirs before subcommand dispatch; new worktree lands in the -C
+  target repo
+
+repos:
+  - name: repo-a
+    use_fixture: standard-remote
+  - name: repo-b
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone repo-a
+    run: git-worktree-clone --layout contained $REMOTE_REPO_A
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/repo-a/main"
+
+  - name: Clone repo-b
+    run: git-worktree-clone --layout contained $REMOTE_REPO_B
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/repo-b/main"
+
+  - name:
+      From inside repo-a/main, run daft -C against repo-b to checkout a branch
+    # If -C didn't take effect, the new worktree would be created inside repo-a
+    # (since that's the cwd). dirs_exist on the repo-b path proves the chdir.
+    run: daft -C "$WORK_DIR/repo-b/main" go develop
+    cwd: "$WORK_DIR/repo-a/main"
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/repo-b/develop"
+      files_not_exist:
+        - "$WORK_DIR/repo-a/develop"

--- a/tests/manual/scenarios/global-flags/c-cd-redirect.yml
+++ b/tests/manual/scenarios/global-flags/c-cd-redirect.yml
@@ -1,0 +1,40 @@
+name: -C cooperates with DAFT_CD_FILE redirect
+description:
+  With -C and DAFT_CD_FILE set, the binary writes the target inside the -C repo
+
+repos:
+  - name: test-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone the repo
+    run: git-worktree-clone --layout contained $REMOTE_TEST_REPO
+    expect:
+      exit_code: 0
+
+  - name: With DAFT_CD_FILE set, daft -C ... checkout writes target inside repo
+    # Simulates the shell wrapper: pre-create temp file, set DAFT_CD_FILE,
+    # run daft -C, then read the file to confirm the binary wrote the
+    # new-worktree path under the -C target (not under cwd).
+    #
+    # macOS quirk: /tmp is a symlink to /private/tmp and daft canonicalizes
+    # paths when writing the cd target. Resolve both sides via realpath
+    # before comparing so the test is platform-agnostic.
+    run: |
+      cd_file=$(mktemp)
+      DAFT_CD_FILE="$cd_file" daft -C "$WORK_DIR/test-repo/main" go develop
+      target=$(cat "$cd_file")
+      expected_prefix=$(python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$WORK_DIR/test-repo/develop")
+      target_resolved=$(python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$target")
+      echo "TARGET=$target_resolved"
+      echo "EXPECTED=$expected_prefix"
+      case "$target_resolved" in
+        "$expected_prefix"*) echo "OK" ;;
+        *) echo "FAIL: expected target under $expected_prefix, got $target_resolved" ; exit 1 ;;
+      esac
+      rm -f "$cd_file"
+    cwd: "/"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "OK"

--- a/tests/manual/scenarios/global-flags/c-compose.yml
+++ b/tests/manual/scenarios/global-flags/c-compose.yml
@@ -1,0 +1,25 @@
+name: -C composes like git
+description: Multiple -C flags compose (matches `git -C`), they don't last-win
+
+repos:
+  - name: repo-b
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone repo-b
+    run: git-worktree-clone --layout contained $REMOTE_REPO_B
+    expect:
+      exit_code: 0
+
+  - name: daft -C $WORK_DIR -C repo-b/main behaves like -C $WORK_DIR/repo-b/main
+    # If the impl was "last-wins", `-C repo-b/main` would be resolved against
+    # the original cwd ($WORK_DIR) — same outcome by coincidence. So we use a
+    # different cwd to make composition observable: start from /, then
+    # `-C $WORK_DIR -C repo-b/main` should land in $WORK_DIR/repo-b/main.
+    # Last-wins would try to resolve `repo-b/main` relative to /, fail.
+    run: daft -C "$WORK_DIR" -C repo-b/main go develop
+    cwd: "/"
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/repo-b/develop"

--- a/tests/manual/scenarios/global-flags/c-empty-noop.yml
+++ b/tests/manual/scenarios/global-flags/c-empty-noop.yml
@@ -1,0 +1,20 @@
+name: -C "" is a no-op
+description: Matches git's `-C ""` semantic — cwd unchanged
+
+repos:
+  - name: test-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone the repo
+    run: git-worktree-clone --layout contained $REMOTE_TEST_REPO
+    expect:
+      exit_code: 0
+
+  - name: daft -C "" list from inside the repo lists the current repo
+    run: NO_COLOR=1 daft -C "" list 2>&1
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "main"

--- a/tests/manual/scenarios/global-flags/c-hooks-from-new-cwd.yml
+++ b/tests/manual/scenarios/global-flags/c-hooks-from-new-cwd.yml
@@ -1,0 +1,53 @@
+name: -C runs hooks from the target repo
+description:
+  worktree-post-create hook in the -C target fires when invoking from outside
+
+repos:
+  - name: repo-a
+    use_fixture: standard-remote
+  - name: repo-b
+    default_branch: main
+    branches:
+      - name: main
+        files:
+          - path: README.md
+            content: "# repo-b"
+        commits:
+          - message: "Initial commit"
+      - name: develop
+        from: main
+    daft_yml: |
+      hooks:
+        worktree-post-create:
+          jobs:
+            - name: write-sentinel
+              run: 'echo hook-fired > "$DAFT_WORKTREE_PATH/.hook-sentinel"'
+
+steps:
+  - name: Clone repo-a
+    run: git-worktree-clone --layout contained $REMOTE_REPO_A
+    expect:
+      exit_code: 0
+
+  - name: Clone repo-b
+    run: git-worktree-clone --layout contained $REMOTE_REPO_B
+    expect:
+      exit_code: 0
+
+  - name: Trust the hooks config in repo-b
+    run: daft hooks trust --force
+    cwd: "$WORK_DIR/repo-b/main"
+    expect:
+      exit_code: 0
+
+  - name:
+      From repo-a/main, run daft -C against repo-b; the hook fires inside repo-b
+    run: daft -C "$WORK_DIR/repo-b/main" go develop
+    cwd: "$WORK_DIR/repo-a/main"
+    expect:
+      exit_code: 0
+      files_exist:
+        - "$WORK_DIR/repo-b/develop/.hook-sentinel"
+      file_contains:
+        - path: "$WORK_DIR/repo-b/develop/.hook-sentinel"
+          content: "hook-fired"

--- a/tests/manual/scenarios/global-flags/c-missing.yml
+++ b/tests/manual/scenarios/global-flags/c-missing.yml
@@ -1,6 +1,8 @@
-name: -C missing path errors with exit 2
+name: -C error paths exit with usage-error code 2
 description:
-  -C with a non-existent path fails fast with clap usage-error exit code
+  Both `-C /missing` (non-directory) and trailing `-C` (no path argument) must
+  exit with clap usage-error code 2, not 1. Regression for the consistency issue
+  where MissingPathAfterC originally exited via anyhow Err → 1.
 
 steps:
   - name: daft -C /nonexistent/path exits 2 with terse message
@@ -10,3 +12,11 @@ steps:
       output_contains:
         - "-C"
         - "not a directory"
+
+  - name: trailing -C (no path argument) exits 2 with terse message
+    run: daft -C 2>&1
+    expect:
+      exit_code: 2
+      output_contains:
+        - "-C"
+        - "requires an argument"

--- a/tests/manual/scenarios/global-flags/c-missing.yml
+++ b/tests/manual/scenarios/global-flags/c-missing.yml
@@ -1,0 +1,12 @@
+name: -C missing path errors with exit 2
+description:
+  -C with a non-existent path fails fast with clap usage-error exit code
+
+steps:
+  - name: daft -C /nonexistent/path exits 2 with terse message
+    run: daft -C /nonexistent/path-for-c-flag-test list 2>&1
+    expect:
+      exit_code: 2
+      output_contains:
+        - "-C"
+        - "not a directory"

--- a/tests/manual/scenarios/global-flags/c-relative.yml
+++ b/tests/manual/scenarios/global-flags/c-relative.yml
@@ -1,0 +1,28 @@
+name: -C relative path resolves against current cwd
+description:
+  First -C with a relative path resolves against the cwd at invocation time
+
+repos:
+  - name: repo-a
+    use_fixture: standard-remote
+  - name: repo-b
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone repo-a
+    run: git-worktree-clone --layout contained $REMOTE_REPO_A
+    expect:
+      exit_code: 0
+
+  - name: Clone repo-b
+    run: git-worktree-clone --layout contained $REMOTE_REPO_B
+    expect:
+      exit_code: 0
+
+  - name: From repo-a/main, use relative ../../repo-b/main to checkout in b
+    run: daft -C ../../repo-b/main go develop
+    cwd: "$WORK_DIR/repo-a/main"
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/repo-b/develop"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -660,6 +660,22 @@ fn build_top_level_command() -> clap::Command {
              See daft-shell-init(1) for details.",
         )
         .subcommand_required(false)
+        // Top-level `-C <path>` flag (issue #519). The flag is actually parsed
+        // pre-clap in `daft::cli::install_and_apply`; declaring it here only
+        // affects man-page generation and `--help` output so the global option
+        // is documented in the standard OPTIONS section.
+        .arg(
+            clap::Arg::new("cwd")
+                .short('C')
+                .value_name("path")
+                .global(false)
+                .num_args(1)
+                .help(
+                    "Run as if started in <path> instead of the current working directory. \
+                     Applied before subcommand dispatch, layout resolution, and hook discovery. \
+                     Multiple `-C` flags compose, matching `git -C` semantics.",
+                ),
+        )
         // Setup commands
         .subcommand(daft::commands::clone::Args::command().name("clone"))
         .subcommand(daft::commands::init::Args::command().name("init"))


### PR DESCRIPTION
> **Note:** Replaces #522 — that PR was accidentally merged then reverted (master force-pushed back to pre-merge state). This is the same work on the same branch; opening fresh here because GitHub doesn't allow reopening a merged PR. Original comment thread: https://github.com/avihut/daft/pull/522

## Summary

Adds a top-level `daft -C <path> <subcommand>` global flag that chdirs before
any path-dependent state is resolved (repo discovery, layout, hooks,
`daft.yml`, multicall dispatch). Semantics match `git -C` / `make -C` /
`pnpm -C`. Works for both the `daft` multicall arm and every `git-worktree-*`
symlinked entry.

Motivating use case (per the issue): coding agents operating across multiple
daft worktrees in one session can't reliably `cd`, so each invocation has to
be self-contained. `-C <path>` turns every call into "do X in path Y".

Fixes #519.

## Two corrections to the issue (raised in [this comment](https://github.com/avihut/daft/issues/519#issuecomment-4472426580))

1. **Multi-`-C` composes, doesn't last-win.** The issue claimed "last `-C` wins
   matches git" — that's empirically wrong about git, which composes
   (verified: `git -C /tmp/x -C a -C b ...` lands in `/tmp/x/a/b`).
   Implementation matches git: compose. Reasons in the issue comment.
2. **Stripped argv has to be globally visible**, not just a local in `main()`.
   Subcommands re-read `std::env::args()` directly via `crate::get_clap_args()`
   and a dozen other callers. Implemented as a `OnceLock<Vec<String>>` in a
   new `src/cli/` module that owns the strip-and-install lifecycle; all argv
   readers now route through `cli::argv()`.

## Architecture (per ARCHITECTURE.md)

The new `src/cli/` module is the seed for the future `daft-cli` crate, applied
as a small functional-core / imperative-shell split:

- `src/cli/argv.rs` — pure `parse_top_level_cwd()`, 10 unit tests, no I/O.
- `src/cli/mod.rs` — `install_and_apply()` (chdir + OnceLock install), tiny
  imperative shell.

No ports/adapters ceremony for a CLI-layer concern — explicitly out of scope
per the doc's "vertical slice at the CLI command layer" rule. Just lifts argv
reading from "scattered `env::args()` calls" into one accessor.

## Wrapper bug surfaced during integration testing

Adding the bash integration test caught a real wrapper-level bug: the
bash/zsh and fish `daft()` wrappers dispatched on `case "\$1"`, so
`daft -C /path verb args` matched `-C` (not the verb) and fell through to the
no-`DAFT_CD_FILE` default arm. The shell would never follow the binary into
the new worktree — defeating the cd-redirect for the primary use case.

Fixed by stripping leading `-C <path>` pairs into a local before dispatching,
reattaching as args to the wrapped binary. Same pattern in both bash/zsh and
fish wrappers. The existing `layout|repo` cd-redirect branch also benefits.

## Commits (4, logically separated for review)

1. **`feat(cli): add top-level -C <path> flag with git semantics`** — core
   `cli::install_and_apply` + `cli::argv()`, wired into `main.rs`, all argv
   readers migrated.
2. **`test(cli): cover -C end-to-end across YAML, integration, wrapper`** —
   7 YAML scenarios in `tests/manual/scenarios/global-flags/` (basic,
   missing, relative, compose, empty-noop, cd-redirect, hooks-from-new-cwd),
   2 bash integration tests in `test_shell_init.sh`, plus the wrapper fix.
3. **`docs(cli): document -C across completions, man, help, skill, docs
   site`** — bash/zsh/fish/fig completions, man-page declaration in xtask
   (man-gen only; still parsed pre-clap), new `Global options` section in
   `daft --help` / `git daft --help`, new `docs/cli/daft.md` reference page,
   new `docs/worktrees/from-anywhere.md` how-to, `SKILL.md` "Global Flags"
   section for agents.
4. **`fix(cli): -C trailing-no-arg exits 2 (was 1)`** — post-review fix.
   `daft -C` (no path) was exiting via anyhow Err → 1; now matches the
   directory-not-found branch with exit 2 (clap usage-error convention).
   Regression covered.

## Acceptance criteria (from the issue)

- [x] `daft -C <path> <subcommand>` runs as if invoked from `<path>`
- [x] Works for `daft` and all `git-worktree-*` / shortcut-alias symlinks
- [x] **Compose like git** (corrected from the issue's "last wins")
- [x] Relative paths resolve against original cwd (first `-C`) or prior
      applied cwd (subsequent `-C`s) — git's actual semantic
- [x] Missing/inaccessible path: exit 2 with terse `daft: -C: '<path>': not a
      directory`. Trailing `-C` (no arg): exit 2 with `option requires an
      argument`
- [x] Shell-integration cd-redirect works through `-C`
- [x] Hooks fire from post-`-C` cwd; `daft.yml` resolves from new repo root
- [x] XDG state / config dirs unaffected
- [x] All four shell completions register `-C` with path completion
- [x] Man pages regenerated; `daft --help` documents `-C` as global flag
- [x] YAML scenarios under `tests/manual/scenarios/global-flags/`
- [x] Bash integration test for the symlink-entry + shell-wrapper case

## Test plan

- [x] `cargo test --lib` — 1813/1813
- [x] `cargo clippy --all-targets -D warnings` — clean
- [x] `mise run fmt` — clean
- [x] `mise run man:verify` — up-to-date
- [x] `mise run test:integration` (full matrix: default+gitoxide × bash+yaml)
      — 2211/2211 across 579 scenarios
- [x] `mise run test:manual -- --ci global-flags:*` — 8 scenarios pass
- [x] `tests/integration/test_completions.sh` — 27/27
- [x] `tests/integration/test_shell_init.sh` — 19/21 (see Known issues below)
- [x] Spot-checked: shell wrapper followed daft into new worktree for both
      `-C` and non-`-C` invocations.

## Known issues, not from this PR

`test_shell_init_bash_aliases` and `test_shell_init_fish_aliases` fail
because they expect a `gwcob` alias that was renamed to `gwcb` upstream. The
failures pre-exist this PR; do not chase them as part of review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
