### PR TITLE
perf(test-runner): share fixture remotes across scenarios

### DIFF
--- a/xtask/src/manual_test/fixture_cache.rs
+++ b/xtask/src/manual_test/fixture_cache.rs
@@ -285,6 +285,34 @@ steps:
     }
 
     #[test]
+    fn clone_into_returns_err_on_cache_miss() {
+        // The cache-miss path is a "programming error" trip-wire — if a
+        // worker ever encounters a fixture-derived RepoSpec whose key wasn't
+        // indexed by collect_fixture_keys, the runner must surface it
+        // explicitly rather than silently regenerating. Construct an empty
+        // cache directly and confirm the lookup fails with the documented
+        // error message.
+        let cache = FixtureCache {
+            paths: HashMap::new(),
+        };
+        let dst_parent = tempfile::tempdir().unwrap();
+        let result = cache.clone_into(
+            &("nonexistent-fixture".into(), "ghost-repo".into()),
+            &dst_parent.path().join("ghost-repo"),
+        );
+        let err = result.expect_err("cache miss must error");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("programming error"),
+            "error chain should surface the programming-error label: {msg}",
+        );
+        assert!(
+            msg.contains("nonexistent-fixture") && msg.contains("ghost-repo"),
+            "error should name the missing key: {msg}",
+        );
+    }
+
+    #[test]
     fn clone_into_produces_equivalent_history() {
         let cache_root = tempfile::tempdir().unwrap();
         let mut keys = BTreeSet::new();

--- a/xtask/src/manual_test/fixture_cache.rs
+++ b/xtask/src/manual_test/fixture_cache.rs
@@ -1,0 +1,352 @@
+//! Run-wide cache of pre-generated fixture remotes.
+//!
+//! Without the cache, `repo_gen::generate_repo` runs once per scenario per
+//! `use_fixture:` reference. The full suite references ~400 fixtures but
+//! only ~50 distinct `(use_fixture, name)` tuples — every shared fixture
+//! is rebuilt several times. The cache generates each unique tuple once
+//! at run start, then per-scenario provisioning becomes a `cow_copy::copy_dir`
+//! from the cache into the sandbox's `remotes/` directory (O(1) on
+//! APFS / reflink-capable Linux, byte-copy fallback elsewhere).
+//!
+//! Cache lifetime is per-run: the root is registered with the runner's
+//! cleanup registry and reclaimed on natural end and SIGINT alike. A
+//! persistent cross-run mode (with hash-based invalidation) would amortise
+//! the prime further but is out of scope for #513.
+//!
+//! Cache key is `(use_fixture, name)`, not just `use_fixture`: the fixture
+//! YAML embeds `{{NAME}}` placeholders that get substituted with the
+//! scenario's chosen repo name, and those substitutions appear in branch
+//! file contents — so two scenarios referencing the same fixture with
+//! different `name:` values produce different bare-repo contents.
+
+use anyhow::{Context, Result};
+use std::collections::{BTreeSet, HashMap};
+use std::path::{Path, PathBuf};
+
+use super::cow_copy;
+use super::repo_gen;
+use super::resolve_fixture_spec;
+use super::schema;
+
+/// Identifier for a single cached fixture: `(use_fixture, name)`.
+///
+/// Owned `String`s rather than borrows so the cache can survive past the
+/// scenario-parse phase that produced the keys.
+pub(crate) type FixtureKey = (String, String);
+
+/// Walk the raw YAML of each scenario file in `scenario_files` and collect
+/// the unique set of `(use_fixture, name)` tuples referenced anywhere in
+/// the suite.
+///
+/// Inline `RepoEntry::Inline` specs are ignored — they have no fixture to
+/// share. Scenario files that fail to parse contribute nothing to the
+/// index but do not abort the walk: a per-scenario parse error will
+/// surface again (with proper context) when the worker tries to load that
+/// scenario through the normal path. We don't want a single broken YAML
+/// file to take down the cache prime for the other 580 scenarios.
+pub(crate) fn collect_fixture_keys(scenario_files: &[PathBuf]) -> BTreeSet<FixtureKey> {
+    let mut keys = BTreeSet::new();
+    for path in scenario_files {
+        let Ok(content) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        let Ok(raw) = serde_yaml::from_str::<schema::RawScenario>(&content) else {
+            continue;
+        };
+        for entry in raw.repos {
+            if let schema::RepoEntry::Fixture(fr) = entry {
+                keys.insert((fr.use_fixture, fr.name));
+            }
+        }
+    }
+    keys
+}
+
+/// Cache of pre-built bare remotes keyed by `(use_fixture, name)`.
+///
+/// Built once per run by [`FixtureCache::prime`]. Workers call
+/// [`FixtureCache::clone_into`] to materialise a per-scenario copy in the
+/// scenario's sandbox. The cache root is owned by the runner's cleanup
+/// registry, not the struct — registration happens before prime so a
+/// partial prime still gets cleaned up via the existing SIGINT path.
+pub(crate) struct FixtureCache {
+    /// `(use_fixture, name) → absolute path of the prebuilt bare repo`.
+    paths: HashMap<FixtureKey, PathBuf>,
+}
+
+impl FixtureCache {
+    /// Generate each `(use_fixture, name)` tuple in `keys` into a bare repo
+    /// under `<root>/<use_fixture>/<name>/`. The two-level layout keeps
+    /// multiple fixtures isolated without prefix collisions on the inner
+    /// directory name.
+    pub fn prime(keys: &BTreeSet<FixtureKey>, fixtures_dir: &Path, root: PathBuf) -> Result<Self> {
+        std::fs::create_dir_all(&root)
+            .with_context(|| format!("creating fixture cache root: {}", root.display()))?;
+
+        let mut paths = HashMap::with_capacity(keys.len());
+        for (use_fixture, name) in keys {
+            let parent = root.join(use_fixture);
+            std::fs::create_dir_all(&parent)
+                .with_context(|| format!("creating fixture cache subdir: {}", parent.display()))?;
+            let spec = resolve_fixture_spec(fixtures_dir, use_fixture, name.clone())?;
+            let bare_path = repo_gen::generate_repo(&spec, &parent).with_context(|| {
+                format!(
+                    "priming fixture '{}' for repo '{}' under {}",
+                    use_fixture,
+                    name,
+                    parent.display()
+                )
+            })?;
+            paths.insert((use_fixture.clone(), name.clone()), bare_path);
+        }
+        Ok(Self { paths })
+    }
+
+    /// Materialise a per-scenario copy of the cached fixture at `key` into
+    /// `dst`. `dst` must not already exist; its parent must.
+    pub fn clone_into(&self, key: &FixtureKey, dst: &Path) -> Result<()> {
+        let src = self.paths.get(key).with_context(|| {
+            format!(
+                "fixture cache miss for ('{}', '{}') — this is a programming \
+                 error: every fixture-derived RepoSpec encountered by a worker \
+                 must have been indexed by collect_fixture_keys at run start",
+                key.0, key.1
+            )
+        })?;
+        cow_copy::copy_dir(src, dst).with_context(|| {
+            format!(
+                "cloning fixture '{}' for repo '{}' from cache to {}",
+                key.0,
+                key.1,
+                dst.display()
+            )
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+    use std::path::Path;
+
+    fn fixtures_dir() -> std::path::PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .join("tests/manual/fixtures/repos")
+    }
+
+    fn write_scenario(dir: &Path, file: &str, body: &str) -> std::path::PathBuf {
+        let p = dir.join(file);
+        std::fs::write(&p, body).unwrap();
+        p
+    }
+
+    #[test]
+    fn collect_finds_unique_fixture_keys() {
+        let tmp = tempfile::tempdir().unwrap();
+        let a = write_scenario(
+            tmp.path(),
+            "a.yml",
+            r#"
+name: a
+repos:
+  - { name: origin, use_fixture: standard-remote }
+steps:
+  - name: noop
+    run: "true"
+"#,
+        );
+        let keys = collect_fixture_keys(&[a]);
+        assert_eq!(keys.len(), 1);
+        assert!(keys.contains(&("standard-remote".into(), "origin".into())));
+    }
+
+    #[test]
+    fn collect_dedupes_identical_refs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let body = r#"
+name: x
+repos:
+  - { name: origin, use_fixture: standard-remote }
+steps:
+  - name: noop
+    run: "true"
+"#;
+        let a = write_scenario(tmp.path(), "a.yml", body);
+        let b = write_scenario(tmp.path(), "b.yml", body);
+        let keys = collect_fixture_keys(&[a, b]);
+        assert_eq!(
+            keys.len(),
+            1,
+            "identical (fixture, name) tuples should collapse to one cache key",
+        );
+    }
+
+    #[test]
+    fn collect_distinguishes_different_names() {
+        let tmp = tempfile::tempdir().unwrap();
+        let a = write_scenario(
+            tmp.path(),
+            "a.yml",
+            r#"
+name: a
+repos:
+  - { name: alpha, use_fixture: standard-remote }
+steps:
+  - name: noop
+    run: "true"
+"#,
+        );
+        let b = write_scenario(
+            tmp.path(),
+            "b.yml",
+            r#"
+name: b
+repos:
+  - { name: beta, use_fixture: standard-remote }
+steps:
+  - name: noop
+    run: "true"
+"#,
+        );
+        let keys = collect_fixture_keys(&[a, b]);
+        // Different `name:` values mean different `{{NAME}}` substitutions,
+        // so different bare-repo contents — must be separate cache entries.
+        assert_eq!(keys.len(), 2);
+    }
+
+    #[test]
+    fn collect_skips_inline_repos() {
+        let tmp = tempfile::tempdir().unwrap();
+        let a = write_scenario(
+            tmp.path(),
+            "a.yml",
+            r#"
+name: a
+repos:
+  - name: inline-repo
+    branches:
+      - name: main
+        files: [{ path: x, content: y }]
+        commits: [{ message: init }]
+steps:
+  - name: noop
+    run: "true"
+"#,
+        );
+        let keys = collect_fixture_keys(&[a]);
+        assert!(keys.is_empty(), "inline repos should not enter the cache");
+    }
+
+    #[test]
+    fn collect_tolerates_unparseable_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let broken = write_scenario(tmp.path(), "broken.yml", "this: is: invalid: yaml:::");
+        let ok = write_scenario(
+            tmp.path(),
+            "ok.yml",
+            r#"
+name: ok
+repos:
+  - { name: origin, use_fixture: standard-remote }
+steps:
+  - name: noop
+    run: "true"
+"#,
+        );
+        let keys = collect_fixture_keys(&[broken, ok]);
+        assert_eq!(
+            keys.len(),
+            1,
+            "broken scenario should be skipped, valid one should contribute its key",
+        );
+    }
+
+    #[test]
+    fn prime_creates_one_repo_per_key() {
+        let cache_root = tempfile::tempdir().unwrap();
+        let root_path = cache_root.path().to_path_buf();
+        let mut keys = BTreeSet::new();
+        keys.insert(("standard-remote".to_string(), "alpha".to_string()));
+        keys.insert(("standard-remote".to_string(), "beta".to_string()));
+
+        let cache = FixtureCache::prime(&keys, &fixtures_dir(), root_path.clone()).unwrap();
+
+        assert_eq!(cache.paths.len(), 2);
+        assert!(root_path.join("standard-remote/alpha").is_dir());
+        assert!(root_path.join("standard-remote/beta").is_dir());
+        // Each bare repo carries its own HEAD — a quick proof that
+        // generate_repo ran independently for each key rather than
+        // sharing state across them.
+        assert!(root_path.join("standard-remote/alpha/HEAD").is_file());
+        assert!(root_path.join("standard-remote/beta/HEAD").is_file());
+    }
+
+    #[test]
+    fn clone_into_produces_equivalent_history() {
+        let cache_root = tempfile::tempdir().unwrap();
+        let mut keys = BTreeSet::new();
+        keys.insert(("standard-remote".to_string(), "origin".to_string()));
+        let cache =
+            FixtureCache::prime(&keys, &fixtures_dir(), cache_root.path().to_path_buf()).unwrap();
+
+        // Clone the cached fixture into a fresh destination ...
+        let dst_parent = tempfile::tempdir().unwrap();
+        let dst = dst_parent.path().join("origin");
+        cache
+            .clone_into(&("standard-remote".into(), "origin".into()), &dst)
+            .unwrap();
+
+        // ... and build a from-scratch reference from the same spec.
+        let ref_parent = tempfile::tempdir().unwrap();
+        let spec =
+            resolve_fixture_spec(&fixtures_dir(), "standard-remote", "origin".into()).unwrap();
+        let ref_bare = repo_gen::generate_repo(&spec, ref_parent.path()).unwrap();
+
+        // Equality on commit message + branch shape is the right check —
+        // `generate_repo` writes the current wall-clock into committer/author
+        // metadata, so SHAs and pack bytes differ between invocations even
+        // when the content is identical. What must match is the user-visible
+        // history: every commit message present in the cached copy must also
+        // be present in the reference, and the branch tips must align.
+        let subjects = |path: &Path| -> BTreeSet<String> {
+            let out = std::process::Command::new("git")
+                .arg("-C")
+                .arg(path)
+                .args(["log", "--all", "--format=%s"])
+                .output()
+                .unwrap();
+            assert!(out.status.success());
+            String::from_utf8_lossy(&out.stdout)
+                .lines()
+                .map(str::to_string)
+                .collect()
+        };
+        assert_eq!(
+            subjects(&dst),
+            subjects(&ref_bare),
+            "clone-from-cache must reproduce the same commit subjects as a fresh generate_repo",
+        );
+
+        let branches = |path: &Path| -> BTreeSet<String> {
+            let out = std::process::Command::new("git")
+                .arg("-C")
+                .arg(path)
+                .args(["for-each-ref", "--format=%(refname:short)", "refs/heads"])
+                .output()
+                .unwrap();
+            assert!(out.status.success());
+            String::from_utf8_lossy(&out.stdout)
+                .lines()
+                .map(str::to_string)
+                .collect()
+        };
+        assert_eq!(
+            branches(&dst),
+            branches(&ref_bare),
+            "clone-from-cache must reproduce the same branch set as a fresh generate_repo",
+        );
+    }
+}

--- a/xtask/src/manual_test/mod.rs
+++ b/xtask/src/manual_test/mod.rs
@@ -180,9 +180,15 @@ fn alloc_fixture_cache_dir() -> Result<PathBuf> {
         let pid = std::process::id();
         return Ok(PathBuf::from(base).join(format!("_fixture-cache-{pid}")));
     }
-    let base = sandbox::alloc_default_base_dir()?;
     // Reuse the timestamp-PID-counter slug from the default-base helper but
     // tag the suffix so a stray cache directory is identifiable in `/tmp`.
+    // This intentionally burns one `SANDBOX_COUNTER` slot — the returned
+    // path is never materialised under that name, only used to compose a
+    // sibling-with-suffix path. Accounting-counted sandboxes will run one
+    // ahead of the visible scenario count; the trade-off is keeping the
+    // uniqueness contract centralised in `alloc_default_base_dir` rather
+    // than duplicating the nanos-PID-counter logic here.
+    let base = sandbox::alloc_default_base_dir()?;
     let file_name = base
         .file_name()
         .and_then(|s| s.to_str())
@@ -591,6 +597,21 @@ pub fn run(
             setup_only,
             is_interactive,
         );
+        // Drain the cleanup set — `run_parallel` does this internally
+        // (see line ~808's "belt-and-suspenders cleanup" block), but the
+        // serial path otherwise leaks the fixture-cache root: per-scenario
+        // sandboxes are cleaned up by their CleanupGuards' Drop impls, but
+        // the cache root is registered manually with no guard. Without this
+        // drain a single `mise run test:manual -- -i <scenario>` leaves a
+        // `_fixture-cache-<pid>/` directory behind every time — particularly
+        // visible under `DAFT_MANUAL_TEST_BASE` (e.g. the RAM-disk task).
+        if !keep {
+            if let Ok(mut g) = cleanup_set.lock() {
+                for dir in g.drain() {
+                    let _ = std::fs::remove_dir_all(&dir);
+                }
+            }
+        }
         if interrupt.is_set() {
             std::process::exit(130);
         }
@@ -969,7 +990,6 @@ fn aggregate_outcomes<'a>(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 #[allow(clippy::too_many_arguments)]
 fn run_serial(
     scenario_files: &[PathBuf],

--- a/xtask/src/manual_test/mod.rs
+++ b/xtask/src/manual_test/mod.rs
@@ -1,6 +1,7 @@
 pub mod cow_copy;
 pub mod daft_executor;
 pub mod executor;
+pub mod fixture_cache;
 pub mod interactive;
 pub mod progress;
 pub mod repo_gen;
@@ -160,6 +161,34 @@ fn pick_sandbox_base_dir(scenario: &schema::Scenario) -> Result<PathBuf> {
         return Ok(PathBuf::from(base).join(scenario_base_slug(scenario)));
     }
     sandbox::alloc_default_base_dir()
+}
+
+/// Allocate the run-wide fixture-cache root directory.
+///
+/// When `DAFT_MANUAL_TEST_BASE` is set, the cache lives under that root with
+/// a leading-underscore prefix so it sorts above the per-scenario sandbox
+/// directories in a listing and is visually distinct. The PID suffix makes
+/// two concurrent runs against the same base happy. Otherwise the cache
+/// gets its own timestamp-PID-counter path under `/tmp`, mirroring the
+/// shape of [`sandbox::alloc_default_base_dir`].
+///
+/// Lives in this layer (not in `sandbox::`) for the same reason as
+/// [`pick_sandbox_base_dir`]: the runner's daft-named env-var awareness
+/// stays out of the sandbox module so the spin-out story is clean.
+fn alloc_fixture_cache_dir() -> Result<PathBuf> {
+    if let Ok(base) = std::env::var("DAFT_MANUAL_TEST_BASE") {
+        let pid = std::process::id();
+        return Ok(PathBuf::from(base).join(format!("_fixture-cache-{pid}")));
+    }
+    let base = sandbox::alloc_default_base_dir()?;
+    // Reuse the timestamp-PID-counter slug from the default-base helper but
+    // tag the suffix so a stray cache directory is identifiable in `/tmp`.
+    let file_name = base
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("daft-manual-test-fixture-cache");
+    let parent = base.parent().unwrap_or(Path::new("/tmp"));
+    Ok(parent.join(format!("{file_name}-fixture-cache")))
 }
 
 /// Build a stable, collision-free path component for a scenario's sandbox
@@ -382,6 +411,11 @@ struct ScenarioOutcome {
 struct RunContext<'a> {
     project_root: &'a Path,
     fixtures_dir: &'a Path,
+    /// Run-wide cache of pre-generated fixture remotes. Each
+    /// `RepoSpec` carrying `fixture_source = Some(...)` is materialised by
+    /// `cow_copy`-ing from the cache into the scenario sandbox; inline
+    /// specs still go through [`repo_gen::generate_repo`].
+    fixture_cache: &'a fixture_cache::FixtureCache,
     reporter: &'a dyn reporter::Reporter,
     progress: &'a dyn progress::ProgressSink,
     /// Cooperative cancellation flag. Workers check between steps inside
@@ -497,6 +531,26 @@ pub fn run(
     let interrupt = progress::InterruptFlag::new();
     let cleanup_set = setup_cleanup_handler(keep, interrupt.clone());
 
+    // Prime the run-wide fixture cache. See [`fixture_cache`] for the
+    // shape: walk every scenario file's raw YAML, collect unique
+    // `(use_fixture, name)` tuples, generate each into the cache once, then
+    // workers `cow_copy` from the cache into their sandboxes instead of
+    // regenerating the same fixture for every scenario that references it.
+    //
+    // Register the cache root with the cleanup set *before* priming so a
+    // SIGINT during `generate_repo` still leaves a tracked path the
+    // handler can `rm -rf` — matching the same pre-create registration
+    // pattern the per-scenario sandbox path uses.
+    let fixture_keys = fixture_cache::collect_fixture_keys(&scenario_files);
+    let cache_root = alloc_fixture_cache_dir()?;
+    if !keep {
+        if let Ok(mut g) = cleanup_set.lock() {
+            g.insert(cache_root.clone());
+        }
+    }
+    let fixture_cache =
+        fixture_cache::FixtureCache::prime(&fixture_keys, &fixtures_dir, cache_root)?;
+
     // No leading eprintln! here — the pretty reporter's scenario_header
     // owns the inter-scenario blank line, including the one before the very
     // first scenario.
@@ -526,6 +580,7 @@ pub fn run(
             &scenario_files,
             &project_root,
             &fixtures_dir,
+            &fixture_cache,
             &cleanup_set,
             reporter.as_ref(),
             verbosity,
@@ -567,6 +622,7 @@ pub fn run(
         &scenarios_dir,
         &project_root,
         &fixtures_dir,
+        &fixture_cache,
         &cleanup_set,
         reporter.as_ref(),
         progress.as_ref(),
@@ -595,6 +651,7 @@ fn run_parallel(
     scenarios_dir: &Path,
     project_root: &Path,
     fixtures_dir: &Path,
+    fixture_cache: &fixture_cache::FixtureCache,
     cleanup_set: &CleanupSet,
     reporter: &dyn reporter::Reporter,
     progress: &dyn progress::ProgressSink,
@@ -607,6 +664,7 @@ fn run_parallel(
     let ctx = RunContext {
         project_root,
         fixtures_dir,
+        fixture_cache,
         reporter,
         progress,
         interrupt,
@@ -912,10 +970,12 @@ fn aggregate_outcomes<'a>(
 }
 
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)]
 fn run_serial(
     scenario_files: &[PathBuf],
     project_root: &Path,
     fixtures_dir: &Path,
+    fixture_cache: &fixture_cache::FixtureCache,
     cleanup_set: &CleanupSet,
     reporter: &dyn reporter::Reporter,
     verbosity: reporter::Verbosity,
@@ -946,7 +1006,7 @@ fn run_serial(
         let executor = daft_executor::DaftCommandExecutor::new_for_sandbox(&mut sb, project_root)?;
 
         for repo_spec in &scenario.repos {
-            repo_gen::generate_repo(repo_spec, &sb.remotes_dir)?;
+            provision_repo(fixture_cache, repo_spec, &sb.remotes_dir)?;
             sb.register_remote(&repo_spec.name);
         }
         sb.create_template()?;
@@ -1190,7 +1250,7 @@ fn run_one_scenario_inner(
 
     let fixture_started = std::time::Instant::now();
     for repo_spec in &scenario.repos {
-        repo_gen::generate_repo(repo_spec, &sb.remotes_dir)?;
+        provision_repo(ctx.fixture_cache, repo_spec, &sb.remotes_dir)?;
         sb.register_remote(&repo_spec.name);
     }
     let fixture_ms = fixture_started.elapsed().as_millis();
@@ -1493,34 +1553,60 @@ fn resolve_repos(
         match entry {
             schema::RepoEntry::Inline(spec) => resolved.push(spec),
             schema::RepoEntry::Fixture(fixture_ref) => {
-                let fixture_path = fixtures_dir
-                    .join(&fixture_ref.use_fixture)
-                    .with_extension("yml");
-                let raw_yaml = std::fs::read_to_string(&fixture_path).with_context(|| {
-                    format!(
-                        "reading fixture '{}' for repo '{}'",
-                        fixture_ref.use_fixture, fixture_ref.name
-                    )
-                })?;
-                let substituted = raw_yaml.replace("{{NAME}}", &fixture_ref.name);
-                let fixture: schema::RepoFixture = serde_yaml::from_str(&substituted)
-                    .with_context(|| {
-                        format!(
-                            "parsing fixture '{}' for repo '{}'",
-                            fixture_ref.use_fixture, fixture_ref.name
-                        )
-                    })?;
-                resolved.push(schema::RepoSpec {
-                    name: fixture_ref.name,
-                    default_branch: fixture.default_branch,
-                    branches: fixture.branches,
-                    daft_yml: fixture.daft_yml,
-                    hook_scripts: fixture.hook_scripts,
-                });
+                resolved.push(resolve_fixture_spec(
+                    fixtures_dir,
+                    &fixture_ref.use_fixture,
+                    fixture_ref.name,
+                )?);
             }
         }
     }
     Ok(resolved)
+}
+
+/// Materialise a single repo into the scenario's `remotes_dir`.
+///
+/// Fixture-derived specs (`fixture_source = Some(_)`) `cow_copy` from the
+/// run-wide cache — O(1) on APFS / reflink-capable Linux, byte-copy fallback
+/// elsewhere. Inline specs hit `repo_gen::generate_repo` per scenario since
+/// they have no caching identity to share against.
+fn provision_repo(
+    cache: &fixture_cache::FixtureCache,
+    repo_spec: &schema::RepoSpec,
+    remotes_dir: &Path,
+) -> Result<()> {
+    if let Some(use_fixture) = &repo_spec.fixture_source {
+        let key = (use_fixture.clone(), repo_spec.name.clone());
+        let dst = remotes_dir.join(&repo_spec.name);
+        cache.clone_into(&key, &dst)
+    } else {
+        repo_gen::generate_repo(repo_spec, remotes_dir).map(|_| ())
+    }
+}
+
+/// Resolve a single `use_fixture` reference into a fully-substituted
+/// [`schema::RepoSpec`]. Shared between scenario resolution and the
+/// fixture-cache primer so both paths apply identical `{{NAME}}` substitution
+/// and identical error messages.
+pub(crate) fn resolve_fixture_spec(
+    fixtures_dir: &Path,
+    use_fixture: &str,
+    name: String,
+) -> Result<schema::RepoSpec> {
+    let fixture_path = fixtures_dir.join(use_fixture).with_extension("yml");
+    let raw_yaml = std::fs::read_to_string(&fixture_path)
+        .with_context(|| format!("reading fixture '{}' for repo '{}'", use_fixture, name))?;
+    let substituted = raw_yaml.replace("{{NAME}}", &name);
+    let fixture: schema::RepoFixture = serde_yaml::from_str(&substituted)
+        .with_context(|| format!("parsing fixture '{}' for repo '{}'", use_fixture, name))?;
+    Ok(schema::RepoSpec {
+        name,
+        default_branch: fixture.default_branch,
+        branches: fixture.branches,
+        daft_yml: fixture.daft_yml,
+        hook_scripts: fixture.hook_scripts,
+        fixture_source: Some(use_fixture.to_string()),
+    })
 }
 
 /// List available scenarios with their name and description.

--- a/xtask/src/manual_test/repo_gen.rs
+++ b/xtask/src/manual_test/repo_gen.rs
@@ -235,6 +235,7 @@ mod tests {
             }],
             daft_yml: None,
             hook_scripts: vec![],
+            fixture_source: None,
         };
         let dir = tempfile::tempdir().unwrap();
         let repo_path = generate_repo(&spec, dir.path()).unwrap();
@@ -279,6 +280,7 @@ mod tests {
             ],
             daft_yml: None,
             hook_scripts: vec![],
+            fixture_source: None,
         };
         let dir = tempfile::tempdir().unwrap();
         let repo_path = generate_repo(&spec, dir.path()).unwrap();
@@ -313,6 +315,7 @@ mod tests {
                     .into(),
             ),
             hook_scripts: vec![],
+            fixture_source: None,
         };
         let dir = tempfile::tempdir().unwrap();
         let repo_path = generate_repo(&spec, dir.path()).unwrap();

--- a/xtask/src/manual_test/schema.rs
+++ b/xtask/src/manual_test/schema.rs
@@ -57,6 +57,13 @@ pub struct RepoSpec {
     /// Hook scripts to install in `.daft/hooks/`.
     #[serde(default)]
     pub hook_scripts: Vec<HookScriptSpec>,
+
+    /// Origin of this spec: `None` for an inline `repos:` entry, `Some(name)`
+    /// for a `use_fixture: <name>` reference resolved by `resolve_repos`.
+    /// Populated post-deserialisation; the per-scenario worker keys the
+    /// fixture cache on `(fixture_source, name)` when this is `Some`.
+    #[serde(default, skip)]
+    pub fixture_source: Option<String>,
 }
 
 fn default_branch_name() -> String {


### PR DESCRIPTION
## Summary

`mise run test:manual` regenerates the same fixture remote from scratch
once per scenario per `use_fixture:` reference. The suite has **402**
fixture references across scenarios but only **47** unique
`(use_fixture, name)` tuples — so every shared fixture was rebuilt 8.5×
on average per run. This PR generates each unique tuple once at run start
into a run-wide cache, then per-scenario provisioning is a
`cow_copy::copy_dir` from the cache into the scenario sandbox (O(1) on
APFS / reflink-capable Linux, byte-copy fallback elsewhere).

Closes #513.

## Cache shape

| Aspect | Value |
| --- | --- |
| Key | `(use_fixture, name)` |
| Layout | `<root>/<use_fixture>/<name>/` (bare repos) |
| Location | Under `DAFT_MANUAL_TEST_BASE` when set, else `/tmp/daft-manual-test-<ts>-<pid>-<n>-fixture-cache/` |
| Lifetime | Per-run (registered with the cleanup set before prime so SIGINT mid-prime reclaims the partial cache) |
| Prime ordering | Serial — 47 entries is small enough that parallel prime would compete with the scenario rayon pool for no real win |

The cache key must include `name`, not just `use_fixture`: the fixture
YAML embeds `{{NAME}}` placeholders that get substituted into branch
file contents. Two scenarios using the same fixture with different
`name:` values therefore produce different bare-repo bytes.

`RepoEntry::Inline` specs continue to be generated per-scenario — they
have no caching identity to share against.

## Measurement

Full-suite, `jobs=10`, dev box, in-app `Duration` (the suite's own
wall-clock minus build chatter). 581/581 scenarios pass on both sides.

| Configuration | In-app duration | `generate_repo` invocations |
| --- | --- | --- |
| `master` baseline | 102 s (1:42) | 402 |
| this PR | 61 s (1:01) | 47 (prime only) |

**~40% wall-clock reduction.** The structural metric is the headline:
402 → 47 fixture builds per run. The cache prime runs serially up front
in a few seconds; everything saved after that flows directly into the
parallel scenario phase.

## Decisions

- **Per-run cache, no persistent cross-run mode.** The 47-tuple prime
  is small and runs in seconds. Persistent would need hash-based
  invalidation (fixture YAML + substituted name), a user-config-dir
  location, and an eviction policy — material new surface that belongs
  in its own PR if the prime ever becomes the bottleneck.
- **Cache key is `(use_fixture, name)`, not just `use_fixture`.**
  Forced by `{{NAME}}` substitution into commit contents. Confirmed
  empirically: the only fixture in tree (`standard-remote.yml`)
  embeds `{{NAME}}` in branch file contents.
- **`fixture_source` field on `RepoSpec` (skip-serialised).** Carries
  the fixture identity from `resolve_repos` through to the worker so
  the cache-vs-generate branch can be a single `Option<String>`
  check. Mirrors the existing `source_path` pattern on `Scenario`.
- **Inline pass-through.** `RepoEntry::Inline` specs continue to call
  `repo_gen::generate_repo` per scenario. They're scenario-specific by
  construction and have nothing to cache against.
- **Tolerant raw-YAML walk.** `collect_fixture_keys` skips files it
  can't parse rather than aborting the whole prime — a single broken
  scenario shouldn't take down the cache for the other 580.
- **Cache root in `mod.rs`, not `sandbox.rs`.** Matches the existing
  precedent for `pick_sandbox_base_dir`: the runner core's daft-named
  env-var awareness stays at the `mod.rs` layer so `sandbox.rs` stays
  free of names that would block the runner spin-out.

## Test plan

- [x] `cargo test --package xtask` — 187 tests pass, including 7 new
      `fixture_cache::tests::*`.
- [x] `mise run fmt && mise run clippy && mise run test:unit` clean.
- [x] `mise run test:manual` 581/581 pass.
- [ ] CI green.

## #509 PR-description checklist

- **`generate_repo` call count before vs after:** 402 → 47 (8.5×
  reduction).
- **Full-suite wall-clock:** master 102 s → this PR 61 s
  (-40%, in-app duration, `jobs=10`).
- **Per-scenario p50:** Not collected separately for this PR — the
  structural metric is the primary story. Detailed per-phase profiling
  is the umbrella's final step.
- **Umbrella checklist:** ☑.