### PR TITLE
fix(deps): bump shlex constraint to 2 and prevent grouped major-bump drift

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,11 +17,25 @@ updates:
       timezone: "Asia/Jerusalem"
     cooldown:
       default-days: 7
-    # Group all Cargo updates into a single PR when possible
+    # Group Cargo minor/patch updates into a single PR. Major bumps are
+    # excluded so each one opens an individual PR — Dependabot's cargo
+    # handler has a known interaction where grouped major bumps update
+    # Cargo.lock but not Cargo.toml, leaving the workspace with a
+    # constraint (e.g. `shlex = "1.3"`) that doesn't permit the locked
+    # version (`shlex 2.0.1`). The next `cargo` invocation silently
+    # rewrites Cargo.lock back, which trips the `git_dirty` pre-flight in
+    # `cargo release` and breaks `release-flow.yml` on master. Individual
+    # major-bump PRs go through the non-grouped codepath, which updates
+    # the manifest. The `cargo check --locked` guards in
+    # `.github/workflows/test.yml` (msrv-check, windows-check) are the
+    # backstop if this ever regresses.
     groups:
       cargo-dependencies:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
     # Automatically add labels to PRs
     labels:
       - "dependencies"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -212,8 +212,13 @@ jobs:
         with:
           key: msrv-1.93
 
+      # `--locked` refuses to rewrite Cargo.lock, so a manifest/lockfile
+      # mismatch (e.g. a Dependabot grouped-update PR that bumps Cargo.lock
+      # past the Cargo.toml constraint) fails here instead of being silently
+      # auto-fixed at build time and tripping the release-flow `git_dirty`
+      # check on master.
       - name: Cargo check at MSRV
-        run: cargo check --all-targets
+        run: cargo check --all-targets --locked
 
   # Windows compile check — ensures the codebase still builds for the
   # x86_64-pc-windows-msvc target that the release workflow ships. This
@@ -237,7 +242,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Cargo check (Windows)
-        run: cargo check --all-targets
+        run: cargo check --all-targets --locked
 
   # Test xtask man page generation
   xtask-test:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,7 @@ csv = "1.3"
 tera = { version = "1.20", default-features = false }
 thiserror = "2.0"
 toon-format = "0.3"
-shlex = "1.3"
+shlex = "2"
 uuid = { version = "1", features = ["v7"] }
 fs2 = "0.4"
 walkdir = "2.5"

--- a/mise-tasks/clippy
+++ b/mise-tasks/clippy
@@ -2,4 +2,4 @@
 #MISE description="Run Rust clippy linter (zero warnings)"
 set -euo pipefail
 
-cargo clippy --tests -- -D warnings
+cargo clippy --tests --locked -- -D warnings

--- a/mise-tasks/test/unit
+++ b/mise-tasks/test/unit
@@ -9,4 +9,4 @@ echo "Running Rust unit tests..."
 # git::oxide, store::{migrate,pool}, and hooks::yaml_executor cases — and
 # flaking the pre-push hook. --test-threads=4 keeps wall-clock close to the
 # uncapped run (~+2s on ~1800 tests) and eliminates the flake.
-cargo test --lib --tests -- --test-threads=4
+cargo test --lib --tests --locked -- --test-threads=4


### PR DESCRIPTION
## Summary

Fixes the recurring `release-flow.yml` failures on master (most recently after PRs #564 and #566) caused by a `Cargo.toml` / `Cargo.lock` drift introduced by Dependabot's grouped cargo updater.

### Root cause

Dependabot PRs #553 and #566 bumped the direct `shlex` entry in `Cargo.lock` from `1.3.0` to `2.0.1` but **did not** update the `shlex = \"1.3\"` constraint in `Cargo.toml`. `^1.3` excludes 2.x, so every subsequent `cargo` invocation auto-rewrites `Cargo.lock` back to `1.3.0`. The release-flow job runs `cargo release …` on a fresh `git checkout -B release-pr master`, `cargo release`'s startup `cargo metadata` call triggers that rewrite, and the `git_dirty` pre-flight aborts with:

```
error: uncommitted changes detected, please resolve before release:
         Cargo.lock (Status(WT_MODIFIED))
```

Regular `cargo build` / `cargo check` don't trip this — they silently rewrite the lockfile and move on — which is why the bad Dependabot PRs merged green.

### Fix

Three changes:

1. **`Cargo.toml`**: bump `shlex = \"1.3\"` → `shlex = \"2\"`. Manifest and lockfile now agree on `2.0.1`. shlex 2.0's only breaking changes (removal of the deprecated `join`/`quote` functions and the unsound `DerefMut` impl) don't touch our two `try_quote` call sites in `src/core/worktree/exec/mod.rs`.

2. **`.github/workflows/test.yml`**: add `--locked` to the `cargo check` in `msrv-check` and `windows-check`. Without it, cargo silently fixes a manifest/lockfile mismatch and CI passes. With it, any future PR that introduces drift fails at PR time instead of breaking release-flow on master — this is also the regression test for this fix.

3. **`.github/dependabot.yml`**: restrict the `cargo-dependencies` group to `minor` / `patch` updates. Major bumps now open individual PRs, which go through Dependabot's non-grouped cargo codepath that does update the manifest. The CI guard above is the backstop if this ever regresses.

### Why not just touch Dependabot config?

Cargo's `versioning-strategy` only supports `auto` and `lockfile-only`, and `auto` is already the effective default — there's no setting that flips the grouped major-bump behavior. The `update-types` filter on the group is the only knob that routes major bumps through the working codepath. The `--locked` CI guard is the real safety net.

## Test plan

- [x] `cargo check --workspace --locked --all-targets` passes locally (manifest + lockfile consistent)
- [x] `mise run clippy` passes
- [x] `mise run test:unit` — 1830+ tests pass
- [x] `mise run fmt:check` clean
- [ ] CI checks green (msrv-check + windows-check with `--locked` exercise the new guard)
- [ ] Next push to master successfully runs release-flow.yml without `WT_MODIFIED` abort

## Notes

- Branch name doesn't follow `daft-<issue>/<short-name>` convention — there is no issue for this; happy to rename or open one if preferred.