### PR TITLE
refactor(test-runner): gate startup background work on DAFT_TESTING

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,12 +172,49 @@ pub fn get_clap_args(expected_cmd: &str) -> Vec<String> {
 /// tab completion responsive.
 ///
 /// New commands with similar constraints should be added here rather than
-/// introducing a parallel gate at the call sites.
+/// introducing a parallel gate at the call sites. Callers that need the
+/// composed test-mode/coordinator gates as well should use
+/// [`should_skip_background_tasks`] instead.
 pub fn skip_startup_tasks_for(args: &[String]) -> bool {
     let Some(sub) = args.get(1).map(String::as_str) else {
         return false;
     };
     sub.starts_with("__") || matches!(sub, "shell-init" | "completions")
+}
+
+/// Whether daft's startup-time background work should be skipped for this
+/// invocation. Composes three independent gates, each of which is sufficient
+/// on its own:
+///
+/// 1. [`skip_startup_tasks_for`] — argv-driven gate for invocations whose
+///    codepaths must stay lean (shell-init, completions, `__*` background
+///    tasks). See its doc comment for the security/perf rationale.
+/// 2. `DAFT_IS_COORDINATOR` — set by the hook coordinator process when it
+///    spawns daft children, so daemons don't spawn further daemons.
+/// 3. `DAFT_TESTING` — set by the YAML manual-test runner on every step.
+///    Suppresses update-check/trust-prune/log-clean spawns that would
+///    otherwise reparent under PID 1 and pile up as orphans across the
+///    suite's ~2000 invocations.
+///
+/// Each gate has its own surface: argv shape, coordinator env var, runner env
+/// var. Composing them here means main.rs makes the dispatch decision once,
+/// instead of every `maybe_*` background-spawn helper re-deriving the same
+/// "should I run?" condition from per-feature env vars (`DAFT_NO_UPDATE_CHECK`
+/// etc.). Those per-feature flags remain as user-facing opt-outs.
+pub fn should_skip_background_tasks(args: &[String]) -> bool {
+    should_skip_background_tasks_impl(
+        skip_startup_tasks_for(args),
+        std::env::var("DAFT_IS_COORDINATOR").is_ok(),
+        std::env::var("DAFT_TESTING").is_ok(),
+    )
+}
+
+fn should_skip_background_tasks_impl(
+    skip_startup_tasks: bool,
+    is_coordinator: bool,
+    is_test_mode: bool,
+) -> bool {
+    skip_startup_tasks || is_coordinator || is_test_mode
 }
 
 pub mod cli;
@@ -486,5 +523,35 @@ mod tests {
             "daft",
             "shell-init-something"
         ])));
