### PR TITLE
fix(ci): allow squash-merge ' (#nnn)' suffix in tag-merged-release regex

### DIFF
--- a/.github/workflows/release-flow.yml
+++ b/.github/workflows/release-flow.yml
@@ -74,7 +74,10 @@ jobs:
           echo "HEAD commit subject: $FIRST_LINE"
 
           # Match "chore: release vX.Y.Z" with optional pre-release suffix.
-          if [[ "$FIRST_LINE" =~ ^chore:\ release\ (v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?)$ ]]; then
+          # The trailing `( \(#[0-9]+\))?` allows GitHub's default
+          # squash-merge title format, which appends ` (#nnn)` to the PR
+          # title when the PR is squash-merged via the UI.
+          if [[ "$FIRST_LINE" =~ ^chore:\ release\ (v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?)(\ \(#[0-9]+\))?$ ]]; then
             VER="${BASH_REMATCH[1]}"
             echo "Release commit detected for $VER"
 


### PR DESCRIPTION
## Summary

Fixes #548. PR #545's merge surfaced this — GitHub's default squash-merge UI appends \` (#545)\` to the squash commit subject, so the regex anchor in \`tag-merged-release\` didn't match:

\`\`\`
HEAD commit subject: chore: release v1.14.2 (#545)
Not a release commit, nothing to tag
\`\`\`

Result: v1.14.2 tag had to be pushed manually to unblock cargo-dist. Fix is one regex tweak — append \`(\\ \\(#[0-9]+\\))?\` so the optional PR-number suffix matches but doesn't capture into \`\${BASH_REMATCH[1]}\` (the version capture stays unchanged).

## Verification

Tested locally against five inputs:

| Subject | Expected | Actual |
|--|--|--|
| \`chore: release v1.14.2\` | match v1.14.2 | ✓ matches v1.14.2 |
| \`chore: release v1.14.2 (#545)\` | match v1.14.2 | ✓ matches v1.14.2 |
| \`chore: release v2.0.0-rc.1 (#999)\` | match v2.0.0-rc.1 | ✓ matches v2.0.0-rc.1 |
| \`feat: add thing (#100)\` | reject | ✓ rejected |
| \`chore: release v1.14.2 stuff\` | reject (no parens) | ✓ rejected |

Pre-release suffix (\`-rc.1\`), trailing garbage, and non-release prefixes all behave correctly. Empty/missing PR-number suffix also still matches (for the case where someone amends the squash subject to strip the \` (#nnn)\`).

## What's NOT fixed by this PR

If a maintainer manually edits the squash-merge subject to something the regex doesn't cover (e.g. drops the \`v\`, appends additional text after the version, changes \`release\` to \`Release\`), the tag won't be created. Manual recovery is \`git tag v1.14.X <merge-sha> && git push origin v1.14.X\`. The CLAUDE.md release-process section already implicitly relies on the canonical \`chore: release vX.Y.Z\` shape produced by cargo-release; this PR ensures the GitHub UI's default squash format also matches without further intervention.

## Test plan

- [x] Regex coverage table above
- [x] YAML parses
- [ ] After merge: the next release-flow.yml run via squash-merging the next release PR successfully creates and pushes the tag (proving the regex change works in CI, not just locally)