### PR TITLE
fix(list): honor daft.remote for default-branch resolution in blocking list path

### DIFF
--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -198,12 +198,9 @@ fn should_use_live(args: &Args) -> bool {
         && std::io::stdout().is_terminal()
 }
 
-/// Resolve the branch that worktrees/branches are compared against, honoring the
-/// configured `daft.remote` (not a hardcoded `origin`), with a `master` fallback
-/// when it can't be determined. Both `daft list` rendering paths (`run_blocking`
-/// here and `list_live::run_live`) route through this so they can't drift on which
-/// remote they consult — the blocking path previously hardcoded `origin`, ignoring
-/// `daft.remote` (#597).
+/// Resolve the base branch to compare against, honoring `daft.remote` (not a
+/// hardcoded `origin`) with a `master` fallback. Both list paths route through
+/// this so they can't drift again (#597).
 pub(crate) fn resolve_base_branch(
     git_common_dir: &std::path::Path,
     settings: &DaftSettings,
@@ -1119,13 +1116,9 @@ fn size_column_index(selected_columns: &[ListColumn], show_annotations: bool) ->
 mod tests {
     use super::*;
 
-    /// #597 regression: `daft list` must resolve the comparison base branch via
-    /// the configured `daft.remote`, not a hardcoded `origin`. With both remotes'
-    /// HEAD present, a repo configured with `upstream` resolves to upstream's
-    /// default branch, while the (previously hardcoded) `origin` points elsewhere
-    /// — so the old blocking path would have picked the wrong base. Deterministic:
-    /// both HEAD files exist, so resolution stays on the file-read path (no ambient
-    /// git, no `#[serial]` needed).
+    /// #597 regression: list must resolve the base branch via the configured
+    /// `daft.remote`, not a hardcoded `origin`. Both HEAD files exist so it stays
+    /// on the deterministic file-read path (no ambient git, no `#[serial]`).
     #[test]
     fn resolve_base_branch_honors_configured_remote_not_hardcoded_origin() {
         let tmp = tempfile::tempdir().unwrap();

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -198,11 +198,29 @@ fn should_use_live(args: &Args) -> bool {
         && std::io::stdout().is_terminal()
 }
 
+/// Resolve the branch that worktrees/branches are compared against, honoring the
+/// configured `daft.remote` (not a hardcoded `origin`), with a `master` fallback
+/// when it can't be determined. Both `daft list` rendering paths (`run_blocking`
+/// here and `list_live::run_live`) route through this so they can't drift on which
+/// remote they consult — the blocking path previously hardcoded `origin`, ignoring
+/// `daft.remote` (#597).
+pub(crate) fn resolve_base_branch(
+    git_common_dir: &std::path::Path,
+    settings: &DaftSettings,
+) -> String {
+    get_default_branch_local(git_common_dir, &settings.remote, settings.use_gitoxide)
+        .unwrap_or_else(|_| "master".to_string())
+}
+
 fn run_blocking(args: Args) -> Result<()> {
     // Construct the body `GitCommand` first and load settings through it so the
     // repo is discovered once and reused for the command body (#584).
     let git = GitCommand::new(false);
     let settings = DaftSettings::load_with(&git)?;
+    // Resolve the base branch before the `settings` field-moves below, since it
+    // borrows `&settings` (honoring `daft.remote` rather than a hardcoded remote).
+    let git_common_dir = get_git_common_dir()?;
+    let base_branch = resolve_base_branch(&git_common_dir, &settings);
     let stat = args.stat.unwrap_or(settings.list_stat);
     let columns_input = args.columns.or(settings.list_columns);
     let resolved = match columns_input {
@@ -223,9 +241,6 @@ fn run_blocking(args: Args) -> Result<()> {
     let compute_mtime = sort_spec.needs_mtime();
     let git = git.with_gitoxide(settings.use_gitoxide);
     let user_email: Option<String> = git.config_get("user.email").ok().flatten();
-    let git_common_dir = get_git_common_dir()?;
-    let base_branch = get_default_branch_local(&git_common_dir, "origin", settings.use_gitoxide)
-        .unwrap_or_else(|_| "master".to_string());
     let current_path = get_current_worktree_path()
         .ok()
         .and_then(|p| p.canonicalize().ok());
@@ -1103,6 +1118,39 @@ fn size_column_index(selected_columns: &[ListColumn], show_annotations: bool) ->
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #597 regression: `daft list` must resolve the comparison base branch via
+    /// the configured `daft.remote`, not a hardcoded `origin`. With both remotes'
+    /// HEAD present, a repo configured with `upstream` resolves to upstream's
+    /// default branch, while the (previously hardcoded) `origin` points elsewhere
+    /// — so the old blocking path would have picked the wrong base. Deterministic:
+    /// both HEAD files exist, so resolution stays on the file-read path (no ambient
+    /// git, no `#[serial]` needed).
+    #[test]
+    fn resolve_base_branch_honors_configured_remote_not_hardcoded_origin() {
+        let tmp = tempfile::tempdir().unwrap();
+        let gcd = tmp.path();
+        for (remote, branch) in [("upstream", "main"), ("origin", "wrongdefault")] {
+            let head = gcd.join("refs/remotes").join(remote).join("HEAD");
+            std::fs::create_dir_all(head.parent().unwrap()).unwrap();
+            std::fs::write(&head, format!("ref: refs/remotes/{remote}/{branch}\n")).unwrap();
+        }
+
+        // Honors settings.remote: a repo configured with `upstream` resolves to
+        // upstream's default branch.
+        let upstream = DaftSettings {
+            remote: "upstream".into(),
+            ..Default::default()
+        };
+        assert_eq!(resolve_base_branch(gcd, &upstream), "main");
+
+        // Hardcoding `origin` (the #597 bug) would have resolved the wrong branch.
+        let origin = DaftSettings {
+            remote: "origin".into(),
+            ..Default::default()
+        };
+        assert_eq!(resolve_base_branch(gcd, &origin), "wrongdefault");
+    }
 
     #[test]
     fn build_emit_table_headers_match_default_columns() {

--- a/src/commands/list_live.rs
+++ b/src/commands/list_live.rs
@@ -5,7 +5,7 @@
 //! in `list::run` falls back to `list::run_blocking` (today's behavior).
 
 use crate::{
-    commands::list::Args,
+    commands::list::{Args, resolve_base_branch},
     core::{
         columns::{ColumnSelection, CommandKind, ListColumn, ResolvedColumns},
         repo::{get_current_worktree_path, get_git_common_dir, get_project_root},
@@ -19,7 +19,6 @@ use crate::{
     },
     git::GitCommand,
     output::tui::{Column, TuiRenderer, TuiState},
-    remote::get_default_branch_local,
     settings::DaftSettings,
 };
 use anyhow::Result;
@@ -87,9 +86,7 @@ pub fn run_live(args: Args) -> Result<()> {
     let git = git.with_gitoxide(settings.use_gitoxide);
     let user_email: Option<String> = git.config_get("user.email").ok().flatten();
     let git_common_dir = get_git_common_dir()?;
-    let base_branch =
-        get_default_branch_local(&git_common_dir, &settings.remote, settings.use_gitoxide)
-            .unwrap_or_else(|_| "master".to_string());
+    let base_branch = resolve_base_branch(&git_common_dir, &settings);
     let current_path = get_current_worktree_path()
         .ok()
         .and_then(|p| p.canonicalize().ok());


### PR DESCRIPTION
## Summary

`daft list`'s blocking render path (`run_blocking`) hardcoded the remote name
`"origin"` when resolving the repository's default branch via
`get_default_branch_local`, while the live path (`run_live`) correctly used
`settings.remote`. For repositories whose remote isn't named `origin`
(configured via `daft.remote`), the blocking path resolved against a
non-existent remote and silently fell back to `"master"` — a config-handling
inconsistency between the two `daft list` rendering paths.

## Fix

Extract a shared `resolve_base_branch(git_common_dir, &settings)` helper (reads
`settings.remote`, with the `"master"` fallback) and route **both** list paths
through it, so they can't drift again — the bug existed precisely because the
two paths were byte-identical except for that one token. (In `run_blocking` the
resolution moved a few lines up, ahead of the `settings` field-moves, so it can
borrow `&settings`.)

## Test

`resolve_base_branch_honors_configured_remote_not_hardcoded_origin` is
deterministic: it writes both `refs/remotes/<remote>/HEAD` files so resolution
stays on the file-read path (no ambient git, no `#[serial]`). It asserts a repo
configured with `upstream` resolves to upstream's default branch, and that a
hardcoded `origin` would have resolved a different branch. Verified it **fails**
on the unfixed code (`left: "wrongdefault", right: "main"`) and passes with the
fix.

Surfaced by the #592 Claude review (flagged as pre-existing, not introduced by
#584); verified pre-existing — the hardcode sat in untouched context in the #584
diff.

Fixes #597

🤖 Generated with [Claude Code](https://claude.com/claude-code)
