### PR TITLE
test(test-runner): dedupe inline repo specs into fixtures, fix parallel-prime collision

### DIFF
--- a/tests/manual/fixtures/repos/daft-yml-clone-hooks.yml
+++ b/tests/manual/fixtures/repos/daft-yml-clone-hooks.yml
@@ -1,0 +1,24 @@
+# Single-branch repo whose daft.yml defines post-clone + worktree-post-create
+# marker hooks. NOTE: intentionally NO `layout:` field — the layout is chosen
+# per-scenario via the --layout flag, which only takes effect because daft.yml
+# does not pin one. Shared by the clone/layout-*-hooks scenarios. Use {{NAME}}
+# as a placeholder for the repo name.
+
+default_branch: main
+branches:
+  - name: main
+    files:
+      - path: README.md
+        content: "# {{NAME}}"
+    commits:
+      - message: "Initial commit"
+daft_yml: |
+  hooks:
+    post-clone:
+      jobs:
+        - name: clone-marker
+          run: touch "$DAFT_WORKTREE_PATH/.clone-hook-ran"
+    worktree-post-create:
+      jobs:
+        - name: create-marker
+          run: touch "$DAFT_WORKTREE_PATH/.create-hook-ran"

--- a/tests/manual/fixtures/repos/daft-yml-contained-layout.yml
+++ b/tests/manual/fixtures/repos/daft-yml-contained-layout.yml
@@ -1,0 +1,14 @@
+# Single-branch repo whose daft.yml pins `layout: contained`. Shared by the
+# clone/layout scenarios that verify daft clones directly with the layout
+# declared in daft.yml. Use {{NAME}} as a placeholder for the repo name.
+
+default_branch: main
+branches:
+  - name: main
+    files:
+      - path: README.md
+        content: "# {{NAME}}"
+    commits:
+      - message: "Initial commit"
+daft_yml: |
+  layout: contained

--- a/tests/manual/fixtures/repos/main-with-feature-branch.yml
+++ b/tests/manual/fixtures/repos/main-with-feature-branch.yml
@@ -1,0 +1,19 @@
+# main + feature/test-feature (branched from main), no daft.yml. Shared by the
+# merge --rebase style scenarios, which create their own divergent main-side
+# commit in-step. Use {{NAME}} as a placeholder for the repo name.
+
+default_branch: main
+branches:
+  - name: main
+    files:
+      - path: README.md
+        content: "# {{NAME}}"
+    commits:
+      - message: "Initial commit"
+  - name: feature/test-feature
+    from: main
+    files:
+      - path: feature.txt
+        content: "feature content"
+    commits:
+      - message: "Add feature"

--- a/tests/manual/scenarios/clone/layout-contained-hooks.yml
+++ b/tests/manual/scenarios/clone/layout-contained-hooks.yml
@@ -6,24 +6,7 @@ description:
 
 repos:
   - name: test-repo
-    default_branch: main
-    branches:
-      - name: main
-        files:
-          - path: README.md
-            content: "# test-repo"
-        commits:
-          - message: "Initial commit"
-    daft_yml: |
-      hooks:
-        post-clone:
-          jobs:
-            - name: clone-marker
-              run: touch "$DAFT_WORKTREE_PATH/.clone-hook-ran"
-        worktree-post-create:
-          jobs:
-            - name: create-marker
-              run: touch "$DAFT_WORKTREE_PATH/.create-hook-ran"
+    use_fixture: daft-yml-clone-hooks
 
 steps:
   - name: Clone with contained layout and trust hooks

--- a/tests/manual/scenarios/clone/layout-from-daft-yml.yml
+++ b/tests/manual/scenarios/clone/layout-from-daft-yml.yml
@@ -5,16 +5,7 @@ description:
 
 repos:
   - name: test-repo
-    default_branch: main
-    branches:
-      - name: main
-        files:
-          - path: README.md
-            content: "# test-repo"
-        commits:
-          - message: "Initial commit"
-    daft_yml: |
-      layout: contained
+    use_fixture: daft-yml-contained-layout
 
 steps:
   - name: Clone without --layout flag

--- a/tests/manual/scenarios/clone/layout-prompt-skipped-for-daft-yml.yml
+++ b/tests/manual/scenarios/clone/layout-prompt-skipped-for-daft-yml.yml
@@ -5,16 +5,7 @@ description:
 
 repos:
   - name: test-repo
-    default_branch: main
-    branches:
-      - name: main
-        files:
-          - path: README.md
-            content: "# test-repo"
-        commits:
-          - message: "Initial commit"
-    daft_yml: |
-      layout: contained
+    use_fixture: daft-yml-contained-layout
 
 steps:
   - name: Clone (no prompt should appear, daft.yml takes over)

