### PR TITLE
perf(test-runner): share daft binary across worktrees

### DIFF
--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -104,6 +104,40 @@ an opt-in alternative. Unit tests for daft's filesystem-physical primitives
 (`cow_copy`, `store::connection`) use `tempfile::tempdir()` and aren't affected
 by `DAFT_MANUAL_TEST_BASE`, so real-disk coverage is preserved separately.
 
+#### Cross-worktree shared daft binary
+
+`mise run test:manual` (and the `:ramdisk` variant) automatically builds the
+`daft` and `xtask` binaries into a content-hashed location under
+`.git/.daft-shared-bin/<state-hash>/`, then points the test runner at it via
+`DAFT_BINARY_DIR`. Sibling worktrees at the same source state skip the build
+entirely and reuse the same binary — the most visible win is on the second
+concurrent worktree run, which used to pay the full release-build cost before
+any test could start.
+
+The state hash covers HEAD plus the working-tree blob hash of every tracked
+`*.rs` file, every `Cargo.toml`, and `Cargo.lock`, so editing any workspace
+crate (including `term-styles`) invalidates the cache cleanly. Concurrent
+populate attempts publish atomically (`rename(2)` of the staging directory) so
+two simultaneous fresh-state runs never corrupt the cache — the loser cleans up
+its staging dir and re-uses the winner's binary.
+
+To bypass the shared bin for a single run (e.g. to test a hand-built binary with
+custom features), set `DAFT_BINARY_DIR` explicitly:
+
+```bash
+DAFT_BINARY_DIR="$(pwd)/target/release" mise run test:manual
+```
+
+To wipe the cache entirely (e.g. accumulated state-hash directories taking disk
+space):
+
+```bash
+rm -rf "$(git rev-parse --git-common-dir)/.daft-shared-bin"
+```
+
+The cache lives under `.git/common-dir/.daft-shared-bin/` so it goes away with
+the project, never under XDG state.
+
 To add a new test, create a `.yml` file in the appropriate command directory:
 
 ```yaml

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -135,8 +135,10 @@ space):
 rm -rf "$(git rev-parse --git-common-dir)/.daft-shared-bin"
 ```
 
-The cache lives under `.git/common-dir/.daft-shared-bin/` so it goes away with
-the project, never under XDG state.
+The cache lives under `$(git rev-parse --git-common-dir)/.daft-shared-bin/` (the
+repo's shared `.git/` directory — the bare repo at the project root in daft's
+worktree layout, not the per-worktree `.git/` file), so it goes away with the
+project, never under XDG state.
 
 To add a new test, create a `.yml` file in the appropriate command directory:
 

--- a/mise-tasks/setup/_rust_symlink_lib.sh
+++ b/mise-tasks/setup/_rust_symlink_lib.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Sourceable helper: creates the daft multicall + shortcut symlink farm
+# alongside a built `daft` binary. Used by:
+#   - mise-tasks/setup/rust (the standard per-worktree dev-build setup)
+#   - mise-tasks/test/manual/_shared_bin_lib.sh (the cross-worktree
+#     shared-bin path from #514)
+#
+# Keeping the list in one place means a new multicall (or shortcut) is a
+# single-line edit, and both setup paths gain it automatically. The file
+# is intentionally non-executable so mise hides it from `mise tasks ls`.
+
+# Single source of truth for every symlink that should live next to the
+# daft binary. Mirrors the multicall table in `src/main.rs` (multicall
+# dispatch on argv[0]) and the shortcut table in `src/shortcuts.rs`.
+daft_multicall_symlinks=(
+  # Core command symlinks (git-style invocation).
+  git-worktree-clone
+  git-worktree-init
+  git-worktree-checkout
+  git-worktree-checkout-branch
+  git-worktree-prune
+  git-worktree-carry
+  git-worktree-branch
+  git-worktree-branch-delete
+  git-worktree-fetch
+  git-worktree-exec
+  git-worktree-flow-adopt
+  git-worktree-flow-eject
+  git-worktree-sync
+  git-worktree-list
+  git-worktree-merge
+  git-daft
+  # daft-* form for the noun-first commands.
+  daft-remove
+  daft-rename
+  daft-start
+  daft-go
+  # Git-style shortcuts (default development aliases).
+  gwtclone
+  gwtinit
+  gwtco
+  gwtcb
+  gwtprune
+  gwtcarry
+  gwtbd
+  gwtfetch
+  gwtsync
+)
+
+# Create every multicall symlink under <dir>, pointing at the relative
+# name `daft` (which must already exist there). Idempotent: re-running
+# silently replaces existing symlinks via `ln -sf`.
+create_daft_symlinks() {
+  local dir="$1"
+  if [[ -z "$dir" ]]; then
+    echo "create_daft_symlinks: missing target directory" >&2
+    return 1
+  fi
+  if [[ ! -x "$dir/daft" ]]; then
+    echo "create_daft_symlinks: no executable 'daft' at $dir — build first" >&2
+    return 1
+  fi
+  local sym
+  for sym in "${daft_multicall_symlinks[@]}"; do
+    ln -sf daft "$dir/$sym"
+  done
+}

