### PR TITLE
fix(ci): allow cargo-release to run from release-pr branch in workflow

### DIFF
--- a/.github/workflows/release-flow.yml
+++ b/.github/workflows/release-flow.yml
@@ -207,7 +207,11 @@ jobs:
           # (git-cliff + gen-man + gen-cli-docs), commit
           # "chore: release vNEXT_VER". --no-tag --no-push because the
           # workflow handles tagging on merge and the push is explicit.
-          cargo release "$NEXT_VER" --package daft --execute --no-confirm --no-tag --no-push
+          # --allow-branch release-pr overrides release.toml's
+          # allow-branch=["master"] (which stays as-is to protect local
+          # cargo-release runs from accidentally releasing off a random
+          # feature branch).
+          cargo release "$NEXT_VER" --package daft --execute --no-confirm --no-tag --no-push --allow-branch release-pr
 
           # Force-push — each run replaces the previous attempt cleanly.
           git push -f origin release-pr


### PR DESCRIPTION
## Summary

Fixes #543. First push after #542 merged surfaced this — \`release-flow.yml\`'s \`maintain-release-pr\` job failed at the "Rebuild release-pr branch" step because cargo-release refused to operate on the \`release-pr\` branch (release.toml restricts it to \`master\`).

\`\`\`
error: cannot release from branch \`release-pr\` as it doesn't match \`master\`;
either switch to an allowed branch or add this branch to \`allow-branch\`
\`\`\`

One-line fix: pass \`--allow-branch release-pr\` to the workflow's \`cargo release\` invocation. \`release.toml\` stays at \`allow-branch = ["master"]\` so local \`cargo release\` runs remain protected from accidental feature-branch releases.

## Why the test plan didn't catch this

The local dry-run from #542 used \`--allow-branch '*'\` to bypass the check on the experiment branch. That validated cargo-release's version math + hook + commit/tag/push logic, but elided the constraint check the workflow actually has to satisfy. Tracking that gap explicitly in the test plan in case future workflow changes have analogous "tested with override, ran without it in production" failure modes.

## Test plan

- [x] YAML still parses
- [ ] After merge, \`release-flow.yml\` runs cleanly: \`tag-merged-release\` no-ops (HEAD is \`fix(ci):...\` not \`chore: release v...\`), \`maintain-release-pr\` gets through cargo-release and opens the release PR for v1.14.2 (git-cliff sees the merged \`fix(ci):\` from #541 + \`fix(ci):\` from this PR as patch-bump-worthy)