### PR TITLE
fix(ci): avoid broken pipe in MSRV staleness version fetch

### DIFF
--- a/.github/workflows/msrv-staleness-check.yml
+++ b/.github/workflows/msrv-staleness-check.yml
@@ -52,17 +52,20 @@ jobs:
           # ~850 KB file to write; curl then dies with a write-output error
           # (exit 23) that `pipefail` propagates, aborting the step even though
           # the parse already succeeded. Downloading first removes the pipe
-          # (and keeps `curl -f`'s HTTP-error handling unambiguous).
+          # (and keeps `curl -f`'s HTTP-error handling unambiguous). $RUNNER_TEMP
+          # is the runner's per-job scratch dir (emptied each job), so the file
+          # never lands in the checked-out workspace.
           #
           # The `[pkg.rust]` block's `version` field carries the form
           #   version = "1.96.0 (ac68faa20 2026-05-25)"
           # — extract the leading semver triple.
+          channel_toml="$RUNNER_TEMP/channel-rust-stable.toml"
           curl -fsSL https://static.rust-lang.org/dist/channel-rust-stable.toml \
-            -o channel-rust-stable.toml
+            -o "$channel_toml"
           LATEST=$(awk '/^\[pkg\.rust\]$/{f=1; next} f && /^version *=/{
               match($0, /[0-9]+\.[0-9]+\.[0-9]+/);
               print substr($0, RSTART, RLENGTH); exit
-            }' channel-rust-stable.toml)
+            }' "$channel_toml")
 
           if [ -z "$CURRENT" ] || [ -z "$LATEST" ]; then
             echo "::error::Failed to parse MSRV (current=$CURRENT, latest=$LATEST)"

--- a/.github/workflows/msrv-staleness-check.yml
+++ b/.github/workflows/msrv-staleness-check.yml
@@ -46,15 +46,23 @@ jobs:
           CURRENT=$(grep -E '^rust-version *=' Cargo.toml | head -1 \
             | sed -E 's/^rust-version *= *"([0-9.]+)".*/\1/')
 
-          # Fetch the canonical current stable Rust version. The `[pkg.rust]`
-          # block's `version` field carries the form
-          #   version = "1.95.0 (59807616e 2026-04-14)"
+          # Fetch the canonical current stable Rust version to a file first.
+          # Piping curl straight into an awk that `exit`s on the first match
+          # closes the read end of the pipe while curl still has most of the
+          # ~850 KB file to write; curl then dies with a write-output error
+          # (exit 23) that `pipefail` propagates, aborting the step even though
+          # the parse already succeeded. Downloading first removes the pipe
+          # (and keeps `curl -f`'s HTTP-error handling unambiguous).
+          #
+          # The `[pkg.rust]` block's `version` field carries the form
+          #   version = "1.96.0 (ac68faa20 2026-05-25)"
           # — extract the leading semver triple.
-          LATEST=$(curl -fsSL https://static.rust-lang.org/dist/channel-rust-stable.toml \
-            | awk '/^\[pkg\.rust\]$/{f=1; next} f && /^version *=/{
-                match($0, /[0-9]+\.[0-9]+\.[0-9]+/);
-                print substr($0, RSTART, RLENGTH); exit
-              }')
+          curl -fsSL https://static.rust-lang.org/dist/channel-rust-stable.toml \
+            -o channel-rust-stable.toml
+          LATEST=$(awk '/^\[pkg\.rust\]$/{f=1; next} f && /^version *=/{
+              match($0, /[0-9]+\.[0-9]+\.[0-9]+/);
+              print substr($0, RSTART, RLENGTH); exit
+            }' channel-rust-stable.toml)
 
           if [ -z "$CURRENT" ] || [ -z "$LATEST" ]; then
             echo "::error::Failed to parse MSRV (current=$CURRENT, latest=$LATEST)"


### PR DESCRIPTION
## What

The `MSRV staleness check` workflow failed on its first scheduled run (2026-06-01, [run 26742377175](https://github.com/avihut/daft/actions/runs/26742377175)) with `curl: (23) Failure writing output to destination`, aborting before it computed the MSRV gap.

## Why it failed

The version fetch piped a ~850 KB file (`channel-rust-stable.toml`) straight into an `awk` that `exit`s on the first match. `awk` closes the read end of the pipe early; curl can't finish writing and exits **23**, and `set -euo pipefail` propagates that as the step's failure — even though the parse had already succeeded. Latent since the workflow was added in #481; it only surfaced now because the monthly `0 6 1 * *` cron had its first execution.

## Fix

Download the channel file first, then parse it from disk — there's no pipe to break. `curl -f` still surfaces a genuine HTTP error cleanly.

## Verification

Ran the fetch/parse/gap logic under **bash 5.x** (runner-accurate — older bash masks the failure) with `set -euo pipefail`:

- exits **0**
- computes `Declared MSRV: 1.93  Current stable: 1.96.0  Gap: 3`

A conventional unit/YAML regression test doesn't map to a GitHub Actions shell step (the repo has no test harness for workflows). The workflow keeps its `workflow_dispatch` trigger, so it can be validated end-to-end by dispatching it manually.

## Note (separate work)

The gap it now computes (3, vs the policy's 2) is real: once this merges and the workflow runs, it will open a "bump MSRV 1.93 → 1.94" tracking issue. That bump is separate human-triage work and is intentionally out of scope here.

Fixes #606

🤖 Generated with [Claude Code](https://claude.com/claude-code)
