### PR TITLE
chore(release-plz): give term-styles its own tag namespace

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -32,6 +32,18 @@ changelog_update = false
 git_tag_name = "{{ package }}-v{{ version }}"
 git_only = false
 
+# term-styles is an internal workspace crate - don't release it
+# Use package-specific tag format so release-plz doesn't misattribute the
+# top-level `v{{ version }}` tag (which belongs to daft) to this crate and
+# then fail to find term-styles/ at that historical tag.
+[[package]]
+name = "term-styles"
+release = false
+publish = false
+changelog_update = false
+git_tag_name = "{{ package }}-v{{ version }}"
+git_only = false
+
 [changelog]
 # Use git-cliff for changelog generation (matches cliff.toml)
 commit_parsers = [


### PR DESCRIPTION
## Summary

- Adds a per-package `release-plz.toml` entry for `term-styles` mirroring how `xtask` is configured: own tag template (`{{ package }}-v{{ version }}`), `release = false`, `publish = false`, no changelog.
- Unblocks the Release-plz workflow on master, which has failed on every push since #521 introduced the `term-styles` workspace crate.

## Why this fixes it

Without a per-package `git_tag_name`, release-plz uses the workspace-wide `v{{ version }}` template — the daft tag format — for every crate it discovers. It then picks up the latest `v1.13.0` daft tag and attributes it to `term-styles`:

```
INFO Latest release of package term-styles: tag `v1.13.0` (version 1.13.0)
ERROR failed to update packages
    0: failed to determine next versions
    1: get cargo package term-styles from worktree at "/tmp/release-plz-term-styles-…/worktree"
    2: Failed to find package "term-styles"
```

release-plz then tries to read `term-styles/Cargo.toml` from a worktree checked out at v1.13.0, where the crate doesn't exist yet (it was added after v1.13.0 was cut), and the run aborts.

With a distinct tag template, release-plz looks for `term-styles-v*` tags, finds none, treats the crate as never released, and skips it — same defense `xtask` already uses.

Fixes #527

## Test plan

- [ ] Release-plz workflow run on this PR's branch parses the manifest without erroring out on `term-styles`.
- [ ] After merge, the next push to master triggers a Release-plz run that completes successfully and either opens a release PR for `daft` or no-ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)