### PR TITLE
fix(hooks): support background jobs depending on foreground jobs

### DIFF
--- a/src/coordinator/process.rs
+++ b/src/coordinator/process.rs
@@ -73,6 +73,19 @@ pub struct CoordinatorState {
     pub trigger_command: String,
     pub hook_type: String,
     pub worktree: String,
+    /// Names of background jobs that must be recorded as `DepFailed`
+    /// before the wave loop starts. Populated by the caller from the
+    /// foreground `JobResult`s: a BG job whose original (pre-partition)
+    /// `needs:` referenced a foreground job that did not succeed lands
+    /// here so it is not run, and its dependents cascade through the
+    /// same `DepFailed` path that handles runtime failures.
+    ///
+    /// `#[serde(default)]` is load-bearing: older parents that haven't
+    /// learned this field serialize a payload without it, and a freshly
+    /// spawned coordinator deserializes them as an empty list (i.e. no
+    /// prefailed jobs).
+    #[serde(default)]
+    pub prefailed_jobs: Vec<String>,
 }
 
 /// Wire format for state passed from parent to spawned `__coordinator`
@@ -94,6 +107,7 @@ impl CoordinatorState {
             trigger_command: String::new(),
             hook_type: String::new(),
             worktree: String::new(),
+            prefailed_jobs: Vec::new(),
         }
     }
 
@@ -101,6 +115,13 @@ impl CoordinatorState {
         self.trigger_command = trigger_command.to_string();
         self.hook_type = hook_type.to_string();
         self.worktree = worktree.to_string();
+        self
+    }
+
+    /// Set the list of background-job names that should be recorded as
+    /// `DepFailed` before the wave loop starts (see [`Self::prefailed_jobs`]).
+    pub fn with_prefailed(mut self, names: Vec<String>) -> Self {
+        self.prefailed_jobs = names;
         self
     }
 