+    }
+
+    #[test]
+    fn test_should_skip_background_all_false_is_false() {
+        assert!(!should_skip_background_tasks_impl(false, false, false));
+    }
+
+    #[test]
+    fn test_should_skip_background_argv_gate_is_sufficient() {
+        // skip_startup_tasks_for already returned true (e.g. `shell-init`).
+        assert!(should_skip_background_tasks_impl(true, false, false));
+    }
+
+    #[test]
+    fn test_should_skip_background_coordinator_is_sufficient() {
+        // DAFT_IS_COORDINATOR alone is sufficient — coordinator children must
+        // not recursively spawn more background work.
+        assert!(should_skip_background_tasks_impl(false, true, false));
+    }
+
+    #[test]
+    fn test_should_skip_background_test_mode_is_sufficient() {
+        // DAFT_TESTING alone is sufficient — the YAML test runner sets this on
+        // every step to suppress orphaned background spawns.
+        assert!(should_skip_background_tasks_impl(false, false, true));
+    }
+
+    #[test]
+    fn test_should_skip_background_all_true_is_true() {
+        assert!(should_skip_background_tasks_impl(true, true, true));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,10 +12,11 @@ use std::path::Path;
 
 fn main() -> Result<()> {
     // Parse and apply top-level flags (currently just `-C <path>`) before any
-    // other work. This MUST happen before `skip_startup_tasks_for` below — that
-    // gate inspects argv[1] to detect `shell-init`/`__*` invocations that must
-    // skip background spawns, and if `-C` is still in argv at that point the
-    // gate fails open (see the fork-bomb warning further down).
+    // other work. This MUST happen before `should_skip_background_tasks` below
+    // — its argv-side gate (`skip_startup_tasks_for`) inspects argv[1] to detect
+    // `shell-init`/`__*` invocations that must skip background spawns, and if
+    // `-C` is still in argv at that point the gate fails open (see the
+    // fork-bomb warning further down).
     let raw_argv: Vec<String> = std::env::args().collect();
     daft::cli::install_and_apply(raw_argv)?;
     let argv = daft::cli::argv();

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,15 +39,9 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
-    // Skip startup-time background work for invocations that must stay lean:
-    // - `__*` background tasks (__check-update, __prune-trust, etc.) — spawning
-    //   further background processes from them would recursively fan out into a
-    //   fork bomb.
-    // - `shell-init` — sourced from the user's shell rc files on every
-    //   interactive shell startup; any subprocess call, file IO, network
-    //   request, or background spawn here adds latency to every new shell, and
-    //   stderr output (e.g., the update banner) leaks past `eval`'s stdout
-    //   capture into the user's terminal.
+    // Skip startup-time background work for invocations that must stay lean.
+    // Three independent gates compose here; see
+    // `daft::should_skip_background_tasks` for the per-gate rationale.
     //
     // If a fork bomb occurs (hundreds of daft processes consuming all CPU):
     //   pkill -9 -f "daft.*__check-update"
@@ -55,12 +49,7 @@ fn main() -> Result<()> {
     // Or more broadly:
     //   pkill -9 -f "<worktree-path>/target/release"
     // Repeat until `ps aux | grep __check-update | wc -l` returns 0.
-    let skip_startup_tasks = daft::skip_startup_tasks_for(argv);
-
-    // Also skip background spawning if we're inside a coordinator process
-    let is_coordinator = std::env::var("DAFT_IS_COORDINATOR").is_ok();
-
-    let skip_background = skip_startup_tasks || is_coordinator;
+    let skip_background = daft::should_skip_background_tasks(argv);
 
     // Warn if config directory is overridden (security measure against trust DB hijacking).
     // Only in dev builds — release builds ignore DAFT_CONFIG_DIR entirely.

--- a/xtask/src/manual_test/daft_executor.rs
+++ b/xtask/src/manual_test/daft_executor.rs
@@ -94,15 +94,19 @@ impl DaftCommandExecutor {
             sandbox.git_config_path.to_string_lossy().into_owned(),
         );
 
-        // Daft feature flags. Disable every daemon-style background spawn:
-        // the test harness invokes `daft` many times back-to-back, and any
-        // detached child that survives its parent (e.g. `daft __clean-logs`)
-        // accumulates as init-reparented orphans and steals CPU — visible as
-        // load-average climbing into the hundreds during parallel runs.
+        // Disable every daemon-style background spawn: the test harness
+        // invokes `daft` many times back-to-back, and any detached child that
+        // survives its parent (e.g. `daft __clean-logs`) accumulates as
+        // init-reparented orphans and steals CPU — visible as load-average
+        // climbing into the hundreds during parallel runs.
+        //
+        // `DAFT_TESTING` alone is sufficient: it flips daft's central
+        // `should_skip_background_tasks` gate in main.rs, which suppresses
+        // every `maybe_*` spawn helper before it runs. The per-feature env
+        // vars (`DAFT_NO_UPDATE_CHECK` / `DAFT_NO_TRUST_PRUNE` /
+        // `DAFT_NO_LOG_CLEAN`) remain as user-facing opt-outs but are
+        // redundant for the test runner.
         env.insert("DAFT_TESTING".into(), "1".into());
-        env.insert("DAFT_NO_UPDATE_CHECK".into(), "1".into());
-        env.insert("DAFT_NO_TRUST_PRUNE".into(), "1".into());
-        env.insert("DAFT_NO_LOG_CLEAN".into(), "1".into());
         env.insert(
             "DAFT_CONFIG_DIR".into(),
             self.daft_config_dir.to_string_lossy().into_owned(),

--- a/xtask/src/manual_test/daft_executor.rs
+++ b/xtask/src/manual_test/daft_executor.rs
@@ -5,10 +5,12 @@
 //!     system install).
 //!   - `DAFT_CONFIG_DIR` and `DAFT_DATA_DIR` are per-sandbox so suites running
 //!     in parallel never read each other's trust / repo state.
-//!   - The daemon-suppression flags (`DAFT_TESTING`, `DAFT_NO_UPDATE_CHECK`,
-//!     `DAFT_NO_TRUST_PRUNE`, `DAFT_NO_LOG_CLEAN`) prevent orphaned background
-//!     processes from accumulating across a parallel suite — load average
-//!     used to climb into the hundreds without them.
+//!   - `DAFT_TESTING=1` prevents orphaned background processes from
+//!     accumulating across a parallel suite — load average used to climb
+//!     into the hundreds without it. The flag flips daft's central
+//!     `should_skip_background_tasks` gate in `src/main.rs`, which is the
+//!     single source of truth for update-check / trust-prune / log-clean
+//!     suppression under tests.
 //!
 //! Keeping all of this in the adapter is what lets the runner core compile
 //! and run against a non-daft executor (see [`super::runner`]'s `FakeExecutor`
@@ -347,8 +349,18 @@ mod tests {
         let env = exec.build_env(&sandbox);
 
         assert_eq!(env.get("GIT_AUTHOR_NAME").unwrap(), "Manual Test");
+        // `DAFT_TESTING=1` is the single daemon-suppression contract — it
+        // trips daft's central `should_skip_background_tasks` gate, which
+        // makes the per-feature `DAFT_NO_UPDATE_CHECK` / `DAFT_NO_TRUST_PRUNE`
+        // / `DAFT_NO_LOG_CLEAN` flags redundant for the test runner.
         assert_eq!(env.get("DAFT_TESTING").unwrap(), "1");
-        assert_eq!(env.get("DAFT_NO_UPDATE_CHECK").unwrap(), "1");
+        assert!(
+            !env.contains_key("DAFT_NO_UPDATE_CHECK"),
+            "the runner intentionally stops setting per-feature suppression flags; \
+             DAFT_TESTING=1 alone gates all three maybe_* startup helpers"
+        );
+        assert!(!env.contains_key("DAFT_NO_TRUST_PRUNE"));
+        assert!(!env.contains_key("DAFT_NO_LOG_CLEAN"));
         assert!(env.get("PATH").unwrap().contains("target/release"));
         assert!(env.get("DAFT_CONFIG_DIR").unwrap().contains("daft-config"));
         assert!(env.get("DAFT_DATA_DIR").unwrap().contains("daft-data"));

--- a/xtask/src/manual_test/daft_executor.rs
+++ b/xtask/src/manual_test/daft_executor.rs
@@ -354,13 +354,25 @@ mod tests {
         // makes the per-feature `DAFT_NO_UPDATE_CHECK` / `DAFT_NO_TRUST_PRUNE`
         // / `DAFT_NO_LOG_CLEAN` flags redundant for the test runner.
         assert_eq!(env.get("DAFT_TESTING").unwrap(), "1");
+        // The runner intentionally stops setting per-feature suppression
+        // flags; DAFT_TESTING=1 alone gates all three maybe_* startup helpers
+        // via daft::should_skip_background_tasks. Symmetric messages so any
+        // future regression points straight at the contract.
+        const SINGLE_FLAG_CONTRACT: &str =
+            "DAFT_TESTING=1 is the single daemon-suppression contract; per-feature \
+             DAFT_NO_* flags must not be reintroduced by the runner adapter";
         assert!(
             !env.contains_key("DAFT_NO_UPDATE_CHECK"),
-            "the runner intentionally stops setting per-feature suppression flags; \
-             DAFT_TESTING=1 alone gates all three maybe_* startup helpers"
+            "{SINGLE_FLAG_CONTRACT}"
         );
-        assert!(!env.contains_key("DAFT_NO_TRUST_PRUNE"));
-        assert!(!env.contains_key("DAFT_NO_LOG_CLEAN"));
+        assert!(
+            !env.contains_key("DAFT_NO_TRUST_PRUNE"),
+            "{SINGLE_FLAG_CONTRACT}"
+        );
+        assert!(
+            !env.contains_key("DAFT_NO_LOG_CLEAN"),
+            "{SINGLE_FLAG_CONTRACT}"
+        );
         assert!(env.get("PATH").unwrap().contains("target/release"));
         assert!(env.get("DAFT_CONFIG_DIR").unwrap().contains("daft-config"));
         assert!(env.get("DAFT_DATA_DIR").unwrap().contains("daft-data"));


### PR DESCRIPTION
## Summary

Consolidates the YAML test runner's daft-suppression contract from four env
vars to one. `DAFT_TESTING=1` now flips daft's central `should_skip_background_tasks`
gate in `src/main.rs`, alongside `skip_startup_tasks_for` (argv-driven) and
`DAFT_IS_COORDINATOR` (env-driven). The three `maybe_*` background-spawn
helpers short-circuit at one decision point in main.rs instead of each
re-deriving its own gate from a per-feature `DAFT_NO_*` env var. The
per-feature flags remain as user-facing opt-outs.

The runner adapter (`xtask/src/manual_test/daft_executor.rs::build_env`) drops
the now-redundant `DAFT_NO_UPDATE_CHECK` / `DAFT_NO_TRUST_PRUNE` /
`DAFT_NO_LOG_CLEAN` insertions; `DAFT_TESTING=1` alone now achieves the same
suppression.

Refs #561, closes #561 (see the "Scope / why not a perf PR" section below).

## Scope / why not a perf PR

#561 originally projected option (a) of the three approaches in its issue body
as a ~5–10ms/invocation win (~15–25s/suite at jobs=1). Measurement says
otherwise once #570 is taken into account.

PR #570 ("exec daft directly when no shell features are needed") wired all
four daft-suppression env vars (`DAFT_TESTING`, plus the three `DAFT_NO_*`)
into the executor's per-step env. With those four already set, the three
`maybe_*` helpers short-circuit on a single `env::var` lookup each — the
"theoretical (a)" gain is already mostly realised.

Hyperfine on the patched release binary (M1 Max, warmed, 100 runs/group,
arranged here for direct comparison):

| Config                                                                | Mean    |
| --------------------------------------------------------------------- | ------- |
| no flags                                                              | 21.3 ms |
| `DAFT_NO_UPDATE_CHECK=1` only                                         | 15.9 ms |
| Master + all 4 runner flags                                           |  6.6 ms |
| **Patched + `DAFT_TESTING=1` only** (this PR's runner contract)       |  **6.7 ms** |
| `DAFT_IS_COORDINATOR=1`                                               |  8.7 ms |
| `daft shell-init bash` (built-in argv gate)                           |  7.4 ms |

The one-flag patched contract (6.7 ms) is statistically tied with the
four-flag master contract (6.6 ms) — the gate consolidation is correct and
the redundant flags really were redundant. Closeable gap to the
`shell-init`-style minimum is ~1.5 ms/invocation.

Suite extrapolation, 2,217 step invocations:

- jobs=1: ~3.3 s saved on a ~64-minute baseline → well inside #509's noise
  floor.
- jobs=10: ~0.33 s saved → invisible.

This is therefore filed as **`refactor`, not `perf`** — a cleanup that
retires #561 with measurement evidence rather than a wall-clock improvement.

## Why options (b) and (c) are out of scope

Both would address the structural per-step startup floor (~7 ms), not just
the gate-check residue. Both require daft commands to become re-entrant —
no global cwd or env mutation, no process-exclusive SQLite pool ownership,
no direct `std::env::args()` / `current_dir()` reads — so a long-lived daft
process can serve many commands without losing isolation guarantees.

That's a daft-wide architectural change that conflicts with the multicall-
binary model documented in ARCHITECTURE.md, not a YAML-runner perf change.
It belongs in its own issue under a different umbrella (likely a daft
architecture umbrella, not #509). The PR does **not** ship (b)/(c) and does
not attempt the refactor; if the ~7 ms floor is worth attacking, that's a
follow-up decision.

## Decisions made along the way

- **Single gate-evaluation point.** Pulled the three-OR composition out of
  `src/main.rs` into a `daft::should_skip_background_tasks(argv)` helper so
  the truth table is unit-testable with a pure inner function, and so
  future test-mode bookkeeping has one obvious place to plug in.
- **Kept the per-feature `DAFT_NO_*` env vars.** They're user-facing opt-outs
  documented externally and shouldn't change semantics for users running
  daft outside the test runner. The runner just no longer needs to set them.
- **Did not extend the gate to suppress other startup work.** `cli::install_and_apply`
  / `cli::argv` / `shortcuts::resolve` / clap-dispatch are all ~free per
  measurement; there's no further `maybe_*` style work hiding in main.rs.

## Test plan

- [x] `mise run fmt` clean
- [x] `mise run clippy` zero warnings
- [x] `mise run test:unit` (1836 passed, 3 ignored — the new `should_skip_background_tasks_impl` truth-table tests added)
- [x] `mise run test:manual` full YAML suite passes
- [x] Hyperfine reproduced from clean shell with the patched binary
- [ ] CI green

## #509 PR-description checklist

- **Wall-clock vs baseline:** ~3.3 s saved at jobs=1 on a multi-thousand-second baseline. Within noise. Captured via per-invocation hyperfine above (more reliable than suite-level wall-clock at this delta).
- **Per-phase `elapsed_ms` table:** No curve-shape change expected — the existing flags already short-circuited; only constant overhead drops. Per-phase breakdown skipped since the per-invocation table directly measures what changed.
- **Honest assessment of what moved:** Explicitly framed as cleanup, not perf. The expected (a) gain was mostly absorbed by #570's env-var wiring; what this PR removes is the redundancy, not the cost.
- **Fresh baseline:** Not needed — no curve-shape change.
- **Umbrella checklist:** ☑.

## Notes

- The dev-build `DAFT_CONFIG_DIR` warning at `src/main.rs:67-74` continues to
  be suppressed under `DAFT_TESTING=1` because `skip_background` is now the
  composed value — preserved behaviour, more concisely expressed.
- Existing scenarios that explicitly set `DAFT_NO_LOG_CLEAN=1` in their YAML
  (the seven hooks scenarios that test log-cleanup) continue to work
  unchanged; daft still respects all three `DAFT_NO_*` flags.