### PR TITLE
fix(sync): refresh remote ahead/behind after Update task

### DIFF
--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -949,12 +949,7 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
 
 // ── DAG task execution functions ───────────────────────────────────────────
 
-/// Fields to refresh after a successful `Update` task. An Update is a pull /
-/// fast-forward, so it changes the branch's relationship to its base, its
-/// last commit, its working-tree state, and — critically — its position
-/// relative to upstream (`REMOTE_AHEAD_BEHIND`). Without re-collecting the
-/// remote ahead/behind here, the value written by the post-fetch refresh
-/// (e.g. `⇣3`) persists on screen even after the fast-forward has cleared it.
+/// Must include `REMOTE_AHEAD_BEHIND` — fast-forward clears it, otherwise the post-fetch value persists.
 fn update_post_task_fields() -> FieldSet {
     FieldSet::BASE_AHEAD_BEHIND
         | FieldSet::LAST_COMMIT
@@ -1948,10 +1943,7 @@ mod tests {
         ));
     }
 
-    // Regression for #567. A successful Update fast-forwards the branch
-    // toward upstream, so REMOTE_AHEAD_BEHIND must be re-collected by the
-    // post-task refresh — otherwise the PostFetch-written value (e.g. ⇣3)
-    // persists in the live table even after the fast-forward clears it.
+    // Regression: #567 — Update fast-forward must clear the PostFetch REMOTE_AHEAD_BEHIND value.
     #[test]
     fn update_post_task_fields_includes_remote_ahead_behind() {
         let fields = update_post_task_fields();

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -754,9 +754,7 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
                             spawn_post_task_refresh(
                                 branch_name,
                                 OperationPhase::Update,
-                                FieldSet::BASE_AHEAD_BEHIND
-                                    | FieldSet::LAST_COMMIT
-                                    | FieldSet::CHANGES,
+                                update_post_task_fields(),
                                 &shared_worktree_map,
                                 &orch_settings,
                                 &orch_base_branch,
@@ -950,6 +948,19 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
 }
 
 // ── DAG task execution functions ───────────────────────────────────────────
+
+/// Fields to refresh after a successful `Update` task. An Update is a pull /
+/// fast-forward, so it changes the branch's relationship to its base, its
+/// last commit, its working-tree state, and — critically — its position
+/// relative to upstream (`REMOTE_AHEAD_BEHIND`). Without re-collecting the
+/// remote ahead/behind here, the value written by the post-fetch refresh
+/// (e.g. `⇣3`) persists on screen even after the fast-forward has cleared it.
+fn update_post_task_fields() -> FieldSet {
+    FieldSet::BASE_AHEAD_BEHIND
+        | FieldSet::LAST_COMMIT
+        | FieldSet::CHANGES
+        | FieldSet::REMOTE_AHEAD_BEHIND
+}
 
 /// Spawn a streaming-collector run that re-emits the given `fields` for
 /// `branch_name` as `PatchSource::PostTask(phase)` patches. Blocks until the
@@ -1935,5 +1946,18 @@ mod tests {
             None,
             &[IncludeFilter::Branch("feat/x".into())],
         ));
+    }
+
+    // Regression for #567. A successful Update fast-forwards the branch
+    // toward upstream, so REMOTE_AHEAD_BEHIND must be re-collected by the
+    // post-task refresh — otherwise the PostFetch-written value (e.g. ⇣3)
+    // persists in the live table even after the fast-forward clears it.
+    #[test]
+    fn update_post_task_fields_includes_remote_ahead_behind() {
+        let fields = update_post_task_fields();
+        assert!(fields.contains(FieldSet::REMOTE_AHEAD_BEHIND));
+        assert!(fields.contains(FieldSet::BASE_AHEAD_BEHIND));
+        assert!(fields.contains(FieldSet::LAST_COMMIT));
+        assert!(fields.contains(FieldSet::CHANGES));
     }
 }


### PR DESCRIPTION
## Summary

- `daft sync` was leaving the `Remote` column with the pre-fetch indicator (e.g. `⇣3`) on a row whose worktree had just been fast-forwarded — the post-task refresh for `OperationPhase::Update` requested only `BASE_AHEAD_BEHIND | LAST_COMMIT | CHANGES` and missed `REMOTE_AHEAD_BEHIND`.
- Pull / fast-forward moves the branch tip relative to upstream just like the sibling `Rebase` and `Push` tasks (both already include `REMOTE_AHEAD_BEHIND` in their refresh sets). With the field omitted, the value written by `spawn_post_fetch_refresh` persists in the live table after the fast-forward has cleared it.
- Extracted the field set into a small `update_post_task_fields()` helper so the bitmask is unit-testable directly. Added a regression test that fails without the fix.

## Test plan

- [x] `mise run fmt:check`
- [x] `mise run clippy` — zero warnings
- [x] `mise run test:unit` — 1831 passed
- [x] New regression test fails on the pre-fix bitmask (manually verified by temporarily dropping `| FieldSet::REMOTE_AHEAD_BEHIND` and re-running the test), passes with the fix.

Fixes #567