### PR TITLE
chore: release v1.14.1

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -33,7 +33,7 @@ jobs:
         uses: release-plz/action@v0.5.129
         with:
           command: release
-          version: 0.3.156
+          version: 0.3.158
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
@@ -69,7 +69,7 @@ jobs:
         uses: release-plz/action@v0.5.129
         with:
           command: release-pr
-          version: 0.3.156
+          version: 0.3.158
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.14.1](https://github.com/avihut/daft/compare/v1.14.0...v1.14.1) - 2026-05-21
+
+### Features
+
+- *(exec)* add --show-output to dump captured output for successful worktrees ([#530](https://github.com/avihut/daft/pull/530))
+
 ## [1.14.0](https://github.com/avihut/daft/compare/v1.13.0...v1.14.0) - 2026-05-18
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "daft"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ term-styles = { path = "term-styles", version = "0.1.0" }
 
 [package]
 name = "daft"
-version = "1.14.0"
+version = "1.14.1"
 edition = "2024"
 rust-version = "1.93"
 description = "A comprehensive Git extensions toolkit that enhances developer workflows, starting with powerful worktree management"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,10 @@
 members = [".", "term-styles", "xtask"]
 resolver = "2"
 
+# Internal path deps need `version` to be packageable. See release-plz#2595.
+[workspace.dependencies]
+term-styles = { path = "term-styles", version = "0.1.0" }
+
 [package]
 name = "daft"
 version = "1.14.0"
@@ -80,7 +84,7 @@ anyhow = "1.0"
 dirs = "6.0"
 which = "8.0"
 tempfile = "3.8"
-term-styles = { path = "term-styles" }
+term-styles = { workspace = true }
 regex = "1.10"
 url = "2.5"
 serde = { version = "1.0", features = ["derive"] }

--- a/man/daft-adopt.1
+++ b/man/daft-adopt.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH daft-adopt 1  "daft-adopt 1.14.0" 
+.TH daft-adopt 1  "daft-adopt 1.14.1" 
 .SH NAME
 daft\-adopt \- Convert a traditional repository to worktree\-based layout
 .SH SYNOPSIS
@@ -92,4 +92,4 @@ Print version
 [\fIREPOSITORY_PATH\fR]
 Path to the repository to convert (defaults to current directory)
 .SH VERSION
-v1.14.0
+v1.14.1

--- a/man/daft-carry.1
+++ b/man/daft-carry.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH daft-carry 1  "daft-carry 1.14.0" 
+.TH daft-carry 1  "daft-carry 1.14.1" 
 .SH NAME
 daft\-carry \- Transfer uncommitted changes to other worktrees
 .SH SYNOPSIS
@@ -38,4 +38,4 @@ Print version
 <\fITARGETS\fR>
 Target worktree(s) by directory name or branch name
 .SH VERSION
-v1.14.0
+v1.14.1

--- a/man/daft-clone.1
+++ b/man/daft-clone.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH daft-clone 1  "daft-clone 1.14.0" 
+.TH daft-clone 1  "daft-clone 1.14.1" 
 .SH NAME
 daft\-clone \- Clone a repository into a worktree\-based directory structure
 .SH SYNOPSIS
@@ -69,4 +69,4 @@ Print version
 <\fIREPOSITORY_URL\fR>
 The repository URL to clone (HTTPS or SSH)
 .SH VERSION
-v1.14.0
+v1.14.1

--- a/man/daft-eject.1
+++ b/man/daft-eject.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH daft-eject 1  "daft-eject 1.14.0" 
+.TH daft-eject 1  "daft-eject 1.14.1" 
 .SH NAME
 daft\-eject \- Convert a worktree\-based repository back to traditional layout
 .SH SYNOPSIS
@@ -67,4 +67,4 @@ Print version
 [\fIREPOSITORY_PATH\fR]
 Path to the repository to convert (defaults to current directory)
 .SH VERSION
-v1.14.0
+v1.14.1

--- a/man/daft-exec.1
+++ b/man/daft-exec.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH daft-exec 1  "daft-exec 1.14.0" 
+.TH daft-exec 1  "daft-exec 1.14.1" 
 .SH NAME
 daft\-exec \- Run a command across one or more worktrees
 .SH SYNOPSIS
@@ -77,4 +77,4 @@ EXAMPLES:
     Dump captured output for successful worktrees too:
         daft exec \-\-all \-\-show\-output \-\- cargo build \-\-timings
 .SH VERSION
-v1.14.0
+v1.14.1

--- a/man/daft-go.1
+++ b/man/daft-go.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH "daft go" 1  "daft go 1.14.0" 
+.TH "daft go" 1  "daft go 1.14.1" 
 .SH NAME
 daft go \- Open a worktree for an existing branch, or create one with \-b
 .SH SYNOPSIS
@@ -78,4 +78,4 @@ Branch to open; use \*(Aq\-\*(Aq for previous worktree
 [\fIBASE_BRANCH_NAME\fR]
 Base branch for \-b (defaults to current branch)
 .SH VERSION
-v1.14.0
+v1.14.1

--- a/man/daft-init.1
+++ b/man/daft-init.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH daft-init 1  "daft-init 1.14.0" 
+.TH daft-init 1  "daft-init 1.14.1" 
 .SH NAME
 daft\-init \- Initialize a new repository in the worktree\-based directory structure
 .SH SYNOPSIS
@@ -59,4 +59,4 @@ Print version
 <\fIREPOSITORY_NAME\fR>
 Name for the new repository directory
 .SH VERSION
-v1.14.0
+v1.14.1

--- a/man/daft-list.1
+++ b/man/daft-list.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH daft-list 1  "daft-list 1.14.0" 
+.TH daft-list 1  "daft-list 1.14.1" 
 .SH NAME
 daft\-list \- List all worktrees with status information
 .SH SYNOPSIS
@@ -130,4 +130,4 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 \fB\-V\fR, \fB\-\-version\fR
 Print version
 .SH VERSION
-v1.14.0
+v1.14.1

--- a/man/daft-merge.1
+++ b/man/daft-merge.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH daft-merge 1  "daft-merge 1.14.0" 
+.TH daft-merge 1  "daft-merge 1.14.1" 
 .SH NAME
 daft\-merge \- Merge branches across worktrees
 .SH SYNOPSIS
@@ -129,4 +129,4 @@ Print version
 [\fISOURCE_OR_TARGET\fR]
 Source branches/commits to merge (start mode), OR optional target worktree/branch for \-\-abort / \-\-continue / \-\-quit (finish mode; max one positional)
 .SH VERSION
-v1.14.0
+v1.14.1

--- a/man/daft-prune.1
+++ b/man/daft-prune.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH daft-prune 1  "daft-prune 1.14.0" 
+.TH daft-prune 1  "daft-prune 1.14.1" 
 .SH NAME
 daft\-prune \- Remove worktrees and branches for deleted remote branches
 .SH SYNOPSIS
@@ -58,4 +58,4 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 \fB\-V\fR, \fB\-\-version\fR
 Print version
 .SH VERSION
-v1.14.0
+v1.14.1

--- a/man/daft-release-notes.1
+++ b/man/daft-release-notes.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH daft-release-notes 1  "daft-release-notes 1.14.0" 
+.TH daft-release-notes 1  "daft-release-notes 1.14.1" 
 .SH NAME
 daft\-release\-notes \- Display release notes from the changelog
 .SH SYNOPSIS
@@ -66,4 +66,4 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 [\fIVERSION\fR]
 Show notes for a specific version (e.g., "1.0.5" or "v1.0.5")
 .SH VERSION
-v1.14.0
+v1.14.1

--- a/man/daft-remove.1
+++ b/man/daft-remove.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH "daft remove" 1  "daft remove 1.14.0" 
+.TH "daft remove" 1  "daft remove 1.14.1" 
 .SH NAME
 daft remove \- Delete branches and their worktrees
 .SH SYNOPSIS
@@ -62,4 +62,4 @@ Print version
 <\fIBRANCHES\fR>
 Branches or worktree paths to delete
 .SH VERSION
-v1.14.0
+v1.14.1

--- a/man/daft-rename.1
+++ b/man/daft-rename.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH "daft rename" 1  "daft rename 1.14.0" 
+.TH "daft rename" 1  "daft rename 1.14.1" 
 .SH NAME
 daft rename \- Rename a branch and move its worktree
 .SH SYNOPSIS
@@ -45,4 +45,4 @@ Source branch or worktree path
 <\fINEW_BRANCH\fR>
 New branch name
 .SH VERSION
-v1.14.0
+v1.14.1

--- a/man/daft-shared.1
+++ b/man/daft-shared.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH daft-shared 1  "daft-shared 1.14.0" 
+.TH daft-shared 1  "daft-shared 1.14.1" 
 .SH NAME
 daft\-shared \- Manage shared files across worktrees
 .SH SYNOPSIS
@@ -48,4 +48,4 @@ Interactive TUI for managing shared file state across worktrees
 daft\-shared\-help(1)
 Print this message or the help of the given subcommand(s)
 .SH VERSION
-v1.14.0
+v1.14.1

--- a/man/daft-start.1
+++ b/man/daft-start.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH "daft start" 1  "daft start 1.14.0" 
+.TH "daft start" 1  "daft start 1.14.1" 
 .SH NAME
 daft start \- Create a new branch and worktree
 .SH SYNOPSIS
@@ -60,4 +60,4 @@ Name for the new branch
 [\fIBASE_BRANCH_NAME\fR]
 Branch to use as the base; defaults to the current branch
 .SH VERSION
-v1.14.0
+v1.14.1

--- a/man/daft-sync.1
+++ b/man/daft-sync.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH daft-sync 1  "daft-sync 1.14.0" 
+.TH daft-sync 1  "daft-sync 1.14.1" 
 .SH NAME
 daft\-sync \- Synchronize worktrees with remote (prune + update all)
 .SH SYNOPSIS
@@ -75,4 +75,4 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 \fB\-V\fR, \fB\-\-version\fR
 Print version
 .SH VERSION
-v1.14.0
+v1.14.1

--- a/man/daft-update.1
+++ b/man/daft-update.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH daft-update 1  "daft-update 1.14.0" 
+.TH daft-update 1  "daft-update 1.14.1" 
 .SH NAME
 daft\-update \- Update worktree branches from their remote tracking branches
 .SH SYNOPSIS
@@ -64,4 +64,4 @@ Target worktree(s) by name or refspec (source:destination)
 [\fIPULL_ARGS\fR]
 Additional arguments to pass to git pull
 .SH VERSION
-v1.14.0
+v1.14.1

--- a/man/git-daft-repo-remove.1
+++ b/man/git-daft-repo-remove.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-daft-repo-remove 1  "git-daft-repo-remove 1.14.0" 
+.TH git-daft-repo-remove 1  "git-daft-repo-remove 1.14.1" 
 .SH NAME
 git\-daft\-repo\-remove \- Remove a Git repository and all its worktrees
 .SH SYNOPSIS
@@ -40,4 +40,4 @@ Print version
 [\fIPATH\fR]
 Path to the repo or any directory inside it (default: cwd)
 .SH VERSION
-v1.14.0
+v1.14.1

--- a/man/git-worktree-branch-delete.1
+++ b/man/git-worktree-branch-delete.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-branch-delete 1  "git-worktree-branch-delete 1.14.0" 
+.TH git-worktree-branch-delete 1  "git-worktree-branch-delete 1.14.1" 
 .SH NAME
 git\-worktree\-branch\-delete \- Delete branches and their worktrees
 .SH SYNOPSIS
@@ -59,4 +59,4 @@ Print version
 <\fIBRANCHES\fR>
 Branches to delete (names or worktree paths)
 .SH VERSION
-v1.14.0
+v1.14.1

--- a/man/git-worktree-branch.1
+++ b/man/git-worktree-branch.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-branch 1  "git-worktree-branch 1.14.0" 
+.TH git-worktree-branch 1  "git-worktree-branch 1.14.1" 
 .SH NAME
 git\-worktree\-branch \- Delete or rename branches and their worktrees
 .SH SYNOPSIS
@@ -94,4 +94,4 @@ Print version
 [\fIBRANCHES\fR]
 Branches (delete mode) or source + new\-name (rename mode)
 .SH VERSION
-v1.14.0
+v1.14.1

--- a/man/git-worktree-carry.1
+++ b/man/git-worktree-carry.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-carry 1  "git-worktree-carry 1.14.0" 
+.TH git-worktree-carry 1  "git-worktree-carry 1.14.1" 
 .SH NAME
 git\-worktree\-carry \- Transfer uncommitted changes to other worktrees
 .SH SYNOPSIS
@@ -38,4 +38,4 @@ Print version
 <\fITARGETS\fR>
 Target worktree(s) by directory name or branch name
 .SH VERSION
-v1.14.0
+v1.14.1

--- a/man/git-worktree-checkout.1
+++ b/man/git-worktree-checkout.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-checkout 1  "git-worktree-checkout 1.14.0" 
+.TH git-worktree-checkout 1  "git-worktree-checkout 1.14.1" 
 .SH NAME
 git\-worktree\-checkout \- Create a worktree for an existing branch, or a new branch with \-b
 .SH SYNOPSIS
@@ -82,4 +82,4 @@ Name of the branch to check out (or create with \-b); use \*(Aq\-\*(Aq for previ
 [\fIBASE_BRANCH_NAME\fR]
 Branch to use as the base for the new branch (only with \-b); defaults to the current branch
 .SH VERSION
-v1.14.0
+v1.14.1

--- a/man/git-worktree-clone.1
+++ b/man/git-worktree-clone.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-clone 1  "git-worktree-clone 1.14.0" 
+.TH git-worktree-clone 1  "git-worktree-clone 1.14.1" 
 .SH NAME
 git\-worktree\-clone \- Clone a repository into a worktree\-based directory structure
 .SH SYNOPSIS
@@ -69,4 +69,4 @@ Print version
 <\fIREPOSITORY_URL\fR>
 The repository URL to clone (HTTPS or SSH)
 .SH VERSION
-v1.14.0
+v1.14.1

--- a/man/git-worktree-exec.1
+++ b/man/git-worktree-exec.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-exec 1  "git-worktree-exec 1.14.0" 
+.TH git-worktree-exec 1  "git-worktree-exec 1.14.1" 
 .SH NAME
 git\-worktree\-exec \- Run a command across one or more worktrees
 .SH SYNOPSIS
@@ -77,4 +77,4 @@ EXAMPLES:
     Dump captured output for successful worktrees too:
         daft exec \-\-all \-\-show\-output \-\- cargo build \-\-timings
 .SH VERSION
-v1.14.0
+v1.14.1

--- a/man/git-worktree-fetch.1
+++ b/man/git-worktree-fetch.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-fetch 1  "git-worktree-fetch 1.14.0" 
+.TH git-worktree-fetch 1  "git-worktree-fetch 1.14.1" 
 .SH NAME
 git\-worktree\-fetch \- Update worktree branches from their remote tracking branches
 .SH SYNOPSIS
@@ -64,4 +64,4 @@ Target worktree(s) by name or refspec (source:destination)
 [\fIPULL_ARGS\fR]
 Additional arguments to pass to git pull
 .SH VERSION
-v1.14.0
+v1.14.1

--- a/man/git-worktree-flow-adopt.1
+++ b/man/git-worktree-flow-adopt.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-flow-adopt 1  "git-worktree-flow-adopt 1.14.0" 
+.TH git-worktree-flow-adopt 1  "git-worktree-flow-adopt 1.14.1" 
 .SH NAME
 git\-worktree\-flow\-adopt \- Convert a traditional repository to worktree\-based layout
 .SH SYNOPSIS
@@ -92,4 +92,4 @@ Print version
 [\fIREPOSITORY_PATH\fR]
 Path to the repository to convert (defaults to current directory)
 .SH VERSION
-v1.14.0
+v1.14.1

--- a/man/git-worktree-flow-eject.1
+++ b/man/git-worktree-flow-eject.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-flow-eject 1  "git-worktree-flow-eject 1.14.0" 
+.TH git-worktree-flow-eject 1  "git-worktree-flow-eject 1.14.1" 
 .SH NAME
 git\-worktree\-flow\-eject \- Convert a worktree\-based repository back to traditional layout
 .SH SYNOPSIS
@@ -67,4 +67,4 @@ Print version
 [\fIREPOSITORY_PATH\fR]
 Path to the repository to convert (defaults to current directory)
 .SH VERSION
-v1.14.0
+v1.14.1

--- a/man/git-worktree-init.1
+++ b/man/git-worktree-init.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-init 1  "git-worktree-init 1.14.0" 
+.TH git-worktree-init 1  "git-worktree-init 1.14.1" 
 .SH NAME
 git\-worktree\-init \- Initialize a new repository in the worktree\-based directory structure
 .SH SYNOPSIS
@@ -59,4 +59,4 @@ Print version
 <\fIREPOSITORY_NAME\fR>
 Name for the new repository directory
 .SH VERSION
-v1.14.0
+v1.14.1

--- a/man/git-worktree-list.1
+++ b/man/git-worktree-list.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-list 1  "git-worktree-list 1.14.0" 
+.TH git-worktree-list 1  "git-worktree-list 1.14.1" 
 .SH NAME
 git\-worktree\-list \- List all worktrees with status information
 .SH SYNOPSIS
@@ -130,4 +130,4 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 \fB\-V\fR, \fB\-\-version\fR
 Print version
 .SH VERSION
-v1.14.0
+v1.14.1

--- a/man/git-worktree-merge.1
+++ b/man/git-worktree-merge.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-merge 1  "git-worktree-merge 1.14.0" 
+.TH git-worktree-merge 1  "git-worktree-merge 1.14.1" 
 .SH NAME
 git\-worktree\-merge \- Merge branches across worktrees
 .SH SYNOPSIS
@@ -129,4 +129,4 @@ Print version
 [\fISOURCE_OR_TARGET\fR]
 Source branches/commits to merge (start mode), OR optional target worktree/branch for \-\-abort / \-\-continue / \-\-quit (finish mode; max one positional)
 .SH VERSION
-v1.14.0
+v1.14.1

--- a/man/git-worktree-prune.1
+++ b/man/git-worktree-prune.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-prune 1  "git-worktree-prune 1.14.0" 
+.TH git-worktree-prune 1  "git-worktree-prune 1.14.1" 
 .SH NAME
 git\-worktree\-prune \- Remove worktrees and branches for deleted remote branches
 .SH SYNOPSIS
@@ -58,4 +58,4 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 \fB\-V\fR, \fB\-\-version\fR
 Print version
 .SH VERSION
-v1.14.0
+v1.14.1

--- a/man/git-worktree-sync.1
+++ b/man/git-worktree-sync.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH git-worktree-sync 1  "git-worktree-sync 1.14.0" 
+.TH git-worktree-sync 1  "git-worktree-sync 1.14.1" 
 .SH NAME
 git\-worktree\-sync \- Synchronize worktrees with remote (prune + update all)
 .SH SYNOPSIS
@@ -75,4 +75,4 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 \fB\-V\fR, \fB\-\-version\fR
 Print version
 .SH VERSION
-v1.14.0
+v1.14.1

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -10,7 +10,7 @@ clap = { version = "4.5", features = ["derive"] }
 clap_mangen = "0.3"
 crossterm = "0.29"
 ctrlc = "3.5.2"
-daft = { path = "..", version = "1.14.0" }
+daft = { path = "..", version = "1.14.1" }
 rayon = "1.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -14,7 +14,7 @@ daft = { path = "..", version = "1.14.0" }
 rayon = "1.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
-term-styles = { path = "../term-styles" }
+term-styles = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 # Used by `xtask test-matrix` to detect parent-process death and self-terminate.


### PR DESCRIPTION
## Summary

`v1.14.1` release that simultaneously fixes the release-plz deadlock that's been failing the workflow on every push since v1.14.0 was tagged.

Two commits, intended to squash into one `chore: release v1.14.1` commit on master:

1. `ci(release-plz): unblock by versioning internal path deps` — declares `term-styles` in `[workspace.dependencies]` with both `path` and `version`, updates daft + xtask to consume via `workspace = true`, and bumps the release-plz CLI pin `0.3.156 → 0.3.158` (picks up release-plz/release-plz#2655's `cargo package --workspace` invocation).
2. `chore: release v1.14.1` — bumps `Cargo.toml` and `xtask/Cargo.toml`'s `daft` path dep to `1.14.1`, adds the `[1.14.1]` CHANGELOG entry (covers #530's `--show-output` feature), refreshes `Cargo.lock`, and regenerates man pages + CLI docs (what release-plz's PR-update step would normally do).

Refs #536, release-plz/release-plz#2595.

## Why both commits live in one PR

The HEAD-side convention fix alone does not unblock the workflow — release-plz in `git_only` mode checks out the latest release tag (`v1.14.0`) into a temp worktree and packages *that historical state* for diffing. `v1.14.0`'s `Cargo.toml` is frozen without the `version` field on `term-styles`:

```
ERROR failed to determine next versions
  cargo package failed: Packaging term-styles v0.1.0 (.../release-plz-daft-…/worktree/term-styles)
  error: failed to verify manifest at .../worktree/Cargo.toml
  Caused by: dependency `term-styles` does not specify a version
```

Reproduced locally with the bumped CLI (0.3.158) running against this branch — the deadlock is inside the v1.14.0 tag's manifest, not on HEAD. The only way out is a new tag whose `Cargo.toml` already contains the fix. Bundling the release commit here means the merge commit *is* that tag's target.

## Post-merge step — Action Required

After squash-merging, tag the merge commit and push:

```sh
git fetch origin master
git tag v1.14.1 origin/master
git push origin v1.14.1
```

cargo-dist (`release.yml`) builds binaries on tag push. Subsequent pushes to master will run release-plz against `v1.14.1` (which has the fix) and succeed.

## Dependabot note (out of scope, worth flagging separately)

The `github-actions` ecosystem in `dependabot.yml` will keep `release-plz/action@v0.5.129` (the action wrapper) current automatically, but the `version: 0.3.158` *input* to that action is a string Dependabot can't see — release-plz CLI version bumps remain manual. Two ways to handle: drop the explicit pin (the action defaults to whatever CLI it bundles), or keep the pin with a comment that it's hand-maintained. Not changed here.

## Test plan

- [x] `cargo check --workspace`, `mise run fmt:check`, `mise run clippy` pass on the branch
- [x] `release-plz update` (CLI 0.3.158) locally reproduces the v1.14.0-tag deadlock — proves the release-bump-in-PR shape is necessary
- [ ] After merge + `git tag v1.14.1 origin/master && git push origin v1.14.1`: cargo-dist builds the release
- [ ] After cargo-dist completes, the next push to master runs Release-plz cleanly