### PR TITLE
perf(test-runner): use APFS clonefile / Linux FICLONE for sandbox template snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,6 +741,7 @@ dependencies = [
  "r2d2",
  "r2d2_sqlite",
  "ratatui",
+ "reflink-copy",
  "regex",
  "rusqlite",
  "rusqlite_migration",
@@ -3733,6 +3734,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "reflink-copy"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13362233b147e57674c37b802d216b7c5e3dcccbed8967c84f0d8d223868ae27"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "rustix",
+ "windows",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5196,6 +5209,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5206,6 +5240,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -5235,6 +5280,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-result"
@@ -5360,6 +5415,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5751,10 +5751,12 @@ dependencies = [
  "indicatif",
  "nix",
  "rayon",
+ "reflink-copy",
  "serde",
  "serde_yaml",
  "tempfile",
  "term-styles",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,6 +130,14 @@ shlex = "1.3"
 uuid = { version = "1", features = ["v7"] }
 fs2 = "0.4"
 walkdir = "2.5"
+# Copy-on-write file copy (APFS clonefile on macOS, ioctl(FICLONE) on Linux
+# btrfs/XFS/ZFS, ReFS block-clone on Windows). Falls back to byte-copy on
+# unsupported filesystems via `reflink_or_copy`. Used by `src/cow_copy.rs`
+# and consumed from xtask's manual-test runner; future home of #387's
+# `copy_paths:` implementation. Public API is fully safe (`unsafe` is
+# confined to the crate's internal sys layer), so `forbid(unsafe_code)`
+# stays intact — same precedent as `rusqlite` over `heed`.
+reflink-copy = "0.1.29"
 # `bundled` compiles SQLite from source into the daft binary (~+1 MB on
 # release builds, +C compiler at build time). The rationale is in CLAUDE.md
 # under "Database & Storage" — every daft installation gets the same SQLite

--- a/benches/README.md
+++ b/benches/README.md
@@ -61,15 +61,32 @@ BENCH_SKIP_TIMING=1    # skip per-scenario distribution phase (faster)
 ### Per-scenario timing
 
 When `DAFT_MANUAL_TEST_EMIT_TIMING=1` is set, the manual-test runner emits one
-grep-friendly line per scenario:
+grep-friendly line per scenario, broken down by phase:
 
 ```
-[bench] scenario="Clone basic" elapsed_ms=412
+[bench] scenario="Clone basic" elapsed_ms=412 setup_ms=0 fixture_ms=244 template_ms=5
 ```
 
-The scaling sweep script uses this to compute p50/p95/max distributions. Outside
-the bench harness, you can pipe the output through `grep ^\[bench\]` to capture
-per-scenario timings yourself.
+The four fields, in order:
+
+- **`elapsed_ms`** — the **step phase**: actual scenario commands running
+  through the executor (every `daft …` / `git-worktree-* …` / `bash -c …`
+  invocation defined in the scenario YAML). First on the line so the existing
+  `awk -F'elapsed_ms='` percentiles pipeline in `test_manual_scale.sh` stays
+  compatible.
+- **`setup_ms`** — `Sandbox::create_at`: making the per-scenario `/tmp` dirs,
+  registering with the cleanup set.
+- **`fixture_ms`** — `repo_gen::generate_repo` calls (one per `repos:` entry):
+  the bare-git fixture construction that happens before the scenario's steps
+  run.
+- **`template_ms`** — `Sandbox::create_template`: snapshot of `remotes/` →
+  `remotes-template/` so `reset()` can restore from it (post-#511 this is a
+  reflink, so it's typically 1–10ms; was 100s+ms with `cp -a`).
+
+The total per-scenario wall-clock at jobs=1 is approximately the sum of all four
+(drop/teardown is the residual, typically <20ms). The scaling sweep script's
+percentile output uses `elapsed_ms` only; for phase attribution use the full
+line.
 
 ## Methodology notes
 
@@ -124,5 +141,73 @@ When a PR is meant to move the needle on #509:
 4. `mise run bench:tests:manual:scale-compare` for the diff.
 5. Paste the diff into the PR description, and consider whether to add a fresh
    `benches/baselines/test-manual-scale-<date>.md` reference snapshot.
+
+### Phase attribution
+
+For PRs that move per-scenario cost between phases (e.g. clonefile shrinks
+`template_ms`; a fixture cache shrinks `fixture_ms`; a daft-startup amortization
+shrinks `elapsed_ms`), wall-clock at high parallelism alone often misses the
+real signal — the per-scenario win can get masked by the parallel floor
+(contention, scheduler tail, etc.).
+
+The remedy is to run with `DAFT_MANUAL_TEST_EMIT_TIMING=1` at `--jobs 1`,
+extract the `[bench]` lines, and build a per-phase cumulative table:
+
+```bash
+DAFT_MANUAL_TEST_EMIT_TIMING=1 ./target/release/xtask manual-test --jobs 1 \
+    > /tmp/bench.txt
+grep '^\[bench\] scenario=' /tmp/bench.txt > /tmp/bench-lines.txt
+# Then parse with a small awk/python script — see #511 PR description for an
+# example. Sum each phase across all scenarios; report p50/p95/max of the
+# non-zero values per phase.
+```
+
+The cumulative table in the PR description should look like:
+
+| Phase               | Sum (s) |   % | p50 | p95 | max | scenarios non-zero |
+| ------------------- | ------: | --: | --: | --: | --: | -----------------: |
+| Step (`elapsed`)    |       A |  A% |   … |   … |   … |                  … |
+| Fixture gen         |       B |  B% |   … |   … |   … |                  … |
+| Template snapshot   |       C |  C% |   … |   … |   … |                  … |
+| Setup (`create_at`) |       D |  D% |   … |   … |   … |                  … |
+
+`A + B + C + D` should match the serial wall-clock minus a few seconds of
+drop/teardown. If they don't, something's miscounted. Add the table before/after
+the change so reviewers can see which phase moved.
+
+Top-N slowest scenarios per phase is a useful diagnostic addendum when a
+particular phase has high p95 or max — surfaces the specific scenarios driving
+that tail. Not required, but cheap to include.
+
+## PR description checklist for #509 sub-tasks
+
+Every PR landing under #509's umbrella must include all of these in its
+description so future contributors can build on the measurement, not just the
+code:
+
+- [ ] **Wall-clock numbers from `mise run bench:tests:manual:scale`** — at
+      minimum `BENCH_JOBS=10 BENCH_RUNS=3` (the default-cap measurement), more
+      jobs values if the PR is changing parallel scaling specifically. Mean ±
+      stddev. State the machine (CPU, OS).
+- [ ] **Comparison against a reference baseline** — either the pinned
+      `benches/baselines/test-manual-scale-<date>.md` on master, or the
+      pre-change SHA captured via `scale-baseline` / `scale-compare`. State the
+      diff explicitly; don't make the reader compute it.
+- [ ] **Per-phase cumulative table** (see "Phase attribution" above) at
+      `--jobs 1`. Even when the PR's headline gain is at high parallelism, the
+      phase table is what attributes the change correctly across `setup_ms` /
+      `fixture_ms` / `template_ms` / `elapsed_ms`.
+- [ ] **Honest assessment of what moved vs what's left**. If the suite-level
+      wall-clock at `--jobs 10` didn't change measurably, say so and explain why
+      (e.g., "the phase this PR shrank was already a 0.6% slice; the win becomes
+      visible after [other sub-task] lands").
+- [ ] **Coverage of #509's umbrella checklist** — which sub-tasks remain after
+      this lands, and whether any new gaps were surfaced during measurement
+      (file fresh issues, link them).
+
+If the PR materially changes the curve shape (parallel efficiency, p95 of any
+phase, etc.), add a fresh `benches/baselines/test-manual-scale-<date>.md`
+snapshot capturing the post-change numbers — future PRs will compare against it.
+Don't edit prior baselines in place.
 
 [`hyperfine`]: https://github.com/sharkdp/hyperfine

--- a/src/cow_copy.rs
+++ b/src/cow_copy.rs
@@ -1,0 +1,210 @@
+//! Copy-on-write file and directory copies.
+//!
+//! Wraps [`reflink_copy::reflink_or_copy`] so callers get APFS clonefile on
+//! macOS, `ioctl(FICLONE)` on reflink-capable Linux filesystems (btrfs, XFS
+//! with `reflink=1`, OpenZFS 2.2+, bcachefs), and block-clone on Windows ReFS
+//! — with a transparent byte-copy fallback everywhere else.
+//!
+//! [`copy_file`] is the file-level primitive; [`copy_dir`] recursively
+//! reproduces a directory tree using [`copy_file`] for regular files and
+//! recreating directories and symlinks. Mode bits are preserved per entry;
+//! ownership, timestamps, and xattrs are not — current callsites don't
+//! depend on them, and #387 will revisit if its `copy_paths:` surface needs
+//! richer semantics.
+
+use anyhow::{Context, Result};
+use std::fs;
+use std::os::unix::fs::symlink;
+use std::path::Path;
+use walkdir::WalkDir;
+
+/// Copy a regular file from `src` to `dst`, using reflink where supported
+/// and a byte copy otherwise. Preserves mode bits.
+///
+/// `dst` must not already exist; its parent must.
+pub fn copy_file(src: &Path, dst: &Path) -> Result<()> {
+    reflink_copy::reflink_or_copy(src, dst)
+        .with_context(|| format!("copying {} -> {}", src.display(), dst.display()))?;
+    // Linux `FICLONE` copies content only; macOS clonefile copies metadata;
+    // the byte-copy fallback copies mode. Normalize across all three.
+    let src_meta = fs::symlink_metadata(src)
+        .with_context(|| format!("reading metadata of {}", src.display()))?;
+    fs::set_permissions(dst, src_meta.permissions())
+        .with_context(|| format!("setting mode of {}", dst.display()))?;
+    Ok(())
+}
+
+/// Recursively copy a directory tree from `src` to `dst`.
+///
+/// Regular files go through [`copy_file`] (reflink-or-byte-copy); directories
+/// are recreated empty and then populated; symlinks are recreated with the
+/// same link target (never dereferenced). Mode bits are preserved per entry.
+///
+/// `dst` must not already exist; its parent must. `src` must be a directory.
+pub fn copy_dir(src: &Path, dst: &Path) -> Result<()> {
+    let src_meta = fs::symlink_metadata(src)
+        .with_context(|| format!("reading metadata of {}", src.display()))?;
+    anyhow::ensure!(
+        src_meta.is_dir(),
+        "copy_dir source is not a directory: {}",
+        src.display()
+    );
+    fs::create_dir(dst).with_context(|| format!("creating {}", dst.display()))?;
+    fs::set_permissions(dst, src_meta.permissions())
+        .with_context(|| format!("setting mode of {}", dst.display()))?;
+
+    for entry in WalkDir::new(src).follow_links(false).min_depth(1) {
+        let entry = entry.with_context(|| format!("walking {}", src.display()))?;
+        let rel = entry
+            .path()
+            .strip_prefix(src)
+            .expect("walkdir paths are rooted at src");
+        let dst_path = dst.join(rel);
+        let ftype = entry.file_type();
+
+        if ftype.is_dir() {
+            fs::create_dir(&dst_path)
+                .with_context(|| format!("creating {}", dst_path.display()))?;
+            let meta = entry
+                .metadata()
+                .with_context(|| format!("reading metadata of {}", entry.path().display()))?;
+            fs::set_permissions(&dst_path, meta.permissions())
+                .with_context(|| format!("setting mode of {}", dst_path.display()))?;
+        } else if ftype.is_symlink() {
+            let target = fs::read_link(entry.path())
+                .with_context(|| format!("reading symlink {}", entry.path().display()))?;
+            symlink(target, &dst_path)
+                .with_context(|| format!("creating symlink {}", dst_path.display()))?;
+        } else if ftype.is_file() {
+            copy_file(entry.path(), &dst_path)?;
+        }
+        // Block / char / fifo / socket entries are skipped. Daft's existing
+        // callsites don't produce them; future consumers that need them
+        // should extend this dispatch deliberately.
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use std::os::unix::fs::PermissionsExt;
+    use tempfile::TempDir;
+
+    fn write_file(path: &Path, content: &[u8]) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        let mut f = fs::File::create(path).unwrap();
+        f.write_all(content).unwrap();
+    }
+
+    #[test]
+    fn copy_file_independence_after_source_mutation() {
+        let tmp = TempDir::new().unwrap();
+        let src = tmp.path().join("src.bin");
+        let dst = tmp.path().join("dst.bin");
+        write_file(&src, b"original");
+
+        copy_file(&src, &dst).unwrap();
+        write_file(&src, b"MUTATED!");
+
+        assert_eq!(fs::read(&dst).unwrap(), b"original");
+    }
+
+    #[test]
+    fn copy_file_preserves_mode_bits() {
+        let tmp = TempDir::new().unwrap();
+        let src = tmp.path().join("hook");
+        let dst = tmp.path().join("hook.copy");
+        write_file(&src, b"#!/bin/sh\necho hi\n");
+        fs::set_permissions(&src, fs::Permissions::from_mode(0o755)).unwrap();
+
+        copy_file(&src, &dst).unwrap();
+
+        let mode = fs::metadata(&dst).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o755);
+    }
+
+    #[test]
+    fn copy_dir_replicates_tree_and_survives_source_mutation() {
+        let tmp = TempDir::new().unwrap();
+        let src = tmp.path().join("src");
+        let dst = tmp.path().join("dst");
+        write_file(&src.join("a.txt"), b"alpha");
+        write_file(&src.join("nested/b.txt"), b"beta");
+        write_file(&src.join("nested/deep/c.txt"), b"gamma");
+
+        copy_dir(&src, &dst).unwrap();
+
+        assert_eq!(fs::read(dst.join("a.txt")).unwrap(), b"alpha");
+        assert_eq!(fs::read(dst.join("nested/b.txt")).unwrap(), b"beta");
+        assert_eq!(fs::read(dst.join("nested/deep/c.txt")).unwrap(), b"gamma");
+
+        write_file(&src.join("a.txt"), b"MUTATED");
+        write_file(&src.join("nested/b.txt"), b"MUTATED");
+        assert_eq!(fs::read(dst.join("a.txt")).unwrap(), b"alpha");
+        assert_eq!(fs::read(dst.join("nested/b.txt")).unwrap(), b"beta");
+    }
+
+    #[test]
+    fn copy_dir_recreates_symlinks_without_dereferencing() {
+        let tmp = TempDir::new().unwrap();
+        let src = tmp.path().join("src");
+        let dst = tmp.path().join("dst");
+        fs::create_dir(&src).unwrap();
+        write_file(&src.join("target.txt"), b"linked");
+        symlink("target.txt", src.join("link.txt")).unwrap();
+
+        copy_dir(&src, &dst).unwrap();
+
+        let dst_link_meta = fs::symlink_metadata(dst.join("link.txt")).unwrap();
+        assert!(dst_link_meta.file_type().is_symlink());
+        assert_eq!(
+            fs::read_link(dst.join("link.txt")).unwrap(),
+            Path::new("target.txt")
+        );
+    }
+
+    #[test]
+    fn copy_dir_preserves_directory_mode_bits() {
+        let tmp = TempDir::new().unwrap();
+        let src = tmp.path().join("src");
+        let dst = tmp.path().join("dst");
+        fs::create_dir(&src).unwrap();
+        let inner = src.join("hooks");
+        fs::create_dir(&inner).unwrap();
+        fs::set_permissions(&inner, fs::Permissions::from_mode(0o700)).unwrap();
+
+        copy_dir(&src, &dst).unwrap();
+
+        let mode = fs::metadata(dst.join("hooks"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o700);
+    }
+
+    #[test]
+    fn copy_dir_errors_when_destination_exists() {
+        let tmp = TempDir::new().unwrap();
+        let src = tmp.path().join("src");
+        let dst = tmp.path().join("dst");
+        fs::create_dir(&src).unwrap();
+        fs::create_dir(&dst).unwrap();
+
+        assert!(copy_dir(&src, &dst).is_err());
+    }
+
+    #[test]
+    fn copy_dir_errors_when_source_is_a_file() {
+        let tmp = TempDir::new().unwrap();
+        let src = tmp.path().join("not-a-dir");
+        let dst = tmp.path().join("dst");
+        write_file(&src, b"hi");
+
+        assert!(copy_dir(&src, &dst).is_err());
+    }
+}

--- a/src/cow_copy.rs
+++ b/src/cow_copy.rs
@@ -14,7 +14,6 @@
 
 use anyhow::{Context, Result};
 use std::fs;
-use std::os::unix::fs::symlink;
 use std::path::Path;
 use walkdir::WalkDir;
 
@@ -71,10 +70,25 @@ pub fn copy_dir(src: &Path, dst: &Path) -> Result<()> {
             fs::set_permissions(&dst_path, meta.permissions())
                 .with_context(|| format!("setting mode of {}", dst_path.display()))?;
         } else if ftype.is_symlink() {
-            let target = fs::read_link(entry.path())
-                .with_context(|| format!("reading symlink {}", entry.path().display()))?;
-            symlink(target, &dst_path)
-                .with_context(|| format!("creating symlink {}", dst_path.display()))?;
+            #[cfg(unix)]
+            {
+                let target = fs::read_link(entry.path())
+                    .with_context(|| format!("reading symlink {}", entry.path().display()))?;
+                std::os::unix::fs::symlink(target, &dst_path)
+                    .with_context(|| format!("creating symlink {}", dst_path.display()))?;
+            }
+            #[cfg(not(unix))]
+            {
+                // Windows / non-Unix targets: symlink replication needs the
+                // file-vs-dir distinction up front (`symlink_file` /
+                // `symlink_dir`) and admin/dev-mode privileges. Daft's
+                // current consumers don't produce symlinks in their copy
+                // trees; #387's `copy_paths:` work will revisit if needed.
+                anyhow::bail!(
+                    "symlink replication not yet implemented on this platform: {}",
+                    entry.path().display()
+                );
+            }
         } else if ftype.is_file() {
             copy_file(entry.path(), &dst_path)?;
         }
@@ -89,8 +103,10 @@ pub fn copy_dir(src: &Path, dst: &Path) -> Result<()> {
 mod tests {
     use super::*;
     use std::io::Write;
-    use std::os::unix::fs::PermissionsExt;
     use tempfile::TempDir;
+
+    #[cfg(unix)]
+    use std::os::unix::fs::{PermissionsExt, symlink};
 
     fn write_file(path: &Path, content: &[u8]) {
         if let Some(parent) = path.parent() {
@@ -113,6 +129,7 @@ mod tests {
         assert_eq!(fs::read(&dst).unwrap(), b"original");
     }
 
+    #[cfg(unix)]
     #[test]
     fn copy_file_preserves_mode_bits() {
         let tmp = TempDir::new().unwrap();
@@ -148,6 +165,7 @@ mod tests {
         assert_eq!(fs::read(dst.join("nested/b.txt")).unwrap(), b"beta");
     }
 
+    #[cfg(unix)]
     #[test]
     fn copy_dir_recreates_symlinks_without_dereferencing() {
         let tmp = TempDir::new().unwrap();
@@ -167,6 +185,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[test]
     fn copy_dir_preserves_directory_mode_bits() {
         let tmp = TempDir::new().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,6 +185,7 @@ pub mod commands;
 pub mod completion_spinner;
 pub mod coordinator;
 pub mod core;
+pub mod cow_copy;
 pub mod doctor;
 pub mod exec;
 pub mod executor;

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -17,9 +17,15 @@ ctrlc = "3.5.2"
 daft = { path = "..", version = "1.14.4" }
 indicatif = "0.18.4"
 rayon = "1.10"
+# Reflink + recursive walk for the sandbox's template snapshot / reset.
+# Inlined in xtask rather than imported from `daft::cow_copy` because the
+# YAML runner port rule in CLAUDE.md forbids `runner.rs / sandbox.rs /
+# executor.rs` from naming `daft::`. The duplication is intentional.
+reflink-copy = "0.1.29"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 term-styles = { workspace = true }
+walkdir = "2.5"
 
 [target.'cfg(unix)'.dependencies]
 # Used by `xtask test-matrix` to detect parent-process death and self-terminate.

--- a/xtask/src/manual_test/cow_copy.rs
+++ b/xtask/src/manual_test/cow_copy.rs
@@ -1,0 +1,157 @@
+//! Copy-on-write directory copy for the manual-test sandbox.
+//!
+//! Used by `sandbox.rs` to snapshot `remotes/` → `remotes-template/` and to
+//! restore from the template. On APFS this is clonefile; on reflink-capable
+//! Linux filesystems (btrfs, XFS with `reflink=1`, OpenZFS 2.2+, bcachefs)
+//! it's `ioctl(FICLONE)`. Other filesystems silently fall back to a byte
+//! copy.
+//!
+//! Intentionally duplicates the logic that lives in the daft library's
+//! `daft::cow_copy` module (introduced by #511 for #387's `copy_paths:`
+//! feature). The duplication is deliberate: the YAML runner port rule in
+//! the project's CLAUDE.md forbids `runner.rs / sandbox.rs / executor.rs`
+//! from importing `daft::*`, because the runner is intended to spin out as
+//! its own product. Sharing the helper would either pull `daft` into the
+//! spin-out's dep set or require widening that port — both larger
+//! commitments than the ~30 lines below.
+
+use anyhow::{Context, Result};
+use std::fs;
+use std::os::unix::fs::symlink;
+use std::path::Path;
+use walkdir::WalkDir;
+
+/// Recursively copy `src` → `dst`, using reflink where supported and a byte
+/// copy fallback otherwise. Mode bits are preserved per entry; symlinks are
+/// recreated without dereferencing.
+///
+/// `dst` must not already exist; its parent must. `src` must be a directory.
+pub fn copy_dir(src: &Path, dst: &Path) -> Result<()> {
+    let src_meta = fs::symlink_metadata(src)
+        .with_context(|| format!("reading metadata of {}", src.display()))?;
+    anyhow::ensure!(
+        src_meta.is_dir(),
+        "copy_dir source is not a directory: {}",
+        src.display()
+    );
+    fs::create_dir(dst).with_context(|| format!("creating {}", dst.display()))?;
+    fs::set_permissions(dst, src_meta.permissions())
+        .with_context(|| format!("setting mode of {}", dst.display()))?;
+
+    for entry in WalkDir::new(src).follow_links(false).min_depth(1) {
+        let entry = entry.with_context(|| format!("walking {}", src.display()))?;
+        let rel = entry
+            .path()
+            .strip_prefix(src)
+            .expect("walkdir paths are rooted at src");
+        let dst_path = dst.join(rel);
+        let ftype = entry.file_type();
+
+        if ftype.is_dir() {
+            fs::create_dir(&dst_path)
+                .with_context(|| format!("creating {}", dst_path.display()))?;
+            let meta = entry
+                .metadata()
+                .with_context(|| format!("reading metadata of {}", entry.path().display()))?;
+            fs::set_permissions(&dst_path, meta.permissions())
+                .with_context(|| format!("setting mode of {}", dst_path.display()))?;
+        } else if ftype.is_symlink() {
+            let target = fs::read_link(entry.path())
+                .with_context(|| format!("reading symlink {}", entry.path().display()))?;
+            symlink(target, &dst_path)
+                .with_context(|| format!("creating symlink {}", dst_path.display()))?;
+        } else if ftype.is_file() {
+            copy_file(entry.path(), &dst_path)?;
+        }
+        // Block / char / fifo / socket entries are skipped. Sandbox fixtures
+        // don't produce them.
+    }
+    Ok(())
+}
+
+/// Copy a single regular file, reflink-or-byte-copy. Preserves mode bits.
+fn copy_file(src: &Path, dst: &Path) -> Result<()> {
+    reflink_copy::reflink_or_copy(src, dst)
+        .with_context(|| format!("copying {} -> {}", src.display(), dst.display()))?;
+    // Linux `FICLONE` copies content only; macOS clonefile copies metadata;
+    // the byte-copy fallback copies mode. Normalize across all three.
+    let src_meta = fs::symlink_metadata(src)
+        .with_context(|| format!("reading metadata of {}", src.display()))?;
+    fs::set_permissions(dst, src_meta.permissions())
+        .with_context(|| format!("setting mode of {}", dst.display()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use std::os::unix::fs::PermissionsExt;
+    use tempfile::TempDir;
+
+    fn write_file(path: &Path, content: &[u8]) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        let mut f = fs::File::create(path).unwrap();
+        f.write_all(content).unwrap();
+    }
+
+    #[test]
+    fn replicates_tree_and_survives_source_mutation() {
+        let tmp = TempDir::new().unwrap();
+        let src = tmp.path().join("src");
+        let dst = tmp.path().join("dst");
+        write_file(&src.join("a.txt"), b"alpha");
+        write_file(&src.join("nested/b.txt"), b"beta");
+        fs::set_permissions(src.join("a.txt"), fs::Permissions::from_mode(0o755)).unwrap();
+
+        copy_dir(&src, &dst).unwrap();
+
+        assert_eq!(fs::read(dst.join("a.txt")).unwrap(), b"alpha");
+        assert_eq!(fs::read(dst.join("nested/b.txt")).unwrap(), b"beta");
+        assert_eq!(
+            fs::metadata(dst.join("a.txt"))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o755
+        );
+
+        write_file(&src.join("a.txt"), b"MUTATED");
+        assert_eq!(fs::read(dst.join("a.txt")).unwrap(), b"alpha");
+    }
+
+    #[test]
+    fn recreates_symlinks_without_dereferencing() {
+        let tmp = TempDir::new().unwrap();
+        let src = tmp.path().join("src");
+        let dst = tmp.path().join("dst");
+        fs::create_dir(&src).unwrap();
+        write_file(&src.join("target.txt"), b"linked");
+        symlink("target.txt", src.join("link.txt")).unwrap();
+
+        copy_dir(&src, &dst).unwrap();
+
+        assert!(fs::symlink_metadata(dst.join("link.txt"))
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert_eq!(
+            fs::read_link(dst.join("link.txt")).unwrap(),
+            Path::new("target.txt")
+        );
+    }
+
+    #[test]
+    fn errors_when_destination_exists() {
+        let tmp = TempDir::new().unwrap();
+        let src = tmp.path().join("src");
+        let dst = tmp.path().join("dst");
+        fs::create_dir(&src).unwrap();
+        fs::create_dir(&dst).unwrap();
+
+        assert!(copy_dir(&src, &dst).is_err());
+    }
+}

--- a/xtask/src/manual_test/cow_copy.rs
+++ b/xtask/src/manual_test/cow_copy.rs
@@ -154,4 +154,14 @@ mod tests {
 
         assert!(copy_dir(&src, &dst).is_err());
     }
+
+    #[test]
+    fn errors_when_source_is_a_file() {
+        let tmp = TempDir::new().unwrap();
+        let src = tmp.path().join("not-a-dir");
+        let dst = tmp.path().join("dst");
+        write_file(&src, b"hi");
+
+        assert!(copy_dir(&src, &dst).is_err());
+    }
 }

--- a/xtask/src/manual_test/mod.rs
+++ b/xtask/src/manual_test/mod.rs
@@ -1059,6 +1059,11 @@ fn run_one_scenario_inner(
     ctx: &RunContext<'_>,
     cleanup_set: &CleanupSet,
 ) -> Result<Option<(runner::ScenarioResult, Vec<u8>)>> {
+    // Per-phase wall-clock — emitted alongside the existing `elapsed_ms` step
+    // duration under `DAFT_MANUAL_TEST_EMIT_TIMING` for the bench harness.
+    // Lets a #509 perf investigation attribute per-scenario cost to setup vs
+    // fixture gen vs template snapshot vs the step phase itself.
+    let setup_started = std::time::Instant::now();
     // Pre-register the sandbox path so a SIGINT during create_at still leaves
     // a tracked path the cleanup handler can `rm -rf`. See [`setup_cleanup_handler`]
     // for the matching drain-loop logic.
@@ -1066,12 +1071,18 @@ fn run_one_scenario_inner(
     let _guard = CleanupGuard::new(Arc::clone(cleanup_set), base_dir.clone());
     let mut sb = sandbox::Sandbox::create_at(scenario, base_dir, ctx.keep)?;
     let executor = daft_executor::DaftCommandExecutor::new_for_sandbox(&mut sb, ctx.project_root)?;
+    let setup_ms = setup_started.elapsed().as_millis();
 
+    let fixture_started = std::time::Instant::now();
     for repo_spec in &scenario.repos {
         repo_gen::generate_repo(repo_spec, &sb.remotes_dir)?;
         sb.register_remote(&repo_spec.name);
     }
+    let fixture_ms = fixture_started.elapsed().as_millis();
+
+    let template_started = std::time::Instant::now();
     sb.create_template()?;
+    let template_ms = template_started.elapsed().as_millis();
 
     let mut buf: Vec<u8> = Vec::new();
     // `None` = the runner saw the interrupt flag before `scenario_started`
@@ -1094,14 +1105,20 @@ fn run_one_scenario_inner(
 
     // Opt-in per-scenario timing for the bench harness. Lines are
     // grep-friendly and live inside the scenario's buffered output so they
-    // print in input order alongside the scenario's own report. Reuses the
-    // duration the runner already tracks so we have a single source of truth.
+    // print in input order alongside the scenario's own report. `elapsed_ms`
+    // stays compatible with the percentiles script
+    // (`benches/scenarios/test_manual_scale.sh`); the per-phase fields
+    // (`setup_ms`, `fixture_ms`, `template_ms`) are additional diagnostics
+    // for #509 bottleneck attribution.
     if std::env::var_os("DAFT_MANUAL_TEST_EMIT_TIMING").is_some() {
         writeln!(
             &mut buf,
-            "[bench] scenario={:?} elapsed_ms={}",
+            "[bench] scenario={:?} elapsed_ms={} setup_ms={} fixture_ms={} template_ms={}",
             scenario.name,
-            result.duration.as_millis()
+            result.duration.as_millis(),
+            setup_ms,
+            fixture_ms,
+            template_ms,
         )?;
     }
 

--- a/xtask/src/manual_test/mod.rs
+++ b/xtask/src/manual_test/mod.rs
@@ -1,3 +1,4 @@
+pub mod cow_copy;
 pub mod daft_executor;
 pub mod executor;
 pub mod interactive;

--- a/xtask/src/manual_test/sandbox.rs
+++ b/xtask/src/manual_test/sandbox.rs
@@ -8,12 +8,12 @@
 //! the [`super::executor::CommandExecutor`] port.
 
 use anyhow::{Context, Result};
-use daft::cow_copy;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use super::cow_copy;
 use super::schema::Scenario;
 
 /// Within-process counter that guarantees [`alloc_default_base_dir`] produces
@@ -358,6 +358,67 @@ mod tests {
         let mut sb = Sandbox::new_with_vars(HashMap::new());
         sb.register_var("MY_VAR", "/some/path".into());
         assert_eq!(sb.expand_vars("$MY_VAR/foo"), "/some/path/foo");
+    }
+
+    /// End-to-end check for the create_template / reset lifecycle, with
+    /// the live `cow_copy` integration. Confirms reflinked snapshots are
+    /// independent of subsequent source mutation (CoW guarantee) and that
+    /// reset restores the template byte-for-byte after the live remotes are
+    /// scrambled.
+    #[test]
+    fn test_create_template_and_reset_lifecycle() {
+        let scenario = Scenario {
+            name: "lifecycle-test".to_string(),
+            description: None,
+            repos: Vec::new(),
+            env: HashMap::new(),
+            steps: Vec::new(),
+            source_path: std::path::PathBuf::new(),
+        };
+        let base_dir = alloc_default_base_dir().expect("alloc base dir");
+        let sb = Sandbox::create_at(&scenario, base_dir, false).expect("create sandbox");
+
+        // Populate remotes/ with a minimal directory shape mirroring what a
+        // generated bare-git fixture would have: nested dirs, regular files,
+        // and an executable.
+        std::fs::create_dir(sb.remotes_dir.join("hooks")).unwrap();
+        std::fs::write(sb.remotes_dir.join("HEAD"), b"ref: refs/heads/main\n").unwrap();
+        std::fs::write(sb.remotes_dir.join("hooks/post-receive"), b"#!/bin/sh\n").unwrap();
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(
+            sb.remotes_dir.join("hooks/post-receive"),
+            std::fs::Permissions::from_mode(0o755),
+        )
+        .unwrap();
+
+        sb.create_template().expect("create_template");
+        assert!(sb.template_dir.join("HEAD").exists());
+        assert_eq!(
+            std::fs::read(sb.template_dir.join("HEAD")).unwrap(),
+            b"ref: refs/heads/main\n"
+        );
+
+        // Scramble remotes/ and confirm the template is unaffected (CoW).
+        std::fs::write(sb.remotes_dir.join("HEAD"), b"SCRAMBLED\n").unwrap();
+        std::fs::remove_file(sb.remotes_dir.join("hooks/post-receive")).unwrap();
+        assert_eq!(
+            std::fs::read(sb.template_dir.join("HEAD")).unwrap(),
+            b"ref: refs/heads/main\n"
+        );
+
+        sb.reset().expect("reset");
+        assert_eq!(
+            std::fs::read(sb.remotes_dir.join("HEAD")).unwrap(),
+            b"ref: refs/heads/main\n"
+        );
+        let post_receive = sb.remotes_dir.join("hooks/post-receive");
+        assert!(post_receive.exists());
+        let mode = std::fs::metadata(&post_receive)
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o755);
     }
 
     /// Regression test for the millisecond-timestamp collision bug:

--- a/xtask/src/manual_test/sandbox.rs
+++ b/xtask/src/manual_test/sandbox.rs
@@ -8,8 +8,8 @@
 //! the [`super::executor::CommandExecutor`] port.
 
 use anyhow::{Context, Result};
+use daft::cow_copy;
 use std::collections::HashMap;
-use std::os::unix::process::CommandExt;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -222,23 +222,13 @@ impl Sandbox {
     }
 
     /// Snapshot `remotes/` → `remotes-template/` so that `reset()` can
-    /// restore the original state. Uses `cp -a` to preserve git objects.
+    /// restore the original state. Uses reflink (APFS clonefile on macOS,
+    /// `ioctl(FICLONE)` on reflink-capable Linux filesystems) where the
+    /// filesystem supports it, with a transparent byte-copy fallback
+    /// elsewhere.
     pub fn create_template(&self) -> Result<()> {
-        // `process_group(0)` insulates `cp` from terminal SIGINT — see the
-        // same explanation on `DaftCommandExecutor::execute`. Without it,
-        // Ctrl+C during a scenario's setup phase kills `cp` mid-copy and
-        // the scenario surfaces as an `error:` row instead of a clean
-        // cancellation.
-        let status = std::process::Command::new("cp")
-            .process_group(0)
-            .args(["-a"])
-            .arg(&self.remotes_dir)
-            .arg(&self.template_dir)
-            .status()
-            .context("failed to run cp -a for template creation")?;
-
-        anyhow::ensure!(status.success(), "cp -a failed with status {status}");
-        Ok(())
+        cow_copy::copy_dir(&self.remotes_dir, &self.template_dir)
+            .context("snapshotting remotes/ to remotes-template/")
     }
 
     /// Reset the sandbox to its initial state: clear `work/`, restore
@@ -260,15 +250,8 @@ impl Sandbox {
                 })?;
             }
 
-            let status = std::process::Command::new("cp")
-                .process_group(0)
-                .args(["-a"])
-                .arg(&self.template_dir)
-                .arg(&self.remotes_dir)
-                .status()
-                .context("failed to run cp -a for reset")?;
-
-            anyhow::ensure!(status.success(), "cp -a failed with status {status}");
+            cow_copy::copy_dir(&self.template_dir, &self.remotes_dir)
+                .context("restoring remotes/ from remotes-template/")?;
         }
 
         Ok(())


### PR DESCRIPTION
## Summary

- New `daft::cow_copy::{copy_file, copy_dir}` primitive — reflink-or-byte-copy via the `reflink-copy` crate. Same primitive #387's `copy_paths:` will consume in production daft code.
- xtask's manual-test sandbox uses an inlined sibling helper (`xtask::manual_test::cow_copy`) instead of `cp -a`, keeping `runner.rs / sandbox.rs / executor.rs` free of `daft::*` imports per the YAML runner port rule in CLAUDE.md.
- Per-phase timing instrumentation added under `DAFT_MANUAL_TEST_EMIT_TIMING` (`setup_ms`, `fixture_ms`, `template_ms` alongside `elapsed_ms`) so future #509 perf work can attribute wall-clock to the right phase.

Fixes #511.

## What changed

- `Cargo.toml` — adds `reflink-copy = "0.1.29"`. Crate published 2025-03-04, well past the 7-day cooldown. Public API is fully safe (`reflink`, `reflink_or_copy`, `check_reflink_support` — no `unsafe fn`), preserving daft's `forbid(unsafe_code)` posture. Same precedent as `rusqlite` over `heed`.
- `src/cow_copy.rs` (new) + `src/lib.rs` — `pub mod cow_copy;`. File-level + dir-level primitives with reflink-or-byte-copy fallback, mode-bit preservation, symlink recreation. 7 unit tests cover CoW independence, mode preservation, symlink handling, and error contract.
- `xtask/Cargo.toml` — adds `reflink-copy` and `walkdir` as xtask's own deps.
- `xtask/src/manual_test/cow_copy.rs` (new) — inlined sibling using the same primitives. The ~30 lines of duplication is intentional and documented in the module's docstring (CLAUDE.md's YAML runner port rule forbids runner-core from naming `daft::*` so the spin-out invariant holds).
- `xtask/src/manual_test/sandbox.rs` — `Sandbox::create_template` and `Sandbox::reset` switch from `Command::new(\"cp\").args([\"-a\"])` to `cow_copy::copy_dir`. The `.process_group(0)` SIGINT-insulation plumbing is gone (no subprocess to insulate). Adds an end-to-end test exercising the `create_template` → mutate → `reset` lifecycle.
- `xtask/src/manual_test/mod.rs` — `run_one_scenario_inner` now times each phase and emits `setup_ms` / `fixture_ms` / `template_ms` on the `[bench]` line alongside `elapsed_ms` when `DAFT_MANUAL_TEST_EMIT_TIMING=1`. The percentiles script in `benches/scenarios/test_manual_scale.sh` is backwards-compatible (it greps `elapsed_ms=` then takes `\$1`).

## Issue #387 amended

#387 (`copy_paths:` in `daft.yml`) is now wired to consume `daft::cow_copy::{copy_file, copy_dir}` directly — its body has been updated to reframe its scope as adding policy (`prefer | only | never`), `max_size` filtering, and the daft.yml surface on top of #511's primitives.

## Measurement

Full manual-test suite: **581/581 passing** on macOS APFS / M1 Max.

Wall-clock numbers (`mise run bench:tests:manual:scale BENCH_JOBS=10 BENCH_RUNS=3`):

| | This PR | Pre-PR (post-#510 baseline at jobs=10) |
| --- | ---:| ---:|
| Mean | 88.5s ± 6.9s | 82.2s (single trial) |
| Min | 84.4s | — |

**Net wall-clock effect at jobs=10 is within hyperfine's noise floor.** Per-phase instrumentation explains why: template snapshot is only 2.6s / 0.6% of the suite's serial CPU work, so clonefile-ing it shaves milliseconds that get lost in parallel scheduling noise.

### Per-phase breakdown (serial, with this PR's instrumentation, 579 fixture-using scenarios sampled at jobs=1)

| Phase | Cumulative | % | p50 | p95 | max |
| --- | ---:| ---:| ---:| ---:| ---:|
| Step (`elapsed`) | 286.7s | 70.3% | 476ms | 1037ms | 3170ms |
| Fixture gen | 118.8s | 29.1% | 241ms | 265ms | 959ms |
| Template snapshot | 2.6s | 0.6% | 5ms | 6ms | 23ms |
| Setup (`create_at`) | 0.0s | 0.0% | 1ms | — | 11ms |

The clonefile path is engaging and dropping template snapshot to a 5ms median. The dominant remaining costs are fixture generation (which #513 targets — its hot path becomes O(1) with the helper this PR introduces) and the step phase (subject of #560/#561).

## Follow-up issues opened

The bench data surfaced three actionable bottlenecks not previously mapped under #509. All three are filed, milestoned for Public Launch, and parked in the daft project's **Ready** column:

- **#559** — `perf(test-runner): interleave scenarios across workers to flatten the parallel tail`. Diagnosed during PR review: rayon's `par_iter` chunks the alphabetically-sorted scenario list contiguously, clustering same-namespace scenarios on the same worker.
- **#560** — `perf(test-runner): exec daft directly when no shell features are needed`. Floor measurement showed `bash -c \"daft …\"` adds ~17ms × 2,217 steps = ~38s serial overhead.
- **#561** — `perf(test-runner): amortize daft binary startup cost across steps`. Floor measurement: ~33ms × 2,217 = ~72s serial of pure daft startup tax.

The expected stacking — #511 + #512 + #513 + #559 + #560 + #561(a) — should land the suite at ~35-45s wall-clock at jobs=10, down from today's ~75-88s. #561(b) (long-lived daft daemon per sandbox) is gated on whether the cheaper wins suffice.

## Test plan

- [x] Unit tests for `daft::cow_copy::{copy_file, copy_dir}` — CoW independence, mode-bit preservation, symlink handling, error contract.
- [x] Unit tests for `xtask::manual_test::cow_copy::copy_dir` — same coverage on the inlined sibling.
- [x] `Sandbox::create_template` → mutate → `reset` lifecycle test in `sandbox.rs::tests` (the previously-uncovered `reset()` path).
- [x] CLAUDE.md runner-core rule: `rg 'daft::|DAFT_' xtask/src/manual_test/{runner,sandbox,executor}.rs` returns zero matches outside docstrings.
- [x] Full manual-test suite: 581/581 passing on macOS APFS.
- [x] Clippy zero-warnings, fmt clean (lefthook pre-commit enforced).
- [ ] CI / Linux validation — exercised via `cp --reflink=auto`-equivalent fall-through (Linux runners are typically on ext4 which doesn't reflink; the silent byte-copy fallback path is what gets exercised).

🤖 Generated with [Claude Code](https://claude.com/claude-code)