### PR TITLE
feat(test-runner): default to automatic; add --interactive (-i) for step-through

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -483,7 +483,7 @@ jobs:
         # No `${{ github.event.* }}` substitutions touch the run: body.
         run: |
           GIT_CONFIG_GLOBAL="${{ steps.config.outputs.config_file }}" \
-            DAFT_TESTING=1 ./target/release/xtask manual-test --ci --jobs "$(nproc)"
+            DAFT_TESTING=1 ./target/release/xtask manual-test --jobs "$(nproc)"
 
       - name: Test shell completions
         if: matrix.suite == 'bash'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,9 +58,9 @@ mise run dev                # Build + create symlinks (quick dev setup)
 mise run test               # Run all tests (unit + integration)
 mise run test:unit          # Rust unit tests only
 mise run test:integration   # Integration tests (bash + YAML, full matrix)
-mise run test:manual -- --ci           # YAML manual tests only (all scenarios)
-mise run test:manual -- --ci checkout  # YAML tests for one command
-mise run test:manual -- checkout:basic # Interactive mode for one scenario
+mise run test:manual                       # YAML manual tests (all scenarios, automatic)
+mise run test:manual checkout              # YAML tests for one command (automatic)
+mise run test:manual -- -i checkout:basic  # Step through one scenario interactively
 mise run clippy             # Lint (must pass with zero warnings)
 mise run fmt                # Auto-format code
 mise run fmt:check          # Verify formatting

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex 1.3.0",
+ "shlex",
 ]
 
 [[package]]
@@ -748,7 +748,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "serial_test",
- "shlex 2.0.1",
+ "shlex",
  "similar",
  "syntect",
  "tabled",
@@ -4198,12 +4198,6 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "shlex"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"

--- a/benches/scenarios/test_manual_scale.sh
+++ b/benches/scenarios/test_manual_scale.sh
@@ -77,7 +77,7 @@ hyperfine \
     --command-name "jobs={jobs}" \
     --export-json "$JSON_OUT" \
     --export-markdown "${MD_OUT}.phase1" \
-    "$REPO_ROOT/target/release/xtask manual-test --ci --jobs {jobs}"
+    "$REPO_ROOT/target/release/xtask manual-test --jobs {jobs}"
 HF_STATUS=$?
 set -e
 if [[ $HF_STATUS -ne 0 ]]; then
@@ -98,13 +98,13 @@ if [[ -z "${BENCH_SKIP_TIMING:-}" ]]; then
     echo "=== Phase 2: per-scenario timing — jobs=1 ==="
     eval "$PREPARE"
     DAFT_MANUAL_TEST_EMIT_TIMING=1 \
-        "$REPO_ROOT/target/release/xtask" manual-test --ci --jobs 1 2>&1 \
+        "$REPO_ROOT/target/release/xtask" manual-test --jobs 1 2>&1 \
         | grep '^\[bench\] scenario=' > "$SERIAL_TIMINGS" || true
 
     echo "=== Phase 2: per-scenario timing — jobs=$DEFAULT_CAP ==="
     eval "$PREPARE"
     DAFT_MANUAL_TEST_EMIT_TIMING=1 \
-        "$REPO_ROOT/target/release/xtask" manual-test --ci --jobs "$DEFAULT_CAP" 2>&1 \
+        "$REPO_ROOT/target/release/xtask" manual-test --jobs "$DEFAULT_CAP" 2>&1 \
         | grep '^\[bench\] scenario=' > "$PARALLEL_TIMINGS" || true
 fi
 

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -74,10 +74,10 @@ Declarative test scenarios in `tests/manual/scenarios/`. Each YAML file defines
 repos to create, steps to run, and expectations to verify.
 
 ```bash
-mise run test:manual -- --ci              # Run all 252 scenarios
-mise run test:manual -- --ci checkout     # Run one command's tests
-mise run test:manual -- checkout:basic    # Interactive mode for one scenario
-mise run test:manual -- --list            # List all available scenarios
+mise run test:manual                       # Run all 252 scenarios (automatic, default)
+mise run test:manual checkout              # Run one command's tests (automatic)
+mise run test:manual -- -i checkout:basic  # Step through one scenario interactively
+mise run test:manual -- --list             # List all available scenarios
 ```
 
 To add a new test, create a `.yml` file in the appropriate command directory:

