### PR TITLE
feat(exec): add --show-output to dump captured output for successful worktrees

### DIFF
--- a/docs/cli/git-worktree-exec.md
+++ b/docs/cli/git-worktree-exec.md
@@ -29,6 +29,10 @@ When a single worktree is targeted, stdio is fully inherited, making
 interactive programs (claude, vim, fzf) work the same as if you had cd'd
 into the worktree first.
 
+By default, captured stdout/stderr is dumped only for failed or cancelled
+worktrees. Pass --show-output to dump it for successful worktrees too. The
+flag has no effect on single-target runs (stdio is already inherited).
+
 ## Usage
 
 ```
@@ -51,6 +55,7 @@ git worktree-exec [OPTIONS] [TARGETS] [CMD]
 | `--sequential` | Run worktrees one at a time and stop on first failure |  |
 | `--keep-going` | Run worktrees one at a time and continue through failures |  |
 | `--refresh-aliases` | Re-capture user shell aliases instead of using the cached snapshot |  |
+| `--show-output` | Dump captured stdout/stderr for successful worktrees too (no-op for single-target runs) |  |
 
 ## Global Options
 

--- a/man/daft-exec.1
+++ b/man/daft-exec.1
@@ -4,7 +4,7 @@
 .SH NAME
 daft\-exec \- Run a command across one or more worktrees
 .SH SYNOPSIS
-\fBdaft\-exec\fR [\fB\-\-all\fR] [\fB\-x\fR|\fB\-\-exec\fR] [\fB\-\-sequential\fR] [\fB\-\-keep\-going\fR] [\fB\-\-refresh\-aliases\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fITARGETS\fR] [\fICMD\fR] 
+\fBdaft\-exec\fR [\fB\-\-all\fR] [\fB\-x\fR|\fB\-\-exec\fR] [\fB\-\-sequential\fR] [\fB\-\-keep\-going\fR] [\fB\-\-refresh\-aliases\fR] [\fB\-\-show\-output\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fITARGETS\fR] [\fICMD\fR] 
 .SH DESCRIPTION
 .PP
 Runs one or more commands against one or more selected worktrees without
@@ -22,6 +22,10 @@ does not stop other worktrees.
 When a single worktree is targeted, stdio is fully inherited, making
 interactive programs (claude, vim, fzf) work the same as if you had cd\*(Aqd
 into the worktree first.
+.PP
+By default, captured stdout/stderr is dumped only for failed or cancelled
+worktrees. Pass \-\-show\-output to dump it for successful worktrees too. The
+flag has no effect on single\-target runs (stdio is already inherited).
 .SH OPTIONS
 .TP
 \fB\-\-all\fR
@@ -38,6 +42,9 @@ Run worktrees one at a time and continue through failures
 .TP
 \fB\-\-refresh\-aliases\fR
 Re\-capture user shell aliases instead of using the cached snapshot
+.TP
+\fB\-\-show\-output\fR
+Dump captured stdout/stderr for successful worktrees too (no\-op for single\-target runs)
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help (see a summary with \*(Aq\-h\*(Aq)
@@ -66,5 +73,8 @@ EXAMPLES:
 
     Pass\-through to an interactive program (single target):
         daft exec feat/auth \-\- claude
+
+    Dump captured output for successful worktrees too:
+        daft exec \-\-all \-\-show\-output \-\- cargo build \-\-timings
 .SH VERSION
 v1.14.0

--- a/man/git-worktree-exec.1
+++ b/man/git-worktree-exec.1
@@ -4,7 +4,7 @@
 .SH NAME
 git\-worktree\-exec \- Run a command across one or more worktrees
 .SH SYNOPSIS
-\fBgit\-worktree\-exec\fR [\fB\-\-all\fR] [\fB\-x\fR|\fB\-\-exec\fR] [\fB\-\-sequential\fR] [\fB\-\-keep\-going\fR] [\fB\-\-refresh\-aliases\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fITARGETS\fR] [\fICMD\fR] 
+\fBgit\-worktree\-exec\fR [\fB\-\-all\fR] [\fB\-x\fR|\fB\-\-exec\fR] [\fB\-\-sequential\fR] [\fB\-\-keep\-going\fR] [\fB\-\-refresh\-aliases\fR] [\fB\-\-show\-output\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fITARGETS\fR] [\fICMD\fR] 
 .SH DESCRIPTION
 .PP
 Runs one or more commands against one or more selected worktrees without
@@ -22,6 +22,10 @@ does not stop other worktrees.
 When a single worktree is targeted, stdio is fully inherited, making
 interactive programs (claude, vim, fzf) work the same as if you had cd\*(Aqd
 into the worktree first.
+.PP
+By default, captured stdout/stderr is dumped only for failed or cancelled
+worktrees. Pass \-\-show\-output to dump it for successful worktrees too. The
+flag has no effect on single\-target runs (stdio is already inherited).
 .SH OPTIONS
 .TP
 \fB\-\-all\fR
@@ -38,6 +42,9 @@ Run worktrees one at a time and continue through failures
 .TP
 \fB\-\-refresh\-aliases\fR
 Re\-capture user shell aliases instead of using the cached snapshot
+.TP
+\fB\-\-show\-output\fR
+Dump captured stdout/stderr for successful worktrees too (no\-op for single\-target runs)
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help (see a summary with \*(Aq\-h\*(Aq)
@@ -66,5 +73,8 @@ EXAMPLES:
 
     Pass\-through to an interactive program (single target):
         daft exec feat/auth \-\- claude
+
+    Dump captured output for successful worktrees too:
+        daft exec \-\-all \-\-show\-output \-\- cargo build \-\-timings
 .SH VERSION
 v1.14.0

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -28,6 +28,10 @@ does not stop other worktrees.
 When a single worktree is targeted, stdio is fully inherited, making
 interactive programs (claude, vim, fzf) work the same as if you had cd'd
 into the worktree first.
+
+By default, captured stdout/stderr is dumped only for failed or cancelled
+worktrees. Pass --show-output to dump it for successful worktrees too. The
+flag has no effect on single-target runs (stdio is already inherited).
 "#)]
 #[command(after_help = r#"EXAMPLES:
     Run a single command across all worktrees:
@@ -44,6 +48,9 @@ into the worktree first.
 
     Pass-through to an interactive program (single target):
         daft exec feat/auth -- claude
+
+    Dump captured output for successful worktrees too:
+        daft exec --all --show-output -- cargo build --timings
 "#)]
 pub struct Args {
     #[arg(help = "Target worktree(s) by branch name, directory name, or glob")]
@@ -82,6 +89,12 @@ pub struct Args {
         help = "Re-capture user shell aliases instead of using the cached snapshot"
     )]
     pub refresh_aliases: bool,
+
+    #[arg(
+        long = "show-output",
+        help = "Dump captured stdout/stderr for successful worktrees too (no-op for single-target runs)"
+    )]
+    pub show_output: bool,
 
     /// Trailing command vector after `--`. Mutually exclusive with `-x`.
     #[arg(last = true, value_name = "CMD")]
@@ -205,9 +218,14 @@ pub fn run() -> Result<()> {
         alias_cache.as_ref(),
     )?;
 
+    let dump_mode = if args.show_output {
+        core::list_renderer::DumpMode::All
+    } else {
+        core::list_renderer::DumpMode::FailuresOnly
+    };
     let stdout = std::io::stdout();
     let mut sink = stdout.lock();
-    core::list_renderer::render_failed_output_dump(&mut sink, &report, &pipeline)?;
+    core::list_renderer::render_output_dump(&mut sink, &report, &pipeline, dump_mode)?;
     drop(sink);
 
     std::process::exit(report.aggregate_exit_code());

--- a/src/core/worktree/exec/list_renderer.rs
+++ b/src/core/worktree/exec/list_renderer.rs
@@ -82,7 +82,16 @@ pub fn render_outcome<W: Sink>(
     Ok(())
 }
 
-/// Per-failure output dump. Each failed/cancelled worktree gets:
+/// Selects which outcomes get an output block dumped after the progress UI.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DumpMode {
+    /// Default: only failed or cancelled worktrees are dumped.
+    FailuresOnly,
+    /// `--show-output`: every worktree is dumped, including successes.
+    All,
+}
+
+/// Per-outcome output dump. Each rendered worktree gets:
 ///
 /// ```text
 /// <sigil> <branch>  ·  <cmd>  ·  <status>, <elapsed>, exit <code>
