### PR TITLE
ci(release): include changelog in PR body + skip heavy tests on release PRs + clean up release-plz residue

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -15,7 +15,7 @@ on:
       - "!.github/workflows/claude-pr-review.yml"
       - "!.github/workflows/docs.yml"
       - "!.github/workflows/mise-tool-updates.yml"
-      - "!.github/workflows/release-plz.yml"
+      - "!.github/workflows/release-flow.yml"
       - "!.github/workflows/release.yml"
       - "!.github/workflows/test-homebrew.yml"
       - "!.github/workflows/test.yml"

--- a/.github/workflows/release-flow.yml
+++ b/.github/workflows/release-flow.yml
@@ -232,8 +232,12 @@ jobs:
           # CHANGELOG.md (from `## [<NEXT_VER>]` to the line before the next
           # `## [` heading) so reviewers can see exactly what's going into the
           # release without leaving the PR. Mirrors the release-plz body
-          # format we used to have.
+          # format we used to have. The `gsub` in BEGIN escapes the dots in
+          # the semver so they match literally rather than any-char (defense
+          # against a CHANGELOG heading line that happens to fit the
+          # dot-wildcard shape).
           CHANGELOG_SECTION=$(awk -v ver="$NEXT_VER" '
+            BEGIN { gsub(/\./, "\\.", ver) }
             $0 ~ "^## \\["ver"\\]" { found=1; print; next }
             found && /^## \[/ { exit }
             found { print }
@@ -265,7 +269,10 @@ jobs:
           EXISTING=$(gh pr list --head release-pr --state open --json number --jq '.[0].number // empty')
           if [ -n "$EXISTING" ]; then
             echo "Updating existing release PR #$EXISTING"
-            gh pr edit "$EXISTING" --title "$TITLE" --body "$BODY"
+            # --add-label keeps the `release` label self-healing in case it
+            # was manually removed — the CI-skip logic in test.yml/bench.yml
+            # gates on this label being present.
+            gh pr edit "$EXISTING" --title "$TITLE" --body "$BODY" --add-label release
           else
             echo "Opening new release PR"
             gh pr create --base master --head release-pr \

--- a/.github/workflows/release-flow.yml
+++ b/.github/workflows/release-flow.yml
@@ -162,6 +162,7 @@ jobs:
             fi
             echo "should_release=true" >> "$GITHUB_OUTPUT"
             echo "next_version=$NEXT_VER_STRIPPED" >> "$GITHUB_OUTPUT"
+            echo "current_version=$CURRENT_VER" >> "$GITHUB_OUTPUT"
             echo "::notice::Releasing v$NEXT_VER_STRIPPED via manual override (conventional-commit auto-compute would have picked something else)."
             exit 0
           fi
@@ -191,6 +192,7 @@ jobs:
 
           echo "should_release=true" >> "$GITHUB_OUTPUT"
           echo "next_version=$NEXT_VER_STRIPPED" >> "$GITHUB_OUTPUT"
+          echo "current_version=$CURRENT_VER" >> "$GITHUB_OUTPUT"
 
       - name: Rebuild release-pr branch
         if: steps.nextver.outputs.should_release == 'true'
@@ -221,15 +223,42 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           NEXT_VER: ${{ steps.nextver.outputs.next_version }}
+          CURRENT_VER: ${{ steps.nextver.outputs.current_version }}
         run: |
           set -euo pipefail
           TITLE="chore: release v$NEXT_VER"
+
+          # Extract just this release's section from the freshly-regenerated
+          # CHANGELOG.md (from `## [<NEXT_VER>]` to the line before the next
+          # `## [` heading) so reviewers can see exactly what's going into the
+          # release without leaving the PR. Mirrors the release-plz body
+          # format we used to have.
+          CHANGELOG_SECTION=$(awk -v ver="$NEXT_VER" '
+            $0 ~ "^## \\["ver"\\]" { found=1; print; next }
+            found && /^## \[/ { exit }
+            found { print }
+          ' CHANGELOG.md)
+
           BODY=$(cat <<EOF
-          Automatically maintained release PR. Merging this PR adds the \`chore: release v$NEXT_VER\` commit to \`master\`; the \`tag-merged-release\` job in \`.github/workflows/release-flow.yml\` then tags that commit \`v$NEXT_VER\` and pushes the tag, which triggers \`release.yml\` (cargo-dist) to build the binary release.
+          ## 🤖 New release
 
-          New commits to \`master\` update this PR continuously (force-pushed) — the version bump, changelog entries, man pages, and CLI docs all re-derive from current master state.
+          * \`daft\`: $CURRENT_VER -> $NEXT_VER
 
-          The next version was computed from conventional commits via \`git-cliff --bumped-version\`. When no releasable commits remain since the last tag, this PR is closed automatically.
+          <details><summary><i><b>Changelog</b></i></summary><p>
+
+          <blockquote>
+
+          $CHANGELOG_SECTION
+
+          </blockquote>
+
+          </p></details>
+
+          ---
+
+          Automatically maintained release PR. Merging adds the \`chore: release v$NEXT_VER\` commit to \`master\`; the \`tag-merged-release\` job in \`.github/workflows/release-flow.yml\` then tags that commit \`v$NEXT_VER\` and pushes the tag, which triggers \`release.yml\` (cargo-dist) to build the binary release.
+
+          New commits to \`master\` update this PR continuously (force-pushed) — the version bump, changelog entries, man pages, and CLI docs all re-derive from current master state. The next version was computed from conventional commits via \`git-cliff --bumped-version\`; when no releasable commits remain, this PR is closed automatically.
           EOF
           )
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ on:
       - "!.github/workflows/claude-pr-review.yml"
       - "!.github/workflows/docs.yml"
       - "!.github/workflows/mise-tool-updates.yml"
-      - "!.github/workflows/release-plz.yml"
+      - "!.github/workflows/release-flow.yml"
       - "!.github/workflows/release.yml"
       - "!.github/workflows/test-homebrew.yml"
 
@@ -89,9 +89,10 @@ jobs:
   # rationale) or commit env ALLOW_FRESH_DEPS=1 in an emergency.
   dep-age-check:
     needs: changes
-    if:
-      needs.changes.outputs.self == 'true' || needs.changes.outputs.lockfile ==
-      'true'
+    if: >-
+      !contains(github.event.pull_request.labels.*.name, 'release') &&
+      (needs.changes.outputs.self == 'true' || needs.changes.outputs.lockfile ==
+      'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -111,9 +112,10 @@ jobs:
   # license, an open RustSec advisory, or comes from an unexpected source.
   dep-license-check:
     needs: changes
-    if:
-      needs.changes.outputs.self == 'true' || needs.changes.outputs.rust ==
-      'true' || needs.changes.outputs.lockfile == 'true'
+    if: >-
+      !contains(github.event.pull_request.labels.*.name, 'release') &&
+      (needs.changes.outputs.self == 'true' || needs.changes.outputs.rust ==
+      'true' || needs.changes.outputs.lockfile == 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -133,10 +135,11 @@ jobs:
   # Fast feedback: formatting, linting, unit tests (debug mode only - no release build needed)
   lint:
     needs: changes
-    if:
-      needs.changes.outputs.self == 'true' || needs.changes.outputs.rust ==
+    if: >-
+      !contains(github.event.pull_request.labels.*.name, 'release') &&
+      (needs.changes.outputs.self == 'true' || needs.changes.outputs.rust ==
       'true' || needs.changes.outputs.tests == 'true' ||
-      needs.changes.outputs.xtask == 'true'
+      needs.changes.outputs.xtask == 'true')
     runs-on: ubuntu-latest
     env:
       # cargo-cooldown is a local-dev supply-chain guard that wraps `cargo
@@ -193,9 +196,10 @@ jobs:
   # uses post-1.93 stdlib features.
   msrv-check:
     needs: changes
-    if:
-      needs.changes.outputs.self == 'true' || needs.changes.outputs.rust ==
-      'true'
+    if: >-
+      !contains(github.event.pull_request.labels.*.name, 'release') &&
+      (needs.changes.outputs.self == 'true' || needs.changes.outputs.rust ==
+      'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -218,9 +222,10 @@ jobs:
   # of `std::os::unix::*` or `libc`) before they reach a release tag.
   windows-check:
     needs: changes
-    if:
-      needs.changes.outputs.self == 'true' || needs.changes.outputs.rust ==
-      'true'
+    if: >-
+      !contains(github.event.pull_request.labels.*.name, 'release') &&
+      (needs.changes.outputs.self == 'true' || needs.changes.outputs.rust ==
+      'true')
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
@@ -277,13 +282,6 @@ jobs:
 
       - name: Verify committed man pages are up-to-date
         run: |
-          # Skip verification on release PRs - release-plz bumps version in Cargo.toml
-          # which causes man pages (that embed version) to appear outdated
-          if [[ "${{ github.head_ref }}" == release-plz-* ]]; then
-            echo "Skipping man page verification on release PR (version bump expected)"
-            exit 0
-          fi
-
           cargo run --package xtask -- gen-man --output-dir=man
           if ! git diff --exit-code man/; then
             echo "FAILED: Committed man pages are out of date!"
@@ -322,13 +320,6 @@ jobs:
 
       - name: Verify committed CLI docs are up-to-date
         run: |
-          # Skip verification on release PRs - release-plz bumps version in Cargo.toml
-          # which causes CLI docs (that embed version) to appear outdated
-          if [[ "${{ github.head_ref }}" == release-plz-* ]]; then
-            echo "Skipping CLI docs verification on release PR (version bump expected)"
-            exit 0
-          fi
-
           cargo run --package xtask -- gen-cli-docs --output-dir=docs/cli
           if ! git diff --exit-code docs/cli/; then
             echo "FAILED: Committed CLI docs are out of date!"
@@ -343,9 +334,10 @@ jobs:
   # Build release binary once, share across integration test matrix
   build:
     needs: changes
-    if:
-      needs.changes.outputs.self == 'true' || needs.changes.outputs.rust ==
-      'true' || needs.changes.outputs.tests == 'true'
+    if: >-
+      !contains(github.event.pull_request.labels.*.name, 'release') &&
+      (needs.changes.outputs.self == 'true' || needs.changes.outputs.rust ==
+      'true' || needs.changes.outputs.tests == 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -529,11 +521,11 @@ jobs:
   # Homebrew installation simulation (macOS)
   homebrew-simulation:
     needs: changes
-    if:
-      needs.changes.outputs.self == 'true' || needs.changes.outputs.rust ==
-      'true' || needs.changes.outputs.man == 'true'
+    if: >-
+      !contains(github.event.pull_request.labels.*.name, 'release') &&
+      (needs.changes.outputs.self == 'true' || needs.changes.outputs.rust ==
+      'true' || needs.changes.outputs.man == 'true')
     runs-on: macos-latest
-
     steps:
       - uses: actions/checkout@v6
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,9 +319,33 @@ Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `ci`
 
 ## Release Process
 
-Uses [release-plz](https://release-plz.dev/): push to master → Release PR
-auto-created → merge it → GitHub Release + tag → binary builds. All commits
-produce patch bumps; edit `Cargo.toml` in the Release PR for minor/major bumps.
+Uses [cargo-release](https://github.com/crate-ci/cargo-release) wired into
+`.github/workflows/release-flow.yml` to mimic the release-plz UX it replaced
+(see #540 for the migration motivation: release-plz's `cargo package` codepath
+was broken against our root-package workspace with an unpublished internal
+crate, upstream release-plz#2595).
+
+Mechanics: every push to master runs two jobs.
+
+1. `tag-merged-release` — if HEAD's subject is `chore: release vX.Y.Z` (i.e.
+   someone just merged the release PR), tag the commit and push the tag.
+   `release.yml` (cargo-dist) then builds the binary release.
+2. `maintain-release-pr` — compute the next version from conventional commits
+   via `git-cliff --bumped-version`. If releasable commits exist since the last
+   tag, force-rebuild a `release-pr` branch on top of master via
+   `cargo release <next> --no-tag --no-push` (bumps Cargo.toml + xtask path-dep,
+   runs the `pre-release-hook` in `release.toml` to regenerate CHANGELOG.md +
+   man pages + CLI docs, commits `chore: release vNEXT`), and open/update the
+   release PR. If no releasable commits remain, close any stale release PR.
+
+Conventional-commit-driven bump (per `cliff.toml`): `feat` → minor, `fix`/`perf`
+→ patch, `feat!`/`BREAKING CHANGE:` → major, `ci`/`deps`/`docs` → no bump.
+
+Manual version override: `workflow_dispatch` exposes an `override_version` input
+(Actions → Release flow → Run workflow → fill `1.14.3`) for one-off overrides —
+the input is per-run and the next push to master returns to auto-compute. Useful
+when conventional-commit detection picks a different bump than you want (e.g.
+demote a `feat:` from minor to patch).
 
 ## Adding a New Command
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -165,7 +165,7 @@ export default defineConfig({
 
       // Reformat changelog version headings:
       //   ## [1.0.22] - 2026-02-07            →  version + date on separate line
-      //   ## [1.0.24](compare-url) - 2026-02-15  →  same treatment (new release-plz format)
+      //   ## [1.0.24](compare-url) - 2026-02-15  →  same treatment (with GitHub compare URL)
       const defaultHeadingOpen =
         md.renderer.rules.heading_open ||
         ((tokens, idx, options, _env, self) =>

--- a/mise-tasks/test/version-format
+++ b/mise-tasks/test/version-format
@@ -53,7 +53,7 @@ check_version "dev format" "^daft ${CARGO_VERSION//./\\.} \\(dev .+ [0-9a-f]+\\)
 echo ""
 
 # ── Test 2: Simulated release build (detached HEAD + version tag) ──
-# This mirrors what cargo-dist / release-plz does:
+# This mirrors what cargo-dist / cargo-release does:
 #   actions/checkout checks out the tag → detached HEAD with tag at HEAD
 echo "2. Simulated release build (detached HEAD + version tag at HEAD)"
 


### PR DESCRIPTION
## Summary

Three bundled changes under release-PR ergonomics, picked up while validating the cargo-release migration from #542 was working as intended.

### 1. Restore release-plz-style expandable changelog block in the release PR body (fixes #546)

The maintain-release-pr job's PR body now matches the release-plz format we used to have (see PR #520 for the canonical example): \`🤖 New release\` header, \`* daft: X.Y.Z -> A.B.C\` version-bump line, expandable \`<details>\` containing the new version's changelog section pulled directly from the freshly-regenerated CHANGELOG.md.

Mechanics: \`Compute next version\` step now also exports \`current_version\` to \`$GITHUB_OUTPUT\` (both paths); \`Open or update release PR\` step extracts the section via awk (matches the \`## [<NEXT_VER>]\` heading, prints lines until the next \`## [\`) and embeds it inside the details/blockquote block. Backtick safety verified — double-quoted variable expansion inside an unquoted heredoc doesn't re-evaluate backticks in the variable's value, so future commit messages containing code-style markup won't trigger command substitution at body-build time.

### 2. Skip heavy CI jobs on release PRs (label-gated)

Release PRs only contain mechanical changes — Cargo.toml + Cargo.lock + CHANGELOG.md + regenerated man/CLI docs. The actual code is bit-identical to the last green master push. Running the full ~15-minute test suite on every release-PR update is genuinely redundant.

Added \`!contains(github.event.pull_request.labels.*.name, 'release')\` to the \`if:\` of: \`dep-age-check\`, \`dep-license-check\`, \`lint\`, \`msrv-check\`, \`windows-check\`, \`build\`, \`homebrew-simulation\`. Integration tests skip automatically (they need: build).

Kept running on release PRs:
- \`changes\` — needed to derive other state
- \`xtask-test\` — runs the verify-man / verify-cli-docs checks that actively validate the release PR's own regenerated content. This is the one check that's *more* useful on a release PR than a regular one.

PR #545 demonstrated the verify checks pass cleanly on the new flow's release PRs because the pre-release-hook regenerates docs in the same commit as the version bump (no temporal mismatch).

YAML quoting note: the new \`!contains(...)\` conditions use \`if: >-\` block scalar so the leading \`!\` isn't parsed as a YAML tag.

### 3. Repo-wide cleanup of stale release-plz references

Surfaced by grepping the repo for \`release-plz\` after #542 + #544 landed:
- \`.github/workflows/bench.yml\` paths-ignore: \`release-plz.yml\` → \`release-flow.yml\` (old file no longer exists)
- \`.github/workflows/test.yml\` paths-ignore: same
- \`.github/workflows/test.yml\` xtask-test: removed two stale \`if [[ \"${{ github.head_ref }}\" == release-plz-* ]]\` skip blocks that no longer match our \`release-pr\` branch
- \`CLAUDE.md\` Release Process section: rewritten to describe the new cargo-release flow + manual-override input + conventional-commit parser rules
- \`mise-tasks/test/version-format\` comment: release-plz → cargo-release
- \`docs/.vitepress/config.ts\` comment: dropped tool-specific attribution in favor of describing the format itself

Intentionally retained: comments in \`release.toml\`, \`Cargo.toml\`, \`release-flow.yml\` that reference release-plz as migration context, and historical planning documents under \`docs/superpowers/\` (snapshots of decisions made when release-plz was the active tool).

## Test plan

- [x] YAML parses for all modified workflow files
- [x] Awk changelog-section extraction verified against PR #545's CHANGELOG.md (clean output, no leading/trailing junk)
- [x] Backtick safety verified locally with sample \`feat: improve \`gwco\` shortcut\` text
- [x] Tag-detection regex tested
- [x] Override-version regex tested
- [x] Repo grep finds zero unintentional \`release-plz\` references
- [ ] After merge: the next maintain-release-pr run updates the open #545 with the new body format
- [ ] PR-checks UI on #545 (or the next release PR) shows only \`changes\`, \`xtask-test\` running — all other heavy jobs skipped

## Validation strategy after merge

\`maintain-release-pr\` runs on the master push from this merge, force-rebuilds release-pr (still v1.14.2 since fix commits accumulated), \`gh pr edit\`s #545's title/body in place with the new format. Fastest end-to-end signal that the changelog-extraction works. The CI-skip behavior is also visible on #545's checks immediately after the body update — should show the heavy jobs as \"Skipped\" instead of running.