### PR TITLE
fix(ci): ensure release build toolchain meets MSRV on every runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,6 +140,20 @@ jobs:
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
             echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           fi
+      # Some runner images — notably the ubuntu-24.04-arm partner image used for
+      # aarch64-unknown-linux-gnu — ship a pre-installed Rust that can lag behind
+      # a freshly-bumped MSRV, and cargo-dist only force-installs Rust inside
+      # containers (the step above). Ensure a current stable toolchain (always
+      # >= MSRV, so it never becomes another version sync-point) is the default
+      # on every runner. `rustup target add` keeps cross-builds (e.g.
+      # x86_64-apple-darwin on the aarch64 macOS runner) working. See issue #613.
+      - name: Ensure a current Rust toolchain (>= MSRV) on all runners
+        shell: bash
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
+          rustup target add ${{ join(matrix.targets, ' ') }}
+          rustc --version --verbose
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest


### PR DESCRIPTION
## What

The `v1.15.1` release failed: `build-local-artifacts (aarch64-unknown-linux-gnu)` errored within ~16s with `rustc 1.93.1 is not supported ... daft@1.15.1 requires rustc 1.94`. This adds a step to the release workflow's `build-local-artifacts` job that ensures a current Rust toolchain on **every** runner before building.

## Why

- The MSRV was bumped 1.93 → 1.94 in #610, included in the `v1.15.1` tag.
- `aarch64-unknown-linux-gnu` builds on a **native ARM runner** (`ubuntu-24.04-arm`, `dist-workspace.toml` `[dist.github-custom-runners]`), not a container.
- cargo-dist's generated "Install Rust non-interactively if not already installed" step is gated `if: ${{ matrix.container }}` **and** only installs when `cargo` is absent. On the native ARM runner it is skipped, so the build used that image's **pre-installed `rustc 1.93.1`** — now below MSRV. The other five targets ship a newer pre-installed Rust and built fine; `v1.15.0` shipped on the same ARM runner days earlier because it predated the 1.94 bump.

## The fix

Inject one step (after the container-gated install, before `Install dist`):

```yaml
- name: Ensure a current Rust toolchain (>= MSRV) on all runners
  shell: bash
  run: |
    rustup toolchain install stable --profile minimal --no-self-update
    rustup default stable
    rustup target add ${{ join(matrix.targets, ' ') }}
    rustc --version --verbose
```

- **Pinned to floating `stable`, not the MSRV floor.** Stable is always ≥ MSRV, so this never becomes a seventh MSRV sync-point that the next bump would silently re-break. Mirrors the `dtolnay/rust-toolchain@stable` already used elsewhere in this workflow.
- **`rustup target add`** keeps cross-builds working (e.g. `x86_64-apple-darwin` built on the aarch64 macOS runner) when a freshly installed stable would otherwise lack the cross target's std.
- **Applied directly to `release.yml`, not via `github-build-setup`.** This file is hand-maintained (`allow-dirty = ["ci"]`) — e.g. the action versions are bumped in place (`checkout@v6`, `upload-artifact@v7`), and the `workflow_dispatch` tag input + tag-only trigger are local customizations. A full `dist generate` would revert all of that (I verified: it produces a 394-deletion diff that downgrades the actions and adds a `pull_request:` trigger). So the toolchain step is hand-applied like every other customization in this file. The injected step format/placement was lifted from a throwaway `dist generate` to keep it identical to what cargo-dist would emit.

## Verification

`release.yml` only triggers on tag pushes / `workflow_dispatch` (no `pull_request` trigger), so **this PR's CI does not exercise the release path** — the change is correct-by-inspection here; the actual proof is the next tagged release. No code change, so no unit test (the guard is the release job itself).

## Re-release

`v1.15.1` published no GitHub Release or Homebrew formula (the build died before the `host`/`announce` stages) — only an orphan tag exists, nothing to clean up. As a `fix:`, merging this auto-opens the `v1.15.2` release PR, which would carry the previously-unshipped `v1.15.1` content plus this fix. (Alternatively, trigger Release flow with `override_version`.)

Fixes #613