@@ -170,8 +191,40 @@ impl CoordinatorState {
         // malloc-arena constraint, which is moot post-spawn.
         let n = graph.len();
         let mut statuses = vec![NodeStatus::Pending; n];
-        let mut in_degree: Vec<usize> = (0..n).map(|i| graph.dependencies_of(i).len()).collect();
-        let mut ready: Vec<usize> = (0..n).filter(|&i| in_degree[i] == 0).collect();
+        let in_degree: Vec<usize> = (0..n).map(|i| graph.dependencies_of(i).len()).collect();
+
+        // Apply prefailed cascade before computing the initial ready set.
+        // A name in `prefailed_jobs` is treated identically to a runtime
+        // failure in this DAG: the node itself is marked `DepFailed` (the
+        // wave loop and the post-loop synthesis loop both already handle
+        // that variant) and the same transitive cascade used inside the
+        // wave loop fans out to all Pending dependents. The names come
+        // from the caller's view of foreground outcomes; missing names
+        // are ignored (a stale list from an upgrade racing with a config
+        // edit shouldn't crash the coordinator).
+        if !self.prefailed_jobs.is_empty() {
+            let prefailed: HashSet<&str> = self.prefailed_jobs.iter().map(String::as_str).collect();
+            for (idx, job) in self.jobs.iter().enumerate() {
+                if !prefailed.contains(job.name.as_str()) {
+                    continue;
+                }
+                statuses[idx] = NodeStatus::DepFailed;
+                let mut stack = vec![idx];
+                while let Some(i) = stack.pop() {
+                    for &d in graph.dependents_of(i) {
+                        if statuses[d] == NodeStatus::Pending {
+                            statuses[d] = NodeStatus::DepFailed;
+                            stack.push(d);
+                        }
+                    }
+                }
+            }
+        }
+
+        let mut in_degree = in_degree;
+        let mut ready: Vec<usize> = (0..n)
+            .filter(|&i| statuses[i] == NodeStatus::Pending && in_degree[i] == 0)
+            .collect();
 
         // Each iteration of this loop is one wave: every ready node is
         // spawned in parallel and the loop blocks until ALL of them finish
@@ -2646,6 +2699,14 @@ mod tests {
 
     #[test]
     fn bg_missing_dep_in_needs_returns_error() {
+        // Defensive: the partitioner now strips foreground names from BG
+        // `needs:` before the slice reaches the coordinator (see #556 /
+        // `partition::partition_foreground_background`), so the only way
+        // to reach this code path in production is a typoed name —
+        // already rejected by the config validator. The behavior still
+        // matters as a contract: if some caller does hand the coordinator
+        // a dangling reference, surface it as a hard error rather than
+        // silently dropping the job.
         let (_tmp, store, _job_store, child_pids, cancel_all, cancelled_jobs, _results) =
             make_test_state();
 
@@ -2669,5 +2730,148 @@ mod tests {
             result.is_err(),
             "missing dep should be reported as an error"
         );
+    }
+
+    #[test]
+    fn prefailed_job_recorded_as_skipped_without_running() {
+        // Regression for #556: a BG job pre-marked as DepFailed by the
+        // caller (because its FG dep failed) must not be executed, but
+        // must still be persisted to SQLite so `daft hooks jobs` shows
+        // it as `skipped` rather than silently vanishing.
+        let (_tmp, store, job_store, child_pids, cancel_all, cancelled_jobs, _results) =
+            make_test_state();
+
+        let mut state = CoordinatorState::new("test-repo", "inv-prefail-1")
+            .with_metadata("worktree-post-create", "worktree-post-create", "feat/x")
+            .with_prefailed(vec!["doomed".to_string()]);
+
+        // The command is `false` (always fails) so that if the cascade
+        // misbehaves and the job actually runs, the test catches it via
+        // the recorded status being `failed` rather than `skipped`.
+        state.add_job(JobSpec {
+            name: "doomed".to_string(),
+            command: "false".to_string(),
+            working_dir: std::env::temp_dir(),
+            background: true,
+            ..Default::default()
+        });
+
+        state
+            .run_all_with_cancel(
+                &store,
+                &child_pids,
+                &cancel_all,
+                &cancelled_jobs,
+                Some(&job_store),
+            )
+            .unwrap();
+
+        use crate::coordinator::ports::JobsStorePort;
+        let row = job_store
+            .get_job("test-repo", "inv-prefail-1", "doomed")
+            .unwrap()
+            .expect("doomed row should exist");
+        assert_eq!(
+            row.status, "skipped",
+            "prefailed BG job should be recorded as skipped, got {}",
+            row.status
+        );
+        assert!(
+            row.pid.is_none(),
+            "prefailed BG job must not have spawned a child process (pid={:?})",
+            row.pid
+        );
+    }
+
+    #[test]
+    fn prefailed_cascade_skips_transitive_bg_dependents() {
+        // Regression for #556: a BG job that itself depends on a
+        // prefailed BG job must also be recorded as skipped, matching
+        // the cascade the wave loop applies for runtime failures.
+        let (_tmp, store, job_store, child_pids, cancel_all, cancelled_jobs, _results) =
+            make_test_state();
+
+        let mut state = CoordinatorState::new("test-repo", "inv-prefail-2")
+            .with_metadata("worktree-post-create", "worktree-post-create", "feat/x")
+            .with_prefailed(vec!["doomed".to_string()]);
+
+        state.add_job(JobSpec {
+            name: "doomed".to_string(),
+            command: "true".to_string(),
+            working_dir: std::env::temp_dir(),
+            background: true,
+            ..Default::default()
+        });
+        state.add_job(JobSpec {
+            name: "downstream".to_string(),
+            command: "true".to_string(),
+            working_dir: std::env::temp_dir(),
+            background: true,
+            needs: vec!["doomed".to_string()],
+            ..Default::default()
+        });
+
+        state
+            .run_all_with_cancel(
+                &store,
+                &child_pids,
+                &cancel_all,
+                &cancelled_jobs,
+                Some(&job_store),
+            )
+            .unwrap();
+
+        use crate::coordinator::ports::JobsStorePort;
+        let down = job_store
+            .get_job("test-repo", "inv-prefail-2", "downstream")
+            .unwrap()
+            .expect("downstream row should exist");
+        assert_eq!(down.status, "skipped");
+        assert!(down.pid.is_none());
+    }
+
+    #[test]
+    fn prefailed_does_not_block_unrelated_bg_jobs() {
+        // A prefailed BG job must not poison BG jobs in a different
+        // dependency subtree. Sibling BG jobs that don't depend on the
+        // prefailed name run normally.
+        let (_tmp, store, job_store, child_pids, cancel_all, cancelled_jobs, _results) =
+            make_test_state();
+
+        let mut state = CoordinatorState::new("test-repo", "inv-prefail-3")
+            .with_metadata("worktree-post-create", "worktree-post-create", "feat/x")
+            .with_prefailed(vec!["doomed".to_string()]);
+
+        state.add_job(JobSpec {
+            name: "doomed".to_string(),
+            command: "true".to_string(),
+            working_dir: std::env::temp_dir(),
+            background: true,
+            ..Default::default()
+        });
+        state.add_job(JobSpec {
+            name: "sibling".to_string(),
+            command: "true".to_string(),
+            working_dir: std::env::temp_dir(),
+            background: true,
+            ..Default::default()
+        });
+
+        state
+            .run_all_with_cancel(
+                &store,
+                &child_pids,
+                &cancel_all,
+                &cancelled_jobs,
+                Some(&job_store),
+            )
+            .unwrap();
+
+        use crate::coordinator::ports::JobsStorePort;
+        let sib = job_store
+            .get_job("test-repo", "inv-prefail-3", "sibling")
+            .unwrap()
+            .expect("sibling row should exist");
+        assert_eq!(sib.status, "completed");
     }
 }

--- a/src/hooks/yaml_executor/mod.rs
+++ b/src/hooks/yaml_executor/mod.rs
@@ -468,14 +468,24 @@ pub fn execute_yaml_hook_with_rc(
             coord_state.add_job(spec);
         }
 
-        let bg_count = coord_state.jobs.len();
+        // Only count jobs that the coordinator will actually run.
+        // Prefailed jobs are still added to the coordinator state so they
+        // produce `skipped` rows in SQLite (visible via `daft hooks jobs`),
+        // but counting them in the user-facing "N background job(s) running"
+        // message would overstate runtime concurrency.
+        let bg_count = coord_state
+            .jobs
+            .len()
+            .saturating_sub(coord_state.prefailed_jobs.len());
         crate::coordinator::process::spawn_coordinator(coord_state, (*store).clone())?;
 
-        presenter.on_message(&format!(
-            "⟳ {} background job{} running — daft hooks jobs to manage",
-            bg_count,
-            if bg_count == 1 { "" } else { "s" },
-        ));
+        if bg_count > 0 {
+            presenter.on_message(&format!(
+                "⟳ {} background job{} running — daft hooks jobs to manage",
+                bg_count,
+                if bg_count == 1 { "" } else { "s" },
+            ));
+        }
     }
 
     // On non-Unix platforms, background coordinator is not available.