--- a/tests/manual/scenarios/clone/layout-sibling-hooks.yml
+++ b/tests/manual/scenarios/clone/layout-sibling-hooks.yml
@@ -5,24 +5,7 @@ description:
 
 repos:
   - name: test-repo
-    default_branch: main
-    branches:
-      - name: main
-        files:
-          - path: README.md
-            content: "# test-repo"
-        commits:
-          - message: "Initial commit"
-    daft_yml: |
-      hooks:
-        post-clone:
-          jobs:
-            - name: clone-marker
-              run: touch "$DAFT_WORKTREE_PATH/.clone-hook-ran"
-        worktree-post-create:
-          jobs:
-            - name: create-marker
-              run: touch "$DAFT_WORKTREE_PATH/.create-hook-ran"
+    use_fixture: daft-yml-clone-hooks
 
 steps:
   - name: Clone with sibling layout and trust hooks

--- a/tests/manual/scenarios/layout/resolution-daft-yml.yml
+++ b/tests/manual/scenarios/layout/resolution-daft-yml.yml
@@ -6,16 +6,7 @@ description:
 
 repos:
   - name: test-repo
-    default_branch: main
-    branches:
-      - name: main
-        files:
-          - path: README.md
-            content: "# test-repo"
-        commits:
-          - message: "Initial commit"
-    daft_yml: |
-      layout: contained
+    use_fixture: daft-yml-contained-layout
 
 steps:
   - name: Clone without --layout flag (repo has daft.yml with contained)

--- a/tests/manual/scenarios/merge/style-rebase-merge.yml
+++ b/tests/manual/scenarios/merge/style-rebase-merge.yml
@@ -5,21 +5,7 @@ description:
 
 repos:
   - name: test-repo
-    default_branch: main
-    branches:
-      - name: main
-        files:
-          - path: README.md
-            content: "# test-repo"
-        commits:
-          - message: "Initial commit"
-      - name: feature/test-feature
-        from: main
-        files:
-          - path: feature.txt
-            content: "feature content"
-        commits:
-          - message: "Add feature"
+    use_fixture: main-with-feature-branch
 
 steps:
   - name: Clone

--- a/tests/manual/scenarios/merge/style-rebase.yml
+++ b/tests/manual/scenarios/merge/style-rebase.yml
@@ -5,21 +5,7 @@ description:
 
 repos:
   - name: test-repo
-    default_branch: main
-    branches:
-      - name: main
-        files:
-          - path: README.md
-            content: "# test-repo"
-        commits:
-          - message: "Initial commit"
-      - name: feature/test-feature
-        from: main
-        files:
-          - path: feature.txt
-            content: "feature content"
-        commits:
-          - message: "Add feature"
+    use_fixture: main-with-feature-branch
 
 steps:
   - name: Clone

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -25,12 +25,10 @@ reflink-copy = "0.1.29"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 shlex = "2"
+tempfile = "3.8"
 term-styles = { workspace = true }
 walkdir = "2.5"
 
 [target.'cfg(unix)'.dependencies]
 # Used by `xtask test-matrix` to detect parent-process death and self-terminate.
 nix = { version = "0.31", features = ["process"] }
-
-[dev-dependencies]
-tempfile = "3.8"

--- a/xtask/src/manual_test/fixture_cache.rs
+++ b/xtask/src/manual_test/fixture_cache.rs
@@ -364,6 +364,41 @@ steps:
     }
 
     #[test]
