### PR TITLE
ci: add area:* PR auto-labeler, label taxonomy, and docs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,99 @@
+# Auto-applies `area:*` zone labels to PRs based on the files they touch.
+#
+# WHAT: each `area:*` label marks a code / conflict zone. PRs are labeled
+#   automatically from their diff here; issues are hand-labeled by *predicted*
+#   zone at triage. A PR carrying more zones than its issue predicted flags
+#   scope creep; two open PRs sharing a zone flag a likely rebase conflict.
+#   See CONTRIBUTING.md and CLAUDE.md ("### Labels") for the policy.
+#
+# SOURCE OF TRUTH: this file is the ONLY place the glob -> zone map lives.
+#   When you add a top-level `src/` module or a new workspace crate, add its
+#   glob here AND create the matching `area:*` label. Do not duplicate this
+#   list into CLAUDE.md or the docs — they describe the scheme and point here.
+#
+# Syntax: actions/labeler v5+ (changed-files / any-glob-to-any-file).
+
+"area:worktree":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/core/worktree/**"
+
+"area:layout":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/core/layout/**"
+
+"area:config":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/core/config.rs"
+          - "src/core/config/**"
+
+"area:commands":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/commands/*.rs"
+          - "src/commands/repo/**"
+          - "src/main.rs"
+          - "src/shortcuts.rs"
+          - "src/exec.rs"
+
+"area:completions":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/commands/completions/**"
+
+"area:hooks":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/hooks/**"
+          - "src/commands/hooks/**"
+          - "src/executor/**"
+          - "src/trust_prune.rs"
+
+"area:coordinator":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/coordinator/**"
+
+"area:store":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/store/**"
+
+"area:git":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/git/**"
+
+"area:output":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/output/**"
+
+"area:docs":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/**"
+
+"area:ci":
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/**"
+          - "mise.toml"
+          - "release.toml"
+          - "cliff.toml"
+          - "cooldown.toml"
+          - "bunfig.toml"
+          - "scripts/**"
+          - ".dep-age-allowlist"
+
+"area:test-runner":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "xtask/**"
+
+"area:term-styles":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "term-styles/**"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -28,12 +28,15 @@
       - any-glob-to-any-file:
           - "src/core/config.rs"
           - "src/core/config/**"
+          - "src/commands/config/**" # config commands share the config zone
 
 "area:commands":
   - changed-files:
       - any-glob-to-any-file:
           - "src/commands/*.rs"
           - "src/commands/repo/**"
+          - "src/cli/**" # argv parsing layer
+          - "src/doctor/**" # doctor folded into commands (low-churn)
           - "src/main.rs"
           - "src/shortcuts.rs"
           - "src/exec.rs"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -5,6 +5,10 @@
 # same-repo branches (the worktree model), so the default token can label them,
 # and we avoid the privileged base-repo context. Minimal permissions; this
 # workflow is independent of and does not touch claude-pr-review.yml.
+#
+# Labels are ADDITIVE: actions/labeler defaults sync-labels to false, so zones
+# are added from the diff and manually-applied labels are never stripped
+# (intentional — the labeler should not fight manual overrides).
 name: Labeler
 
 on:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,21 @@
+# Applies `area:*` zone labels to PRs from their changed files.
+# Map lives in .github/labeler.yml (the source of truth).
+#
+# Triggered on `pull_request` (NOT pull_request_target): daft PRs come from
+# same-repo branches (the worktree model), so the default token can label them,
+# and we avoid the privileged base-repo context. Minimal permissions; this
+# workflow is independent of and does not touch claude-pr-review.yml.
+name: Labeler
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -325,6 +325,36 @@ Every PR must be tagged with:
   `refactor`, `style`, `perf`, `test`, `chore`, `ci`)
 - **Milestone**: `Public Launch` (current active milestone)
 
+### Labels
+
+Labels live on orthogonal axes — keep them from blurring:
+
+- **Kind** (issues): `bug`, `enhancement`, `documentation` — what the issue
+  _is_.
+- **Type** (PRs, conventional): `feat`, `fix`, `docs`, `perf`, `refactor`,
+  `chore`, `ci`, `style`, `test` — what the change _does_ (matches the commit
+  type).
+- **Area** (`area:*`): the code / conflict _zone_ a change touches —
+  `area:worktree`, `area:hooks`, `area:store`, `area:coordinator`, `area:git`,
+  `area:layout`, `area:config`, `area:commands`, `area:completions`,
+  `area:output`, `area:docs`, `area:ci`, `area:test-runner`, `area:term-styles`.
+  The `area:` prefix is load-bearing — it keeps zones a distinct axis and avoids
+  colliding with the like-named `hooks`/`docs`/`ci` labels on other axes.
+- **Topic / triage**: `security`, `audit`, `dependencies`, `release`;
+  `high-priority`, `good first issue`, `help wanted`.
+
+**`area:*` is the parallelization + conflict signal.** PRs are auto-labeled by
+zone from their diff (`.github/labeler.yml`); label _issues_ by their
+**predicted** zone at triage. A PR carrying more zones than its issue predicted
+flags scope creep; two open PRs sharing a zone flag a likely rebase; the same
+zone on two in-progress items means serialize them.
+
+**Drift rule (same spirit as Shell Completions below):** `.github/labeler.yml`
+is the _only_ place the glob → zone map lives. When you add a top-level `src/`
+module or a new workspace crate, add its glob there and create the matching
+`area:*` label. Never duplicate the glob list into this file or the docs — they
+describe the scheme and point at `labeler.yml`.
+
 ## Commits
 
 [Conventional Commits](https://www.conventionalcommits.org/) format:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -337,9 +337,10 @@ Labels live on orthogonal axes — keep them from blurring:
 - **Area** (`area:*`): the code / conflict _zone_ a change touches —
   `area:worktree`, `area:hooks`, `area:store`, `area:coordinator`, `area:git`,
   `area:layout`, `area:config`, `area:commands`, `area:completions`,
-  `area:output`, `area:docs`, `area:ci`, `area:test-runner`, `area:term-styles`.
-  The `area:` prefix is load-bearing — it keeps zones a distinct axis and avoids
-  colliding with the like-named `hooks`/`docs`/`ci` labels on other axes.
+  `area:output`, `area:docs`, `area:ci`, `area:test-runner`, `area:term-styles`
+  (canonical list + globs: `.github/labeler.yml`). The `area:` prefix is
+  load-bearing — it keeps zones a distinct axis and avoids colliding with the
+  like-named `hooks`/`docs`/`ci` labels on other axes.
 - **Topic / triage**: `security`, `audit`, `dependencies`, `release`;
   `high-priority`, `good first issue`, `help wanted`.
 

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -233,6 +233,24 @@ docs: update installation instructions
 - Issue references go in the PR body, not the title: `Fixes #42`
 - All PRs target `master` and are squash-merged
 
+## Labels
+
+Issues and PRs are organized on a few orthogonal axes:
+
+- **Kind** (issues): `bug`, `enhancement`, `documentation`
+- **Type** (PRs): the conventional-commit type — `feat`, `fix`, `docs`, `perf`,
+  `refactor`, `chore`, `ci`, `style`, `test`
+- **Area** (`area:*`): the part of the codebase a change touches (e.g.
+  `area:worktree`, `area:hooks`, `area:store`, `area:docs`, `area:ci`). On PRs
+  these are **applied automatically** from the changed files — you don't add
+  them by hand. They make conflict-prone overlaps visible: two open PRs sharing
+  an `area:` are likely to need a rebase.
+- **Topic / triage**: `security`, `audit`, `release`, `high-priority`, and so on
+
+When filing an issue, add its kind and, if you know it, the `area:*` you expect
+the work to touch. The zone map is defined in
+[`.github/labeler.yml`](https://github.com/avihut/daft/blob/master/.github/labeler.yml).
+
 ## Branch Naming
 
 Follow the convention: `daft-<issue-number>/<short-description>`


### PR DESCRIPTION
## What

Establishes the project's label taxonomy and wires up automatic PR labeling.

- **`area:*` zone labels** — one axis = code/conflict territory, 14 zones mapped to real module/crate boundaries.
- **Auto-label PRs from the diff** via `actions/labeler` + `.github/labeler.yml`, so a PR's zones reflect what it *actually* touched: divergence from an issue's predicted zone surfaces scope creep, and two open PRs sharing a zone is a rebase heads-up.
- **CLAUDE.md** — label axes (kind / type / area / topic), the `area:` policy, and a drift rule (single source of truth = `.github/labeler.yml`).
- **docs/about/contributing.md** — contributor-facing label section.

## Applied to the live repo separately (not in this PR — labels aren't version-controlled)

- Created the 14 `area:*` labels.
- Consolidated stray duplicates: `performance` → `perf`, `refactoring` → `refactor`.
- Kept `bug` / `enhancement` / `documentation` as issue *kinds* and kept `hooks`, per the agreed kind/type/area model.

## Safety

The labeler workflow uses `pull_request` (not `pull_request_target`), a SHA-pinned `actions/labeler@v6.1.0`, and minimal permissions (`contents: read`, `pull-requests: write`). It is independent of and does not touch or reference `claude-pr-review.yml`.

Fixes #601