--- a/mise-tasks/bench/tests/integration/_bench_command
+++ b/mise-tasks/bench/tests/integration/_bench_command
@@ -41,7 +41,7 @@ echo
 echo "Running YAML manual tests..."
 yaml_start=$(ms_now)
 yaml_result=0
-"$REPO_ROOT/target/release/xtask" manual-test --ci "$REPO_ROOT/tests/manual/scenarios/$YAML_DIR/" || yaml_result=$?
+"$REPO_ROOT/target/release/xtask" manual-test "$REPO_ROOT/tests/manual/scenarios/$YAML_DIR/" || yaml_result=$?
 yaml_end=$(ms_now)
 yaml_ms=$((yaml_end - yaml_start))
 

--- a/mise-tasks/bench/tests/manual/_default
+++ b/mise-tasks/bench/tests/manual/_default
@@ -33,9 +33,9 @@ echo
 start=$(ms_now)
 result=0
 if [ -n "$scenario_arg" ]; then
-    "$REPO_ROOT/target/release/xtask" manual-test --ci "$scenario_arg" || result=$?
+    "$REPO_ROOT/target/release/xtask" manual-test "$scenario_arg" || result=$?
 else
-    "$REPO_ROOT/target/release/xtask" manual-test --ci || result=$?
+    "$REPO_ROOT/target/release/xtask" manual-test || result=$?
 fi
 end=$(ms_now)
 duration=$((end - start))