+    fn prime_same_repo_name_across_fixtures_does_not_collide() {
+        // Regression (#586): generate_repo's temp clone dir must be unique per
+        // call. Priming runs in parallel with `remotes_dir.parent()` = the
+        // shared cache root, so several fixtures that reuse one repo name would
+        // otherwise all target `<cache>/tmp-clone-<name>` — which lives for the
+        // whole generation — and collide on `git clone`. Prime three different
+        // fixtures under the same repo name concurrently; all must succeed.
+        let cache_root = tempfile::tempdir().unwrap();
+        let root_path = cache_root.path().to_path_buf();
+        let name = "test-repo";
+        let fixtures = [
+            "daft-yml-contained-layout",
+            "main-with-feature-branch",
+            "daft-yml-clone-hooks",
+        ];
+        let mut keys = BTreeSet::new();
+        for fx in fixtures {
+            keys.insert((fx.to_string(), name.to_string()));
+        }
+
+        // jobs == key count: all three generate_repo calls run concurrently, so
+        // a fixed temp-clone path collides deterministically (each temp dir is
+        // alive for its whole generation, not just an instant).
+        FixtureCache::prime(&keys, &fixtures_dir(), root_path.clone(), fixtures.len())
+            .expect("parallel prime of same-named repos across fixtures must not collide");
+
+        for fx in fixtures {
+            assert!(
+                root_path.join(format!("{fx}/{name}/HEAD")).is_file(),
+                "fixture {fx} bare repo should exist after priming",
+            );
+        }
+    }
+
+    #[test]
     fn clone_into_returns_err_on_cache_miss() {
         // The cache-miss path is a "programming error" trip-wire — if a
         // worker ever encounters a fixture-derived RepoSpec whose key wasn't

--- a/xtask/src/manual_test/repo_gen.rs
+++ b/xtask/src/manual_test/repo_gen.rs
@@ -94,10 +94,6 @@ fn commit_branch(clone_dir: &Path, branch: &BranchSpec) -> Result<()> {
 /// Returns the path to the bare repository.
 pub fn generate_repo(spec: &RepoSpec, remotes_dir: &Path) -> Result<PathBuf> {
     let bare_path = remotes_dir.join(&spec.name);
-    let tmp_clone_path = remotes_dir
-        .parent()
-        .unwrap_or(remotes_dir)
-        .join(format!("tmp-clone-{}", spec.name));
 
     // 1. Create bare repo.
     std::fs::create_dir_all(&bare_path)
@@ -108,11 +104,22 @@ pub fn generate_repo(spec: &RepoSpec, remotes_dir: &Path) -> Result<PathBuf> {
     )
     .context("initialising bare repo")?;
 
-    // 2. Clone the bare repo into a temp working directory.
-    //    We need a parent dir that exists for the clone target.
-    if let Some(parent) = tmp_clone_path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
+    // 2. Clone the bare repo into a temp working directory. The temp dir is a
+    //    UNIQUELY-named sibling of `remotes_dir` (random suffix via tempfile),
+    //    not inside it, so the inline path's sandbox never scans it as a remote.
+    //    Uniqueness is load-bearing: fixture priming runs `generate_repo` in
+    //    parallel with `remotes_dir.parent()` = the *shared* cache root, so two
+    //    different fixtures that reuse the same repo name would otherwise both
+    //    target `tmp-clone-<name>` (alive for the whole generation) and collide
+    //    on `git clone` (#586).
+    let tmp_parent = remotes_dir.parent().unwrap_or(remotes_dir);
+    std::fs::create_dir_all(tmp_parent)
+        .with_context(|| format!("creating temp-clone parent dir: {}", tmp_parent.display()))?;
+    let tmp_clone = tempfile::Builder::new()
+        .prefix(&format!("tmp-clone-{}-", spec.name))
+        .tempdir_in(tmp_parent)
+        .context("creating temp clone dir")?;
+    let tmp_clone_path = tmp_clone.path().to_path_buf();
     let bare_str = bare_path
         .to_str()
         .context("bare repo path is not valid UTF-8")?;
@@ -205,9 +212,9 @@ pub fn generate_repo(spec: &RepoSpec, remotes_dir: &Path) -> Result<PathBuf> {
         ],
     )?;
 
-    // 9. Cleanup temp clone.
-    std::fs::remove_dir_all(&tmp_clone_path)
-        .with_context(|| format!("removing temp clone dir: {}", tmp_clone_path.display()))?;
+    // 9. The temp clone is removed when `tmp_clone` (a tempfile::TempDir) drops
+    //    — on success here, or on any early `?` return above.
+    drop(tmp_clone);
 
     Ok(bare_path)
 }


### PR DESCRIPTION
## Summary

#586 proposed routing the ~104 inline-repo scenarios through the shared fixture
cache for a performance win. An audit-first pass (see below) found that premise
**unfounded** — the realizable dedup is 4 repo generations / ~0.1 s wall, because
the fixture mechanism is `{{NAME}}`-substitution only and 100 of 104 inline
specs are genuinely distinct. So this PR delivers the **consistency** half:
the 3 verified byte-identical conversions, reframed as deduplication, not speed.

Implementing it also surfaced and fixes a **latent concurrency bug** in the test
runner.

## What landed

- **3 new fixtures** + **7 scenario conversions** (all verified byte-identical as
  written; baked content is inert for every step):
  - `daft-yml-contained-layout` ← `clone/layout-from-daft-yml`,
    `clone/layout-prompt-skipped-for-daft-yml`, `layout/resolution-daft-yml`
  - `main-with-feature-branch` ← `merge/style-rebase`, `merge/style-rebase-merge`
  - `daft-yml-clone-hooks` ← `clone/layout-contained-hooks`,
    `clone/layout-sibling-hooks` (fixture intentionally has **no** `layout:`
    field — the contained-vs-sibling divergence rides on the `--layout` step flag)
- **Bug fix:** `generate_repo`'s temp clone used a fixed
  `tmp-clone-<name>` path under the *shared* cache root. With multiple fixtures
  priming the same repo name (`test-repo`) concurrently — newly possible once
  these 3 fixtures exist — the parallel prime collided and the clone failed with
  `exit status: 128`. Replaced with a unique `tempfile`-based temp dir
  (auto-cleaned on drop). `tempfile` promoted from dev- to regular xtask dep
  (already in the lockfile — no cooldown impact).
- **Regression test** `prime_same_repo_name_across_fixtures_does_not_collide`
  primes all 3 same-named fixtures with `jobs=3` and asserts each HEAD exists —
  fails deterministically without the fix.

## Verification

- The 7 converted scenarios pass (20/20 steps).
- `cargo test -p xtask` clean; full suite green via pre-push.

## Notes for the reviewer

- **Commit/PR typed `test(test-runner):`** despite carrying a real fix — it's
  test-infra only (no shipped-binary change) and avoids a spurious release bump.
  The bug fix is the more consequential half; happy to retype to `fix` if you'd
  rather it drive a patch release.
- **#586's `perf` label/title** no longer matches the delivered work (consistency
  cleanup + fix). Consider relabeling or closing-as-superseded once this merges.