@@ -496,14 +506,23 @@ pub fn execute_yaml_hook_with_rc(
 }
 
 /// Run background jobs inline (no coordinator), synthesizing `Skipped`
-/// results for any job in `prefailed_bg`. Used by the `DAFT_NO_BACKGROUND_JOBS`
-/// debug path and by the non-Unix fallback, both of which would otherwise
-/// silently run BG jobs whose FG dep failed (no coordinator to consult
-/// `prefailed_jobs`).
+/// results for any job in `prefailed_bg` *and* its transitive BG→BG
+/// dependents. Used by the `DAFT_NO_BACKGROUND_JOBS` debug path and by
+/// the non-Unix fallback, both of which would otherwise silently run BG
+/// jobs whose FG dep failed (no coordinator to consult `prefailed_jobs`).
 ///
-/// The skip semantic matches the coordinator: prefailed jobs surface as
-/// `NodeStatus::Skipped` in the returned `JobResult`s, so the hook outcome
-/// classifier sees the same failure shape regardless of execution path.
+/// The skip semantic matches the coordinator: prefailed jobs and their
+/// dependents surface as `NodeStatus::Skipped` in the returned
+/// `JobResult`s, so the hook outcome classifier sees the same failure
+/// shape regardless of execution path.
+///
+/// Without the transitive expansion below, a BG→BG dependent of a
+/// prefailed job would stay in `to_run` with a `needs:` entry pointing
+/// at a name that's been moved to `skipped_specs`. `DagGraph::new`
+/// inside `run_jobs` would then reject the dangling reference as
+/// `MissingDependency` — the exact failure mode the coordinator-side
+/// cascade was written to avoid (see
+/// `coordinator::process::run_all_with_cancel`).
 fn run_bg_inline_with_prefailed(
     bg_specs: &[crate::executor::JobSpec],
     prefailed_bg: &[String],
@@ -515,11 +534,11 @@ fn run_bg_inline_with_prefailed(
         return crate::executor::runner::run_jobs(bg_specs, exec_mode, presenter, Some(sink));
     }
 
-    let prefailed: HashSet<&str> = prefailed_bg.iter().map(String::as_str).collect();
+    let skip_set = expand_prefailed_closure(bg_specs, prefailed_bg);
     let (skipped_specs, to_run): (Vec<_>, Vec<_>) = bg_specs
         .iter()
         .cloned()
-        .partition(|s| prefailed.contains(s.name.as_str()));
+        .partition(|s| skip_set.contains(s.name.as_str()));
 
     let mut results = crate::executor::runner::run_jobs(&to_run, exec_mode, presenter, Some(sink))?;
     for spec in skipped_specs {
@@ -540,6 +559,47 @@ fn run_bg_inline_with_prefailed(
         });
     }
     Ok(results)