--- a/mise-tasks/sandbox/_default
+++ b/mise-tasks/sandbox/_default
@@ -325,8 +325,7 @@ _manual-test() {
     fi
 
     _arguments -s \
-        '--ci[Run in non-interactive mode]' \
-        '--no-interactive[Run in non-interactive mode]' \
+        {-i,--interactive}'[Step through scenarios interactively]' \
         {-v,--verbose}'[Show verbose output]' \
         '--step[Jump to a specific step number]:step number:' \
         '--loop-count[Re-run a specific step N times]:count:' \
@@ -340,7 +339,7 @@ cat > "${bin_dir}/completions/manual-test.bash" <<'BASH_COMP'
 _manual_test() {
     local cur="${COMP_WORDS[COMP_CWORD]}"
     if [[ "$cur" == -* ]]; then
-        COMPREPLY=($(compgen -W "--ci --no-interactive -v --verbose --step --loop-count --keep --list" -- "$cur"))
+        COMPREPLY=($(compgen -W "-i --interactive -v --verbose --step --loop-count --keep --list" -- "$cur"))
         return
     fi
     local scenarios_dir="${DAFT_WORKTREE}/tests/manual/scenarios"
@@ -595,7 +594,8 @@ Initialize completions and daft shell integration:
     help                     Show this guide
     help --env               Show currently-set sandbox DAFT_* and GIT_* env vars
     test-plan [name]         Open branch test plan in neovim (auto-detects branch)
-    manual-test <scenario>   Run a manual test scenario interactively
+    manual-test <scenario>   Run a manual test scenario (automatic by default)
+    manual-test -i <scen>    Step through a scenario interactively
     manual-test --list       List available scenarios
     show-test <scenario>     Show test steps and commands for a scenario
     setup-test <scenario>    Set up a test environment for manual exploration

--- a/tests/README.md
+++ b/tests/README.md
@@ -35,17 +35,17 @@ mise run test:unit
 # Bash integration tests (full matrix: default + gitoxide)
 mise run test:integration
 
-# YAML manual tests (all 252 scenarios)
-mise run test:manual -- --ci
+# YAML manual tests (all 252 scenarios, automatic — default)
+mise run test:manual
 
-# YAML tests for a specific command
-mise run test:manual -- --ci tests/manual/scenarios/checkout/
+# YAML tests for a specific command (automatic)
+mise run test:manual tests/manual/scenarios/checkout/
 
-# YAML tests by namespace
-mise run test:manual -- --ci checkout:basic
+# YAML tests by namespace (automatic)
+mise run test:manual checkout:basic
 
 # Interactive mode (step through with prompts)
-mise run test:manual -- checkout:basic
+mise run test:manual -- -i checkout:basic
 
 # List all available scenarios
 mise run test:manual -- --list
@@ -89,7 +89,7 @@ scenario-relative `path:line` location pointer on its own line
 (terminal-clickable), a `❯` marker on the failing step, the failed assertions,
 and any captured stdout/stderr. Then come separate `Scenarios:` / `Steps:`
 lines, `Duration:`, an optional `parallel jobs: N` suffix, and a `Reproduce:`
-block with one `mise run test:manual -- --ci <token>` per failure.
+block with one `mise run test:manual -- <token>` per failure.
 
 ### TTY live progress region
 
@@ -214,7 +214,7 @@ dirs_exist:
 
 1. Create `tests/manual/scenarios/<command>/<test-name>.yml`
 2. Use `standard-remote` fixture or define inline repos
-3. Run: `mise run test:manual -- --ci <command>:<test-name>`
+3. Run: `mise run test:manual <command>:<test-name>`
 
 ### Bash integration test
 
@@ -228,6 +228,6 @@ The GitHub Actions workflow runs both test systems for each matrix entry
 (default + gitoxide config):
 
 1. Bash: `test_all.sh` with `GIT_CONFIG_GLOBAL`
-2. YAML: `xtask manual-test --ci` with same config
+2. YAML: `xtask manual-test` with same config
 3. Shell completions: `test_completions.sh`
 4. Help commands: verify all binaries respond to `--help`

--- a/tests/manual/scenarios/runner-output/end-to-end.yml
+++ b/tests/manual/scenarios/runner-output/end-to-end.yml
@@ -24,7 +24,7 @@ steps:
     run: |
       cd "$BINARY_DIR/../.." && \
         NO_COLOR=1 "$BINARY_DIR/xtask" \
-          manual-test --no-interactive \
+          manual-test \
           tests/manual/scenarios/runner-output/_fixtures/fail.yml \
           2>&1 || true
     expect:
@@ -71,7 +71,7 @@ steps:
     run: |
       cd "$BINARY_DIR/../.." && \
         NO_COLOR=1 "$BINARY_DIR/xtask" \
-          manual-test --no-interactive -v \
+          manual-test -v \
           tests/manual/scenarios/runner-output/_fixtures/fail.yml \
           2>&1 || true
     expect:

--- a/xtask/src/bench.rs
+++ b/xtask/src/bench.rs
@@ -325,7 +325,7 @@ fn run_yaml_test(
     let start = Instant::now();
     let scenarios_path = project_root.join("tests/manual/scenarios").join(yaml_dir);
     let status = Command::new(xtask_bin)
-        .args(["manual-test", "--ci"])
+        .args(["manual-test"])
         .arg(&scenarios_path)
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -358,15 +358,15 @@ enum Commands {
         parallel: bool,
     },
 
-    /// Run manual test scenarios interactively
+    /// Run manual test scenarios (automatic by default; use -i to step through)
     ManualTest {
         /// Scenario file(s) to run (default: all in tests/manual/scenarios/)
         #[arg(value_name = "SCENARIO")]
         scenarios: Vec<PathBuf>,
 
-        /// Run in non-interactive mode (auto-detected when not a TTY)
-        #[arg(long, alias = "ci")]
-        no_interactive: bool,
+        /// Step through scenarios interactively (default is automatic, parallel-buffered run)
+        #[arg(long, short = 'i')]
+        interactive: bool,
 
         /// Increase verbosity (-v for per-check icons + captured output on pass,
         /// -vv for expanded commands + untruncated captured output).
@@ -435,7 +435,7 @@ fn main() -> Result<()> {
         Commands::Bench { parallel } => bench::run(parallel),
         Commands::ManualTest {
             scenarios,
-            no_interactive,
+            interactive,
             verbose,
             quiet,
             step,
@@ -452,7 +452,7 @@ fn main() -> Result<()> {
             let verbosity = manual_test::reporter::Verbosity::from_flags(verbose, quiet);
             manual_test::run(
                 scenarios,
-                no_interactive,
+                interactive,
                 verbosity,
                 step,
                 loop_count,
@@ -1363,7 +1363,7 @@ fn run_test_matrix(entries: &[String], list: bool) -> Result<()> {
             let xtask_bin = std::env::current_exe()
                 .unwrap_or_else(|_| PathBuf::from("cargo run --package xtask --"));
             let yaml_status = Command::new(&xtask_bin)
-                .args(["manual-test", "--ci"])
+                .args(["manual-test"])
                 .env("GIT_CONFIG_GLOBAL", &config_path)
                 .env("DAFT_TESTING", "1")
                 .current_dir(&project_root)

--- a/xtask/src/manual_test/mod.rs
+++ b/xtask/src/manual_test/mod.rs
@@ -330,7 +330,7 @@ struct RunContext<'a> {
 #[allow(clippy::too_many_arguments)]
 pub fn run(
     scenarios: Vec<PathBuf>,
-    no_interactive: bool,
+    interactive: bool,
     verbosity: reporter::Verbosity,
     step: Option<usize>,
     loop_count: Option<usize>,
@@ -365,6 +365,12 @@ pub fn run(
         return Ok(());
     }
 
+    if loop_count.is_some() && !interactive {
+        anyhow::bail!("--loop-count requires --interactive / -i");
+    }
+    if step.is_some() && !interactive && !setup_only {
+        anyhow::bail!("--step requires --interactive / -i (or --setup-only)");
+    }
     if loop_count.is_some() && step.is_none() {
         anyhow::bail!("--loop-count requires --step");
     }
@@ -382,7 +388,12 @@ pub fn run(
         anyhow::bail!("No scenario files found in {}", scenarios_dir.display());
     }
 
-    let is_interactive = !no_interactive && std::io::stdin().is_terminal();
+    // Explicit opt-in: the flag is the whole signal. TTY detection used to
+    // route mode here, but after #554 the runner is automatic-first; users
+    // who want step-through pass `-i`. TTY detection still gates the live
+    // progress region inside `run_parallel` (see reporter CLAUDE.md §8) —
+    // that's a rendering concern, not a routing one.
+    let is_interactive = interactive;
 
     // Only bail when the user *explicitly* asked for parallel (via `--jobs`,
     // `DAFT_MANUAL_TEST_JOBS`, or `--parallel`) and the mode forbids it. The
@@ -391,9 +402,7 @@ pub fn run(
     // erroring on a default the user didn't choose.
     if jobs_explicit && jobs > 1 {
         if is_interactive {
-            anyhow::bail!(
-                "--jobs/--parallel is only supported in non-interactive mode (pass --ci or run from a non-TTY)"
-            );
+            anyhow::bail!("--jobs/--parallel is incompatible with --interactive / -i");
         }
         if setup_only {
             anyhow::bail!("--jobs/--parallel is incompatible with --setup-only");
@@ -606,8 +615,8 @@ fn run_parallel(
         // Non-TTY: drain buffers in input order at end (today's behavior,
         // byte-identical for CI). Cancelled buffers carry the `⊘ name
         // (cancelled)` footer just like pass/fail buffers carry their
-        // `✓`/`✗` footers — drain them all uniformly so a `--ci` log
-        // shows which scenarios were in flight at the moment of cancel.
+        // `✓`/`✗` footers — drain them all uniformly so an automatic-mode
+        // log shows which scenarios were in flight at the moment of cancel.
         let mut lock = stderr.lock();
         for o in &all_outcomes {
             lock.write_all(&o.output)?;

--- a/xtask/src/manual_test/reporter/CLAUDE.md
+++ b/xtask/src/manual_test/reporter/CLAUDE.md
@@ -152,7 +152,7 @@ fail footer + the end-of-run summary block always surface.
 | Diff label                        | lowercase + colon                        | `expected:`, `actual:`                            |
 | Capture block divider             | `--- {stream} ---` lowercase             | `--- stdout ---`, `--- stderr ---`                |
 | Source citation                   | `at <file>:<line>` lowercase preposition | `at fail.yml:14`                                  |
-| Reproduce hint                    | Imperative, copy-pasteable               | `mise run test:manual -- --ci <token>`            |
+| Reproduce hint                    | Imperative, copy-pasteable               | `mise run test:manual -- <token>`                 |
 | Slow annotation                   | lowercase parenthetical                  | `(slow)`                                          |
 
 **Rule of thumb.** Titles announce, labels anchor, outcomes report, errors

--- a/xtask/src/manual_test/reporter/mod.rs
+++ b/xtask/src/manual_test/reporter/mod.rs
@@ -217,7 +217,7 @@ pub fn reporter_for(verbosity: Verbosity) -> Box<dyn Reporter> {
 /// - `tests/manual/scenarios/hooks/silent-job-logs.yml` → `hooks:silent-job-logs`
 /// - `tests/manual/scenarios/clone-basic.yml` → `clone-basic`
 ///
-/// Used to print copy-pasteable `mise run test:manual -- --ci <token>` lines in
+/// Used to print copy-pasteable `mise run test:manual -- <token>` lines in
 /// the reproduce block.
 pub fn reproduce_token(source: &Path, scenarios_dir: &Path) -> String {
     let relative = source.strip_prefix(scenarios_dir).unwrap_or(source);

--- a/xtask/src/manual_test/reporter/pretty.rs
+++ b/xtask/src/manual_test/reporter/pretty.rs
@@ -394,7 +394,7 @@ fn write_captured_section(
 ///   Duration:   MM:SS (parallel jobs: N)
 ///   <blank>
 ///   Reproduce:
-///     mise run test:manual -- --ci <token>
+///     mise run test:manual -- <token>
 ///     ...
 fn write_run_summary(out: &mut dyn Write, s: &RunSummary<'_>) -> io::Result<()> {
     writeln!(out)?;
@@ -530,7 +530,7 @@ fn write_run_summary(out: &mut dyn Write, s: &RunSummary<'_>) -> io::Result<()> 
         writeln!(out)?;
         writeln!(out, "Reproduce:")?;
         for f in &s.failed {
-            writeln!(out, "  mise run test:manual -- --ci {}", f.reproduce_token)?;
+            writeln!(out, "  mise run test:manual -- {}", f.reproduce_token)?;
         }
     }
     writeln!(out)?;

--- a/xtask/src/manual_test/reporter/tests.rs
+++ b/xtask/src/manual_test/reporter/tests.rs
@@ -795,7 +795,7 @@ fn pretty_run_summary_includes_failed_scenarios_and_reproduce_block() {
     assert!(out.contains("Steps:      2191 passed, 2 failed   (2193 total)"));
     assert!(out.contains("Duration:   01:04 (parallel jobs: 4)"));
     assert!(out.contains("Reproduce:"));
-    assert!(out.contains("mise run test:manual -- --ci hooks:silent-job-logs"));
+    assert!(out.contains("mise run test:manual -- hooks:silent-job-logs"));
 }
 
 #[test]
@@ -970,7 +970,7 @@ fn pretty_quiet_run_summary_matches_pretty() {
     assert!(out.contains("1) ✗ demo"));
     assert!(out.contains("Scenarios:  0 passed, 1 failed   (1 total)"));
     assert!(out.contains("Reproduce:"));
-    assert!(out.contains("mise run test:manual -- --ci demo"));
+    assert!(out.contains("mise run test:manual -- demo"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Flip the YAML test runner's default: automatic (parallel-buffered) is now implicit; `--interactive` / `-i` is the explicit opt-in to step-through. Cuts `--ci` / `--no-interactive` cleanly per `feedback_no_pre_1_0_back_compat` — clap rejects the old shape with a useful error pointing at `-i`.
- Adds explicit validation: `--step` requires `-i` or `--setup-only`; `--loop-count` requires `-i`. The documented `--setup-only --step N` workflow (`docs/about/contributing.md:131`) is preserved because setup-only honors `step` as a "run up to step N" bound independent of mode.
- Strips `--ci` from every in-tree caller (CI workflow, mise tasks, bench scripts, internal smoke spawns, YAML fixture) and updates sandbox completions/help + reporter reproduce hint + design language + developer docs.

Runner internals (`run_serial`, `run_parallel`, sandbox lifecycle, cancellation, reporter) do not change. The `is_interactive` boolean still carries the same downstream meaning — only its source inverts.

Commits land as three logical units: core flip + reporter goldens; sandbox surfaces; developer docs.

Fixes #554

## Test plan

- [x] `mise run fmt:check` — passes
- [x] `mise run clippy` — passes with zero warnings
- [x] `mise run test:unit` — 1816 passed, 0 failed
- [x] `manual-test --ci` rejected by clap (`unexpected argument '--ci'`)
- [x] `manual-test --no-interactive` rejected by clap (`a similar argument exists: '--interactive'`)
- [x] `manual-test --step 1 checkout:basic` errors with `--step requires --interactive / -i (or --setup-only)`
- [x] `manual-test --loop-count 3 --step 1 checkout:basic` errors with `--loop-count requires --interactive / -i`
- [x] `manual-test --setup-only --step 1 checkout:basic` still works (regression guard for `contributing.md:131`)
- [x] `manual-test runner-output:end-to-end` smoke passes (runner-output fixture now exercises the new default)
- [x] Runtime reproduce hint emits `mise run test:manual -- <token>` (no flag)
- [x] `rg "--ci\b|--no-interactive\b|no_interactive"` outside `docs/superpowers/plans/` and `benches/baselines/` returns no hits
- [ ] CI matrix passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)