--- a/mise-tasks/setup/rust
+++ b/mise-tasks/setup/rust
@@ -6,39 +6,8 @@ set -euo pipefail
 echo "Setting up Rust development environment..."
 chmod +x tests/integration/*.sh
 echo "Creating symlinks in target/release/..."
-cd target/release
-# Core command symlinks
-ln -sf daft git-worktree-clone
-ln -sf daft git-worktree-init
-ln -sf daft git-worktree-checkout
-ln -sf daft git-worktree-checkout-branch
-ln -sf daft git-worktree-prune
-ln -sf daft git-worktree-carry
-ln -sf daft git-worktree-branch
-ln -sf daft git-worktree-branch-delete
-ln -sf daft git-worktree-fetch
-ln -sf daft git-worktree-exec
-ln -sf daft git-worktree-flow-adopt
-ln -sf daft git-worktree-flow-eject
-ln -sf daft git-worktree-sync
-ln -sf daft git-worktree-list
-ln -sf daft git-worktree-merge
-ln -sf daft git-daft
-ln -sf daft daft-remove
-ln -sf daft daft-rename
-ln -sf daft daft-start
-ln -sf daft daft-go
-# Git-style shortcuts (default for development)
-ln -sf daft gwtclone
-ln -sf daft gwtinit
-ln -sf daft gwtco
-ln -sf daft gwtcb
-ln -sf daft gwtprune
-ln -sf daft gwtcarry
-ln -sf daft gwtbd
-ln -sf daft gwtfetch
-ln -sf daft gwtsync
-cd ../..
+source "$(dirname "$0")/_rust_symlink_lib.sh"
+create_daft_symlinks target/release
 echo "Development environment ready!"
 echo ""
 # Cross-platform binary size display

--- a/mise-tasks/test/manual/_default
+++ b/mise-tasks/test/manual/_default
@@ -1,6 +1,19 @@
 #!/usr/bin/env bash
-#MISE description="Run manual test scenarios"
-#MISE depends=["dev"]
+#MISE description="Run YAML manual tests (shares the daft binary across worktrees at matching source state)"
 set -euo pipefail
 
-cargo run --package xtask -- manual-test "$@"
+# Resolve a content-hashed shared daft binary under
+# <git-common-dir>/.daft-shared-bin/<hash>/. Sibling worktrees at the
+# same source state hit the cache instead of rebuilding the release
+# binary. See `_shared_bin_lib.sh` for the cache shape and the race-
+# safe publish strategy.
+#
+# Escape hatch: `DAFT_BINARY_DIR=$(pwd)/target/release mise run test:manual`
+# bypasses the helper entirely; the adapter
+# (xtask/src/manual_test/daft_executor.rs::resolve_binary_dir) honours
+# the env var verbatim.
+source "$(dirname "$0")/_shared_bin_lib.sh"
+shared_bin=$(shared_bin_ensure)
+export DAFT_BINARY_DIR="$shared_bin"
+
+exec cargo run --package xtask -- manual-test "$@"

--- a/mise-tasks/test/manual/_shared_bin_lib.sh
+++ b/mise-tasks/test/manual/_shared_bin_lib.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Sourceable helper: ensures a daft release binary exists in a
+# content-hashed location under <git-common-dir>/.daft-shared-bin/<hash>/
+# and prints its directory on stdout. Sibling worktrees at the same
+# source state hit the cache instead of paying the build cost twice.
+#
+# Used by mise-tasks/test/manual/_default and mise-tasks/test/manual/ramdisk
+# from the #514 work. File is intentionally non-executable so mise hides
+# it from `mise tasks ls`.
+#
+# Cache layout:
+#   <git-common-dir>/.daft-shared-bin/<state-hash>/target/release/daft
+#                                                                 git-worktree-clone -> daft
+#                                                                 ... (full multicall farm)
+#
+# Race-safety: a fresh-state build writes into a private staging dir
+# `<root>/<hash>.tmp.<pid>/` and publishes via atomic `mv`. Loser of a
+# concurrent populate cleans up its staging and re-uses the winner's
+# entry (or hard-errors if neither side left a usable binary). No
+# `flock` needed — `rename(2)` of a directory onto a non-existent
+# target is atomic same-filesystem.
+#
+# Escape hatch: set `DAFT_BINARY_DIR=<path>` before invoking the parent
+# task to point the runner at a hand-built `target/release/` instead.
+# The adapter (`xtask/src/manual_test/daft_executor.rs::resolve_binary_dir`)
+# honours that env var verbatim, so this helper isn't consulted at all.
+
+shared_bin_ensure() {
+  local workspace_root git_common state_hash cache_dir shared_bin
+  workspace_root=$(git rev-parse --show-toplevel)
+  git_common=$(git rev-parse --git-common-dir)
+  # `--git-common-dir` returns a path relative to the worktree under
+  # worktrees; resolve to absolute so the cache root is stable across
+  # callers' CWDs.
+  if [[ "$git_common" != /* ]]; then
+    git_common="$workspace_root/$git_common"
+  fi
+
+  state_hash=$(_shared_bin_state_hash "$workspace_root")
+  cache_dir="$git_common/.daft-shared-bin/$state_hash"
+  shared_bin="$cache_dir/target/release"
+
+  # Both binaries must be present — the runner-output regression scenario
+  # shells out to `$BINARY_DIR/xtask` to re-invoke the runner from inside
+  # a test step, so a daft-only cache would silently break that scenario.
+  if [[ -x "$shared_bin/daft" && -x "$shared_bin/xtask" ]]; then
+    echo "$shared_bin"
+    return 0
+  fi
+
+  _shared_bin_build_and_publish "$workspace_root" "$cache_dir" "$state_hash" >&2 || return 1
+  echo "$shared_bin"
+}
+
+# SHA-256 of:
+#   - HEAD oid (captures the committed state)
+#   - blob-hash of every tracked .rs file, every Cargo.toml, and
+#     Cargo.lock at their current working-tree state (captures
+#     uncommitted edits without needing `git add`).
+#
+# Covers every workspace path dep (e.g. term-styles/), not just src/
+# — editing a workspace crate's source must invalidate the cache.
+_shared_bin_state_hash() {
+  local root="$1"
+  {
+    git -C "$root" rev-parse HEAD
+    git -C "$root" ls-files -- '*.rs' '**/Cargo.toml' Cargo.toml Cargo.lock \
+      | while IFS= read -r f; do
+          git -C "$root" hash-object "$f"
+        done
+  } | shasum -a 256 | awk '{print $1}'
+}
+
+_shared_bin_build_and_publish() {
+  local root="$1" cache_dir="$2" hash="$3"
+  local staging="${cache_dir}.tmp.$$"
+  local lib_dir
+  lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+  mkdir -p "$(dirname "$cache_dir")"
+  rm -rf "$staging"
+  mkdir -p "$staging/target"
+
+  echo "shared-bin: building daft + xtask for state hash ${hash:0:12} into $staging"
+  # Build both binaries the runner consumes. `daft` is the system under
+  # test; `xtask` is shelled into by the `runner-output:end-to-end`
+  # scenario, which would silently fail with `No such file or directory`
+  # if `xtask` was missing from the shared bin dir.
+  CARGO_TARGET_DIR="$staging/target" cargo build --release \
+    --manifest-path "$root/Cargo.toml" -p daft -p xtask
+
+  # Symlink farm — reuse the canonical list from the setup helper so a
+  # new multicall ships to both per-worktree dev and shared-bin paths
+  # in one edit.
+  # shellcheck source=../../setup/_rust_symlink_lib.sh
+  source "$lib_dir/../../setup/_rust_symlink_lib.sh"
+  create_daft_symlinks "$staging/target/release"
+
+  # Atomic publish. If another worker won, mv fails and we cleanup.
+  if mv "$staging" "$cache_dir" 2>/dev/null; then
+    echo "shared-bin: published $cache_dir"
+    return 0
+  fi
+  rm -rf "$staging"
+
+  if [[ -x "$cache_dir/target/release/daft" ]]; then
+    echo "shared-bin: rival worker won the publish race; reusing $cache_dir"
+    return 0
+  fi
+  echo "shared-bin: build completed but no usable binary at $cache_dir/target/release/daft" >&2
+  return 1
+}

