### PR TITLE
perf(test-runner): interleave scenarios across workers to flatten the parallel tail

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -199,7 +199,7 @@ jobs:
     if: >-
       !contains(github.event.pull_request.labels.*.name, 'release') &&
       (needs.changes.outputs.self == 'true' || needs.changes.outputs.rust ==
-      'true')
+      'true' || needs.changes.outputs.xtask == 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -225,7 +225,7 @@ jobs:
     if: >-
       !contains(github.event.pull_request.labels.*.name, 'release') &&
       (needs.changes.outputs.self == 'true' || needs.changes.outputs.rust ==
-      'true')
+      'true' || needs.changes.outputs.xtask == 'true')
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
@@ -337,7 +337,8 @@ jobs:
     if: >-
       !contains(github.event.pull_request.labels.*.name, 'release') &&
       (needs.changes.outputs.self == 'true' || needs.changes.outputs.rust ==
-      'true' || needs.changes.outputs.tests == 'true')
+      'true' || needs.changes.outputs.tests == 'true' ||
+      needs.changes.outputs.xtask == 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,9 +282,10 @@ Hard rules:
   evaluation are candidates for future ports. Extracting them speculatively is
   the trap; wait for a downstream PR with a concrete reason.
 - **Intentional exception:** `DAFT_MANUAL_TEST_BASE`,
-  `DAFT_MANUAL_TEST_EMIT_TIMING`, and `DAFT_MANUAL_TEST_JOBS` are the runner's
-  own config knobs and live in `mod.rs` / `main.rs`. Renaming the namespace is a
-  spin-out concern, not a coupling concern.
+  `DAFT_MANUAL_TEST_EMIT_TIMING`, `DAFT_MANUAL_TEST_JOBS`, and
+  `DAFT_MANUAL_TEST_DEBUG_DISPATCH` are the runner's own config knobs and live
+  in `mod.rs` / `main.rs`. Renaming the namespace is a spin-out concern, not a
+  coupling concern.
 
 **Design language**: `xtask/src/manual_test/reporter/CLAUDE.md` constrains the
 output's appearance (color budget, hierarchy, iconography, microcopy, rhythm).