+}
+
+/// Compute the transitive closure of `seeds` over the BG→BG `needs:`
+/// graph induced by `bg_specs`. Returns the set of BG job names that
+/// must be skipped (the seeds plus everything that transitively
+/// depends on a seed).
+///
+/// `bg_specs` is the slice produced by `partition_foreground_background`,
+/// so each `needs:` entry already refers to a BG-only name — no
+/// cross-partition references to filter out.
+fn expand_prefailed_closure<'a>(
+    bg_specs: &'a [crate::executor::JobSpec],
+    seeds: &'a [String],
+) -> HashSet<&'a str> {
+    use std::collections::HashMap;
+
+    // Build dependents adjacency on string slices borrowed from
+    // `bg_specs` to keep the closure pass allocation-light.
+    let mut dependents: HashMap<&str, Vec<&str>> = HashMap::with_capacity(bg_specs.len());
+    for job in bg_specs {
+        for dep in &job.needs {
+            dependents
+                .entry(dep.as_str())
+                .or_default()
+                .push(job.name.as_str());
+        }
+    }
+
+    let mut skip: HashSet<&str> = HashSet::with_capacity(seeds.len());
+    let mut stack: Vec<&str> = seeds.iter().map(String::as_str).collect();
+    while let Some(name) = stack.pop() {
+        if !skip.insert(name) {
+            continue;
+        }
+        if let Some(downs) = dependents.get(name) {
+            for d in downs {
+                stack.push(d);
+            }
+        }
+    }
+    skip
 }
 
 /// Convert generic executor results into a `HookResult`.