@@ -90,29 +99,32 @@ pub fn render_outcome<W: Sink>(
 ///   │ <captured line 2>
 /// ```
 ///
-/// A blank line separates each failure block from whatever precedes it (the
-/// preceding summary rows or a prior failure block) so the boundary is
-/// obvious. The vertical gutter visually contains the captured output; the
-/// header has no gutter, so absence-of-gutter on the next header is the
-/// section break.
-pub fn render_failed_output_dump<W: Sink>(
+/// Sigil/status come from outcome state (`✓ succeeded`, `✗ failed`,
+/// `⊘ cancelled`). `mode` decides whether successful outcomes are included.
+///
+/// A blank line separates each block from whatever precedes it (the preceding
+/// summary rows or a prior block) so the boundary is obvious. The vertical
+/// gutter visually contains the captured output; the header has no gutter, so
+/// absence-of-gutter on the next header is the section break.
+pub fn render_output_dump<W: Sink>(
     sink: &mut W,
     report: &ExecReport,
     pipeline: &[CommandSpec],
+    mode: DumpMode,
 ) -> std::io::Result<()> {
     for outcome in &report.outcomes {
-        if outcome.succeeded() {
+        if matches!(mode, DumpMode::FailuresOnly) && outcome.succeeded() {
             continue;
         }
         writeln!(sink)?;
-        render_failure_block(sink, outcome, pipeline)?;
+        render_outcome_block(sink, outcome, pipeline)?;
     }
     Ok(())
 }
 
 const GUTTER_PREFIX: &[u8] = "  \u{2502} ".as_bytes(); // "  │ "
 
-fn render_failure_block<W: Sink>(
+fn render_outcome_block<W: Sink>(
     sink: &mut W,
     outcome: &WorktreeOutcome,
     pipeline: &[CommandSpec],
@@ -121,15 +133,12 @@ fn render_failure_block<W: Sink>(
         .get(outcome.last_command_index)
         .map(|s| s.display())
         .unwrap_or_default();
-    let sigil = if outcome.cancelled {
-        "\u{2298}"
+    let (sigil, status) = if outcome.cancelled {
+        ("\u{2298}", "cancelled")
+    } else if outcome.succeeded() {
+        ("\u{2713}", "succeeded")
     } else {
-        "\u{2717}"
-    };
-    let status = if outcome.cancelled {
-        "cancelled"
-    } else {
-        "failed"
+        ("\u{2717}", "failed")
     };
     let elapsed = format!("{:.1}s", outcome.elapsed.as_secs_f64());
     writeln!(
@@ -225,8 +234,12 @@ mod tests {
     }
 
     fn dump(report: &ExecReport, pipeline: &[CommandSpec]) -> String {
+        dump_with(report, pipeline, DumpMode::FailuresOnly)
+    }
+
+    fn dump_with(report: &ExecReport, pipeline: &[CommandSpec], mode: DumpMode) -> String {
         let mut out = Vec::new();
-        render_failed_output_dump(&mut out, report, pipeline).unwrap();
+        render_output_dump(&mut out, report, pipeline, mode).unwrap();
         String::from_utf8(out).unwrap()
     }
 
@@ -330,5 +343,68 @@ mod tests {
         // One leading blank + one header line; no gutter lines.
         assert_eq!(s.lines().count(), 2, "expected blank + header only: {s:?}");
         assert!(s.starts_with('\n'));
+    }
+
+    #[test]
+    fn all_mode_includes_successful_outcomes() {
+        // With DumpMode::All, a successful outcome gets its own block — same
+        // gutter format as failures but with the success sigil and label.
+        let pipeline = vec![CommandSpec::Argv(vec!["echo".into(), "hi".into()])];
+        let report = ExecReport {
+            outcomes: vec![outcome("feat/ok", 0, false, b"hi\n")],
+            orphan_branches_skipped: vec![],
+        };
+        let s = dump_with(&report, &pipeline, DumpMode::All);
+        assert_eq!(
+            s,
+            "\n\u{2713} feat/ok  \u{00b7}  echo hi  \u{00b7}  succeeded, 1.2s, exit 0\n  \
+             \u{2502} hi\n",
+        );
+    }
+
+    #[test]
+    fn all_mode_renders_success_failure_and_cancelled_in_order() {
+        // Order of outcomes is preserved; each gets the right sigil/label.
+        let pipeline = vec![CommandSpec::Argv(vec!["mise".into(), "dev".into()])];
+        let report = ExecReport {
+            outcomes: vec![
+                outcome("feat/ok", 0, false, b"good\n"),
+                outcome("feat/bad", 7, false, b"oops\n"),
+                outcome("feat/cancel", -1, true, b"halt\n"),
+            ],
+            orphan_branches_skipped: vec![],
+        };
+        let s = dump_with(&report, &pipeline, DumpMode::All);
+        let ok_pos = s.find("\u{2713} feat/ok").expect("missing success header");
+        let bad_pos = s.find("\u{2717} feat/bad").expect("missing failure header");
+        let cancel_pos = s
+            .find("\u{2298} feat/cancel")
+            .expect("missing cancelled header");
+        assert!(
+            ok_pos < bad_pos && bad_pos < cancel_pos,
+            "blocks rendered out of order: {s}"
+        );
+        assert!(s.contains("succeeded, 1.2s, exit 0"));
+        assert!(s.contains("failed, 1.2s, exit 7"));
+        assert!(s.contains("cancelled, 1.2s, exit -1"));
+        assert!(s.contains("  \u{2502} good\n"));
+        assert!(s.contains("  \u{2502} oops\n"));
+        assert!(s.contains("  \u{2502} halt\n"));
+    }
+
+    #[test]
+    fn all_mode_with_empty_captured_output_emits_only_header() {
+        // Parity with the FailuresOnly case: a success with no output still
+        // gets its header block (leading blank + header line) and nothing else.
+        let pipeline = vec![CommandSpec::Argv(vec!["true".into()])];
+        let report = ExecReport {
+            outcomes: vec![outcome("feat/quiet", 0, false, b"")],
+            orphan_branches_skipped: vec![],
+        };
+        let s = dump_with(&report, &pipeline, DumpMode::All);
+        assert!(!s.contains('\u{2502}'), "unexpected gutter line: {s}");
+        assert_eq!(s.lines().count(), 2, "expected blank + header only: {s:?}");
+        assert!(s.starts_with('\n'));
+        assert!(s.contains("\u{2713} feat/quiet"));
     }
 }

--- a/src/core/worktree/exec/mod.rs
+++ b/src/core/worktree/exec/mod.rs
@@ -1334,7 +1334,7 @@ mod tests {
 
     #[test]
     fn list_renderer_header_and_rows_and_failed_dump() {
-        use super::list_renderer::{render_failed_output_dump, render_header, render_outcome};
+        use super::list_renderer::{DumpMode, render_header, render_outcome, render_output_dump};
 
         let pipeline = vec![CommandSpec::Argv(vec!["cargo".into(), "test".into()])];
         let outcomes = vec![
@@ -1371,7 +1371,7 @@ mod tests {
         for o in &report.outcomes {
             render_outcome(&mut out, o, &pipeline).unwrap();
         }
-        render_failed_output_dump(&mut out, &report, &pipeline).unwrap();
+        render_output_dump(&mut out, &report, &pipeline, DumpMode::FailuresOnly).unwrap();
 
         let s = String::from_utf8(out).unwrap();
         assert!(

--- a/tests/manual/scenarios/worktree-exec/show-output-success-dump.yml
+++ b/tests/manual/scenarios/worktree-exec/show-output-success-dump.yml
@@ -1,0 +1,49 @@
+name: "Exec --show-output dumps successful captured output"
+description:
+  "With --show-output, every worktree (including those that succeeded) gets a
+  ✓-headed block with its captured stdout reproduced in the gutter. Without the
+  flag the same run prints only the summary rows."
+
+repos:
+  - name: exec-show
+    use_fixture: standard-remote
+
+steps:
+  - name: "Clone the repository"
+    run: "git-worktree-clone --layout contained $REMOTE_EXEC_SHOW"
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/exec-show/main"
+
+  - name: "Create feat-a worktree"
+    run: "git-worktree-checkout -b feat-a"
+    cwd: "$WORK_DIR/exec-show/main"
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/exec-show/feat-a"
+
+  - name: "Without --show-output: no per-branch capture is dumped"
+    run: "git-worktree-exec --all -- sh -c 'echo marker-success' 2>&1"
+    cwd: "$WORK_DIR/exec-show/main"
+    expect:
+      exit_code: 0
+      output_not_contains:
+        - "│ marker-success"
+        - "succeeded,"
+
+  - name:
+      "With --show-output: every successful worktree gets a ✓ block with its
+      output"
+    run:
+      "git-worktree-exec --all --show-output -- sh -c 'echo marker-success' 2>&1"
+    cwd: "$WORK_DIR/exec-show/main"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "✓ feat-a"
+        - "✓ main"
+        - "succeeded,"
+        - "exit 0"
+        - "│ marker-success"


### PR DESCRIPTION
## Summary

- Adds `--show-output` to `daft exec`. By default, only failed or cancelled
  worktrees get their captured stdout/stderr dumped after the progress TUI.
  With this flag, successful worktrees get the same gutter-formatted block,
  using a `✓` sigil and `succeeded` status.
- Refactors `render_failed_output_dump` → `render_output_dump(mode)` with a
  new `DumpMode { FailuresOnly, All }` enum. `render_failure_block` →
  `render_outcome_block`, deriving sigil/status from outcome state instead of
  hardcoding the failure variant — the same three-way branch already used in
  `render_outcome` at `list_renderer.rs:57-63`.
- Flag is a no-op on single-target runs (stdio is already inherited).

## Why

Captured output is already populated unconditionally on every `WorktreeOutcome`
(see `src/core/worktree/exec/mod.rs:640-658`); the failure-only dump was a
display gate, not a capture gate. Users running pipelines that legitimately
succeed across all worktrees but emit useful output (`cargo build --timings`,
`pnpm test` summaries, `git status --short`, audit reports) had no way to see
it without contriving a per-command `tee` to a `$DAFT_BRANCH_NAME`-keyed file.

## Test plan

- [x] `mise run fmt` ✓
- [x] `mise run clippy` ✓
- [x] `cargo test --lib list_renderer` → 13/13 (3 new tests for All mode)
- [x] `mise run man:gen` — `man/daft-exec.1` + `man/git-worktree-exec.1`
      include the new flag
- [x] `daft completions {bash,zsh,fish}` all emit `--show-output`
      (auto-propagated via clap; no manual completion edits required)
- [x] YAML scenario `worktree-exec/show-output-success-dump.yml` passes
      4/4 steps (negative path: no flag → no dump; positive: flag → ✓ blocks
      with output present)
- [ ] Manual smoke test in a throwaway repo with 2+ worktrees — confirm
      `daft exec --all -- echo hello` is unchanged and
      `daft exec --all --show-output -- echo hello` prints ✓ blocks per branch

Fixes #529