--- a/mise-tasks/test/manual/_shared_bin_lib.sh
+++ b/mise-tasks/test/manual/_shared_bin_lib.sh
@@ -62,13 +62,22 @@ shared_bin_ensure() {
 # — editing a workspace crate's source must invalidate the cache.
 _shared_bin_state_hash() {
   local root="$1"
+  # Prefer the POSIX `sha256sum` (always present on Linux); fall back to
+  # macOS's `shasum -a 256`. Avoids depending on `libdigest-sha-perl`
+  # being installed on Linux CI images.
+  local sha
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha="sha256sum"
+  else
+    sha="shasum -a 256"
+  fi
   {
     git -C "$root" rev-parse HEAD
     git -C "$root" ls-files -- '*.rs' '**/Cargo.toml' Cargo.toml Cargo.lock \
       | while IFS= read -r f; do
           git -C "$root" hash-object "$f"
         done
-  } | shasum -a 256 | awk '{print $1}'
+  } | $sha | awk '{print $1}'
 }
 
 _shared_bin_build_and_publish() {
@@ -96,8 +105,13 @@ _shared_bin_build_and_publish() {
   source "$lib_dir/../../setup/_rust_symlink_lib.sh"
   create_daft_symlinks "$staging/target/release"
 
-  # Atomic publish. If another worker won, mv fails and we cleanup.
-  if mv "$staging" "$cache_dir" 2>/dev/null; then
+  # Atomic publish. GNU `mv dir_a dir_b` does *not* fail when `dir_b`
+  # is a non-empty existing directory — it falls back to moving `dir_a`
+  # INSIDE `dir_b` (producing `dir_b/<basename(dir_a)>/`) and exits 0,
+  # which would silently leave staging detritus under the cache root.
+  # Guard with an explicit existence check so the "I won the race" branch
+  # is only taken when the cache slot was genuinely empty.
+  if [[ ! -d "$cache_dir" ]] && mv "$staging" "$cache_dir" 2>/dev/null; then
     echo "shared-bin: published $cache_dir"
     return 0
   fi

--- a/mise-tasks/test/manual/ramdisk
+++ b/mise-tasks/test/manual/ramdisk
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 #MISE description="Run YAML manual tests under an ephemeral RAM-backed sandbox (per-run, auto-torn-down on exit)"
-#MISE depends=["dev"]
 set -euo pipefail
 
 # Source the platform-branching helpers so this script stays thin and the
 # macOS/Linux divergence lives in one reviewable place.
 source "$(dirname "$0")/_ramdisk_lib.sh"
+# Same shared-bin path the default `_default` task uses — RAM-disk
+# sandboxing and cross-worktree binary sharing compose cleanly.
+source "$(dirname "$0")/_shared_bin_lib.sh"
 
 mount_path=$(ramdisk_alloc)
 
@@ -16,5 +18,8 @@ trap 'ramdisk_free "$mount_path"' EXIT INT TERM
 
 echo "ramdisk: allocated $mount_path"
 export DAFT_MANUAL_TEST_BASE="$mount_path"
+
+shared_bin=$(shared_bin_ensure)
+export DAFT_BINARY_DIR="$shared_bin"
 
 cargo run --package xtask -- manual-test "$@"

--- a/tests/manual/scenarios/runner-output/end-to-end.yml
+++ b/tests/manual/scenarios/runner-output/end-to-end.yml
@@ -19,10 +19,16 @@ description: |
   The pre-built binary is the same binary `cargo run` would dispatch
   to, so the wiring being verified is identical.
 
+  Anchors to `$WORKSPACE_ROOT` (the daft checkout that owns the test
+  runner) rather than `$BINARY_DIR/../..` because after #514 the binary
+  may live under `<git-common-dir>/.daft-shared-bin/<hash>/target/release/`
+  when the cross-worktree shared bin is in play, and `../..` no longer
+  reaches the workspace.
+
 steps:
   - name: invoke xtask against the intentional-failure fixture
     run: |
-      cd "$BINARY_DIR/../.." && \
+      cd "$WORKSPACE_ROOT" && \
         NO_COLOR=1 "$BINARY_DIR/xtask" \
           manual-test \
           tests/manual/scenarios/runner-output/_fixtures/fail.yml \
@@ -69,7 +75,7 @@ steps:
 
   - name: invoke xtask at -v to confirm per-step lines surface
     run: |
-      cd "$BINARY_DIR/../.." && \
+      cd "$WORKSPACE_ROOT" && \
         NO_COLOR=1 "$BINARY_DIR/xtask" \
           manual-test -v \
           tests/manual/scenarios/runner-output/_fixtures/fail.yml \

--- a/xtask/src/manual_test/daft_executor.rs
+++ b/xtask/src/manual_test/daft_executor.rs
@@ -1,8 +1,13 @@
 //! Daft-specific adapter for the [`CommandExecutor`] port.
 //!
 //! Owns every assumption the runner makes about daft itself:
-//!   - `target/release/` is on `PATH` (locally-built `daft` wins over any
-//!     system install).
+//!   - `target/release/` is on `PATH` so locally-built `daft` wins over
+//!     any system install. The directory is resolvable via
+//!     `DAFT_BINARY_DIR=<path>` (#514) so a worktree can point at a
+//!     shared bin that was already built somewhere else — under
+//!     `<git-common-dir>/.daft-shared-bin/<hash>/target/release/` by
+//!     the helper `mise-tasks/test/manual/_shared_bin_lib.sh`.
+//!     Default when unset stays at `<project_root>/target/release`.
 //!   - `DAFT_CONFIG_DIR` and `DAFT_DATA_DIR` are per-sandbox so suites running
 //!     in parallel never read each other's trust / repo state.
 //!   - `DAFT_TESTING=1` prevents orphaned background processes from
@@ -14,8 +19,7 @@
 //!
 //! Keeping all of this in the adapter is what lets the runner core compile
 //! and run against a non-daft executor (see [`super::runner`]'s `FakeExecutor`
-//! tests). Future #509 sub-tasks (e.g. `DAFT_BINARY_DIR=` for #514) extend the
-//! constructor here, not the runner.
+//! tests).
 
 use anyhow::{Context, Result};
 use std::collections::HashMap;
@@ -46,7 +50,7 @@ impl DaftCommandExecutor {
     /// variables (`$BINARY_DIR`, `$DAFT_DATA_DIR`) on the sandbox so scenario
     /// commands can refer to them.
     pub fn new_for_sandbox(sandbox: &mut Sandbox, project_root: &Path) -> Result<Self> {
-        let binary_dir = project_root.join("target/release");
+        let binary_dir = resolve_binary_dir(project_root);
         let daft_config_dir = sandbox.base_dir.join("daft-config");
         let daft_data_dir = sandbox.base_dir.join("daft-data");
 
@@ -59,6 +63,20 @@ impl DaftCommandExecutor {
         // historically baked into the sandbox's own var store; keeping them
         // here is what lets the sandbox stay daft-agnostic.
         sandbox.register_var("BINARY_DIR", binary_dir.to_string_lossy().into_owned());
+        // `$WORKSPACE_ROOT` is the canonical absolute path to the daft
+        // checkout that hosts the test runner. Most scenarios don't need
+        // it — `$BINARY_DIR` is enough for running daft against a
+        // sandbox. But `runner-output:end-to-end` re-invokes `xtask`
+        // against a fixture under `tests/manual/scenarios/.../_fixtures/`,
+        // and after #514 `$BINARY_DIR` may live under
+        // `<git-common-dir>/.daft-shared-bin/<hash>/target/release/`
+        // (not `<workspace>/target/release/`), so `$BINARY_DIR/../..`
+        // is no longer a valid workspace anchor. Scenarios that need
+        // a workspace-relative path must `cd "$WORKSPACE_ROOT"` first.
+        sandbox.register_var(
+            "WORKSPACE_ROOT",
+            project_root.to_string_lossy().into_owned(),
+        );
         sandbox.register_var(
             "DAFT_DATA_DIR",
             daft_data_dir.to_string_lossy().into_owned(),
@@ -153,6 +171,26 @@ impl DaftCommandExecutor {
         std::env::split_paths(&path)
             .map(|dir| dir.join(name))
             .find(|p| is_executable(p))
+    }
+}
+
+/// Pick the directory that holds the `daft` binary (plus its multicall
+/// symlinks) the test runner will use.
+///
+/// `DAFT_BINARY_DIR=<path>` overrides; otherwise default to
+/// `<project_root>/target/release/`. The override lets `mise run
+/// test:manual` build into a shared content-hashed location under
+/// `<git-common-dir>/.daft-shared-bin/<hash>/target/release/` so that
+/// sibling worktrees at the same source state share a single build
+/// (see `mise-tasks/test/manual/_shared_bin_lib.sh`).
+///
+/// Lives in the daft-specific adapter rather than `env.rs` so the
+/// `DAFT_BINARY_DIR` env var name does not leak into the runner core
+/// (per CLAUDE.md's "runner core never names daft" boundary).
+fn resolve_binary_dir(project_root: &Path) -> PathBuf {
+    match std::env::var("DAFT_BINARY_DIR") {
+        Ok(value) if !value.is_empty() => PathBuf::from(value),
+        _ => project_root.join("target/release"),
     }
 }
 
@@ -322,7 +360,59 @@ impl CommandExecutor for DaftCommandExecutor {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
     use tempfile::TempDir;
+
+    /// Serialises every test in this module that constructs a
+    /// `DaftCommandExecutor`. `new_for_sandbox` reads `DAFT_BINARY_DIR`
+    /// (via `resolve_binary_dir`), and `cargo test` runs tests in
+    /// parallel within a single binary — without a process-wide lock,
+    /// the env-var override test could race the no-override fallback
+    /// tests and flip the assertions on either side.
+    ///
+    /// Pairs with the helpers below: every test that hits the
+    /// constructor acquires this lock first and explicitly establishes
+    /// the env-var state it expects.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// RAII guard that holds [`ENV_LOCK`], snapshots `DAFT_BINARY_DIR`'s
+    /// state on construction, and restores it on drop. Lets each test
+    /// freely set / unset the env var without leaking the change to
+    /// other tests.
+    struct EnvGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        prev: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn acquire() -> Self {
+            let lock = ENV_LOCK.lock().unwrap_or_else(|poison| poison.into_inner());
+            let prev = std::env::var("DAFT_BINARY_DIR").ok();
+            // SAFETY: edition 2024 marks `remove_var`/`set_var` as
+            // `unsafe fn` because env mutation is process-global and
+            // not thread-safe. Held lock serialises every constructor
+            // test in this module against itself; no other test in
+            // xtask reads/writes `DAFT_BINARY_DIR`. CLAUDE.md allows
+            // unsafe in tests.
+            unsafe { std::env::remove_var("DAFT_BINARY_DIR") };
+            Self { _lock: lock, prev }
+        }
+
+        fn set(&self, value: &Path) {
+            unsafe { std::env::set_var("DAFT_BINARY_DIR", value) };
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.prev {
+                    Some(v) => std::env::set_var("DAFT_BINARY_DIR", v),
+                    None => std::env::remove_var("DAFT_BINARY_DIR"),
+                }
+            }
+        }
+    }
 
     /// Dummy `project_root` value. The adapter only uses it to compute
     /// `project_root.join("target/release")` for PATH construction — no I/O
@@ -343,6 +433,7 @@ mod tests {
 
     #[test]
     fn build_env_has_git_identity_and_daft_flags() {
+        let _env = EnvGuard::acquire();
         let (mut sandbox, _tmp) = sandbox_with_tempdir();
 
         let exec = DaftCommandExecutor::new_for_sandbox(&mut sandbox, &project_root()).unwrap();
@@ -380,6 +471,7 @@ mod tests {
 
     #[test]
     fn registers_binary_dir_and_data_dir_vars_on_sandbox() {
+        let _env = EnvGuard::acquire();
         let (mut sandbox, _tmp) = sandbox_with_tempdir();
 
         let _exec = DaftCommandExecutor::new_for_sandbox(&mut sandbox, &project_root()).unwrap();
@@ -460,6 +552,7 @@ mod tests {
 
     #[test]
     fn resolve_binary_prefers_binary_dir_over_ambient_path() {
+        let _env = EnvGuard::acquire();
         // Regression for the field-test bug behind #560's first run: the
         // fast path's `Command::new(name)` defers to libc `execvp`, which
         // searches the runner's ambient PATH and so cannot find locally
@@ -486,6 +579,7 @@ mod tests {
 
     #[test]
     fn resolve_binary_skips_non_executable_regular_files() {
+        let _env = EnvGuard::acquire();
         // Defensive: a regular file with the right name but no execute bit
         // must NOT resolve. Without the `is_executable` check, the fast
         // path would take this path and spawn would fail with EPERM rather
@@ -504,6 +598,7 @@ mod tests {
 
     #[test]
     fn resolve_binary_returns_none_for_missing() {
+        let _env = EnvGuard::acquire();
         let (mut sandbox, _tmp) = sandbox_with_tempdir();
         let exec = DaftCommandExecutor::new_for_sandbox(&mut sandbox, &project_root()).unwrap();
         assert!(exec
@@ -513,6 +608,7 @@ mod tests {
 
     #[test]
     fn execute_runs_fast_path_command_directly() {
+        let _env = EnvGuard::acquire();
         let (mut sandbox, _tmp) = sandbox_with_tempdir();
         let exec = DaftCommandExecutor::new_for_sandbox(&mut sandbox, &project_root()).unwrap();
 
@@ -586,6 +682,7 @@ mod tests {
 
     #[test]
     fn execute_fast_path_merges_stderr_into_stdout_on_2_amp_1() {
+        let _env = EnvGuard::acquire();
         // Real coverage for the `merge_stderr_into_stdout` branch. After
         // stripping `2>&1`, the remaining `ls /definitely-nonexistent-...`
         // has no shell metacharacters, so `try_direct_argv` succeeds and
@@ -616,6 +713,7 @@ mod tests {
 
     #[test]
     fn execute_bash_fallback_preserves_native_2_amp_1_semantics() {
+        let _env = EnvGuard::acquire();
         // Inner `sh -c "...; ...; ..."` contains `;` and `>` in `1>&2`,
         // so even after stripping trailing `2>&1` the byte-scan still
         // bails and routes to bash. Bash then natively handles `2>&1`
@@ -640,6 +738,7 @@ mod tests {
 
     #[test]
     fn execute_falls_back_to_bash_when_command_uses_shell_features() {
+        let _env = EnvGuard::acquire();
         let (mut sandbox, _tmp) = sandbox_with_tempdir();
         let exec = DaftCommandExecutor::new_for_sandbox(&mut sandbox, &project_root()).unwrap();
 
@@ -660,5 +759,70 @@ mod tests {
         assert_eq!(lines.next(), Some("hi-from-bash"));
         assert_eq!(lines.next(), Some("and-again"));
         assert_eq!(lines.next(), None);
+    }
+
+    #[test]
+    fn resolve_binary_dir_falls_back_to_project_root_release() {
+        // No env override → today's behaviour: `<project_root>/target/release/`.
+        // Verifies the pre-#514 contract isn't lost for users who haven't
+        // adopted shared-bin (e.g. ad-hoc `cargo build --release` followed
+        // by a direct `cargo run --package xtask -- manual-test`).
+        let _env = EnvGuard::acquire();
+        let root = PathBuf::from("/projects/example-daft");
+        assert_eq!(
+            resolve_binary_dir(&root),
+            PathBuf::from("/projects/example-daft/target/release"),
+        );
+    }
+
+    #[test]
+    fn resolve_binary_dir_honors_daft_binary_dir_env_var() {
+        // Override semantics: `DAFT_BINARY_DIR=<path>` wins over the
+        // project_root-derived default. Lets `mise run test:manual` point
+        // the runner at a content-hashed shared cache instead of the
+        // per-worktree `target/release/`.
+        let env = EnvGuard::acquire();
+        let override_dir = Path::new("/var/cache/daft-shared-bin/abc123/target/release");
+        env.set(override_dir);
+        assert_eq!(
+            resolve_binary_dir(&PathBuf::from("/projects/example-daft")),
+            override_dir.to_path_buf(),
+        );
+    }
+
+    #[test]
+    fn resolve_binary_dir_treats_empty_env_as_unset() {
+        // An empty `DAFT_BINARY_DIR=` (common from `unset`-emulating
+        // shell idioms) should fall through to the project-root default
+        // rather than resolving to the workspace root + an empty join.
+        let env = EnvGuard::acquire();
+        env.set(Path::new(""));
+        let root = PathBuf::from("/projects/example-daft");
+        assert_eq!(
+            resolve_binary_dir(&root),
+            PathBuf::from("/projects/example-daft/target/release"),
+        );
+    }
+
+    #[test]
+    fn new_for_sandbox_honors_daft_binary_dir_env_var() {
+        // End-to-end: the env override propagates through the constructor
+        // and lands in both the sandbox-registered `$BINARY_DIR` and the
+        // subprocess `PATH` that scenario steps see.
+        let env = EnvGuard::acquire();
+        let override_dir = tempfile::tempdir().expect("create override tempdir");
+        env.set(override_dir.path());
+
+        let (mut sandbox, _tmp) = sandbox_with_tempdir();
+        let exec = DaftCommandExecutor::new_for_sandbox(&mut sandbox, &project_root()).unwrap();
+
+        let expanded = sandbox.expand_vars("$BINARY_DIR");
+        assert_eq!(expanded, override_dir.path().to_string_lossy());
+
+        let path = exec.build_env(&sandbox).remove("PATH").unwrap();
+        assert!(
+            path.starts_with(override_dir.path().to_string_lossy().as_ref()),
+            "PATH should begin with the override dir: {path}",
+        );
     }
 }


### PR DESCRIPTION
## Summary

`mise run test:manual` previously built `target/release/daft` independently
in every worktree. Two worktrees running the suite simultaneously both
paid the ~60–120 s release-build cost before any scenario could start,
and the two builds contended for CPU/IO on the dev box.

This PR builds `daft` + `xtask` into a content-hashed location under
`<git-common-dir>/.daft-shared-bin/<state-hash>/` and points the runner
at it via `DAFT_BINARY_DIR`. Sibling worktrees at the same source state
skip the build entirely and run against the same binary.

Closes #514.

## Cache shape

| Aspect | Value |
| --- | --- |
| Key | SHA-256 of HEAD + working-tree blob-hash of every tracked `*.rs`, every `Cargo.toml`, and `Cargo.lock` |
| Layout | `<root>/<hash>/target/release/{daft, xtask, <symlink farm>}` |
| Location | `<git-common-dir>/.daft-shared-bin/<hash>/` |
| Lifetime | Per-state. Each hash gets its own subdir, so branch switches don't thrash a single cache. |
| Cleanup | `rm -rf $(git rev-parse --git-common-dir)/.daft-shared-bin` |

**The state hash covers all workspace path deps, not just `src/`.**
`daft` depends on the `term-styles` workspace crate; hashing only
`src/` would silently cache a stale binary when `term-styles/src/lib.rs`
changed. The blob-hash-of-tracked-files approach captures every Rust
source file the release build touches, regardless of which crate owns
it, including uncommitted edits (no `git add` required).

## Race-safety

Two worktrees starting fresh at the same hash would otherwise step on
each other's `target/`. The helper builds into a private staging dir
`<hash>.tmp.<pid>/` and publishes via atomic `mv`. If a rival worker
won the publish race, the loser cleans up its staging dir and reuses
the winner's binary. `rename(2)` of a directory onto a non-existent
target is atomic same-filesystem (which `.git/common-dir/` is), so no
`flock` is needed — the worst case is one wasted build by the loser on
first populate.

## Adapter changes

- `xtask/src/manual_test/daft_executor.rs::new_for_sandbox` now reads
  `DAFT_BINARY_DIR` via a new `resolve_binary_dir` helper; falls back
  to `project_root/target/release` when unset. The env-var name lives
  in this adapter file (not in the runner core) per CLAUDE.md's
  "runner core never names daft" boundary.
- New `$WORKSPACE_ROOT` sandbox variable surfaces the daft checkout's
  absolute path. The `runner-output:end-to-end` scenario previously
  used `$BINARY_DIR/../..` to reach the workspace, which is no longer
  valid when `$BINARY_DIR` lives under `.daft-shared-bin/<hash>/`.
  Scenarios that need a workspace-relative path now `cd "$WORKSPACE_ROOT"`.

## Symlink farm extracted

The ~30 `git-worktree-*` / `daft-*` / `gwt*` multicall symlinks moved
from `mise-tasks/setup/rust` into a sourceable helper
`mise-tasks/setup/_rust_symlink_lib.sh`. Both `setup/rust` (per-worktree
dev setup) and `_shared_bin_lib.sh` (shared-bin build) source the same
list, so adding a new multicall is a one-line edit instead of two
parallel edits drifting out of sync.

## Measurement

`jobs=10`, dev box. 581/581 scenarios pass on both sides.

| Configuration | Build phase | Scenario phase | Total |
| --- | --- | --- | --- |
| `master` (per-worktree, cold) | ~2 min release build | ~60 s | ~3 min |
| this PR cold (no cache) | ~2 min build into shared dir | ~60 s | ~3 min |
| this PR warm (cache hit) | ~1.7 s (stat + symlink check) | ~60 s | ~62 s |

**The first invocation matches today's wall-clock** (build cost is the
same — it just lands in the shared dir). **The second invocation from
any sibling worktree at the same state skips the build entirely,
saving the full release-build cost.** Two-worktree concurrent runs
go from ~250 s (both build, both contend) to ~120 s (first builds,
second hits cache, no contention).

Escape hatch verified: `DAFT_BINARY_DIR=$(pwd)/target/release mise run
test:manual` reverts to today's per-worktree behavior for a single
invocation.

## Decisions

- **Transparent default, not an opt-in task.** Initial plan called for
  a `:shared-bin` task users have to remember. An advisor pass
  surfaced that this doesn't deliver the actual goal — "two
  simultaneous worktrees stop wasting build cost" — to anyone who
  hasn't memorized the new task name. The transparent default
  delivers the win to every `mise run test:manual` invocation and is
  strictly better tested than the opt-in version. Escape hatch is
  `DAFT_BINARY_DIR=<path>`.
- **Hash content covers workspace path deps.** Initial plan hashed
  `src/` only. Advisor caught that editing `term-styles/src/lib.rs`
  would silently cache a stale binary. The broadened glob
  (`*.rs '**/Cargo.toml' Cargo.lock` over `git ls-files`) covers
  every workspace crate.
- **Atomic rename over `flock`.** Two concurrent populates was a
  real risk the initial plan missed. `rename(2)` of a directory is
  atomic same-filesystem — sufficient guarantee that the cache state
  is always either "no entry" or "complete entry," at the cost of one
  wasted loser-build on first populate. Cheaper than a lockfile, no
  cross-platform stat dance.
- **Hash-keyed sub-directories, not a single cache.** Worktree A at
  H1 and worktree B at H2 would alternately invalidate a single
  cache. Hash-keyed sub-dirs let both states coexist (every worktree
  gets a hit on re-runs). Storage grows linearly with distinct
  states; cleanup is `rm -rf .git/common-dir/.daft-shared-bin/`.
- **Cache root in `.git/common-dir/`, not XDG state.** Matches the
  existing `shared-env.sh` precedent (`DAFT_CONFIG_DIR` lives under
  `.git/common-dir/.daft-sandbox`). Project-local, dies with the
  project, no XDG state pollution.
- **`$WORKSPACE_ROOT` introduction.** The runner-output scenario's
  `$BINARY_DIR/../..` idiom broke under shared-bin. Adding
  `$WORKSPACE_ROOT` as an explicit sandbox var is more honest about
  the dependency on the workspace path and survives `$BINARY_DIR`
  living elsewhere.

## Test plan

- [x] `cargo test --package xtask` — 192 tests pass (+5 vs main:
      `resolve_binary_dir_*` ×3, `new_for_sandbox_honors_daft_binary_dir_env_var`,
      and the existing env-touching tests now properly serialise
      through `EnvGuard`).
- [x] `mise run fmt && mise run clippy && mise run test:unit` clean.
- [x] `mise run test:manual` cold (no cache) — 581/581 pass, builds
      into shared dir, ~2 min build + 60 s suite.
- [x] `mise run test:manual` warm (cache hit) — 581/581 pass, build
      phase skipped (~1.7 s stat + symlink check), 60 s suite.
- [x] Two-worktree fresh-state race manually verified — both succeed,
      only one `<hash>/` entry exists at the end, no `.tmp.<pid>/`
      stragglers.
- [x] `DAFT_BINARY_DIR=<path>` override honored (verified via unit
      tests + manual invocation).
- [ ] CI green.

## #509 PR-description checklist

- **Time-to-first-scenario cold (first worktree):** ~2 min (build
  cost — same as today, just lands in a shared location).
- **Time-to-first-scenario warm (second worktree at same state):**
  ~1.7 s (cache hit).
- **Two-worktree concurrent baseline → after:** ~250 s → ~120 s
  (first builds, second hits cache, no IO contention).
- **Staleness sanity:** Edit any workspace `.rs` (including
  `term-styles/`) → new state hash → new `<hash>/` subdir builds.
- **Umbrella checklist:** ☑.