### PR TITLE
perf: collapse redundant gix::discover() per command

### DIFF
--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -372,7 +372,12 @@ fn run_with_args(args: Args) -> Result<()> {
         anyhow::bail!("<BASE_BRANCH_NAME> can only be used with -b/--create-branch");
     }
 
-    let settings = DaftSettings::load()?;
+    // Construct one `GitCommand` and load settings (and, in the run_checkout /
+    // run_create_branch bodies, the hooks config) through it so a checkout
+    // discovers the repo exactly once instead of per throwaway instance (#584).
+    let git = GitCommand::new(args.quiet);
+    let settings = DaftSettings::load_with(&git)?;
+    let git = git.with_gitoxide(settings.use_gitoxide);
 
     let autocd = settings.autocd && !args.no_cd;
     let config = OutputConfig::with_autocd(args.quiet, args.verbose, autocd);
@@ -384,9 +389,9 @@ fn run_with_args(args: Args) -> Result<()> {
     let source_worktree = get_current_worktree_path().ok();
 
     let result = if args.create_branch {
-        run_create_branch(&args, &settings, &mut output)
+        run_create_branch(&args, &settings, &git, &mut output)
     } else {
-        match run_checkout(&args, &settings, &mut output) {
+        match run_checkout(&args, &settings, &git, &mut output) {
             Ok(already_existed) => {
                 // --at is invalid when navigating to an existing worktree
                 // (it only applies when creating a new one)
@@ -412,7 +417,7 @@ fn run_with_args(args: Args) -> Result<()> {
                     output.result(&format!(
                         "Branch '{branch}' not found, creating new worktree..."
                     ));
-                    run_create_branch(&args, &settings, &mut output)
+                    run_create_branch(&args, &settings, &git, &mut output)
                 } else {
                     change_directory(&original_dir).ok();
                     // --at with a non-existent branch requires --start or autoStart
@@ -683,16 +688,16 @@ fn maybe_consolidate(chosen_layout: &Layout, output: &mut dyn Output) -> Result<
 fn run_checkout(
     args: &Args,
     settings: &DaftSettings,
+    git: &GitCommand,
     output: &mut dyn Output,
 ) -> Result<bool, checkout::CheckoutError> {
     let wt_config = WorktreeConfig {
         remote_name: settings.remote.clone(),
         quiet: output.is_quiet(),
     };
-    let git = GitCommand::new(output.is_quiet()).with_gitoxide(settings.use_gitoxide);
     let project_root = get_project_root()?;
 
-    let (resolved_layout, source) = resolve_checkout_layout(&git, output);
+    let (resolved_layout, source) = resolve_checkout_layout(git, output);
     let (layout, should_persist) = interactive_layout_resolution(&resolved_layout, source, output)?;
 
     if should_persist && let Ok(git_dir) = get_git_common_dir() {
@@ -720,7 +725,7 @@ fn run_checkout(
         at_path: args.at.clone(),
     };
 
-    let hooks_config = crate::core::settings::load_hooks_config()?;
+    let hooks_config = crate::core::settings::load_hooks_config_with(git)?;
     let executor = HookExecutor::new(hooks_config)?;
 
     if should_show_gitoxide_notice(settings.use_gitoxide) {
@@ -730,7 +735,7 @@ fn run_checkout(
     output.start_spinner("Preparing worktree...");
     let (checkout_result, executor) = {
         let mut bridge = CommandBridge::new(output, executor);
-        let r = checkout::execute(&params, &git, &project_root, &mut bridge);
+        let r = checkout::execute(&params, git, &project_root, &mut bridge);
         (r, bridge.into_executor())
     };
     output.finish_spinner();
@@ -758,15 +763,19 @@ fn run_checkout(
     Ok(result.already_existed)
 }
 
-fn run_create_branch(args: &Args, settings: &DaftSettings, output: &mut dyn Output) -> Result<()> {
+fn run_create_branch(
+    args: &Args,
+    settings: &DaftSettings,
+    git: &GitCommand,
+    output: &mut dyn Output,
+) -> Result<()> {
     let wt_config = WorktreeConfig {
         remote_name: settings.remote.clone(),
         quiet: output.is_quiet(),
     };
-    let git = GitCommand::new(output.is_quiet()).with_gitoxide(settings.use_gitoxide);
     let project_root = get_project_root()?;
 
-    let (resolved_layout, source) = resolve_checkout_layout(&git, output);
+    let (resolved_layout, source) = resolve_checkout_layout(git, output);
     let (layout, should_persist) = interactive_layout_resolution(&resolved_layout, source, output)?;
 
     if should_persist && let Ok(git_dir) = get_git_common_dir() {
@@ -799,7 +808,7 @@ fn run_create_branch(args: &Args, settings: &DaftSettings, output: &mut dyn Outp
         at_path: args.at.clone(),
     };
 
-    let hooks_config = crate::core::settings::load_hooks_config()?;
+    let hooks_config = crate::core::settings::load_hooks_config_with(git)?;
     let executor = HookExecutor::new(hooks_config)?;
 
     if should_show_gitoxide_notice(settings.use_gitoxide) {
@@ -809,7 +818,7 @@ fn run_create_branch(args: &Args, settings: &DaftSettings, output: &mut dyn Outp
     output.start_spinner("Creating worktree...");
     let (checkout_result, executor) = {
         let mut bridge = CommandBridge::new(output, executor);
-        let r = checkout_branch::execute(&params, &git, &project_root, &mut bridge);
+        let r = checkout_branch::execute(&params, git, &project_root, &mut bridge);
         (r, bridge.into_executor())
     };
     output.finish_spinner();

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -182,12 +182,12 @@ pub fn run() -> Result<()> {
         anyhow::bail!("Not inside a Git repository");
     }
 
-    let settings = DaftSettings::load()?;
-
+    // Settings are loaded inside `run_live`/`run_blocking`, co-located with each
+    // path's `GitCommand` so they share a single repo discovery (#584).
     if should_use_live(&args) {
-        crate::commands::list_live::run_live(args, settings)
+        crate::commands::list_live::run_live(args)
     } else {
-        run_blocking(args, settings)
+        run_blocking(args)
     }
 }
 
@@ -198,7 +198,11 @@ fn should_use_live(args: &Args) -> bool {
         && std::io::stdout().is_terminal()
 }
 
-fn run_blocking(args: Args, settings: DaftSettings) -> Result<()> {
+fn run_blocking(args: Args) -> Result<()> {
+    // Construct the body `GitCommand` first and load settings through it so the
+    // repo is discovered once and reused for the command body (#584).
+    let git = GitCommand::new(false);
+    let settings = DaftSettings::load_with(&git)?;
     let stat = args.stat.unwrap_or(settings.list_stat);
     let columns_input = args.columns.or(settings.list_columns);
     let resolved = match columns_input {
@@ -217,7 +221,7 @@ fn run_blocking(args: Args, settings: DaftSettings) -> Result<()> {
     };
     let has_size = selected_columns.contains(&ListColumn::Size) || sort_spec.needs_size();
     let compute_mtime = sort_spec.needs_mtime();
-    let git = GitCommand::new(false).with_gitoxide(settings.use_gitoxide);
+    let git = git.with_gitoxide(settings.use_gitoxide);
     let user_email: Option<String> = git.config_get("user.email").ok().flatten();
     let git_common_dir = get_git_common_dir()?;
     let base_branch = get_default_branch_local(&git_common_dir, "origin", settings.use_gitoxide)

--- a/src/commands/list_live.rs
+++ b/src/commands/list_live.rs
@@ -79,8 +79,12 @@ fn parse_porcelain(output: &str) -> Vec<PorcelainEntry> {
     entries
 }
 
-pub fn run_live(args: Args, settings: DaftSettings) -> Result<()> {
-    let git = GitCommand::new(false).with_gitoxide(settings.use_gitoxide);
+pub fn run_live(args: Args) -> Result<()> {
+    // Construct the body `GitCommand` first and load settings through it so the
+    // repo is discovered once and reused for the command body (#584).
+    let git = GitCommand::new(false);
+    let settings = DaftSettings::load_with(&git)?;
+    let git = git.with_gitoxide(settings.use_gitoxide);
     let user_email: Option<String> = git.config_get("user.email").ok().flatten();
     let git_common_dir = get_git_common_dir()?;
     let base_branch =

--- a/src/core/settings.rs
+++ b/src/core/settings.rs
@@ -521,7 +521,14 @@ impl DaftSettings {
     ///
     /// Use this in commands that run inside a git repository.
     pub fn load() -> Result<Self> {
-        let git = GitCommand::new(true);
+        Self::load_with(&GitCommand::new(true))
+    }
+
+    /// Like [`DaftSettings::load`], but reuses a caller-provided [`GitCommand`]
+    /// so the `gix::discover()` it performs is shared with the caller's other
+    /// config reads (hooks-config load, command body) instead of each
+    /// constructing a throwaway instance that re-discovers the repo. See #584.
+    pub fn load_with(git: &GitCommand) -> Result<Self> {
         let mut settings = Self::default();
 
         if let Some(value) = git.config_get(keys::AUTOCD)? {
@@ -662,7 +669,7 @@ impl DaftSettings {
             }
         }
 
-        load_merge_settings(&git, &mut settings)?;
+        load_merge_settings(git, &mut settings)?;
         validate_merge_settings(settings.merge_commit, settings.merge_cleanup)?;
 
         Ok(settings)
@@ -977,7 +984,13 @@ impl Default for HookOutputConfig {
 /// This loads hooks settings from the current repository's config,
 /// falling back to global config and then to defaults.
 pub fn load_hooks_config() -> Result<HooksConfig> {
-    let git = GitCommand::new(true);
+    load_hooks_config_with(&GitCommand::new(true))
+}
+
+/// Like [`load_hooks_config`], but reuses a caller-provided [`GitCommand`] so
+/// the `gix::discover()` it performs is shared with the caller's settings load
+/// and command body rather than re-discovering the repo. See [`DaftSettings::load_with`].
+pub fn load_hooks_config_with(git: &GitCommand) -> Result<HooksConfig> {
     let mut config = HooksConfig::default();
 
     // Load global hooks settings
@@ -1034,7 +1047,7 @@ pub fn load_hooks_config() -> Result<HooksConfig> {
     // Load per-hook settings
     for hook_type in HookType::all() {
         let hook_config = config.get_hook_config_mut(*hook_type);
-        load_hook_type_config(&git, *hook_type, hook_config)?;
+        load_hook_type_config(git, *hook_type, hook_config)?;
     }
 
     Ok(config)

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -25,6 +25,29 @@ pub fn should_show_gitoxide_notice(use_gitoxide: bool) -> bool {
     false
 }
 
+// Per-thread count of `gix::discover()` calls (test-only probe).
+//
+// Used by the shared-`GitCommand` regression test to assert a command shares a
+// single repo discovery across its settings load, hooks-config load, and body
+// rather than re-discovering per throwaway instance (#584). Thread-local keeps
+// it isolated under parallel `cargo test`.
+#[cfg(test)]
+thread_local! {
+    pub(crate) static DISCOVER_COUNT: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+/// Reset the per-thread discover counter (test-only).
+#[cfg(test)]
+pub(crate) fn reset_discover_count() {
+    DISCOVER_COUNT.with(|c| c.set(0));
+}
+
+/// Read the per-thread discover counter (test-only).
+#[cfg(test)]
+pub(crate) fn discover_count() -> usize {
+    DISCOVER_COUNT.with(|c| c.get())
+}
+
 pub struct GitCommand {
     pub(crate) quiet: bool,
     pub(crate) use_gitoxide: bool,
@@ -59,6 +82,8 @@ impl GitCommand {
         let cwd = std::env::current_dir().context("Failed to get current working directory")?;
         let ts = gix::ThreadSafeRepository::discover(&cwd)
             .context("Failed to discover git repository via gitoxide")?;
+        #[cfg(test)]
+        DISCOVER_COUNT.with(|c| c.set(c.get() + 1));
         // If another thread raced us via set(), that's fine - use whichever won
         let _ = self.gix_repo.set(ts);
         Ok(self
@@ -93,5 +118,77 @@ mod tests {
         let git = GitCommand::new(true).with_gitoxide(false);
         assert!(git.quiet);
         assert!(!git.use_gitoxide);
+    }
+
+    /// #584 regression: a command that shares one `GitCommand` across its
+    /// settings load, hooks-config load, and body must discover the repo
+    /// exactly once — not once per throwaway instance. Guards against any
+    /// future change that reintroduces per-call discovery.
+    #[test]
+    #[serial_test::serial]
+    fn shared_git_command_discovers_repo_once() {
+        use crate::core::settings::{DaftSettings, load_hooks_config_with};
+
+        // Git env vars (set when tests run under a git hook) would redirect
+        // discovery to the host repo — strip them from process + subprocess so
+        // `gix::discover` resolves the temp repo below. Only safe under #[serial].
+        const GIT_ENV_VARS: &[&str] = &[
+            "GIT_DIR",
+            "GIT_WORK_TREE",
+            "GIT_INDEX_FILE",
+            "GIT_OBJECT_DIRECTORY",
+            "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+            "GIT_COMMON_DIR",
+            "GIT_CEILING_DIRECTORIES",
+        ];
+        for var in GIT_ENV_VARS {
+            unsafe {
+                std::env::remove_var(var);
+            }
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().canonicalize().unwrap();
+        let mut init = std::process::Command::new("git");
+        for var in GIT_ENV_VARS {
+            init.env_remove(var);
+        }
+        init.args(["init", "-b", "main"])
+            .arg(&path)
+            .current_dir(&path)
+            .output()
+            .unwrap();
+
+        let saved_cwd = std::env::current_dir().ok();
+        std::env::set_current_dir(&path).unwrap();
+
+        // Shared: one instance across all three config-reading phases.
+        reset_discover_count();
+        let git = GitCommand::new(true);
+        let _settings = DaftSettings::load_with(&git).unwrap();
+        let _hooks = load_hooks_config_with(&git).unwrap();
+        let _ = git.config_get("user.email");
+        let shared = discover_count();
+
+        // Contrast: three independent instances (the pre-#584 pattern) each
+        // discover — proves the probe increments and that sharing is the cause.
+        reset_discover_count();
+        let _settings = DaftSettings::load_with(&GitCommand::new(true)).unwrap();
+        let _hooks = load_hooks_config_with(&GitCommand::new(true)).unwrap();
+        let _ = GitCommand::new(true).config_get("user.email");
+        let separate = discover_count();
+
+        if let Some(cwd) = saved_cwd {
+            let _ = std::env::set_current_dir(cwd);
+        }
+
+        assert_eq!(
+            shared, 1,
+            "shared GitCommand must discover the repo exactly once"
+        );
+        assert_eq!(
+            separate, 3,
+            "independent instances each discover (guards the probe)"
+        );
     }
 }

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -120,6 +120,32 @@ mod tests {
         assert!(!git.use_gitoxide);
     }
 
+    /// Restores the working directory on drop — even on panic — so a failing
+    /// assertion in a cwd-changing `#[serial]` test can't strand a sibling test
+    /// in a since-deleted tempdir. Mirrors the guard in the merge/branch-delete
+    /// tests (the codebase has no shared test-util home for it yet).
+    struct CwdGuard {
+        original: std::path::PathBuf,
+    }
+
+    impl CwdGuard {
+        fn new() -> Self {
+            Self {
+                original: std::env::current_dir().expect("cwd readable at test start"),
+            }
+        }
+    }
+
+    impl Drop for CwdGuard {
+        fn drop(&mut self) {
+            // Best-effort: if the original cwd is gone, fall back to temp_dir so
+            // subsequent tests can at least read cwd.
+            if std::env::set_current_dir(&self.original).is_err() {
+                let _ = std::env::set_current_dir(std::env::temp_dir());
+            }
+        }
+    }
+
     /// #584 regression: a command that shares one `GitCommand` across its
     /// settings load, hooks-config load, and body must discover the repo
     /// exactly once — not once per throwaway instance. Guards against any
@@ -159,7 +185,9 @@ mod tests {
             .output()
             .unwrap();
 
-        let saved_cwd = std::env::current_dir().ok();
+        // Restore cwd on drop (even on panic) so a failure here can't strand a
+        // sibling #[serial] test in this since-deleted tempdir.
+        let _cwd_guard = CwdGuard::new();
         std::env::set_current_dir(&path).unwrap();
 
         // Shared: one instance across all three config-reading phases.
@@ -177,10 +205,6 @@ mod tests {
         let _hooks = load_hooks_config_with(&GitCommand::new(true)).unwrap();
         let _ = GitCommand::new(true).config_get("user.email");
         let separate = discover_count();
-
-        if let Some(cwd) = saved_cwd {
-            let _ = std::env::set_current_dir(cwd);
-        }
 
         assert_eq!(
             shared, 1,


### PR DESCRIPTION
## Summary

`GitCommand` already caches its discovered repository in a per-instance
`OnceLock<gix::ThreadSafeRepository>`, but `list` and `checkout` were
constructing a *fresh* `GitCommand` after loading settings — discarding the
populated cache and forcing a second (and, for `checkout`, third)
`gix::discover()` per invocation. This collapses each command to a single
discover by threading one `GitCommand` instance through settings loading and
command execution.

## Changes

- Added `DaftSettings::load_with(&GitCommand)` and
  `load_hooks_config_with(&GitCommand)` variants; the bare `load()` /
  `load_hooks_config()` delegate to them, so the ~36 existing call sites are
  untouched.
- `list` (`run_blocking` / `run_live`) and `checkout` (`run_checkout` /
  `run_create_branch`) now construct one `GitCommand`, load settings through it,
  then `with_gitoxide(...)` the same instance — the populated `OnceLock` survives
  the move intact.

## Verification

- Real-binary probe: `list` 2→**1** discover, `checkout` 3→**1**.
- New unit test `shared_git_command_discovers_repo_once` asserts a shared
  instance discovers once (1) vs three separate instances (3), via a test-only
  `DISCOVER_COUNT` thread-local.
- `mise run fmt` / `clippy` / `test:unit` clean; full suite green via pre-push.

Surfaced by the #509 manual-test-suite profiling pass.

Fixes #584

🤖 Generated with [Claude Code](https://claude.com/claude-code)