<details>
<summary>Full audit note (#586 step-1 deliverable)</summary>

# #586 Audit — route inline repos through the fixture cache

> Produced by a 4-verifier + synthesis workflow over the 104 inline-repo
> scenarios, cross-checked against a deterministic structural grouping pass.
> **Recommendation: `proceed_small`** — do the 4-generation dedup for
> consistency, not speed; do **not** extend the fixture mechanism.

## (a) Realizable savings under the existing mechanism

The mechanism is confirmed name-only: `resolve_fixture_spec` does exactly
`raw_yaml.replace("{{NAME}}", &name)` and nothing else. Two scenarios can share a
fixture **iff** their inline repo specs are byte-identical after replacing each
spec's own repo name with `{{NAME}}`. daft_yml, file content, commit messages,
and hook-script bodies are baked into the fixture and cannot vary per scenario.

- **Realizable now: 4 generations** (7 scenarios → 3 fixtures), corpus-verified.
  All four independent agents and the structural pre-pass converge on this exact
  figure (104 inline repos → 100 distinct specs → 97 singletons + 3 multi-member
  groups covering 7 scenarios).
- **Wall-time saving: ~0.1 s.** Fixtures prime **in parallel** across ~10
  workers, so 4 eliminated generations overlap with the ~96 unique primes still
  on the critical path.

## (b) Why the 33% near-miss is NOT realizable here

The coarse "~35 gens / 33%" ceiling splits:

1. **Genuinely extension-gated (the real blocker).** Families like the merge
   pre/post-merge-hook set differ in daft_yml / file content that assertions
   depend on (hook phases, hook bodies, sentinel paths, echoed strings). The
   `{{NAME}}`-only mechanism cannot parameterize any of this.
2. **Cheap cosmetic divergence (no extension needed).** A "Group B" of 10
   scenarios shares one byte-identical hooks-only daft_yml but differs only in a
   descriptive README string that no step asserts. ~9 gens reachable today by
   normalizing 10 READMEs to `# {{NAME}}` — out of this PR's headline.

The heaviest single offenders (`prune/many-worktrees` ~1277 ms, `prune/multiple`,
`checkout/complex-branches`, the unique merge specs) are genuine singletons —
dedup cannot touch them.

## (c) Recommendation: proceed_small

Do the 3 verified conversions (4 gens). The justification is **deduplication and
consistency**, explicitly **not** runtime (~0.1 s). Recommend **against**
extending the fixture mechanism: a per-scenario content-templating extension is
the only way to reach the remainder, and even at its 33% ceiling returns ≤1 s
wall — not worth the new maintenance surface.

## (d) Optional follow-up (low priority)

Normalize the 10 hooks-only "Group B" READMEs to `# {{NAME}}` and route them
through a shared fixture (+9 gens, ~0.2 s, pure dedup — READMEs are never
asserted). Track separately.

</details>

Fixes #586

🤖 Generated with [Claude Code](https://claude.com/claude-code)
