### PR TITLE
chore: bump MSRV 1.93 → 1.94

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -65,7 +65,7 @@ updates:
         patterns:
           - "*"
     # dtolnay/rust-toolchain tags name the Rust toolchain version they install
-    # (e.g. @1.93.0 installs Rust 1.93.0), not a version of the action itself.
+    # (e.g. @1.94.0 installs Rust 1.94.0), not a version of the action itself.
     # Dependabot can't see this — bumping the tag would request a non-existent
     # toolchain. The MSRV value is owned by Cargo.toml's rust-version field.
     ignore:

--- a/.github/workflows/msrv-staleness-check.yml
+++ b/.github/workflows/msrv-staleness-check.yml
@@ -94,7 +94,7 @@ jobs:
           ## Action
 
           1. Pick the new MSRV target — typically \`$LATEST\` minus 2.
-          2. Update all five sync-points listed under "Where MSRV is recorded" in \`CLAUDE.md\` (\`Cargo.toml\`, \`mise.toml\`, \`.github/workflows/test.yml\`, \`README.md\`, \`docs/getting-started/installation.md\`).
+          2. Update all six sync-points listed under "Where MSRV is recorded" in \`CLAUDE.md\` (\`Cargo.toml\`, \`term-styles/Cargo.toml\`, \`mise.toml\`, \`.github/workflows/test.yml\`, \`README.md\`, \`docs/getting-started/installation.md\`).
           3. Verify locally: \`rustup run <new-msrv> cargo check --all-targets\`.
           4. Open a PR titled \`chore: bump MSRV $CURRENT → <new>\`.
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -166,10 +166,10 @@ jobs:
       - name: Install mise
         uses: jdx/mise-action@v4
 
-      # mise installs the toolchain pinned in mise.toml (rust = "1.93") and
+      # mise installs the toolchain pinned in mise.toml (rust = "1.94") and
       # exports RUSTUP_TOOLCHAIN, overriding the dtolnay-installed `stable`.
       # Components from the dtolnay step were installed for `stable`, not for
-      # the mise-managed 1.93.x — re-install them for the active toolchain so
+      # the mise-managed 1.94.x — re-install them for the active toolchain so
       # `cargo fmt`/`cargo clippy` resolve against a complete component set.
       - name: Ensure rustfmt + clippy for mise-managed toolchain
         run: rustup component add rustfmt clippy
@@ -193,7 +193,7 @@ jobs:
   # declared in Cargo.toml's `rust-version`. `cargo check` is enough; the
   # `lint` job above already runs full build+test on stable. Cheap minutes
   # gate that prevents silent MSRV regressions when new code accidentally
-  # uses post-1.93 stdlib features.
+  # uses post-1.94 stdlib features.
   msrv-check:
     needs: changes
     if: >-
@@ -204,13 +204,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up Rust 1.93 (MSRV)
-        uses: dtolnay/rust-toolchain@1.93.0
+      - name: Set up Rust 1.94 (MSRV)
+        uses: dtolnay/rust-toolchain@1.94.0
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
-          key: msrv-1.93
+          key: msrv-1.94
 
       # `--locked` refuses to rewrite Cargo.lock, so a manifest/lockfile
       # mismatch (e.g. a Dependabot grouped-update PR that bumps Cargo.lock

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,8 +151,9 @@ MSRV = **`latest_stable - 2`**. Wide enough to keep distro and corporate
 installs working, narrow enough that we can adopt new stdlib/language features
 ~3 months after stabilization.
 
-The version is declared in `Cargo.toml` `rust-version`; other places that
-mention it (`mise.toml`, `.github/workflows/test.yml`, `README.md`,
+The version is declared in `Cargo.toml` `rust-version` and the workspace member
+`term-styles/Cargo.toml`; other places that mention it (`mise.toml`,
+`.github/workflows/test.yml`, `README.md`,
 `docs/getting-started/installation.md`) must match — `rg '1\.\d+'` after a bump
 finds the stragglers.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ term-styles = { path = "term-styles", version = "0.1.0" }
 name = "daft"
 version = "1.15.0"
 edition = "2024"
-rust-version = "1.93"
+rust-version = "1.94"
 description = "A comprehensive Git extensions toolkit that enhances developer workflows, starting with powerful worktree management"
 authors = ["avihu <avihu@users.noreply.github.com>"]
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![CI](https://github.com/avihut/daft/actions/workflows/test.yml/badge.svg)](https://github.com/avihut/daft/actions/workflows/test.yml)
 [![Release](https://img.shields.io/github/v/release/avihut/daft?label=release)](https://github.com/avihut/daft/releases/latest)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](#license)
-[![Rust](https://img.shields.io/badge/rust-1.93%2B-orange.svg)](https://www.rust-lang.org/)
+[![Rust](https://img.shields.io/badge/rust-1.94%2B-orange.svg)](https://www.rust-lang.org/)
 [![Homebrew](https://img.shields.io/badge/homebrew-avihut%2Ftap-blueviolet)](https://github.com/avihut/homebrew-tap)
 [![macOS](https://img.shields.io/badge/macOS-supported-success)](https://github.com/avihut/daft/releases)
 [![Linux](https://img.shields.io/badge/Linux-supported-success)](https://github.com/avihut/daft/releases)
@@ -211,7 +211,7 @@ for manual installation options.
 ## Requirements
 
 - **Git** 2.5+ (for worktree support)
-- **Rust** 1.93+ (only for building from source)
+- **Rust** 1.94+ (only for building from source)
 
 ## Contributing
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -195,4 +195,4 @@ See [Shell Integration](./shell-integration.md) for full details.
 ## Requirements
 
 - **Git** 2.5+ (for worktree support)
-- **Rust** 1.93+ (only needed when building from source)
+- **Rust** 1.94+ (only needed when building from source)

--- a/mise.lock
+++ b/mise.lock
@@ -297,5 +297,5 @@ url = "https://github.com/neovim/neovim/releases/download/stable/nvim-win64.zip"
 url = "https://github.com/neovim/neovim/releases/download/stable/nvim-win64.zip"
 
 [[tools.rust]]
-version = "1.93.1"
+version = "1.94.1"
 backend = "core:rust"

--- a/mise.toml
+++ b/mise.toml
@@ -21,7 +21,7 @@ minimum_release_age = "7d"
 # Pin the aqua backend explicitly so binstall itself never falls back to a
 # cargo-from-source build (chicken-and-egg).
 "aqua:cargo-bins/cargo-binstall" = "1.18.1"
-rust = "1.93"
+rust = "1.94"
 lefthook = "2.1.6"
 cocogitto = "7.0.0"
 bun = "1.3.13"

--- a/term-styles/Cargo.toml
+++ b/term-styles/Cargo.toml
@@ -2,7 +2,7 @@
 name = "term-styles"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.93"
+rust-version = "1.94"
 description = "Terminal ANSI styling utilities (colors, bold, dim) shared across the daft workspace."
 license = "MIT OR Apache-2.0"
 publish = false


### PR DESCRIPTION
## What

Bumps the project's MSRV from **1.93 → 1.94**. Current stable Rust is **1.96.0**, so per the `latest_stable - 2` policy in `CLAUDE.md` the floor moves up one minor, closing the staleness gap (3 → 2) that the monthly `msrv-staleness-check` workflow flagged in #609.

## Sync points updated

Every place the MSRV is recorded (the policy's `rg '1\.\d+'` sweep):

- `Cargo.toml` — root crate `rust-version`
- `term-styles/Cargo.toml` — workspace-member `rust-version` **(straggler: it was not enumerated in CLAUDE.md's sync-point list)**
- `mise.toml` — `rust = "1.94"` (and `mise.lock` → `1.94.1`)
- `.github/workflows/test.yml` — the MSRV job's `dtolnay/rust-toolchain@1.94.0` pin, the `msrv-1.94` cache key, and the explanatory comments
- `README.md` — badge + Requirements
- `docs/getting-started/installation.md` — Requirements

Doc hygiene folded into the same change:

- Added `term-styles/Cargo.toml` to CLAUDE.md's MSRV sync-point list so the next bump can't miss it.
- Refreshed the illustrative `dtolnay` pin in `dependabot.yml`'s comment (`@1.93.0` → `@1.94.0`) so the example matches the real pin.

## Verification (under 1.94)

| Gate | Toolchain | Result |
| --- | --- | --- |
| `cargo check --all-targets --locked` | `1.94.0` (matches CI's `dtolnay@1.94.0` + `--locked`) | clean, ~42s |
| `mise run clippy` | mise `1.94.1` (matches CI lint job) | zero warnings |
| `mise run test:unit` | mise `1.94.1` | 1915 passed, 0 failed |
| `mise run fmt:check` (rustfmt + prettier) | — | clean |

No new clippy lints surfaced on the 1.93 → 1.94 step — this is the clean case the "issue, not auto-PR" design anticipated.

## Note

This is a config/docs-only change with no `.rs` edits, so there is no behavioral regression test to add. The MSRV CI job (`cargo check --locked` at the pinned floor) is itself the guard, and now runs at 1.94. Merging closes the tracking issue; the staleness workflow would also auto-close it once it next sees the gap back at ≤ 2.

Fixes #609

🤖 Generated with [Claude Code](https://claude.com/claude-code)