--- a/xtask/src/manual_test/mod.rs
+++ b/xtask/src/manual_test/mod.rs
@@ -581,7 +581,20 @@ fn run_parallel(
     // can verify per-thread namespace mix without altering normal output.
     // Read once outside the closure — `std::env::var_os` synchronizes on a
     // global lock, no point paying for it per scenario.
-    let debug_dispatch = std::env::var_os("DAFT_MANUAL_TEST_DEBUG_DISPATCH").is_some();
+    //
+    // Suppress on TTY: `eprintln!` from worker threads races indicatif's
+    // live-region redraws and garbles the terminal. Pair the env var with
+    // `CI=1` or `NO_PROGRESS=1` (both already disable `show_progress`) to
+    // see the lines cleanly. If the user set the env on a TTY, warn once so
+    // they know why nothing is appearing.
+    let debug_dispatch_requested = std::env::var_os("DAFT_MANUAL_TEST_DEBUG_DISPATCH").is_some();
+    let debug_dispatch = debug_dispatch_requested && !show_progress;
+    if debug_dispatch_requested && show_progress {
+        eprintln!(
+            "[dispatch] DAFT_MANUAL_TEST_DEBUG_DISPATCH set but TTY progress is on; \
+             suppressing per-scenario output. Re-run with CI=1 or NO_PROGRESS=1 to see it.",
+        );
+    }
 
     let run_start = std::time::Instant::now();
     std::thread::scope(|s| -> Result<()> {

--- a/xtask/src/manual_test/mod.rs
+++ b/xtask/src/manual_test/mod.rs
@@ -11,7 +11,7 @@ pub mod schema;
 
 use anyhow::{Context, Result};
 use rayon::prelude::*;
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet, VecDeque};
 use std::io::{IsTerminal, Write};
 use std::panic::AssertUnwindSafe;
 use std::path::{Path, PathBuf};
@@ -1266,6 +1266,73 @@ fn find_scenario_recursive(dir: &Path, name: &str) -> Result<Option<PathBuf>> {
     Ok(None)
 }
 
+/// Extract the namespace portion of a scenario label (`"namespace:stem"` →
+/// `"namespace"`, bare `"stem"` → `""`). Top-level scenarios share the empty
+/// namespace, which keeps them in their own round-robin bucket below.
+fn namespace_of(label: &str) -> &str {
+    match label.split_once(':') {
+        Some((ns, _)) => ns,
+        None => "",
+    }
+}
+
+/// Compute an interleaved dispatch order over `labels`: returns indices into
+/// `labels` arranged so that consecutive items come from different namespaces.
+///
+/// Rayon's `par_iter` partitions its slice into contiguous per-worker chunks
+/// and only work-steals when a worker finishes its chunk. With scenarios sorted
+/// alphabetically by `"namespace:stem"`, that puts every `layout:*` scenario
+/// on the same worker — and if a heavy namespace lands contiguously on one
+/// worker, the tail of the suite is that worker grinding while every other
+/// worker is idle. Interleaving by namespace ensures each worker's initial
+/// chunk is a mix, so per-namespace cost variance distributes evenly.
+///
+/// Deterministic by construction: a `BTreeMap` iterates by sorted namespace
+/// key, and `VecDeque::pop_front` over input-ordered indices preserves
+/// within-namespace order. No RNG.
+fn interleave_by_namespace(labels: &[String]) -> Vec<usize> {
+    let mut by_namespace: BTreeMap<&str, VecDeque<usize>> = BTreeMap::new();
+    for (i, label) in labels.iter().enumerate() {
+        by_namespace
+            .entry(namespace_of(label))
+            .or_default()
+            .push_back(i);
+    }
+
+    let mut interleaved = Vec::with_capacity(labels.len());
+    let mut keys: Vec<&str> = by_namespace.keys().copied().collect();
+    while !keys.is_empty() {
+        keys.retain(|key| {
+            if let Some(idx) = by_namespace.get_mut(key).and_then(VecDeque::pop_front) {
+                interleaved.push(idx);
+                by_namespace.get(key).is_some_and(|q| !q.is_empty())
+            } else {
+                false
+            }
+        });
+    }
+    interleaved
+}
+
+/// Derive a `"namespace:stem"` label from a scenario `PathBuf` for the explicit
+/// `--scenarios <name>` path, mirroring how `discover_scenarios_recursive`
+/// labels scenarios under `scenarios_dir`. Used so the dispatch interleave can
+/// still group user-named scenarios by namespace.
+fn label_from_path(path: &Path, scenarios_dir: &Path) -> String {
+    let stem = path
+        .file_stem()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .into_owned();
+    match path.parent() {
+        Some(parent) if parent != scenarios_dir => parent
+            .file_name()
+            .map(|ns| format!("{}:{}", ns.to_string_lossy(), stem))
+            .unwrap_or(stem),
+        _ => stem,
+    }
+}
+
 /// Discover all `.yml` and `.yaml` files in the scenarios directory.
 fn discover_scenarios(dir: &PathBuf) -> Result<Vec<PathBuf>> {
     if !dir.exists() {
@@ -1500,6 +1567,105 @@ fn discover_scenarios_recursive(dir: &PathBuf) -> Result<Vec<(String, PathBuf)>>
     }
     scenarios.sort_by(|a, b| a.0.cmp(&b.0));
     Ok(scenarios)
+}
+
+#[cfg(test)]
+mod dispatch_order_tests {
+    use super::{interleave_by_namespace, label_from_path, namespace_of};
+    use std::path::Path;
+
+    fn labels(strs: &[&str]) -> Vec<String> {
+        strs.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    #[test]
+    fn namespace_splits_on_first_colon() {
+        assert_eq!(namespace_of("checkout:basic"), "checkout");
+        assert_eq!(namespace_of("a:b:c"), "a");
+        assert_eq!(namespace_of("bare"), "");
+        assert_eq!(namespace_of(""), "");
+    }
+
+    #[test]
+    fn interleave_round_robins_two_namespaces() {
+        let input = labels(&["a:1", "a:2", "a:3", "b:1"]);
+        // a, b alternate; b runs out first, then a:2, a:3 trail.
+        assert_eq!(interleave_by_namespace(&input), vec![0, 3, 1, 2]);
+    }
+
+    #[test]
+    fn interleave_round_robins_three_namespaces_uneven() {
+        let input = labels(&["a:1", "a:2", "b:1", "c:1", "c:2"]);
+        // Round 1: a:1, b:1, c:1. Round 2: a:2, c:2 (b exhausted).
+        assert_eq!(interleave_by_namespace(&input), vec![0, 2, 3, 1, 4]);
+    }
+
+    #[test]
+    fn interleave_single_namespace_is_identity() {
+        let input = labels(&["a:1", "a:2", "a:3"]);
+        assert_eq!(interleave_by_namespace(&input), vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn interleave_empty_input_is_empty() {
+        assert_eq!(interleave_by_namespace(&[]), Vec::<usize>::new());
+    }
+
+    #[test]
+    fn interleave_preserves_within_namespace_order() {
+        let input = labels(&["a:1", "b:1", "a:2", "b:2", "a:3"]);
+        let order = interleave_by_namespace(&input);
+        let a_positions: Vec<_> = order
+            .iter()
+            .enumerate()
+            .filter(|(_, &idx)| input[idx].starts_with("a:"))
+            .map(|(pos, _)| pos)
+            .collect();
+        let a_indices: Vec<usize> = a_positions.iter().map(|&p| order[p]).collect();
+        assert_eq!(a_indices, vec![0, 2, 4]);
+    }
+
+    #[test]
+    fn interleave_is_deterministic() {
+        let input = labels(&["b:2", "a:1", "c:1", "b:1", "a:2"]);
+        assert_eq!(
+            interleave_by_namespace(&input),
+            interleave_by_namespace(&input)
+        );
+    }
+
+    #[test]
+    fn interleave_groups_top_level_scenarios_together() {
+        // Bare labels share the "" namespace bucket — they round-robin against
+        // namespaced ones, not against each other internally.
+        let input = labels(&["bare1", "a:1", "bare2", "a:2"]);
+        // Round 1: "" -> bare1, "a" -> a:1. Round 2: "" -> bare2, "a" -> a:2.
+        assert_eq!(interleave_by_namespace(&input), vec![0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn label_from_path_uses_parent_dir_as_namespace() {
+        let scenarios_dir = Path::new("/repo/tests/manual/scenarios");
+        assert_eq!(
+            label_from_path(
+                Path::new("/repo/tests/manual/scenarios/checkout/basic.yml"),
+                scenarios_dir,
+            ),
+            "checkout:basic"
+        );
+    }
+
+    #[test]
+    fn label_from_path_top_level_returns_bare_stem() {
+        let scenarios_dir = Path::new("/repo/tests/manual/scenarios");
+        assert_eq!(
+            label_from_path(
+                Path::new("/repo/tests/manual/scenarios/quickcheck.yml"),
+                scenarios_dir,
+            ),
+            "quickcheck"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/xtask/src/manual_test/mod.rs
+++ b/xtask/src/manual_test/mod.rs
@@ -376,18 +376,32 @@ pub fn run(
         anyhow::bail!("--loop-count requires --step");
     }
 
-    let scenario_files = if scenarios.is_empty() {
+    // `scenarios_with_labels` carries `(label, path)` pairs in alphabetical
+    // order — the user-visible ordering preserved for the non-TTY summary.
+    // `dispatch_order` (computed below) is the *parallel-dispatch* permutation
+    // that breaks the alphabetical clustering for rayon's chunked partition.
+    let scenarios_with_labels: Vec<(String, PathBuf)> = if scenarios.is_empty() {
         discover_scenarios_recursive(&scenarios_dir)?
-            .into_iter()
-            .map(|(_, path)| path)
-            .collect()
     } else {
         resolve_scenario_paths(&scenarios, &scenarios_dir)?
+            .into_iter()
+            .map(|p| {
+                let label = label_from_path(&p, &scenarios_dir);
+                (label, p)
+            })
+            .collect()
     };
 
-    if scenario_files.is_empty() {
+    if scenarios_with_labels.is_empty() {
         anyhow::bail!("No scenario files found in {}", scenarios_dir.display());
     }
+
+    let labels: Vec<String> = scenarios_with_labels
+        .iter()
+        .map(|(l, _)| l.clone())
+        .collect();
+    let scenario_files: Vec<PathBuf> = scenarios_with_labels.into_iter().map(|(_, p)| p).collect();
+    let dispatch_order = interleave_by_namespace(&labels);
 
     // Explicit opt-in: the flag is the whole signal. TTY detection used to
     // route mode here, but after #554 the runner is automatic-first; users
@@ -485,6 +499,8 @@ pub fn run(
     );
     let result = run_parallel(
         &scenario_files,
+        &labels,
+        &dispatch_order,
         &scenarios_dir,
         &project_root,
         &fixtures_dir,
@@ -511,6 +527,8 @@ pub fn run(
 #[allow(clippy::too_many_arguments)]
 fn run_parallel(
     scenario_files: &[PathBuf],
+    labels: &[String],
+    dispatch_order: &[usize],
     scenarios_dir: &Path,
     project_root: &Path,
     fixtures_dir: &Path,
@@ -559,19 +577,40 @@ fn run_parallel(
     let (tx, rx) = std::sync::mpsc::channel::<ScenarioOutcome>();
     let mut all_outcomes: Vec<ScenarioOutcome> = Vec::with_capacity(scenario_files.len());
 
+    // Acceptance #1 from #559: dispatch debug print behind an env flag so we
+    // can verify per-thread namespace mix without altering normal output.
+    // Read once outside the closure — `std::env::var_os` synchronizes on a
+    // global lock, no point paying for it per scenario.
+    let debug_dispatch = std::env::var_os("DAFT_MANUAL_TEST_DEBUG_DISPATCH").is_some();
+
     let run_start = std::time::Instant::now();
     std::thread::scope(|s| -> Result<()> {
         let pool_ref = &pool;
         let ctx_ref = &ctx;
         let cleanup_ref = cleanup_set;
         let files_ref = scenario_files;
+        let labels_ref = labels;
+        let dispatch_ref = dispatch_order;
         s.spawn(move || {
             pool_ref.install(|| {
-                files_ref
+                // Iterate `dispatch_order` (an interleaved permutation of
+                // 0..N) rather than `scenario_files` directly. The carried
+                // `display_idx` is the *alphabetical* position — passed
+                // through as `ScenarioOutcome.index` so the post-run sort at
+                // line ~639 still produces alphabetical non-TTY output.
+                dispatch_ref
                     .par_iter()
-                    .enumerate()
-                    .for_each_with(tx, |tx, (idx, path)| {
-                        let outcome = run_one_scenario(idx, path, ctx_ref, cleanup_ref);
+                    .for_each_with(tx, |tx, &display_idx| {
+                        let path = &files_ref[display_idx];
+                        if debug_dispatch {
+                            eprintln!(
+                                "[dispatch] thread={:?} idx={} ns={}",
+                                rayon::current_thread_index(),
+                                display_idx,
+                                namespace_of(&labels_ref[display_idx]),
+                            );
+                        }
+                        let outcome = run_one_scenario(display_idx, path, ctx_ref, cleanup_ref);
                         let _ = tx.send(outcome);
                     });
             });

--- a/xtask/src/manual_test/mod.rs
+++ b/xtask/src/manual_test/mod.rs
@@ -1355,11 +1355,15 @@ fn interleave_by_namespace(labels: &[String]) -> Vec<usize> {
     let mut keys: Vec<&str> = by_namespace.keys().copied().collect();
     while !keys.is_empty() {
         keys.retain(|key| {
-            if let Some(idx) = by_namespace.get_mut(key).and_then(VecDeque::pop_front) {
-                interleaved.push(idx);
-                by_namespace.get(key).is_some_and(|q| !q.is_empty())
-            } else {
-                false
+            let Some(queue) = by_namespace.get_mut(key) else {
+                return false;
+            };
+            match queue.pop_front() {
+                Some(idx) => {
+                    interleaved.push(idx);
+                    !queue.is_empty()
+                }
+                None => false,
             }
         });
     }
@@ -1370,6 +1374,14 @@ fn interleave_by_namespace(labels: &[String]) -> Vec<usize> {
 /// `--scenarios <name>` path, mirroring how `discover_scenarios_recursive`
 /// labels scenarios under `scenarios_dir`. Used so the dispatch interleave can
 /// still group user-named scenarios by namespace.
+///
+/// Assumes the one-level layout `scenarios_dir/<namespace>/<stem>.yml` that
+/// `discover_scenarios_recursive` itself enforces. A path nested deeper, e.g.
+/// `scenarios_dir/checkout/subdir/scenario.yml`, is labeled with the
+/// *immediate* parent (`subdir:scenario`) rather than the top-level namespace
+/// (`checkout:...`) — those scenarios would then form their own interleave
+/// bucket. Acceptable because the discovery side never produces such layouts;
+/// only explicit user paths could.
 fn label_from_path(path: &Path, scenarios_dir: &Path) -> String {
     let stem = path
         .file_stem()
@@ -1687,9 +1699,9 @@ mod dispatch_order_tests {
     }
 
     #[test]
-    fn interleave_groups_top_level_scenarios_together() {
+    fn interleave_bare_scenarios_alternate_with_namespaced() {
         // Bare labels share the "" namespace bucket — they round-robin against
-        // namespaced ones, not against each other internally.
+        // namespaced ones one-per-round, not against each other internally.
         let input = labels(&["bare1", "a:1", "bare2", "a:2"]);
         // Round 1: "" -> bare1, "a" -> a:1. Round 2: "" -> bare2, "a" -> a:2.
         assert_eq!(interleave_by_namespace(&input), vec![0, 1, 2, 3]);


### PR DESCRIPTION
## Summary

- Round-robin interleave by namespace before dispatching to rayon's `par_iter`, breaking the alphabetical clustering that concentrated heavy namespaces (layout, hooks, merge) on single workers.
- Reporter output ordering preserved: `scenario_files` stays alphabetical; a new `dispatch_order: Vec<usize>` carries the interleaved permutation; `ScenarioOutcome.index` keeps its alphabetical-position semantics so the post-run sort still produces alphabetical non-TTY summary.
- `DAFT_MANUAL_TEST_DEBUG_DISPATCH=1` (pair with `CI=1` or `NO_PROGRESS=1`) prints `[dispatch] thread=… idx=… ns=…` per scenario for verifying the per-worker mix.

Closes #559. Part of #509 umbrella.

## Bench

Alternating hyperfine, 1 warmup + 4 runs each, M1 Max, `--jobs 10`:

| | mean [s] | σ [s] | min [s] | max [s] |
|---|---:|---:|---:|---:|
| master `16f6b9ff` | 73.328 | ±3.435 | 70.954 | 78.393 |
| this branch | **70.643** | **±0.310** | 70.257 | 70.926 |
| Δ | **-2.69 (-3.7%)** | **-91%** | | |

The headline is the **variance reduction** (σ 3.4s → 0.3s, 11x tighter) — the mechanism #559 predicted. Mean drops modestly (3.7%) but the operationally meaningful result is that master's *best* run (70.95s) is essentially tied with this branch's *worst* (70.93s) — the change pins the suite to its best-case rather than letting it wander up to ~78s on a bad trial.

Earlier non-alternating benches inflated the mean win because of thermal-order confounding on M1 Max — the second-run side ran hot. Alternating trials eliminates that.

The CI runners are different hardware (shared / burst CPUs) where worker imbalance hits harder, so the variance signal here may translate to either a bigger mean drop OR a tighter run-to-run distribution in the workflow numbers. Worth a glance once the checks land.

## Acceptance criteria (#559)

- [x] Per-worker scenario assignment interleaved across namespaces (verified via `DAFT_MANUAL_TEST_DEBUG_DISPATCH` — 40 dispatch lines spanned 16+ distinct namespaces across all 10 threads).
- [x] Wall-clock at `--jobs 10` improves over master baseline (alternating bench).
- [x] Determinism preserved (BTreeMap + VecDeque round-robin, no RNG; covered by `interleave_is_deterministic` unit test).
- [x] No regression in reporter ordering (empirically verified on a 581-scenario run; first ~50 lines remain alphabetical by `namespace:stem`).

## Test plan

- [x] `mise run fmt:check`, `mise run clippy`, `mise run test:unit` — clean.
- [x] `cargo test -p xtask manual_test::` — clean (131 passed, includes 10 new dispatch-order unit tests).
- [x] `mise run test:manual` — 581/581 scenarios pass.
- [x] Solo branch run timed at 69s (cold); alternating bench averages 70.6s under sustained load.
- [ ] CI workflow checks land green and (bonus) we get a second hardware data point on the variance behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)