@@ -1412,23 +1472,27 @@ mod tests {
     /// equivalent unit coverage for that path is in
     /// `coordinator::process::tests::prefailed_*`).
     ///
-    /// Detection uses a filesystem marker rather than captured output:
+    /// Detection uses filesystem markers rather than captured output:
     /// `TestOutput` does not see the job's shell stdout (the executor
-    /// routes it through the log sink), so the bg-dependent command
-    /// `touch`es a per-test marker file. If the cascade fires, the file
-    /// must not exist after the hook returns.
+    /// routes it through the log sink), so each BG command `touch`es a
+    /// per-test marker file. If the cascade fires, the marker must not
+    /// exist after the hook returns.
+    ///
+    /// `#[serial_test::serial(daft_no_background_jobs)]` is used because
+    /// the test mutates the process-global `DAFT_NO_BACKGROUND_JOBS` env
+    /// var. The same serial key is shared with
+    /// `test_bg_needs_chain_cascade_skips_transitive_in_inline_path` so
+    /// they never race on the env.
     #[test]
+    #[serial_test::serial(daft_no_background_jobs)]
     fn test_bg_needs_failed_fg_skipped_in_inline_path() {
         let marker_dir = TempDir::new().unwrap();
         let marker = marker_dir.path().join("bg-ran.marker");
-        // The shell `touch` keeps quoting simple — the path lives inside
-        // a fresh tempdir, so no special characters to worry about.
+        // The path lives inside a fresh tempdir, so no special characters
+        // need quoting in the shell command.
         let bg_cmd = format!("touch {}", marker.display());
 
-        // SAFETY: edition-2024 marks `set_var`/`remove_var` as unsafe;
-        // setting an env var in tests is the documented use. The matching
-        // `remove_var` below restores the prior state.
-        unsafe { std::env::set_var("DAFT_NO_BACKGROUND_JOBS", "1") };
+        let _guard = NoBackgroundJobsEnv::set();
 
         let hook_def = HookDef {
             jobs: Some(vec![
@@ -1461,14 +1525,115 @@ mod tests {
         )
         .unwrap();
 
-        unsafe { std::env::remove_var("DAFT_NO_BACKGROUND_JOBS") };
-
         assert!(!result.success, "hook should fail because fg-fail failed");
         assert!(
             !marker.exists(),
             "bg-dependent should have been skipped, but its `touch` ran (marker at {} exists)",
             marker.display()
         );
+    }
+
+    /// Regression for the review finding on #558: in the inline path, a
+    /// BG job whose `needs:` chains through another BG job that's
+    /// already prefailed must also be skipped. Pre-fix the chain was
+    /// `fg-fail → bg-dep → bg-transitive`; the partitioner stripped
+    /// `needs:[fg-fail]` from `bg-dep`, the prefailed list contained
+    /// only `bg-dep`, the inline path moved `bg-dep` to skipped without
+    /// expanding the closure, and `run_jobs(&[bg-transitive])` then
+    /// rejected the dangling `needs: [bg-dep]` with `MissingDependency`.
+    #[test]
+    #[serial_test::serial(daft_no_background_jobs)]
+    fn test_bg_needs_chain_cascade_skips_transitive_in_inline_path() {
+        let marker_dir = TempDir::new().unwrap();
+        let dep_marker = marker_dir.path().join("bg-dep-ran.marker");
+        let trans_marker = marker_dir.path().join("bg-transitive-ran.marker");
+
+        let _guard = NoBackgroundJobsEnv::set();
+
+        let hook_def = HookDef {
+            jobs: Some(vec![
+                JobDef {
+                    name: Some("fg-fail".to_string()),
+                    run: Some(RunCommand::Simple("false".to_string())),
+                    ..Default::default()
+                },
+                JobDef {
+                    name: Some("bg-dep".to_string()),
+                    run: Some(RunCommand::Simple(format!(
+                        "touch {}",
+                        dep_marker.display()
+                    ))),
+                    background: Some(true),
+                    needs: Some(vec!["fg-fail".to_string()]),
+                    ..Default::default()
+                },
+                JobDef {
+                    name: Some("bg-transitive".to_string()),
+                    run: Some(RunCommand::Simple(format!(
+                        "touch {}",
+                        trans_marker.display()
+                    ))),
+                    background: Some(true),
+                    needs: Some(vec!["bg-dep".to_string()]),
+                    ..Default::default()
+                },
+            ]),
+            ..Default::default()
+        };
+        let ctx = make_ctx();
+        let mut output = TestOutput::default();
+
+        let result = execute_yaml_hook(
+            "test-hook",
+            &hook_def,
+            &ctx,
+            &mut output,
+            ".daft",
+            Path::new("/tmp"),
+            &HookOutputConfig::default(),
+        )
+        .expect(
+            "hook should return Ok with a failure result rather than Err — pre-fix this \
+             surfaced as a DagGraph::MissingDependency Err",
+        );
+
+        assert!(!result.success);
+        assert!(
+            !dep_marker.exists(),
+            "bg-dep must be skipped (its FG dep failed); marker exists at {}",
+            dep_marker.display()
+        );
+        assert!(
+            !trans_marker.exists(),
+            "bg-transitive must be skipped via the BG→BG cascade; marker exists at {}",
+            trans_marker.display()
+        );
+    }
+
+    /// RAII guard for `DAFT_NO_BACKGROUND_JOBS`. Sets the var on
+    /// construction and removes it on drop so tests that need the inline
+    /// path don't leak the var into other tests if they panic mid-body.
+    /// Paired with `#[serial_test::serial(daft_no_background_jobs)]` on
+    /// the call sites for cross-test isolation.
+    struct NoBackgroundJobsEnv;
+
+    impl NoBackgroundJobsEnv {
+        fn set() -> Self {
+            // SAFETY: edition-2024 marks env mutators as unsafe because
+            // they race with `getenv` in other threads. The `serial`
+            // attribute on the call sites guarantees only this test is
+            // running, so the only reader is this test's own
+            // `execute_yaml_hook` call below.
+            unsafe { std::env::set_var("DAFT_NO_BACKGROUND_JOBS", "1") };
+            Self
+        }
+    }
+
+    impl Drop for NoBackgroundJobsEnv {
+        fn drop(&mut self) {
+            // SAFETY: see `NoBackgroundJobsEnv::set`.
+            unsafe { std::env::remove_var("DAFT_NO_BACKGROUND_JOBS") };
+        }
     }
 }
 

--- a/src/hooks/yaml_executor/mod.rs
+++ b/src/hooks/yaml_executor/mod.rs
@@ -416,10 +416,33 @@ pub fn execute_yaml_hook_with_rc(
         return job_results_to_hook_result(&fg_results);
     }
 
+    // Detect BG jobs whose ORIGINAL (pre-partition) `needs:` referenced a
+    // foreground job that did not succeed. The partitioner already stripped
+    // those names from `bg_specs[*].needs`, so we look at `specs` here to
+    // recover the original cross-partition deps. These names are passed to
+    // the coordinator as `prefailed_jobs` (or filtered out of the inline
+    // run path) so a BG job depending on a failed FG is recorded as
+    // `skipped` rather than executed.
+    let failed_fg_names: HashSet<&str> = fg_results
+        .iter()
+        .filter(|r| !matches!(r.status, crate::executor::NodeStatus::Succeeded))
+        .map(|r| r.name.as_str())
+        .collect();
+    let prefailed_bg: Vec<String> = if failed_fg_names.is_empty() {
+        Vec::new()
+    } else {
+        specs
+            .iter()
+            .filter(|s| s.background)
+            .filter(|s| s.needs.iter().any(|n| failed_fg_names.contains(n.as_str())))
+            .map(|s| s.name.clone())
+            .collect()
+    };
+
     // If DAFT_NO_BACKGROUND_JOBS is set, run background jobs inline as foreground.
     if std::env::var("DAFT_NO_BACKGROUND_JOBS").is_ok() {
         let bg_results =
-            crate::executor::runner::run_jobs(&bg_specs, exec_mode, presenter, Some(&fg_sink))?;
+            run_bg_inline_with_prefailed(&bg_specs, &prefailed_bg, exec_mode, presenter, &fg_sink)?;
         presenter.on_phase_complete(hook_start.elapsed());
         let mut all_results = fg_results;
         all_results.extend(bg_results);
@@ -439,7 +462,8 @@ pub fn execute_yaml_hook_with_rc(
     {
         let mut coord_state =
             crate::coordinator::process::CoordinatorState::new(&repo_hash, &invocation_id)
-                .with_metadata(&trigger_command, hook_name, &ctx.branch_name);
+                .with_metadata(&trigger_command, hook_name, &ctx.branch_name)
+                .with_prefailed(prefailed_bg);
         for spec in bg_specs {
             coord_state.add_job(spec);
         }
@@ -459,7 +483,7 @@ pub fn execute_yaml_hook_with_rc(
     #[cfg(not(unix))]
     {
         let bg_results =
-            crate::executor::runner::run_jobs(&bg_specs, exec_mode, presenter, Some(&fg_sink))?;
+            run_bg_inline_with_prefailed(&bg_specs, &prefailed_bg, exec_mode, presenter, &fg_sink)?;
         let mut all_results = fg_results.clone();
         all_results.extend(bg_results);
         return job_results_to_hook_result(&all_results);
@@ -469,6 +493,53 @@ pub fn execute_yaml_hook_with_rc(
     // running in the forked coordinator and do not affect the hook outcome).
     #[cfg(unix)]
     job_results_to_hook_result(&fg_results)
+}
+
+/// Run background jobs inline (no coordinator), synthesizing `Skipped`
+/// results for any job in `prefailed_bg`. Used by the `DAFT_NO_BACKGROUND_JOBS`
+/// debug path and by the non-Unix fallback, both of which would otherwise
+/// silently run BG jobs whose FG dep failed (no coordinator to consult
+/// `prefailed_jobs`).
+///
+/// The skip semantic matches the coordinator: prefailed jobs surface as
+/// `NodeStatus::Skipped` in the returned `JobResult`s, so the hook outcome
+/// classifier sees the same failure shape regardless of execution path.
+fn run_bg_inline_with_prefailed(
+    bg_specs: &[crate::executor::JobSpec],
+    prefailed_bg: &[String],
+    exec_mode: crate::executor::ExecutionMode,
+    presenter: &Arc<dyn JobPresenter>,
+    sink: &Arc<dyn crate::executor::log_sink::LogSink>,
+) -> Result<Vec<crate::executor::JobResult>> {
+    if prefailed_bg.is_empty() {
+        return crate::executor::runner::run_jobs(bg_specs, exec_mode, presenter, Some(sink));
+    }
+
+    let prefailed: HashSet<&str> = prefailed_bg.iter().map(String::as_str).collect();
+    let (skipped_specs, to_run): (Vec<_>, Vec<_>) = bg_specs
+        .iter()
+        .cloned()
+        .partition(|s| prefailed.contains(s.name.as_str()));
+
+    let mut results = crate::executor::runner::run_jobs(&to_run, exec_mode, presenter, Some(sink))?;
+    for spec in skipped_specs {
+        presenter.on_job_skipped(
+            &spec.name,
+            "foreground dependency failed",
+            std::time::Duration::ZERO,
+            false,
+            None,
+        );
+        results.push(crate::executor::JobResult {
+            name: spec.name,
+            status: crate::executor::NodeStatus::Skipped,
+            duration: std::time::Duration::ZERO,
+            exit_code: None,
+            stdout: String::new(),
+            stderr: "foreground dependency failed".to_string(),
+        });
+    }
+    Ok(results)
 }
 
 /// Convert generic executor results into a `HookResult`.
@@ -1332,6 +1403,72 @@ mod tests {
         .unwrap();
 
         assert!(result.success);
+    }
+
+    /// Regression for #556: when a foreground job fails, BG jobs that
+    /// declared `needs:` on it must surface as `skipped` rather than
+    /// running. This exercises the `DAFT_NO_BACKGROUND_JOBS` inline path
+    /// (the coordinator path requires spawning a real child process; the
+    /// equivalent unit coverage for that path is in
+    /// `coordinator::process::tests::prefailed_*`).
+    ///
+    /// Detection uses a filesystem marker rather than captured output:
+    /// `TestOutput` does not see the job's shell stdout (the executor
+    /// routes it through the log sink), so the bg-dependent command
+    /// `touch`es a per-test marker file. If the cascade fires, the file
+    /// must not exist after the hook returns.
+    #[test]
+    fn test_bg_needs_failed_fg_skipped_in_inline_path() {
+        let marker_dir = TempDir::new().unwrap();
+        let marker = marker_dir.path().join("bg-ran.marker");
+        // The shell `touch` keeps quoting simple — the path lives inside
+        // a fresh tempdir, so no special characters to worry about.
+        let bg_cmd = format!("touch {}", marker.display());
+
+        // SAFETY: edition-2024 marks `set_var`/`remove_var` as unsafe;
+        // setting an env var in tests is the documented use. The matching
+        // `remove_var` below restores the prior state.
+        unsafe { std::env::set_var("DAFT_NO_BACKGROUND_JOBS", "1") };
+
+        let hook_def = HookDef {
+            jobs: Some(vec![
+                JobDef {
+                    name: Some("fg-fail".to_string()),
+                    run: Some(RunCommand::Simple("false".to_string())),
+                    ..Default::default()
+                },
+                JobDef {
+                    name: Some("bg-dependent".to_string()),
+                    run: Some(RunCommand::Simple(bg_cmd)),
+                    background: Some(true),
+                    needs: Some(vec!["fg-fail".to_string()]),
+                    ..Default::default()
+                },
+            ]),
+            ..Default::default()
+        };
+        let ctx = make_ctx();
+        let mut output = TestOutput::default();
+
+        let result = execute_yaml_hook(
+            "test-hook",
+            &hook_def,
+            &ctx,
+            &mut output,
+            ".daft",
+            Path::new("/tmp"),
+            &HookOutputConfig::default(),
+        )
+        .unwrap();
+
+        unsafe { std::env::remove_var("DAFT_NO_BACKGROUND_JOBS") };
+
+        assert!(!result.success, "hook should fail because fg-fail failed");
+        assert!(
+            !marker.exists(),
+            "bg-dependent should have been skipped, but its `touch` ran (marker at {} exists)",
+            marker.display()
+        );
     }
 }
 

--- a/src/hooks/yaml_executor/partition.rs
+++ b/src/hooks/yaml_executor/partition.rs
@@ -4,14 +4,30 @@
 //! are promoted to the foreground phase. This preserves DAG validity and
 //! ensures the daft command does not exit while a foreground job is still
 //! waiting for a background dependency.
+//!
+//! Cross-partition dependencies in the other direction — a background job
+//! declaring `needs:` on a foreground job — are stripped from the BG
+//! `JobSpec.needs` returned here. The coordinator only sees the background
+//! slice, so a `needs:` entry naming a foreground job would be a dangling
+//! reference and `DagGraph::new` would reject it with `MissingDependency`.
+//! FG-before-BG sequencing in the caller already guarantees the
+//! "happens-after" intent of such a dep, so dropping the name in the BG
+//! view is semantically a no-op for ordering. Failure cascade (skip the BG
+//! job when its FG dep failed) is handled by the caller, which has the FG
+//! outcomes and threads the affected BG names into
+//! `CoordinatorState::prefailed_jobs`.
 
 use crate::executor::JobSpec;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// Partition jobs into foreground and background phases.
 ///
 /// Background jobs that are transitively depended on by any foreground job
-/// are promoted to the foreground phase. Returns `(foreground, background)`.
+/// are promoted to the foreground phase. Background jobs that survive the
+/// partition have their `needs:` filtered to BG-only names (cross-partition
+/// references to foreground jobs are removed — see module docs).
+///
+/// Returns `(foreground, background)`.
 pub fn partition_foreground_background(jobs: &[JobSpec]) -> (Vec<JobSpec>, Vec<JobSpec>) {
     if jobs.is_empty() {
         return (Vec::new(), Vec::new());
@@ -47,6 +63,15 @@ pub fn partition_foreground_background(jobs: &[JobSpec]) -> (Vec<JobSpec>, Vec<J
         }
     }
 
+    // Names that landed in the background partition — used to strip
+    // cross-partition needs from BG `JobSpec`s below.
+    let bg_names: HashSet<&str> = jobs
+        .iter()
+        .enumerate()
+        .filter(|&(i, _)| !must_fg[i])
+        .map(|(_, j)| j.name.as_str())
+        .collect();
+
     // Partition
     let mut foreground = Vec::new();
     let mut background = Vec::new();
@@ -54,7 +79,9 @@ pub fn partition_foreground_background(jobs: &[JobSpec]) -> (Vec<JobSpec>, Vec<J
         if must_fg[i] {
             foreground.push(job.clone());
         } else {
-            background.push(job.clone());
+            let mut bg_job = job.clone();
+            bg_job.needs.retain(|n| bg_names.contains(n.as_str()));
+            background.push(bg_job);
         }
     }
 
@@ -138,5 +165,53 @@ mod partition_tests {
         assert!(fg.iter().any(|j| j.name == "types"));
         assert_eq!(bg.len(), 1);
         assert_eq!(bg[0].name, "assets");
+        // assets's needs: ["install"] crosses into the FG partition and
+        // must be stripped — the coordinator's DAG won't have an "install"
+        // node to satisfy the dep. FG-before-BG sequencing in the caller
+        // already guarantees the "happens-after" intent (see module docs).
+        assert!(
+            bg[0].needs.is_empty(),
+            "expected assets.needs to be empty after stripping FG names, got {:?}",
+            bg[0].needs
+        );
+    }
+
+    #[test]
+    fn test_partition_bg_needs_fg_is_stripped() {
+        // Regression for #556: a BG job whose only `needs:` entries are FG
+        // names must end up with empty `needs` in the BG slice, otherwise
+        // the coordinator's `DagGraph::new` rejects it with
+        // `MissingDependency` and the job silently never runs.
+        let jobs = vec![
+            spec("install", false, vec![]),
+            spec("warm", true, vec!["install"]),
+        ];
+        let (fg, bg) = partition_foreground_background(&jobs);
+        assert_eq!(fg.len(), 1);
+        assert_eq!(fg[0].name, "install");
+        assert_eq!(bg.len(), 1);
+        assert_eq!(bg[0].name, "warm");
+        assert!(
+            bg[0].needs.is_empty(),
+            "FG-only needs must be stripped from BG slice, got {:?}",
+            bg[0].needs
+        );
+    }
+
+    #[test]
+    fn test_partition_bg_needs_mix_keeps_bg_drops_fg() {
+        // A BG job that depends on one FG name AND one BG name should keep
+        // the BG name (so the coordinator's wave loop honors bg→bg ordering
+        // — see #454/#463) and drop the FG name (FG already ran).
+        let jobs = vec![
+            spec("install", false, vec![]),
+            spec("bg-a", true, vec![]),
+            spec("bg-b", true, vec!["install", "bg-a"]),
+        ];
+        let (fg, bg) = partition_foreground_background(&jobs);
+        assert_eq!(fg.len(), 1);
+        assert_eq!(bg.len(), 2);
+        let bg_b = bg.iter().find(|j| j.name == "bg-b").unwrap();
+        assert_eq!(bg_b.needs, vec!["bg-a".to_string()]);
     }
 }


### PR DESCRIPTION
## Summary

- BG hook job with `needs:` on a FG job silently never ran — partitioner left the FG name in the BG `JobSpec.needs`, coordinator's `DagGraph::new` rejected the dangling reference as `MissingDependency`, and the coordinator child exited 1 with stderr `/dev/null`'d while the parent unconditionally printed `⟳ N background job(s) running`.
- This is the exact pattern documented in `SKILL.md:506–516` and used in this repo's own `daft.yml` (`mise dev` is bg, `needs: [bun install]` which is fg).

## Fix

Three small layered changes:

1. **`partition.rs`** — strip FG names from BG `needs:`. FG-before-BG sequencing already satisfies the "happens-after" intent; the names are noise in the BG-only DAG.
2. **`coordinator/process.rs`** — `CoordinatorState::prefailed_jobs` is the new channel for "this BG job's FG dep failed; record it as skipped without running it." `run_all_with_cancel` marks these as `DepFailed` before the wave loop and reuses the existing transitive cascade.
3. **`yaml_executor/mod.rs`** — after FG results, derive the prefailed list from the ORIGINAL (pre-partition) specs and thread it into `CoordinatorState`. Inline debug paths (`DAFT_NO_BACKGROUND_JOBS`, non-Unix fallback) get the same cascade via a small `run_bg_inline_with_prefailed` helper that synthesizes `Skipped` results without spawning.

Wire-format compatibility: `prefailed_jobs` is `#[serde(default)]` so older parents that don't populate the field round-trip through the `__coordinator <state-file>` JSON payload as an empty list.

## Test plan

- [x] `partition::test_partition_bg_needs_fg_is_stripped` — partitioner-side regression
- [x] `partition::test_partition_bg_needs_mix_keeps_bg_drops_fg` — mixed BG+FG deps cleaned correctly
- [x] `coordinator::process::tests::prefailed_job_recorded_as_skipped_without_running` — prefailed name lands as `status="skipped"` in SQLite, no child process spawned
- [x] `coordinator::process::tests::prefailed_cascade_skips_transitive_bg_dependents` — transitive BG dependents cascade
- [x] `coordinator::process::tests::prefailed_does_not_block_unrelated_bg_jobs` — sibling BG jobs unaffected
- [x] `hooks::yaml_executor::tests::test_bg_needs_failed_fg_skipped_in_inline_path` — end-to-end via the inline debug path; uses a filesystem marker because the executor routes job stdout through the log sink
- [x] `mise run fmt` clean
- [x] `mise run clippy` clean (0 warnings)
- [x] `mise run test:unit` — 1822 passed

## Out of scope / follow-up

The unconditional `⟳ N background job(s) running` message in `yaml_executor/mod.rs:450` will still lie about runtime if the coordinator fails to start for some other reason (OS error, schema mismatch, etc.). That deserves its own follow-up — either wait for the coordinator to write its first `JobRow` before printing, or stop `/dev/null`'ing the coordinator's stderr.

Fixes #556.

🤖 Generated with [Claude Code](https://claude.com/claude-code)