### PR TITLE
fix(ci): install Node 24 in docs deploy to satisfy wrangler 4

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,6 +20,16 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
 
+      # wrangler-action installs `wrangler@4` via bun and then verifies it with
+      # `bun run wrangler --version`. That verification shells out to system
+      # Node, and wrangler 4 requires Node ≥ 22 — but ubuntu-latest still ships
+      # Node 20.x as the default. Without this step the deploy fails with
+      # "Wrangler requires at least Node.js v22.0.0". Pinning to the current
+      # Active LTS (24, EOL April 2028) buys the longest runway.
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "24"
+
       - name: Install dependencies
         working-directory: docs
         run: bun install --frozen-lockfile


### PR DESCRIPTION
## Summary

- Adds `actions/setup-node@v5` (Node 24) to `.github/workflows/docs.yml` before the `cloudflare/wrangler-action@v4.0.0` step.
- Restores the docs deploy after it started failing on the wrangler step with `Wrangler requires at least Node.js v22.0.0. You are using v20.20.2.`

## Root cause

Not the action itself — `cloudflare/wrangler-action@v4.0.0` installs `wrangler@4` (currently 4.91.0) via bun and verifies it with `bun run wrangler --version`. That verification shells out to **system Node** on `ubuntu-latest` (still 20.20.2). Wrangler 4 recently bumped its floor to Node 22 (Node 20 went EOL April 2026), so the check fails.

The fix is to install a supported Node onto `$PATH` before the wrangler step. Picked 24 because it's the current Active LTS (EOL April 2028) — 22 would work today but only has ~11 months of support left, so we'd be back here in spring 2027.

## Scope: why only `docs.yml`

Audited every workflow's `uses:` and `run:` steps. `setup-node` only matters when a `run:` step shells out to a Node-based CLI; GitHub-bundled Node inside actions like `actions/checkout` or `peter-evans/create-pull-request` is independent of system Node. `docs.yml` (via bun → wrangler) is the only workflow currently doing that.

## Test plan

- [ ] Merge to master and confirm the `Deploy Docs` workflow run succeeds end-to-end (push event triggers it via the `.github/workflows/docs.yml` path filter).
- [ ] Verify the deployed site at https://daft.avihu.dev reflects the latest docs commit.

Fixes #539

🤖 Generated with [Claude Code](https://claude.com/claude-code)