### PR TITLE
feat: DAG-aware --skip-hooks flag for worktree hooks (replaces --no-hooks)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -620,6 +620,36 @@ daft hooks run worktree-post-create --verbose    # Show skipped jobs with reason
 Use cases: re-running after a failure, iterating during hook development, or
 bootstrapping existing worktrees that predate the hooks config.
 
+### Skipping Hooks Per-Invocation (`--skip-hooks`)
+
+The worktree-creating commands (`daft start`, `daft go`,
+`git worktree-checkout`, `git worktree-checkout-branch`) and
+`git worktree-clone` / `git worktree-flow-adopt` accept `--skip-hooks` to
+exclude jobs for one run (repeatable / comma-separated):
+
+```bash
+daft start feat/x --skip-hooks all          # skip every hook (replaces the old --no-hooks)
+daft start feat/x --skip-hooks lint          # skip the lint job AND its dependents
+daft start feat/x --skip-hooks tag:heavy     # skip every heavy-tagged job AND dependents
+daft start feat/x --skip-hooks tag:heavy,lint
+git worktree-clone <url> --skip-hooks all    # clone without running any hooks
+```
+
+Selectors: `all` / `*` (every job), `tag:<tag>` (tagged jobs + dependents),
+`<name>` (a job + its dependents), `job:<name>` (explicit-name escape hatch). A
+bare token is a job **name**; tags need the `tag:` prefix.
+
+Key behavior — the **downstream cascade**: skipping a job also skips every job
+that `needs:` it (transitively), because running a dependent against a
+deliberately-skipped dependency is broken. Upstream dependencies are untouched.
+Excluded jobs are reported as skipped with a reason, not dropped silently; a
+selector matching nothing warns and the run proceeds.
+
+`--skip-hooks` is the **exclusion** counterpart to `daft hooks run --job/--tag`
+(which is an inclusion filter). `--skip-hooks all` cannot be combined with
+`--trust-hooks`; a partial skip (`tag:`/`<job>`) still runs your own hooks and
+remains compatible with `--trust-hooks`.
+
 ### Move Hooks
 
 When a worktree is moved (rename via `daft worktree-branch -m`, layout transform

--- a/SKILL.md
+++ b/SKILL.md
@@ -629,15 +629,20 @@ exclude jobs for one run (repeatable / comma-separated):
 
 ```bash
 daft start feat/x --skip-hooks all          # skip every hook (replaces the old --no-hooks)
+daft start feat/x --skip-hooks worktree-post-create  # skip one whole hook by name
 daft start feat/x --skip-hooks lint          # skip the lint job AND its dependents
 daft start feat/x --skip-hooks tag:heavy     # skip every heavy-tagged job AND dependents
 daft start feat/x --skip-hooks tag:heavy,lint
 git worktree-clone <url> --skip-hooks all    # clone without running any hooks
+git worktree-clone <url> --skip-hooks post-clone  # clone, run worktree hooks but not post-clone
 ```
 
-Selectors: `all` / `*` (every job), `tag:<tag>` (tagged jobs + dependents),
-`<name>` (a job + its dependents), `job:<name>` (explicit-name escape hatch). A
-bare token is a job **name**; tags need the `tag:` prefix.
+Selectors: `all` / `*` (every job), `<hook>` (a whole hook by its canonical
+`daft.yml` key, e.g. `worktree-post-create` / `post-clone`), `tag:<tag>` (tagged
+jobs + dependents), `<name>` (a job + its dependents), `job:<name>`
+(explicit-name escape hatch). A bare token resolves in order: wildcard → hook
+type → job name; tags need the `tag:` prefix. A hook-type selector that names a
+hook the command never fires is a silent no-op (no error, no warning).
 
 Key behavior — the **downstream cascade**: skipping a job also skips every job
 that `needs:` it (transitively), because running a dependent against a

--- a/docs/cli/daft-go.md
+++ b/docs/cli/daft-go.md
@@ -54,6 +54,7 @@ Cannot be combined with `-b`/`--create-branch`.
 |--------|-------------|---------|
 | `-s, --start` | Create a new worktree if the branch does not exist | |
 | `--local` | Skip all remote operations (no fetch) for this invocation | |
+| `--skip-hooks <SELECTOR>` | Skip hooks when `go` creates a worktree (`all` \| a hook name like `worktree-post-create` \| `tag:<tag>` \| `<job>`); repeatable/comma-separated | |
 | `-x, --exec <EXEC>` | Run a command in the worktree after setup (repeatable) | |
 | `--no-cd` | Do not change directory to the new worktree | |
 | `-c, --carry` | Apply uncommitted changes from the current worktree | |

--- a/docs/cli/daft-start.md
+++ b/docs/cli/daft-start.md
@@ -39,6 +39,7 @@ operations for a single invocation regardless of config.
 | Option | Description | Default |
 |--------|-------------|---------|
 | `--local` | Skip all remote operations (no fetch, no push) for this invocation | |
+| `--skip-hooks <SELECTOR>` | Skip hooks this run (`all` \| a hook name like `worktree-post-create` \| `tag:<tag>` \| `<job>`); repeatable/comma-separated | |
 | `-c, --carry` | Apply uncommitted changes from the current worktree to the new one | |
 | `--no-carry` | Do not carry uncommitted changes | |
 | `-x, --exec <EXEC>` | Run a command in the worktree after setup completes (repeatable) | |

--- a/docs/cli/git-worktree-checkout.md
+++ b/docs/cli/git-worktree-checkout.md
@@ -72,6 +72,7 @@ git worktree-checkout [OPTIONS] <BRANCH_NAME> [BASE_BRANCH_NAME]
 | `-s, --start` | Create a new worktree if the branch does not exist |  |
 | `-@, --at <PATH>` | Place the worktree at a specific path instead of using the layout template |  |
 | `--local` | Skip all remote operations (no fetch, no push) |  |
+| `--skip-hooks <SELECTOR>` | Skip hooks this run (all | tag:<tag> | <job>); repeatable/comma-separated |  |
 
 ## Global Options
 

--- a/docs/cli/git-worktree-checkout.md
+++ b/docs/cli/git-worktree-checkout.md
@@ -72,7 +72,7 @@ git worktree-checkout [OPTIONS] <BRANCH_NAME> [BASE_BRANCH_NAME]
 | `-s, --start` | Create a new worktree if the branch does not exist |  |
 | `-@, --at <PATH>` | Place the worktree at a specific path instead of using the layout template |  |
 | `--local` | Skip all remote operations (no fetch, no push) |  |
-| `--skip-hooks <SELECTOR>` | Skip hooks this run (all | tag:<tag> | <job>); repeatable/comma-separated |  |
+| `--skip-hooks <SELECTOR>` | Skip hooks this run (all | <hook> | tag:<tag> | <job>); repeatable/comma-separated |  |
 
 ## Global Options
 

--- a/docs/cli/git-worktree-clone.md
+++ b/docs/cli/git-worktree-clone.md
@@ -49,7 +49,7 @@ git worktree-clone [OPTIONS] <REPOSITORY_URL>
 | `-v, --verbose` | Increase verbosity (-v for hook details, -vv for full sequential output) |  |
 | `-a, --all-branches` | Create a worktree for each remote branch, not just the default |  |
 | `--trust-hooks` | Trust the repository and allow hooks to run without prompting |  |
-| `--no-hooks` | Do not run any hooks from the repository |  |
+| `--skip-hooks <SELECTOR>` | Skip hooks this run (all | tag:<tag> | <job>); repeatable/comma-separated |  |
 | `-r, --remote <REMOTE>` | Organize worktree under this remote folder (enables multi-remote mode) |  |
 | `--no-cd` | Do not change directory to the new worktree |  |
 | `--layout <LAYOUT>` | Worktree layout to use for this repository |  |

--- a/docs/cli/git-worktree-clone.md
+++ b/docs/cli/git-worktree-clone.md
@@ -49,7 +49,7 @@ git worktree-clone [OPTIONS] <REPOSITORY_URL>
 | `-v, --verbose` | Increase verbosity (-v for hook details, -vv for full sequential output) |  |
 | `-a, --all-branches` | Create a worktree for each remote branch, not just the default |  |
 | `--trust-hooks` | Trust the repository and allow hooks to run without prompting |  |
-| `--skip-hooks <SELECTOR>` | Skip hooks this run (all | tag:<tag> | <job>); repeatable/comma-separated |  |
+| `--skip-hooks <SELECTOR>` | Skip hooks this run (all | <hook> | tag:<tag> | <job>); repeatable/comma-separated |  |
 | `-r, --remote <REMOTE>` | Organize worktree under this remote folder (enables multi-remote mode) |  |
 | `--no-cd` | Do not change directory to the new worktree |  |
 | `--layout <LAYOUT>` | Worktree layout to use for this repository |  |

--- a/docs/cli/git-worktree-flow-adopt.md
+++ b/docs/cli/git-worktree-flow-adopt.md
@@ -92,7 +92,7 @@ git worktree-flow-adopt [OPTIONS] [REPOSITORY_PATH]
 | `-q, --quiet` | Operate quietly; suppress progress reporting |  |
 | `-v, --verbose` | Be verbose; show detailed progress |  |
 | `--trust-hooks` | Trust the repository and allow hooks to run without prompting |  |
-| `--skip-hooks <SELECTOR>` | Skip hooks this run (all | tag:<tag> | <job>); repeatable/comma-separated |  |
+| `--skip-hooks <SELECTOR>` | Skip hooks this run (all | <hook> | tag:<tag> | <job>); repeatable/comma-separated |  |
 | `--dry-run` | Show what would be done without making any changes |  |
 
 ## Global Options

--- a/docs/cli/git-worktree-flow-adopt.md
+++ b/docs/cli/git-worktree-flow-adopt.md
@@ -92,7 +92,7 @@ git worktree-flow-adopt [OPTIONS] [REPOSITORY_PATH]
 | `-q, --quiet` | Operate quietly; suppress progress reporting |  |
 | `-v, --verbose` | Be verbose; show detailed progress |  |
 | `--trust-hooks` | Trust the repository and allow hooks to run without prompting |  |
-| `--no-hooks` | Do not run any hooks from the repository |  |
+| `--skip-hooks <SELECTOR>` | Skip hooks this run (all | tag:<tag> | <job>); repeatable/comma-separated |  |
 | `--dry-run` | Show what would be done without making any changes |  |
 
 ## Global Options

--- a/docs/hooks/job-orchestration.md
+++ b/docs/hooks/job-orchestration.md
@@ -140,7 +140,8 @@ For a one-off, the worktree-creating commands (`daft start`, `daft go`,
 that excludes jobs for that single invocation:
 
 ```bash
-daft start feat/x --skip-hooks all          # skip every job
+daft start feat/x --skip-hooks all          # skip every job in every hook
+daft start feat/x --skip-hooks worktree-post-create  # skip one whole hook by name
 daft start feat/x --skip-hooks lint          # drop the lint job (+ its dependents)
 daft start feat/x --skip-hooks tag:heavy     # drop all heavy jobs (+ dependents)
 daft start feat/x --skip-hooks tag:heavy,lint        # comma-separated
@@ -149,14 +150,29 @@ daft start feat/x --skip-hooks tag:heavy --skip-hooks lint   # repeatable, same 
 
 Each selector is one of:
 
-| Selector        | Meaning                                                                       |
-| --------------- | ----------------------------------------------------------------------------- |
-| `all` / `*`     | every job — the whole hook is skipped                                         |
-| `tag:<tag>`     | every job carrying `<tag>`, **plus their dependents**                         |
-| `<name>` (bare) | the job named `<name>`, **plus its dependents**                               |
-| `job:<name>`    | explicit-name form — escape hatch for a job named `all`/`*` or containing `:` |
+| Selector        | Meaning                                                                                     |
+| --------------- | ------------------------------------------------------------------------------------------- |
+| `all` / `*`     | every job — the whole hook is skipped                                                       |
+| `<hook>`        | a whole hook by name (`worktree-post-create`, `worktree-pre-create`, `post-clone`, …)       |
+| `tag:<tag>`     | every job carrying `<tag>`, **plus their dependents**                                       |
+| `<name>` (bare) | the job named `<name>`, **plus its dependents**                                             |
+| `job:<name>`    | explicit-name form — escape hatch for a job named `all`/`*`, a hook type, or containing `:` |
 
-A bare token is a **job name**; tags require the `tag:` prefix.
+A bare token is matched in this order: the wildcard `all`/`*`, then a **hook
+type** (the canonical `daft.yml` hook key, e.g. `worktree-post-create`), then a
+**job name**. Tags require the `tag:` prefix. To skip a job that happens to be
+named after a hook type, use the `job:` escape hatch
+(`job:worktree-post-create`). Only the canonical hook spellings are reserved —
+the deprecated short forms (`post-create`) are treated as job names.
+
+A hook-type selector skips that hook **wholesale** — every job in it, with no
+cascade computation, since the entire hook is gone. It is the targeted
+counterpart to `all`: where `all` skips every hook the command fires,
+`worktree-post-create` skips only that one (leaving, say, `worktree-pre-create`
+to run). **Known limitation:** a hook-type selector naming a hook the command
+never fires (e.g. `--skip-hooks worktree-pre-remove` on `daft start`) is a
+silent no-op — it neither errors nor warns, because the decision is made per
+hook-fire and no fire ever matches it.
 
 The crucial part is the **downstream cascade**. Excluding a job also excludes
 every job that `needs:` it, directly or transitively — because running a

--- a/docs/hooks/job-orchestration.md
+++ b/docs/hooks/job-orchestration.md
@@ -131,6 +131,66 @@ branches that don't need a running server. When a job is skipped, it is treated
 as satisfied for downstream `needs:` references, so skipping one step in a chain
 does not block the rest.
 
+## Skipping at runtime (`--skip-hooks`)
+
+`skip:` / `only:` / `exclude_tags` are configuration — they live in `daft.yml`.
+For a one-off, the worktree-creating commands (`daft start`, `daft go`,
+`git worktree-checkout`, `git worktree-checkout-branch`) and
+`git worktree-clone` / `git worktree-flow-adopt` accept a `--skip-hooks` flag
+that excludes jobs for that single invocation:
+
+```bash
+daft start feat/x --skip-hooks all          # skip every job
+daft start feat/x --skip-hooks lint          # drop the lint job (+ its dependents)
+daft start feat/x --skip-hooks tag:heavy     # drop all heavy jobs (+ dependents)
+daft start feat/x --skip-hooks tag:heavy,lint        # comma-separated
+daft start feat/x --skip-hooks tag:heavy --skip-hooks lint   # repeatable, same effect
+```
+
+Each selector is one of:
+
+| Selector        | Meaning                                                                       |
+| --------------- | ----------------------------------------------------------------------------- |
+| `all` / `*`     | every job — the whole hook is skipped                                         |
+| `tag:<tag>`     | every job carrying `<tag>`, **plus their dependents**                         |
+| `<name>` (bare) | the job named `<name>`, **plus its dependents**                               |
+| `job:<name>`    | explicit-name form — escape hatch for a job named `all`/`*` or containing `:` |
+
+A bare token is a **job name**; tags require the `tag:` prefix.
+
+The crucial part is the **downstream cascade**. Excluding a job also excludes
+every job that `needs:` it, directly or transitively — because running a
+dependent against a dependency that deliberately did not run is the broken
+outcome. Upstream dependencies are left untouched. Given:
+
+```yaml
+install: # no needs
+build: { needs: [install], tags: [heavy] }
+test: { needs: [build] }
+lint: { needs: [install] }
+```
+
+- `--skip-hooks install` skips **install, build, test, lint** (all reach
+  install).
+- `--skip-hooks tag:heavy` skips **build** and **test** (test needs build);
+  `install` and `lint` still run.
+
+Excluded jobs are reported as skipped with a reason (`requested (--skip-hooks)`
+for a direct match, `depends on <job> (skipped)` for a cascade-removed
+dependent) rather than vanishing silently. A selector that matches nothing emits
+a warning and the run proceeds — an empty result after skipping is a no-op, not
+an error.
+
+`--skip-hooks all` is the uniform way to skip every hook; it replaces the older
+`--no-hooks` flag on `clone` / `flow-adopt`. It cannot be combined with
+`--trust-hooks` (a partial `--skip-hooks tag:…` still runs your own hooks, so it
+remains compatible with `--trust-hooks`).
+
+This is distinct from `git daft hooks run --job <name>` / `--tag <tag>`, which
+is an **inclusion** filter (run only the named jobs, re-running against an
+already-set-up worktree); `--skip-hooks` is the **exclusion** side and carries
+the dependents with it.
+
 ## OS and architecture gating
 
 Individual jobs can declare `os:` and `arch:` constraints. A job with

--- a/docs/hooks/yaml-reference.md
+++ b/docs/hooks/yaml-reference.md
@@ -78,32 +78,48 @@ Only one of `parallel`, `piped`, or `follow` can be set at a time.
 
 Each job in the `jobs` list supports:
 
-| Field               | Type                 | Description                                                              |
-| ------------------- | -------------------- | ------------------------------------------------------------------------ |
-| `name`              | string               | Job name (used for display, merging, and dependency references)          |
-| `description`       | string               | Human-readable description (shown in dry-run and completions)            |
-| `run`               | string               | Inline shell command to execute                                          |
-| `script`            | string               | Script file to run (relative to `source_dir`)                            |
-| `runner`            | string               | Interpreter for script files (e.g., `"bash"`, `"python"`)                |
-| `args`              | string               | Arguments to pass to the script                                          |
-| `root`              | string               | Working directory (relative to worktree root)                            |
-| `tags`              | list                 | Tags for filtering with `exclude_tags`                                   |
-| `skip`              | bool / string / list | Skip condition                                                           |
-| `only`              | bool / string / list | Only condition                                                           |
-| `os`                | string / list        | Target OS (`macos`, `linux`, `windows`); skips if no match               |
-| `arch`              | string / list        | Target architecture (`x86_64`, `aarch64`); skips if no match             |
-| `env`               | map                  | Extra environment variables                                              |
-| `fail_text`         | string               | Custom failure message                                                   |
-| `interactive`       | bool                 | Job needs TTY/stdin (forces sequential execution)                        |
-| `priority`          | int                  | Execution ordering (lower runs first)                                    |
-| `needs`             | list                 | Names of jobs that must complete before this job runs                    |
-| `tracks`            | list                 | Worktree attributes this job depends on: `path`, `branch`                |
-| `group`             | object               | Nested group of jobs (see [Groups](#groups))                             |
-| `background`        | bool                 | Run this job in the background (see [Background jobs](#background-jobs)) |
-| `background_output` | `log` / `silent`     | Output behavior for background jobs (default: `log`)                     |
-| `log`               | object               | Log configuration (`retention`, `max_log_size`) for this job             |
+| Field               | Type                 | Description                                                                                           |
+| ------------------- | -------------------- | ----------------------------------------------------------------------------------------------------- |
+| `name`              | string               | Job name (used for display, merging, and dependency references)                                       |
+| `description`       | string               | Human-readable description (shown in dry-run and completions)                                         |
+| `run`               | string               | Inline shell command to execute                                                                       |
+| `script`            | string               | Script file to run (relative to `source_dir`)                                                         |
+| `runner`            | string               | Interpreter for script files (e.g., `"bash"`, `"python"`)                                             |
+| `args`              | string               | Arguments to pass to the script                                                                       |
+| `root`              | string               | Working directory / cwd, relative to worktree root (see [Working directory](#working-directory-root)) |
+| `tags`              | list                 | Tags for filtering with `exclude_tags`                                                                |
+| `skip`              | bool / string / list | Skip condition                                                                                        |
+| `only`              | bool / string / list | Only condition                                                                                        |
+| `os`                | string / list        | Target OS (`macos`, `linux`, `windows`); skips if no match                                            |
+| `arch`              | string / list        | Target architecture (`x86_64`, `aarch64`); skips if no match                                          |
+| `env`               | map                  | Extra environment variables                                                                           |
+| `fail_text`         | string               | Custom failure message                                                                                |
+| `interactive`       | bool                 | Job needs TTY/stdin (forces sequential execution)                                                     |
+| `priority`          | int                  | Execution ordering (lower runs first)                                                                 |
+| `needs`             | list                 | Names of jobs that must complete before this job runs                                                 |
+| `tracks`            | list                 | Worktree attributes this job depends on: `path`, `branch`                                             |
+| `group`             | object               | Nested group of jobs (see [Groups](#groups))                                                          |
+| `background`        | bool                 | Run this job in the background (see [Background jobs](#background-jobs))                              |
+| `background_output` | `log` / `silent`     | Output behavior for background jobs (default: `log`)                                                  |
+| `log`               | object               | Log configuration (`retention`, `max_log_size`) for this job                                          |
 
 A job must have exactly one of `run`, `script`, or `group`.
+
+### Working directory (`root`)
+
+By default each job runs in the worktree root. Set `root` to run the job in a
+subdirectory instead — useful in a monorepo where a job targets a single
+package. The path is relative to the worktree root and sets the job's working
+directory (cwd).
+
+```yaml
+hooks:
+  worktree-post-create:
+    jobs:
+      - name: install-web
+        run: pnpm install
+        root: apps/web
+```
 
 ### Template variables
 

--- a/man/daft-adopt.1
+++ b/man/daft-adopt.1
@@ -4,7 +4,7 @@
 .SH NAME
 daft\-adopt \- Convert a traditional repository to worktree\-based layout
 .SH SYNOPSIS
-\fBdaft\-adopt\fR [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-\-trust\-hooks\fR] [\fB\-\-no\-hooks\fR] [\fB\-\-dry\-run\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fIREPOSITORY_PATH\fR] 
+\fBdaft\-adopt\fR [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-\-trust\-hooks\fR] [\fB\-\-skip\-hooks\fR] [\fB\-\-dry\-run\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fIREPOSITORY_PATH\fR] 
 .SH DESCRIPTION
 .PP
 WHAT THIS COMMAND DOES
@@ -77,8 +77,8 @@ Be verbose; show detailed progress
 \fB\-\-trust\-hooks\fR
 Trust the repository and allow hooks to run without prompting
 .TP
-\fB\-\-no\-hooks\fR
-Do not run any hooks from the repository
+\fB\-\-skip\-hooks\fR \fI<SELECTOR>\fR
+Skip hooks this run (all | tag:<tag> | <job>); repeatable/comma\-separated
 .TP
 \fB\-\-dry\-run\fR
 Show what would be done without making any changes

--- a/man/daft-adopt.1
+++ b/man/daft-adopt.1
@@ -78,7 +78,7 @@ Be verbose; show detailed progress
 Trust the repository and allow hooks to run without prompting
 .TP
 \fB\-\-skip\-hooks\fR \fI<SELECTOR>\fR
-Skip hooks this run (all | tag:<tag> | <job>); repeatable/comma\-separated
+Skip hooks this run (all | <hook> | tag:<tag> | <job>); repeatable/comma\-separated
 .TP
 \fB\-\-dry\-run\fR
 Show what would be done without making any changes

--- a/man/daft-clone.1
+++ b/man/daft-clone.1
@@ -4,7 +4,7 @@
 .SH NAME
 daft\-clone \- Clone a repository into a worktree\-based directory structure
 .SH SYNOPSIS
-\fBdaft\-clone\fR [\fB\-b\fR|\fB\-\-branch\fR] [\fB\-n\fR|\fB\-\-no\-checkout\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR]... [\fB\-a\fR|\fB\-\-all\-branches\fR] [\fB\-\-trust\-hooks\fR] [\fB\-\-no\-hooks\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-\-no\-cd\fR] [\fB\-\-layout\fR] [\fB\-\-columns\fR] [\fB\-x\fR|\fB\-\-exec\fR] [\fB\-\-install\fR] [\fB\-\-git\-exclude\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIREPOSITORY_URL\fR> 
+\fBdaft\-clone\fR [\fB\-b\fR|\fB\-\-branch\fR] [\fB\-n\fR|\fB\-\-no\-checkout\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR]... [\fB\-a\fR|\fB\-\-all\-branches\fR] [\fB\-\-trust\-hooks\fR] [\fB\-\-skip\-hooks\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-\-no\-cd\fR] [\fB\-\-layout\fR] [\fB\-\-columns\fR] [\fB\-x\fR|\fB\-\-exec\fR] [\fB\-\-install\fR] [\fB\-\-git\-exclude\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIREPOSITORY_URL\fR> 
 .SH DESCRIPTION
 .PP
 Clones a repository into a directory structure optimized for worktree\-based
@@ -40,8 +40,8 @@ Create a worktree for each remote branch, not just the default
 \fB\-\-trust\-hooks\fR
 Trust the repository and allow hooks to run without prompting
 .TP
-\fB\-\-no\-hooks\fR
-Do not run any hooks from the repository
+\fB\-\-skip\-hooks\fR \fI<SELECTOR>\fR
+Skip hooks this run (all | tag:<tag> | <job>); repeatable/comma\-separated
 .TP
 \fB\-r\fR, \fB\-\-remote\fR \fI<REMOTE>\fR
 Organize worktree under this remote folder (enables multi\-remote mode)

--- a/man/daft-clone.1
+++ b/man/daft-clone.1
@@ -41,7 +41,7 @@ Create a worktree for each remote branch, not just the default
 Trust the repository and allow hooks to run without prompting
 .TP
 \fB\-\-skip\-hooks\fR \fI<SELECTOR>\fR
-Skip hooks this run (all | tag:<tag> | <job>); repeatable/comma\-separated
+Skip hooks this run (all | <hook> | tag:<tag> | <job>); repeatable/comma\-separated
 .TP
 \fB\-r\fR, \fB\-\-remote\fR \fI<REMOTE>\fR
 Organize worktree under this remote folder (enables multi\-remote mode)

--- a/man/daft-go.1
+++ b/man/daft-go.1
@@ -4,7 +4,7 @@
 .SH NAME
 daft go \- Open a worktree for an existing branch, or create one with \-b
 .SH SYNOPSIS
-\fBdaft go\fR [\fB\-b\fR|\fB\-\-create\-branch\fR] [\fB\-s\fR|\fB\-\-start\fR] [\fB\-c\fR|\fB\-\-carry\fR] [\fB\-\-no\-carry\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-\-no\-cd\fR] [\fB\-x\fR|\fB\-\-exec\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-@\fR|\fB\-\-at\fR] [\fB\-\-local\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIBRANCH_NAME\fR> [\fIBASE_BRANCH_NAME\fR] 
+\fBdaft go\fR [\fB\-b\fR|\fB\-\-create\-branch\fR] [\fB\-s\fR|\fB\-\-start\fR] [\fB\-c\fR|\fB\-\-carry\fR] [\fB\-\-no\-carry\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-\-no\-cd\fR] [\fB\-x\fR|\fB\-\-exec\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-@\fR|\fB\-\-at\fR] [\fB\-\-local\fR] [\fB\-\-skip\-hooks\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIBRANCH_NAME\fR> [\fIBASE_BRANCH_NAME\fR] 
 .SH DESCRIPTION
 .PP
 Opens a worktree for an existing local or remote branch. The worktree is
@@ -65,6 +65,9 @@ Place the worktree at a specific path instead of using the layout template
 .TP
 \fB\-\-local\fR
 Skip all remote operations (no fetch, no push)
+.TP
+\fB\-\-skip\-hooks\fR \fI<SELECTOR>\fR
+Skip hooks when creating a worktree (all | tag:<tag> | <job>); repeatable/comma\-separated
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help (see a summary with \*(Aq\-h\*(Aq)

--- a/man/daft-go.1
+++ b/man/daft-go.1
@@ -67,7 +67,7 @@ Place the worktree at a specific path instead of using the layout template
 Skip all remote operations (no fetch, no push)
 .TP
 \fB\-\-skip\-hooks\fR \fI<SELECTOR>\fR
-Skip hooks when creating a worktree (all | tag:<tag> | <job>); repeatable/comma\-separated
+Skip hooks when creating a worktree (all | <hook> | tag:<tag> | <job>); repeatable/comma\-separated
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help (see a summary with \*(Aq\-h\*(Aq)

--- a/man/daft-start.1
+++ b/man/daft-start.1
@@ -49,7 +49,7 @@ Place the worktree at a specific path instead of using the layout template
 Skip all remote operations (no fetch, no push)
 .TP
 \fB\-\-skip\-hooks\fR \fI<SELECTOR>\fR
-Skip hooks this run (all | tag:<tag> | <job>); repeatable/comma\-separated
+Skip hooks this run (all | <hook> | tag:<tag> | <job>); repeatable/comma\-separated
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help (see a summary with \*(Aq\-h\*(Aq)

--- a/man/daft-start.1
+++ b/man/daft-start.1
@@ -4,7 +4,7 @@
 .SH NAME
 daft start \- Create a new branch and worktree
 .SH SYNOPSIS
-\fBdaft start\fR [\fB\-c\fR|\fB\-\-carry\fR] [\fB\-\-no\-carry\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-\-no\-cd\fR] [\fB\-x\fR|\fB\-\-exec\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-@\fR|\fB\-\-at\fR] [\fB\-\-local\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fINEW_BRANCH_NAME\fR> [\fIBASE_BRANCH_NAME\fR] 
+\fBdaft start\fR [\fB\-c\fR|\fB\-\-carry\fR] [\fB\-\-no\-carry\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-\-no\-cd\fR] [\fB\-x\fR|\fB\-\-exec\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-@\fR|\fB\-\-at\fR] [\fB\-\-local\fR] [\fB\-\-skip\-hooks\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fINEW_BRANCH_NAME\fR> [\fIBASE_BRANCH_NAME\fR] 
 .SH DESCRIPTION
 .PP
 Creates a new branch and a corresponding worktree in a single operation. The
@@ -47,6 +47,9 @@ Place the worktree at a specific path instead of using the layout template
 .TP
 \fB\-\-local\fR
 Skip all remote operations (no fetch, no push)
+.TP
+\fB\-\-skip\-hooks\fR \fI<SELECTOR>\fR
+Skip hooks this run (all | tag:<tag> | <job>); repeatable/comma\-separated
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help (see a summary with \*(Aq\-h\*(Aq)

--- a/man/git-worktree-checkout.1
+++ b/man/git-worktree-checkout.1
@@ -4,7 +4,7 @@
 .SH NAME
 git\-worktree\-checkout \- Create a worktree for an existing branch, or a new branch with \-b
 .SH SYNOPSIS
-\fBgit\-worktree\-checkout\fR [\fB\-b\fR|\fB\-\-create\-branch\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-c\fR|\fB\-\-carry\fR] [\fB\-\-no\-carry\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-\-no\-cd\fR] [\fB\-x\fR|\fB\-\-exec\fR] [\fB\-s\fR|\fB\-\-start\fR] [\fB\-@\fR|\fB\-\-at\fR] [\fB\-\-local\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIBRANCH_NAME\fR> [\fIBASE_BRANCH_NAME\fR] 
+\fBgit\-worktree\-checkout\fR [\fB\-b\fR|\fB\-\-create\-branch\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-c\fR|\fB\-\-carry\fR] [\fB\-\-no\-carry\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-\-no\-cd\fR] [\fB\-x\fR|\fB\-\-exec\fR] [\fB\-s\fR|\fB\-\-start\fR] [\fB\-@\fR|\fB\-\-at\fR] [\fB\-\-local\fR] [\fB\-\-skip\-hooks\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIBRANCH_NAME\fR> [\fIBASE_BRANCH_NAME\fR] 
 .SH DESCRIPTION
 .PP
 Creates a new worktree for an existing local or remote branch. The worktree
@@ -69,6 +69,9 @@ Place the worktree at a specific path instead of using the layout template
 .TP
 \fB\-\-local\fR
 Skip all remote operations (no fetch, no push)
+.TP
+\fB\-\-skip\-hooks\fR \fI<SELECTOR>\fR
+Skip hooks this run (all | tag:<tag> | <job>); repeatable/comma\-separated
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help (see a summary with \*(Aq\-h\*(Aq)

--- a/man/git-worktree-checkout.1
+++ b/man/git-worktree-checkout.1
@@ -71,7 +71,7 @@ Place the worktree at a specific path instead of using the layout template
 Skip all remote operations (no fetch, no push)
 .TP
 \fB\-\-skip\-hooks\fR \fI<SELECTOR>\fR
-Skip hooks this run (all | tag:<tag> | <job>); repeatable/comma\-separated
+Skip hooks this run (all | <hook> | tag:<tag> | <job>); repeatable/comma\-separated
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help (see a summary with \*(Aq\-h\*(Aq)

--- a/man/git-worktree-clone.1
+++ b/man/git-worktree-clone.1
@@ -41,7 +41,7 @@ Create a worktree for each remote branch, not just the default
 Trust the repository and allow hooks to run without prompting
 .TP
 \fB\-\-skip\-hooks\fR \fI<SELECTOR>\fR
-Skip hooks this run (all | tag:<tag> | <job>); repeatable/comma\-separated
+Skip hooks this run (all | <hook> | tag:<tag> | <job>); repeatable/comma\-separated
 .TP
 \fB\-r\fR, \fB\-\-remote\fR \fI<REMOTE>\fR
 Organize worktree under this remote folder (enables multi\-remote mode)

--- a/man/git-worktree-clone.1
+++ b/man/git-worktree-clone.1
@@ -4,7 +4,7 @@
 .SH NAME
 git\-worktree\-clone \- Clone a repository into a worktree\-based directory structure
 .SH SYNOPSIS
-\fBgit\-worktree\-clone\fR [\fB\-b\fR|\fB\-\-branch\fR] [\fB\-n\fR|\fB\-\-no\-checkout\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR]... [\fB\-a\fR|\fB\-\-all\-branches\fR] [\fB\-\-trust\-hooks\fR] [\fB\-\-no\-hooks\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-\-no\-cd\fR] [\fB\-\-layout\fR] [\fB\-\-columns\fR] [\fB\-x\fR|\fB\-\-exec\fR] [\fB\-\-install\fR] [\fB\-\-git\-exclude\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIREPOSITORY_URL\fR> 
+\fBgit\-worktree\-clone\fR [\fB\-b\fR|\fB\-\-branch\fR] [\fB\-n\fR|\fB\-\-no\-checkout\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR]... [\fB\-a\fR|\fB\-\-all\-branches\fR] [\fB\-\-trust\-hooks\fR] [\fB\-\-skip\-hooks\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-\-no\-cd\fR] [\fB\-\-layout\fR] [\fB\-\-columns\fR] [\fB\-x\fR|\fB\-\-exec\fR] [\fB\-\-install\fR] [\fB\-\-git\-exclude\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIREPOSITORY_URL\fR> 
 .SH DESCRIPTION
 .PP
 Clones a repository into a directory structure optimized for worktree\-based
@@ -40,8 +40,8 @@ Create a worktree for each remote branch, not just the default
 \fB\-\-trust\-hooks\fR
 Trust the repository and allow hooks to run without prompting
 .TP
-\fB\-\-no\-hooks\fR
-Do not run any hooks from the repository
+\fB\-\-skip\-hooks\fR \fI<SELECTOR>\fR
+Skip hooks this run (all | tag:<tag> | <job>); repeatable/comma\-separated
 .TP
 \fB\-r\fR, \fB\-\-remote\fR \fI<REMOTE>\fR
 Organize worktree under this remote folder (enables multi\-remote mode)

--- a/man/git-worktree-flow-adopt.1
+++ b/man/git-worktree-flow-adopt.1
@@ -78,7 +78,7 @@ Be verbose; show detailed progress
 Trust the repository and allow hooks to run without prompting
 .TP
 \fB\-\-skip\-hooks\fR \fI<SELECTOR>\fR
-Skip hooks this run (all | tag:<tag> | <job>); repeatable/comma\-separated
+Skip hooks this run (all | <hook> | tag:<tag> | <job>); repeatable/comma\-separated
 .TP
 \fB\-\-dry\-run\fR
 Show what would be done without making any changes

--- a/man/git-worktree-flow-adopt.1
+++ b/man/git-worktree-flow-adopt.1
@@ -4,7 +4,7 @@
 .SH NAME
 git\-worktree\-flow\-adopt \- Convert a traditional repository to worktree\-based layout
 .SH SYNOPSIS
-\fBgit\-worktree\-flow\-adopt\fR [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-\-trust\-hooks\fR] [\fB\-\-no\-hooks\fR] [\fB\-\-dry\-run\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fIREPOSITORY_PATH\fR] 
+\fBgit\-worktree\-flow\-adopt\fR [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-\-trust\-hooks\fR] [\fB\-\-skip\-hooks\fR] [\fB\-\-dry\-run\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fIREPOSITORY_PATH\fR] 
 .SH DESCRIPTION
 .PP
 WHAT THIS COMMAND DOES
@@ -77,8 +77,8 @@ Be verbose; show detailed progress
 \fB\-\-trust\-hooks\fR
 Trust the repository and allow hooks to run without prompting
 .TP
-\fB\-\-no\-hooks\fR
-Do not run any hooks from the repository
+\fB\-\-skip\-hooks\fR \fI<SELECTOR>\fR
+Skip hooks this run (all | tag:<tag> | <job>); repeatable/comma\-separated
 .TP
 \fB\-\-dry\-run\fR
 Show what would be done without making any changes

--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -125,13 +125,13 @@ pub struct Args {
     local: bool,
 
     /// Skip hooks this run. Repeatable / comma-separated.
-    /// Selectors: `all`, `tag:<tag>`, or a job name (plus its dependents).
-    /// See daft-hooks(1).
+    /// Selectors: `all`, a hook name (`worktree-post-create`, …),
+    /// `tag:<tag>`, or a job name (plus its dependents). See daft-hooks(1).
     #[arg(
         long,
         value_name = "SELECTOR",
         value_delimiter = ',',
-        help = "Skip hooks this run (all | tag:<tag> | <job>); repeatable/comma-separated"
+        help = "Skip hooks this run (all | <hook> | tag:<tag> | <job>); repeatable/comma-separated"
     )]
     skip_hooks: Vec<String>,
 }
@@ -236,13 +236,13 @@ pub struct GoArgs {
     local: bool,
 
     /// Skip hooks this run (only applies when `go` creates a worktree).
-    /// Selectors: `all`, `tag:<tag>`, or a job name (plus its dependents).
-    /// See daft-hooks(1).
+    /// Selectors: `all`, a hook name (`worktree-post-create`, …),
+    /// `tag:<tag>`, or a job name (plus its dependents). See daft-hooks(1).
     #[arg(
         long,
         value_name = "SELECTOR",
         value_delimiter = ',',
-        help = "Skip hooks when creating a worktree (all | tag:<tag> | <job>); repeatable/comma-separated"
+        help = "Skip hooks when creating a worktree (all | <hook> | tag:<tag> | <job>); repeatable/comma-separated"
     )]
     skip_hooks: Vec<String>,
 }
@@ -315,13 +315,13 @@ pub struct StartArgs {
     local: bool,
 
     /// Skip hooks this run. Repeatable / comma-separated.
-    /// Selectors: `all`, `tag:<tag>`, or a job name (plus its dependents).
-    /// See daft-hooks(1).
+    /// Selectors: `all`, a hook name (`worktree-post-create`, …),
+    /// `tag:<tag>`, or a job name (plus its dependents). See daft-hooks(1).
     #[arg(
         long,
         value_name = "SELECTOR",
         value_delimiter = ',',
-        help = "Skip hooks this run (all | tag:<tag> | <job>); repeatable/comma-separated"
+        help = "Skip hooks this run (all | <hook> | tag:<tag> | <job>); repeatable/comma-separated"
     )]
     skip_hooks: Vec<String>,
 }

--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -123,6 +123,17 @@ pub struct Args {
 
     #[arg(long, help = "Skip all remote operations (no fetch, no push)")]
     local: bool,
+
+    /// Skip hooks this run. Repeatable / comma-separated.
+    /// Selectors: `all`, `tag:<tag>`, or a job name (plus its dependents).
+    /// See daft-hooks(1).
+    #[arg(
+        long,
+        value_name = "SELECTOR",
+        value_delimiter = ',',
+        help = "Skip hooks this run (all | tag:<tag> | <job>); repeatable/comma-separated"
+    )]
+    skip_hooks: Vec<String>,
 }
 
 /// Daft-style args for `daft go`. Separate from `Args` so that `-h`/`--help`
@@ -223,6 +234,17 @@ pub struct GoArgs {
 
     #[arg(long, help = "Skip all remote operations (no fetch, no push)")]
     local: bool,
+
+    /// Skip hooks this run (only applies when `go` creates a worktree).
+    /// Selectors: `all`, `tag:<tag>`, or a job name (plus its dependents).
+    /// See daft-hooks(1).
+    #[arg(
+        long,
+        value_name = "SELECTOR",
+        value_delimiter = ',',
+        help = "Skip hooks when creating a worktree (all | tag:<tag> | <job>); repeatable/comma-separated"
+    )]
+    skip_hooks: Vec<String>,
 }
 
 /// Daft-style args for `daft start`. Separate from `Args` so that `-h`/`--help`
@@ -291,6 +313,17 @@ pub struct StartArgs {
 
     #[arg(long, help = "Skip all remote operations (no fetch, no push)")]
     local: bool,
+
+    /// Skip hooks this run. Repeatable / comma-separated.
+    /// Selectors: `all`, `tag:<tag>`, or a job name (plus its dependents).
+    /// See daft-hooks(1).
+    #[arg(
+        long,
+        value_name = "SELECTOR",
+        value_delimiter = ',',
+        help = "Skip hooks this run (all | tag:<tag> | <job>); repeatable/comma-separated"
+    )]
+    skip_hooks: Vec<String>,
 }
 
 /// Entry point for `git-worktree-checkout`.
@@ -319,6 +352,7 @@ pub fn run_go() -> Result<()> {
         verbose: go_args.verbose,
         at: go_args.at,
         local: go_args.local,
+        skip_hooks: go_args.skip_hooks,
     };
     run_with_args(args)
 }
@@ -343,6 +377,7 @@ pub fn run_start() -> Result<()> {
         verbose: start_args.verbose,
         at: start_args.at,
         local: start_args.local,
+        skip_hooks: start_args.skip_hooks,
     };
     run_with_args(args)
 }
@@ -726,7 +761,9 @@ fn run_checkout(
     };
 
     let hooks_config = crate::core::settings::load_hooks_config_with(git)?;
-    let executor = HookExecutor::new(hooks_config)?;
+    let executor = HookExecutor::new(hooks_config)?.with_job_filter(
+        crate::hooks::yaml_executor::JobFilter::skipping(&args.skip_hooks),
+    );
 
     if should_show_gitoxide_notice(settings.use_gitoxide) {
         output.warning("[experimental] Using gitoxide backend for git operations");
@@ -809,7 +846,9 @@ fn run_create_branch(
     };
 
     let hooks_config = crate::core::settings::load_hooks_config_with(git)?;
-    let executor = HookExecutor::new(hooks_config)?;
+    let executor = HookExecutor::new(hooks_config)?.with_job_filter(
+        crate::hooks::yaml_executor::JobFilter::skipping(&args.skip_hooks),
+    );
 
     if should_show_gitoxide_notice(settings.use_gitoxide) {
         output.warning("[experimental] Using gitoxide backend for git operations");
@@ -902,4 +941,37 @@ fn render_create_result(result: &checkout_branch::CheckoutBranchResult, output: 
         "Created worktree '{}' from '{}'",
         result.new_branch_name, result.base_branch
     ));
+}
+
+#[cfg(test)]
+mod skip_hooks_parse_tests {
+    use super::*;
+
+    #[test]
+    fn flag_after_positional() {
+        let a = Args::parse_from(["git-worktree-checkout", "feat/x", "--skip-hooks", "all"]);
+        assert_eq!(a.branch_name, "feat/x");
+        assert_eq!(a.skip_hooks, vec!["all".to_string()]);
+    }
+
+    #[test]
+    fn flag_before_positional() {
+        let a = Args::parse_from(["git-worktree-checkout", "--skip-hooks", "all", "feat/x"]);
+        assert_eq!(a.branch_name, "feat/x");
+        assert_eq!(a.skip_hooks, vec!["all".to_string()]);
+    }
+
+    #[test]
+    fn comma_split() {
+        let a = Args::parse_from([
+            "git-worktree-checkout",
+            "feat/x",
+            "--skip-hooks",
+            "all,tag:heavy",
+        ]);
+        assert_eq!(
+            a.skip_hooks,
+            vec!["all".to_string(), "tag:heavy".to_string()]
+        );
+    }
 }

--- a/src/commands/clone.rs
+++ b/src/commands/clone.rs
@@ -106,8 +106,16 @@ pub struct Args {
     )]
     trust_hooks: bool,
 
-    #[arg(long = "no-hooks", help = "Do not run any hooks from the repository")]
-    no_hooks: bool,
+    /// Skip hooks this run. Repeatable / comma-separated.
+    /// Selectors: `all` (every hook), `tag:<tag>`, or a job name (plus its
+    /// dependents). See daft-hooks(1).
+    #[arg(
+        long,
+        value_name = "SELECTOR",
+        value_delimiter = ',',
+        help = "Skip hooks this run (all | tag:<tag> | <job>); repeatable/comma-separated"
+    )]
+    skip_hooks: Vec<String>,
 
     #[arg(
         short = 'r',
@@ -196,8 +204,8 @@ fn validate_arg_combinations(args: &Args) -> Result<()> {
     if args.remote.is_some() && args.branch.len() > 1 {
         anyhow::bail!("--remote cannot be used with multiple -b flags.");
     }
-    if args.trust_hooks && args.no_hooks {
-        anyhow::bail!("--trust-hooks and --no-hooks cannot be used together.");
+    if args.trust_hooks && skip_hooks_all(&args.skip_hooks) {
+        anyhow::bail!("--trust-hooks and --skip-hooks all cannot be used together.");
     }
     if args.install && args.no_checkout {
         anyhow::bail!(
@@ -210,14 +218,23 @@ fn validate_arg_combinations(args: &Args) -> Result<()> {
     Ok(())
 }
 
+/// True when `--skip-hooks` requests skipping *every* hook (`all` / `*`) — the
+/// uniform replacement for the old `--no-hooks`. Partial skips (`tag:`/`<job>`)
+/// are NOT `all`: hooks still fire, just with some jobs excluded.
+fn skip_hooks_all(skip_hooks: &[String]) -> bool {
+    crate::hooks::job_adapter::parse_skip_selectors(skip_hooks).all
+}
+
 /// `--install` implies `--trust-hooks`: bootstrapping your own daft.yml in this
 /// clone is an implicit trust decision — the hooks you'll run are your own, and
 /// you shouldn't be prompted to trust your own config on the next worktree op.
-/// `--no-hooks` opts out of hooks entirely, so it wins (and keeps us clear of
-/// the `--trust-hooks`/`--no-hooks` conflict rejected in `validate_arg_combinations`).
-/// Applied after validation so it never trips that conflict check.
+/// `--skip-hooks all` opts out of hooks entirely, so it wins (and keeps us clear
+/// of the `--trust-hooks`/`--skip-hooks all` conflict rejected in
+/// `validate_arg_combinations`). A *partial* skip still runs your own hooks, so
+/// it does NOT suppress the trust implication. Applied after validation so it
+/// never trips that conflict check.
 fn apply_install_trust(args: &mut Args) {
-    if args.install && !args.no_hooks {
+    if args.install && !skip_hooks_all(&args.skip_hooks) {
         args.trust_hooks = true;
     }
 }
@@ -479,7 +496,7 @@ fn run_clone(args: &Args, settings: &DaftSettings, output: &mut dyn Output) -> R
                 &bare_params,
                 &layout,
                 settings,
-                args.no_hooks,
+                &args.skip_hooks,
                 args.trust_hooks,
                 args.verbose,
                 tui_columns.clone(),
@@ -493,7 +510,7 @@ fn run_clone(args: &Args, settings: &DaftSettings, output: &mut dyn Output) -> R
                 &bare_params,
                 &layout,
                 settings,
-                args.no_hooks,
+                &args.skip_hooks,
                 args.trust_hooks,
                 output,
             )?
@@ -568,7 +585,7 @@ fn create_satellite_worktrees(
     bare_params: &clone::BareCloneParams,
     layout: &crate::core::layout::Layout,
     settings: &DaftSettings,
-    no_hooks: bool,
+    skip_hooks: &[String],
     trust_hooks: bool,
     output: &mut dyn Output,
 ) -> Result<clone::CloneResult> {
@@ -595,10 +612,10 @@ fn create_satellite_worktrees(
     // the new repo: a freshly-cloned repo's `.git/config` is unlikely to
     // hold daft-specific keys yet, and `_global` keeps this consistent
     // with the orchestrator-thread site below — both pre-clone paths.
-    let shared_hooks_config = if !no_hooks {
-        Some(crate::core::settings::load_hooks_config_global()?)
-    } else {
+    let shared_hooks_config = if skip_hooks_all(skip_hooks) {
         None
+    } else {
+        Some(crate::core::settings::load_hooks_config_global()?)
     };
 
     let mut created_count = 0;
@@ -635,8 +652,10 @@ fn create_satellite_worktrees(
 
         // Run worktree-pre-create hook
         if let Some(ref hooks_config) = shared_hooks_config
-            && let Ok(mut executor) = HookExecutor::new(hooks_config.clone())
+            && let Ok(executor) = HookExecutor::new(hooks_config.clone())
         {
+            let mut executor = executor
+                .with_job_filter(crate::hooks::yaml_executor::JobFilter::skipping(skip_hooks));
             if trust_hooks {
                 if let Some(fp) = get_remote_url_for_git_dir(&base_result.git_dir) {
                     let _ = executor.trust_repository_with_fingerprint(
@@ -703,7 +722,10 @@ fn create_satellite_worktrees(
                         &base_result.parent_dir,
                     );
 
-                    if let Ok(mut executor) = HookExecutor::new(hooks_config.clone()) {
+                    if let Ok(executor) = HookExecutor::new(hooks_config.clone()) {
+                        let mut executor = executor.with_job_filter(
+                            crate::hooks::yaml_executor::JobFilter::skipping(skip_hooks),
+                        );
                         if trust_hooks {
                             if let Some(fp) = get_remote_url_for_git_dir(&base_result.git_dir) {
                                 let _ = executor.trust_repository_with_fingerprint(
@@ -810,7 +832,7 @@ fn create_satellite_worktrees_tui(
     bare_params: &clone::BareCloneParams,
     layout: &Layout,
     settings: &DaftSettings,
-    no_hooks: bool,
+    skip_hooks: &[String],
     trust_hooks: bool,
     verbosity: u8,
     tui_columns: Option<Vec<Column>>,
@@ -917,13 +939,18 @@ fn create_satellite_worktrees_tui(
     // Load once for the orchestrator thread; the base-post-create site and the
     // per-satellite loop each clone from this. Loader hits global git-config
     // files which are stable for the life of this command. `Option<None>`
-    // when --no-hooks was passed — the gates below (`if let Some`) replace
-    // the previous `if !no_hooks` checks.
-    let shared_hooks_config = if no_hooks {
+    // when `--skip-hooks all` was passed — the gates below (`if let Some`)
+    // replace the previous `if !no_hooks` checks. Partial skips still load the
+    // config; the per-executor `JobFilter` (built from `shared_skip_hooks`)
+    // excludes the requested jobs.
+    let shared_hooks_config = if skip_hooks_all(skip_hooks) {
         None
     } else {
         Some(crate::core::settings::load_hooks_config_global()?)
     };
+    // Owned copy moved into the orchestrator thread; each executor site builds
+    // a `JobFilter` from it.
+    let shared_skip_hooks = skip_hooks.to_vec();
     let shared_base_branch = base_branch.map(|s| s.to_string());
     let shared_base_path: Option<std::path::PathBuf> =
         worktree_infos.first().and_then(|info| info.path.clone());
@@ -951,8 +978,11 @@ fn create_satellite_worktrees_tui(
 
             // Run worktree-post-create hook for the base worktree via TuiBridge
             if let Some(ref hooks_cfg) = shared_hooks_config
-                && let Ok(mut executor) = HookExecutor::new(hooks_cfg.clone())
+                && let Ok(executor) = HookExecutor::new(hooks_cfg.clone())
             {
+                let mut executor = executor.with_job_filter(
+                    crate::hooks::yaml_executor::JobFilter::skipping(&shared_skip_hooks),
+                );
                 if shared_trust_hooks {
                     if let Some(fp) = get_remote_url_for_git_dir(&shared_git_dir) {
                         let _ = executor.trust_repository_with_fingerprint(
@@ -1042,7 +1072,10 @@ fn create_satellite_worktrees_tui(
                         });
                         continue;
                     }
-                    Ok(mut executor) => {
+                    Ok(executor) => {
+                        let mut executor = executor.with_job_filter(
+                            crate::hooks::yaml_executor::JobFilter::skipping(&shared_skip_hooks),
+                        );
                         if shared_trust_hooks {
                             if let Some(fp) = get_remote_url_for_git_dir(&shared_git_dir) {
                                 let _ = executor.trust_repository_with_fingerprint(
@@ -1117,7 +1150,12 @@ fn create_satellite_worktrees_tui(
                                     )),
                                 });
                             }
-                            Ok(mut executor) => {
+                            Ok(executor) => {
+                                let mut executor = executor.with_job_filter(
+                                    crate::hooks::yaml_executor::JobFilter::skipping(
+                                        &shared_skip_hooks,
+                                    ),
+                                );
                                 if shared_trust_hooks {
                                     if let Some(fp) = get_remote_url_for_git_dir(&shared_git_dir) {
                                         let _ = executor.trust_repository_with_fingerprint(
@@ -1358,8 +1396,8 @@ fn run_post_clone_hook(
     result: &clone::CloneResult,
     output: &mut dyn Output,
 ) -> Result<()> {
-    if args.no_hooks {
-        output.step("Skipping hooks (--no-hooks flag)");
+    if skip_hooks_all(&args.skip_hooks) {
+        output.step("Skipping hooks (--skip-hooks all)");
         return Ok(());
     }
 
@@ -1371,7 +1409,9 @@ fn run_post_clone_hook(
     // freshly-cloned repo are vanishingly rare in practice — a deliberate
     // tradeoff for cwd-tolerance.
     let hooks_config = crate::core::settings::load_hooks_config_global()?;
-    let mut executor = HookExecutor::new(hooks_config)?;
+    let mut executor = HookExecutor::new(hooks_config)?.with_job_filter(
+        crate::hooks::yaml_executor::JobFilter::skipping(&args.skip_hooks),
+    );
 
     if args.trust_hooks {
         output.step("Trusting repository for hooks (--trust-hooks flag)");
@@ -1416,14 +1456,16 @@ fn run_post_create_hook(
     result: &clone::CloneResult,
     output: &mut dyn Output,
 ) -> Result<()> {
-    if args.no_hooks {
+    if skip_hooks_all(&args.skip_hooks) {
         return Ok(());
     }
 
     // `_global` for the same cwd-tolerance reason as `run_post_clone_hook` —
     // see the comment there.
     let hooks_config = crate::core::settings::load_hooks_config_global()?;
-    let mut executor = HookExecutor::new(hooks_config)?;
+    let mut executor = HookExecutor::new(hooks_config)?.with_job_filter(
+        crate::hooks::yaml_executor::JobFilter::skipping(&args.skip_hooks),
+    );
 
     if args.trust_hooks {
         if let Some(fp) = get_remote_url_for_git_dir(&result.git_dir) {
@@ -1625,17 +1667,61 @@ mod tests {
     }
 
     #[test]
-    fn install_with_no_hooks_does_not_trust() {
-        // --no-hooks opts out of hooks entirely, so the trust implication
-        // must not fire (and must not create a --trust-hooks/--no-hooks conflict).
+    fn install_with_skip_hooks_all_does_not_trust() {
+        // --skip-hooks all opts out of hooks entirely, so the trust implication
+        // must not fire (and must not create a --trust-hooks/--skip-hooks all
+        // conflict).
         let mut args = Args::parse_from([
             "git-worktree-clone",
             "https://example.com/r.git",
             "--install",
-            "--no-hooks",
+            "--skip-hooks",
+            "all",
         ]);
         apply_install_trust(&mut args);
         assert!(!args.trust_hooks);
+    }
+
+    #[test]
+    fn install_with_partial_skip_still_trusts() {
+        // A *partial* skip (tag/name) still runs the user's own hooks — just
+        // fewer jobs — so the --install trust implication must still fire.
+        let mut args = Args::parse_from([
+            "git-worktree-clone",
+            "https://example.com/r.git",
+            "--install",
+            "--skip-hooks",
+            "tag:heavy",
+        ]);
+        apply_install_trust(&mut args);
+        assert!(
+            args.trust_hooks,
+            "--install with a partial --skip-hooks should still imply --trust-hooks"
+        );
+    }
+
+    #[test]
+    fn trust_hooks_with_skip_hooks_all_conflicts() {
+        let args = Args::parse_from([
+            "git-worktree-clone",
+            "https://example.com/r.git",
+            "--trust-hooks",
+            "--skip-hooks",
+            "all",
+        ]);
+        assert!(validate_arg_combinations(&args).is_err());
+    }
+
+    #[test]
+    fn trust_hooks_with_partial_skip_is_ok() {
+        let args = Args::parse_from([
+            "git-worktree-clone",
+            "https://example.com/r.git",
+            "--trust-hooks",
+            "--skip-hooks",
+            "tag:heavy",
+        ]);
+        assert!(validate_arg_combinations(&args).is_ok());
     }
 
     #[test]

--- a/src/commands/clone.rs
+++ b/src/commands/clone.rs
@@ -107,13 +107,14 @@ pub struct Args {
     trust_hooks: bool,
 
     /// Skip hooks this run. Repeatable / comma-separated.
-    /// Selectors: `all` (every hook), `tag:<tag>`, or a job name (plus its
+    /// Selectors: `all` (every hook), a hook name (`post-clone`,
+    /// `worktree-post-create`, …), `tag:<tag>`, or a job name (plus its
     /// dependents). See daft-hooks(1).
     #[arg(
         long,
         value_name = "SELECTOR",
         value_delimiter = ',',
-        help = "Skip hooks this run (all | tag:<tag> | <job>); repeatable/comma-separated"
+        help = "Skip hooks this run (all | <hook> | tag:<tag> | <job>); repeatable/comma-separated"
     )]
     skip_hooks: Vec<String>,
 

--- a/src/commands/complete.rs
+++ b/src/commands/complete.rs
@@ -739,6 +739,13 @@ fn complete_skip_hooks(prefix: &str) -> Result<Vec<String>> {
         return Ok(out);
     };
 
+    // Intentionally union job names and tags across *all* configured hooks,
+    // not just the hook(s) that would fire for the command being completed.
+    // Determining the firing set per command would mean re-deriving create-vs-
+    // navigate / clone-vs-adopt at completion time (repo-state dependent); the
+    // wider vocabulary is the cheaper, predictable choice. A consequence is that
+    // e.g. `daft go --skip-hooks <Tab>` may offer a `post-clone` job name that
+    // never runs for `go` — harmless (an unmatched selector just warns).
     let mut hooks: Vec<String> = Vec::new();
     let mut jobs: Vec<String> = Vec::new();
     let mut tags: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();

--- a/src/commands/complete.rs
+++ b/src/commands/complete.rs
@@ -152,6 +152,10 @@ fn complete(
         // hooks run --job: complete job names for a hook type
         ("hooks-run-job", 1) => complete_hook_jobs(word, verbose),
 
+        // --skip-hooks <SELECTOR>: complete the selector vocabulary
+        // (all / hook-type names / job names / tag:<tag>) from daft.yml
+        ("skip-hooks-value", 1) => complete_skip_hooks(word),
+
         // layout transform / layout default / clone --layout: complete layout names
         ("layout-transform", 1) | ("layout-default", 1) | ("layout-value", 1) => {
             complete_layouts(word)
@@ -710,6 +714,61 @@ fn complete_configured_hooks(prefix: &str) -> Result<Vec<String>> {
         }
         None => Ok(vec![]),
     }
+}
+
+/// Complete `--skip-hooks` selector values from the current worktree's
+/// daft.yml: the `all` wildcard, the configured lifecycle hook-type names
+/// (e.g. `worktree-post-create`, `post-clone`), every job name, and a
+/// `tag:<tag>` entry per declared tag — the full selector vocabulary, ordered
+/// by category (wildcard → hooks → jobs → tags). Only daft lifecycle hook
+/// keys are offered as hook-type selectors, since those are the only names the
+/// executor matches wholesale. Falls back to just `all` outside a worktree.
+fn complete_skip_hooks(prefix: &str) -> Result<Vec<String>> {
+    let mut out: Vec<String> = Vec::new();
+    if "all".starts_with(prefix) {
+        out.push("all".to_string());
+    }
+
+    let Some(root) = find_worktree_root().ok() else {
+        return Ok(out);
+    };
+    let Some(cfg) = yaml_config_loader::load_merged_config(root.as_path())
+        .ok()
+        .flatten()
+    else {
+        return Ok(out);
+    };
+
+    let mut hooks: Vec<String> = Vec::new();
+    let mut jobs: Vec<String> = Vec::new();
+    let mut tags: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    for (hook_name, def) in &cfg.hooks {
+        if crate::hooks::HookType::from_yaml_name(hook_name).is_some() {
+            hooks.push(hook_name.clone());
+        }
+        for job in yaml_config_loader::get_effective_jobs(def) {
+            if let Some(name) = job.name {
+                jobs.push(name);
+            }
+            if let Some(job_tags) = job.tags {
+                tags.extend(job_tags);
+            }
+        }
+    }
+    hooks.sort();
+    hooks.dedup();
+    jobs.sort();
+    jobs.dedup();
+
+    out.extend(hooks.into_iter().filter(|h| h.starts_with(prefix)));
+    out.extend(jobs.into_iter().filter(|j| j.starts_with(prefix)));
+    out.extend(
+        tags.into_iter()
+            .map(|t| format!("tag:{t}"))
+            .filter(|s| s.starts_with(prefix)),
+    );
+    out.dedup();
+    Ok(out)
 }
 
 /// Complete job names within a hook type.

--- a/src/commands/completions/bash.rs
+++ b/src/commands/completions/bash.rs
@@ -63,6 +63,28 @@ pub(super) fn generate_bash_completion_string(command_name: &str) -> Result<Stri
         output.push('\n');
     }
 
+    // Value completion for --skip-hooks flag (selector vocabulary from daft.yml)
+    let has_skip_hooks = matches!(
+        command_name,
+        "git-worktree-checkout"
+            | "git-worktree-clone"
+            | "git-worktree-flow-adopt"
+            | "daft-go"
+            | "daft-start"
+    );
+    if has_skip_hooks {
+        output.push_str("    # Skip-hooks selector completion for --skip-hooks\n");
+        output.push_str("    if [[ \"$prev\" == \"--skip-hooks\" ]]; then\n");
+        output.push_str("        local selectors\n");
+        output.push_str(
+            "        selectors=$(daft __complete skip-hooks-value \"$cur\" 2>/dev/null | cut -f1)\n",
+        );
+        output.push_str("        COMPREPLY=( $(compgen -W \"$selectors\" -- \"$cur\") )\n");
+        output.push_str("        return 0\n");
+        output.push_str("    fi\n");
+        output.push('\n');
+    }
+
     // Value completion for --columns flag
     let has_columns = matches!(
         command_name,
@@ -197,12 +219,27 @@ fn generate_bash_rich_completion(command_name: &str) -> String {
         ""
     };
 
+    // Rich commands that also carry --skip-hooks (checkout, go) complete its
+    // selector vocabulary when the previous word is the flag.
+    let skip_hooks_pre = if matches!(command_name, "git-worktree-checkout" | "daft-go") {
+        r#"    if [[ "$prev" == "--skip-hooks" ]]; then
+        local selectors
+        selectors=$(daft __complete skip-hooks-value "$cur" 2>/dev/null | cut -f1)
+        COMPREPLY=( $(compgen -W "$selectors" -- "$cur") )
+        return 0
+    fi
+
+"#
+    } else {
+        ""
+    };
+
     let mut output = format!(
         r#"_{func_name}() {{
     local cur prev words cword
     _init_completion || return
 
-    if [[ "$cur" == -* ]]; then
+{skip_hooks_pre}    if [[ "$cur" == -* ]]; then
         local flags="{flags_joined}"
         COMPREPLY=( $(compgen -W "$flags" -- "$cur") )
         return 0

--- a/src/commands/completions/fish.rs
+++ b/src/commands/completions/fish.rs
@@ -118,6 +118,22 @@ pub(super) fn generate_fish_completion_string(command_name: &str) -> Result<Stri
         ));
     }
 
+    // Value completions for --skip-hooks flag (selector vocabulary from daft.yml)
+    let has_skip_hooks = matches!(
+        command_name,
+        "git-worktree-checkout"
+            | "git-worktree-clone"
+            | "git-worktree-flow-adopt"
+            | "daft-go"
+            | "daft-start"
+    );
+    if has_skip_hooks {
+        output.push_str(&format!(
+            "\n# Skip-hooks selector completions for --skip-hooks\ncomplete -c {} -l skip-hooks -x -a \"(daft __complete skip-hooks-value '' 2>/dev/null)\"\n",
+            command_name
+        ));
+    }
+
     // Value completions for --columns flag
     let has_columns = matches!(
         command_name,
@@ -283,6 +299,19 @@ fn generate_fish_rich_completion(command_name: &str) -> Result<String> {
             ));
         }
     }
+    // Rich commands that also carry --skip-hooks (checkout, go) complete its
+    // selector vocabulary from daft.yml.
+    if matches!(command_name, "git-worktree-checkout" | "daft-go") {
+        output.push_str(&format!(
+            "complete -c {command_name} -l skip-hooks -x -a \"(daft __complete skip-hooks-value '' 2>/dev/null)\"\n",
+        ));
+        if is_git_command {
+            output.push_str(&format!(
+                "complete -c git -n '__fish_seen_subcommand_from {git_subcommand}' -l skip-hooks -x -a \"(daft __complete skip-hooks-value '' 2>/dev/null)\"\n",
+            ));
+        }
+    }
+
     output.push('\n');
     output.push_str("# Static flag completions (extracted from clap)\n");
 

--- a/src/commands/completions/mod.rs
+++ b/src/commands/completions/mod.rs
@@ -645,6 +645,38 @@ mod tests {
     }
 
     #[test]
+    fn skip_hooks_value_completion_wired_for_all_flag_carrying_commands() {
+        // Every command that exposes --skip-hooks must complete its selector
+        // values via `daft __complete skip-hooks-value`, in all three shells.
+        // Regression for the rich/non-rich generator split: checkout and go
+        // take the rich path, so a value block added only to the non-rich
+        // generator silently misses them.
+        for cmd in [
+            "git-worktree-checkout",   // rich
+            "daft-go",                 // rich
+            "git-worktree-clone",      // non-rich
+            "git-worktree-flow-adopt", // non-rich
+            "daft-start",              // non-rich
+        ] {
+            let bash = bash::generate_bash_completion_string(cmd).expect("bash gen");
+            assert!(
+                bash.contains("skip-hooks-value"),
+                "bash completion for {cmd} must complete --skip-hooks values"
+            );
+            let zsh = zsh::generate_zsh_completion_string(cmd).expect("zsh gen");
+            assert!(
+                zsh.contains("skip-hooks-value"),
+                "zsh completion for {cmd} must complete --skip-hooks values"
+            );
+            let fish = fish::generate_fish_completion_string(cmd).expect("fish gen");
+            assert!(
+                fish.contains("skip-hooks-value"),
+                "fish completion for {cmd} must complete --skip-hooks values"
+            );
+        }
+    }
+
+    #[test]
     fn fish_daft_umbrella_passes_fetch_on_miss_for_go() {
         let fish_completions = fish::generate_daft_fish_completions();
         assert!(

--- a/src/commands/completions/zsh.rs
+++ b/src/commands/completions/zsh.rs
@@ -46,9 +46,18 @@ pub(super) fn generate_zsh_completion_string(command_name: &str) -> Result<Strin
     let has_branch_completions = command_name == "git-worktree-clone";
     // Value completion for --layout flag
     let has_layout = matches!(command_name, "git-worktree-clone" | "git-worktree-init");
+    // Value completion for --skip-hooks flag
+    let has_skip_hooks = matches!(
+        command_name,
+        "git-worktree-checkout"
+            | "git-worktree-clone"
+            | "git-worktree-flow-adopt"
+            | "daft-go"
+            | "daft-start"
+    );
 
     // Emit the prev_word variable once if any prev-based completion is needed
-    if has_branch_completions || has_layout {
+    if has_branch_completions || has_layout || has_skip_hooks {
         output.push_str("    local prev_word=\"${words[$((CURRENT-1))]}\"\n");
     }
 
@@ -69,6 +78,17 @@ pub(super) fn generate_zsh_completion_string(command_name: &str) -> Result<Strin
         output.push_str("        local -a layouts\n");
         output.push_str("        layouts=(\"${(@f)$(daft __complete layout-value \"$curword\" 2>/dev/null | sed 's/\\t/:/')}\")\n");
         output.push_str("        _describe 'layout' layouts\n");
+        output.push_str("        return\n");
+        output.push_str("    fi\n");
+        output.push('\n');
+    }
+
+    if has_skip_hooks {
+        output.push_str("    # Skip-hooks selector completion for --skip-hooks\n");
+        output.push_str("    if [[ \"$prev_word\" == \"--skip-hooks\" ]]; then\n");
+        output.push_str("        local -a selectors\n");
+        output.push_str("        selectors=(\"${(@f)$(daft __complete skip-hooks-value \"$curword\" 2>/dev/null | sed 's/\\t/:/')}\")\n");
+        output.push_str("        _describe 'skip-hooks selector' selectors\n");
         output.push_str("        return\n");
         output.push_str("    fi\n");
         output.push('\n');
@@ -271,6 +291,13 @@ fn generate_zsh_rich_completion(command_name: &str) -> String {
     } else {
         ""
     };
+    // Rich commands that also carry --skip-hooks (checkout, go) complete its
+    // selector vocabulary when the previous word is the flag.
+    let skip_hooks_pre = if matches!(command_name, "git-worktree-checkout" | "daft-go") {
+        "    if [[ \"${words[$((CURRENT-1))]}\" == \"--skip-hooks\" ]]; then\n        local -a selectors\n        selectors=(\"${(@f)$(daft __complete skip-hooks-value \"$curword\" 2>/dev/null | sed 's/\\t/:/')}\")\n        _describe 'skip-hooks selector' selectors\n        return\n    fi\n\n"
+    } else {
+        ""
+    };
 
     let mut output = format!(
         r#"#compdef {command_name}
@@ -279,7 +306,7 @@ __{func_name}_impl() {{
     local curword="${{words[$CURRENT]}}"
     local cword=$((CURRENT - 1))
 
-    if [[ "$curword" == -* ]]; then
+{skip_hooks_pre}    if [[ "$curword" == -* ]]; then
         local -a flags
         flags=(
 {flags_block}        )

--- a/src/commands/flow_adopt.rs
+++ b/src/commands/flow_adopt.rs
@@ -104,13 +104,14 @@ pub struct Args {
     trust_hooks: bool,
 
     /// Skip hooks this run. Repeatable / comma-separated.
-    /// Selectors: `all` (every hook), `tag:<tag>`, or a job name (plus its
+    /// Selectors: `all` (every hook), a hook name (`post-clone`,
+    /// `worktree-post-create`, …), `tag:<tag>`, or a job name (plus its
     /// dependents). See daft-hooks(1).
     #[arg(
         long,
         value_name = "SELECTOR",
         value_delimiter = ',',
-        help = "Skip hooks this run (all | tag:<tag> | <job>); repeatable/comma-separated"
+        help = "Skip hooks this run (all | <hook> | tag:<tag> | <job>); repeatable/comma-separated"
     )]
     skip_hooks: Vec<String>,
 

--- a/src/commands/flow_adopt.rs
+++ b/src/commands/flow_adopt.rs
@@ -103,8 +103,16 @@ pub struct Args {
     )]
     trust_hooks: bool,
 
-    #[arg(long = "no-hooks", help = "Do not run any hooks from the repository")]
-    no_hooks: bool,
+    /// Skip hooks this run. Repeatable / comma-separated.
+    /// Selectors: `all` (every hook), `tag:<tag>`, or a job name (plus its
+    /// dependents). See daft-hooks(1).
+    #[arg(
+        long,
+        value_name = "SELECTOR",
+        value_delimiter = ',',
+        help = "Skip hooks this run (all | tag:<tag> | <job>); repeatable/comma-separated"
+    )]
+    skip_hooks: Vec<String>,
 
     #[arg(
         long = "dry-run",
@@ -118,8 +126,8 @@ pub fn run() -> Result<()> {
 
     init_logging(args.verbose);
 
-    if args.trust_hooks && args.no_hooks {
-        anyhow::bail!("--trust-hooks and --no-hooks cannot be used together.");
+    if args.trust_hooks && skip_hooks_all(&args.skip_hooks) {
+        anyhow::bail!("--trust-hooks and --skip-hooks all cannot be used together.");
     }
 
     let settings = DaftSettings::load_global()?;
@@ -194,18 +202,27 @@ fn run_adopt(args: &Args, settings: &DaftSettings, output: &mut dyn Output) -> R
     Ok(())
 }
 
+/// True when `--skip-hooks` requests skipping *every* hook (`all` / `*`) — the
+/// uniform replacement for the old `--no-hooks`. Partial skips (`tag:`/`<job>`)
+/// still fire hooks, just with some jobs excluded.
+fn skip_hooks_all(skip_hooks: &[String]) -> bool {
+    crate::hooks::job_adapter::parse_skip_selectors(skip_hooks).all
+}
+
 fn run_post_adopt_hook(
     args: &Args,
     result: &flow_adopt::AdoptResult,
     output: &mut dyn Output,
 ) -> Result<()> {
-    if args.no_hooks {
-        output.step("Skipping hooks (--no-hooks flag)");
+    if skip_hooks_all(&args.skip_hooks) {
+        output.step("Skipping hooks (--skip-hooks all)");
         return Ok(());
     }
 
     let hooks_config = crate::core::settings::load_hooks_config()?;
-    let mut executor = HookExecutor::new(hooks_config)?;
+    let mut executor = HookExecutor::new(hooks_config)?.with_job_filter(
+        crate::hooks::yaml_executor::JobFilter::skipping(&args.skip_hooks),
+    );
 
     if args.trust_hooks {
         output.step("Trusting repository for hooks (--trust-hooks flag)");

--- a/src/commands/hooks/run_cmd.rs
+++ b/src/commands/hooks/run_cmd.rs
@@ -86,6 +86,7 @@ pub(super) fn cmd_run(args: &HooksRunArgs, output: &mut dyn Output) -> Result<()
     let filter = JobFilter {
         only_job_name: args.job.clone(),
         only_tags: args.tag.clone(),
+        ..Default::default()
     };
 
     // Dry-run: preview jobs without executing

--- a/src/core/worktree/flow_adopt.rs
+++ b/src/core/worktree/flow_adopt.rs
@@ -41,7 +41,7 @@ pub struct AdoptResult {
 ///
 /// Move hooks (teardown before relocation, setup after) are fired inside
 /// `convert_to_bare`. Post-clone hooks are handled separately by the
-/// command layer due to trust semantics (--trust-hooks, --no-hooks).
+/// command layer due to trust semantics (--trust-hooks, --skip-hooks).
 pub fn execute(
     params: &AdoptParams,
     sink: &mut (impl ProgressSink + HookRunner),

--- a/src/hooks/job_adapter.rs
+++ b/src/hooks/job_adapter.rs
@@ -38,6 +38,13 @@ pub struct SkipSelectors {
     pub names: Vec<String>,
     /// Tags to skip (from `tag:<tag>` selectors).
     pub tags: Vec<String>,
+    /// Hook types to skip wholesale (from bare hook-type names like
+    /// `worktree-post-create`). Each entry is a canonical
+    /// [`crate::hooks::HookType::yaml_name`]. Matched against the current
+    /// fire's hook name in the executor, where it short-circuits the whole
+    /// hook (like `all`, but scoped to one hook type). Does NOT feed
+    /// [`compute_skip_cascade`] — it is a hook-level, not job-level, selector.
+    pub hook_types: Vec<String>,
     /// Original selector tokens, retained for no-match warning attribution.
     pub raw: Vec<String>,
 }
@@ -46,7 +53,7 @@ impl SkipSelectors {
     /// True when no selectors were supplied (the common case — no
     /// `--skip-hooks` flag). Lets callers cheaply bypass the exclude path.
     pub fn is_empty(&self) -> bool {
-        !self.all && self.names.is_empty() && self.tags.is_empty()
+        !self.all && self.names.is_empty() && self.tags.is_empty() && self.hook_types.is_empty()
     }
 }
 
@@ -55,10 +62,16 @@ impl SkipSelectors {
 /// Precedence:
 /// - `tag:<tag>` → tag selector
 /// - `job:<name>` → name selector (escape hatch; `job:all` is the job literally
-///   named `all`, NOT the wildcard)
+///   named `all`, NOT the wildcard; `job:worktree-post-create` is the job
+///   literally named after a hook type, NOT the hook-type selector)
 /// - `all` / `*` → wildcard (`all = true`)
+/// - a canonical hook-type name (`worktree-post-create`, `post-clone`, …) →
+///   hook-type selector (skip that whole hook). Only the canonical
+///   [`crate::hooks::HookType::yaml_name`] spellings are reserved; deprecated
+///   short forms (`post-create`) are treated as job names.
 /// - anything else → bare name selector
 pub fn parse_skip_selectors(selectors: &[String]) -> SkipSelectors {
+    use crate::hooks::HookType;
     let mut out = SkipSelectors {
         raw: selectors.to_vec(),
         ..Default::default()
@@ -71,6 +84,8 @@ pub fn parse_skip_selectors(selectors: &[String]) -> SkipSelectors {
             out.names.push(name.to_string());
         } else if s == "all" || s == "*" {
             out.all = true;
+        } else if HookType::from_yaml_name(s).is_some() {
+            out.hook_types.push(s.to_string());
         } else {
             out.names.push(s.to_string());
         }
@@ -1165,7 +1180,40 @@ mod tests {
         assert!(!s.all);
         assert_eq!(s.tags, vec!["heavy"]);
         assert_eq!(s.names, vec!["lint", "build"]);
+        assert!(s.hook_types.is_empty());
         assert_eq!(s.raw.len(), 3);
+    }
+
+    #[test]
+    fn parse_hook_type_name_is_reserved() {
+        let s = parse_skip_selectors(&strs(&["worktree-post-create"]));
+        assert!(!s.all);
+        assert_eq!(s.hook_types, vec!["worktree-post-create"]);
+        assert!(s.names.is_empty());
+        assert!(s.tags.is_empty());
+        // post-clone and the other canonical names are reserved too.
+        assert_eq!(
+            parse_skip_selectors(&strs(&["post-clone"])).hook_types,
+            vec!["post-clone"]
+        );
+    }
+
+    #[test]
+    fn parse_job_prefix_escapes_hook_type_name() {
+        // `job:worktree-post-create` is a job literally named after the hook
+        // type, NOT the hook-type selector.
+        let s = parse_skip_selectors(&strs(&["job:worktree-post-create"]));
+        assert!(s.hook_types.is_empty());
+        assert_eq!(s.names, vec!["worktree-post-create"]);
+    }
+
+    #[test]
+    fn parse_deprecated_hook_short_form_is_a_job_name() {
+        // Deprecated short forms (`post-create`) are NOT reserved — only the
+        // canonical yaml_name spellings are. A bare `post-create` is a job name.
+        let s = parse_skip_selectors(&strs(&["post-create"]));
+        assert!(s.hook_types.is_empty());
+        assert_eq!(s.names, vec!["post-create"]);
     }
 
     // ── compute_skip_cascade ────────────────────────────────────────────

--- a/src/hooks/job_adapter.rs
+++ b/src/hooks/job_adapter.rs
@@ -24,6 +24,183 @@ pub struct SkippedJob {
     pub reason: String,
 }
 
+/// Parsed `--skip-hooks` selectors.
+///
+/// Built by [`parse_skip_selectors`] from the raw CLI tokens and carried on
+/// [`crate::hooks::yaml_executor::JobFilter`]. Drives the exclude side of hook
+/// filtering: [`compute_skip_cascade`] consumes `names`/`tags`, while `all`
+/// short-circuits the whole fire and `raw` is retained for no-match warnings.
+#[derive(Debug, Default, Clone)]
+pub struct SkipSelectors {
+    /// `all` / `*` selector: skip every job (short-circuit the hook fire).
+    pub all: bool,
+    /// Job names to skip (from bare `<name>` and `job:<name>` selectors).
+    pub names: Vec<String>,
+    /// Tags to skip (from `tag:<tag>` selectors).
+    pub tags: Vec<String>,
+    /// Original selector tokens, retained for no-match warning attribution.
+    pub raw: Vec<String>,
+}
+
+impl SkipSelectors {
+    /// True when no selectors were supplied (the common case — no
+    /// `--skip-hooks` flag). Lets callers cheaply bypass the exclude path.
+    pub fn is_empty(&self) -> bool {
+        !self.all && self.names.is_empty() && self.tags.is_empty()
+    }
+}
+
+/// Parse raw `--skip-hooks` tokens into a [`SkipSelectors`].
+///
+/// Precedence:
+/// - `tag:<tag>` → tag selector
+/// - `job:<name>` → name selector (escape hatch; `job:all` is the job literally
+///   named `all`, NOT the wildcard)
+/// - `all` / `*` → wildcard (`all = true`)
+/// - anything else → bare name selector
+pub fn parse_skip_selectors(selectors: &[String]) -> SkipSelectors {
+    let mut out = SkipSelectors {
+        raw: selectors.to_vec(),
+        ..Default::default()
+    };
+    for sel in selectors {
+        let s = sel.trim();
+        if let Some(tag) = s.strip_prefix("tag:") {
+            out.tags.push(tag.to_string());
+        } else if let Some(name) = s.strip_prefix("job:") {
+            out.names.push(name.to_string());
+        } else if s == "all" || s == "*" {
+            out.all = true;
+        } else {
+            out.names.push(s.to_string());
+        }
+    }
+    out
+}
+
+/// Why a job was excluded by `--skip-hooks`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SkipCause {
+    /// Direct selector match (job name or tag).
+    Requested,
+    /// Cascade: this job `needs:` an excluded job. Holds the *immediate*
+    /// excluded dependency (not the cascade root) so the rendered reason reads
+    /// `depends on <that dep> (skipped)`.
+    DependsOn(String),
+}
+
+impl SkipCause {
+    /// Render the user-facing skip reason for this cause.
+    pub fn reason(&self) -> String {
+        match self {
+            SkipCause::Requested => "requested (--skip-hooks)".to_string(),
+            SkipCause::DependsOn(dep) => format!("depends on {dep} (skipped)"),
+        }
+    }
+}
+
+/// Result of [`compute_skip_cascade`]: which jobs are excluded (and why), plus
+/// selector tokens that matched nothing (for warnings).
+#[derive(Debug, Default)]
+pub struct SkipCascade {
+    /// Excluded job name → cause. Membership lookup only; iterate the original
+    /// `jobs` slice in declaration order when ordered output is needed.
+    pub excluded: std::collections::HashMap<String, SkipCause>,
+    /// Selector tokens (`<name>` / `tag:<tag>`) that matched no job.
+    pub unmatched: Vec<String>,
+}
+
+/// Compute the set of jobs excluded by `--skip-hooks`, with attribution.
+///
+/// Operates on [`JobDef`]s while `needs:` is still intact — call BEFORE
+/// [`yaml_jobs_to_specs`]. Does NOT handle the `all` selector; the caller
+/// short-circuits that earlier (see `execute_yaml_hook_with_rc`).
+///
+/// Algorithm:
+/// 1. **Direct pass** (declaration order): a named job is `Requested` if its
+///    name is in `skip.names` OR any of its tags is in `skip.tags`.
+/// 2. **Cascade pass** (BFS over reverse-`needs`): any job that `needs:` an
+///    already-excluded job becomes `DependsOn(<that immediate dep>)`. The BFS
+///    is seeded and scanned in declaration order so the immediate-parent
+///    attribution is deterministic (e.g. the diamond case picks the
+///    first-declared excluded dependency).
+/// 3. **Unmatched**: each `skip.names` entry matching no `job.name`, and each
+///    `skip.tags` entry present on no job, is collected for a warning.
+///
+/// Only named jobs participate (matching and cascade are name-keyed); unnamed
+/// and `group:` jobs are out of scope here — groups carry their own skip
+/// handling in [`yaml_jobs_to_specs`].
+pub fn compute_skip_cascade(jobs: &[JobDef], skip: &SkipSelectors) -> SkipCascade {
+    use std::collections::{HashMap, VecDeque};
+
+    let mut excluded: HashMap<String, SkipCause> = HashMap::new();
+
+    // ── Direct pass (declaration order) ──
+    let mut seeds: VecDeque<String> = VecDeque::new();
+    for job in jobs {
+        let Some(name) = job.name.as_deref() else {
+            continue;
+        };
+        let name_match = skip.names.iter().any(|n| n == name);
+        let tag_match = job
+            .tags
+            .as_ref()
+            .is_some_and(|tags| tags.iter().any(|t| skip.tags.contains(t)));
+        if name_match || tag_match {
+            excluded
+                .entry(name.to_string())
+                .or_insert(SkipCause::Requested);
+            seeds.push_back(name.to_string());
+        }
+    }
+
+    // ── Cascade pass (BFS over reverse-`needs`) ──
+    while let Some(dep) = seeds.pop_front() {
+        // Scan jobs in declaration order so the first dependent discovered keeps
+        // a stable immediate-parent attribution.
+        for job in jobs {
+            let Some(name) = job.name.as_deref() else {
+                continue;
+            };
+            if excluded.contains_key(name) {
+                continue;
+            }
+            let needs_dep = job
+                .needs
+                .as_ref()
+                .is_some_and(|needs| needs.iter().any(|n| n == &dep));
+            if needs_dep {
+                excluded.insert(name.to_string(), SkipCause::DependsOn(dep.clone()));
+                seeds.push_back(name.to_string());
+            }
+        }
+    }
+
+    // ── Unmatched selectors (for warnings) ──
+    let mut unmatched = Vec::new();
+    for n in &skip.names {
+        let matched = jobs.iter().any(|j| j.name.as_deref() == Some(n.as_str()));
+        if !matched {
+            unmatched.push(n.clone());
+        }
+    }
+    for t in &skip.tags {
+        let matched = jobs.iter().any(|j| {
+            j.tags
+                .as_ref()
+                .is_some_and(|tags| tags.iter().any(|tag| tag == t))
+        });
+        if !matched {
+            unmatched.push(format!("tag:{t}"));
+        }
+    }
+
+    SkipCascade {
+        excluded,
+        unmatched,
+    }
+}
+
 /// Passthrough context for [`yaml_jobs_to_specs`]: values sourced from the
 /// outer hook execution but threaded unchanged into every job spec.
 ///
@@ -945,5 +1122,194 @@ mod tests {
 
         assert_eq!(kept.len(), 1);
         assert!(kept[0].log_config.is_none());
+    }
+
+    // ── parse_skip_selectors ────────────────────────────────────────────
+
+    fn strs(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn parse_bare_name_goes_to_names() {
+        let s = parse_skip_selectors(&strs(&["lint"]));
+        assert!(!s.all);
+        assert_eq!(s.names, vec!["lint"]);
+        assert!(s.tags.is_empty());
+    }
+
+    #[test]
+    fn parse_job_prefix_is_escape_hatch() {
+        // `job:all` is a literal job name, never the wildcard.
+        let s = parse_skip_selectors(&strs(&["job:all"]));
+        assert!(!s.all);
+        assert_eq!(s.names, vec!["all"]);
+    }
+
+    #[test]
+    fn parse_wildcard_star_and_all() {
+        assert!(parse_skip_selectors(&strs(&["all"])).all);
+        assert!(parse_skip_selectors(&strs(&["*"])).all);
+    }
+
+    #[test]
+    fn parse_tag_prefix() {
+        let s = parse_skip_selectors(&strs(&["tag:heavy"]));
+        assert_eq!(s.tags, vec!["heavy"]);
+        assert!(s.names.is_empty());
+    }
+
+    #[test]
+    fn parse_mixed_selectors() {
+        let s = parse_skip_selectors(&strs(&["tag:heavy", "lint", "job:build"]));
+        assert!(!s.all);
+        assert_eq!(s.tags, vec!["heavy"]);
+        assert_eq!(s.names, vec!["lint", "build"]);
+        assert_eq!(s.raw.len(), 3);
+    }
+
+    // ── compute_skip_cascade ────────────────────────────────────────────
+
+    /// The issue's worked-example graph:
+    ///   install            (no needs)
+    ///   build  needs install, tags [heavy]
+    ///   test   needs build
+    ///   lint   needs install
+    fn worked_example_jobs() -> Vec<JobDef> {
+        vec![
+            JobDef {
+                name: Some("install".into()),
+                ..Default::default()
+            },
+            JobDef {
+                name: Some("build".into()),
+                needs: Some(vec!["install".into()]),
+                tags: Some(vec!["heavy".into()]),
+                ..Default::default()
+            },
+            JobDef {
+                name: Some("test".into()),
+                needs: Some(vec!["build".into()]),
+                ..Default::default()
+            },
+            JobDef {
+                name: Some("lint".into()),
+                needs: Some(vec!["install".into()]),
+                ..Default::default()
+            },
+        ]
+    }
+
+    #[test]
+    fn cascade_name_seed_pulls_transitive_dependents() {
+        let jobs = worked_example_jobs();
+        let skip = parse_skip_selectors(&strs(&["install"]));
+        let c = compute_skip_cascade(&jobs, &skip);
+
+        assert_eq!(c.excluded.get("install"), Some(&SkipCause::Requested));
+        assert_eq!(
+            c.excluded.get("build"),
+            Some(&SkipCause::DependsOn("install".into()))
+        );
+        assert_eq!(
+            c.excluded.get("test"),
+            Some(&SkipCause::DependsOn("build".into()))
+        );
+        assert_eq!(
+            c.excluded.get("lint"),
+            Some(&SkipCause::DependsOn("install".into()))
+        );
+        assert_eq!(c.excluded.len(), 4);
+        assert!(c.unmatched.is_empty());
+    }
+
+    #[test]
+    fn cascade_tag_seed_drops_only_subtree() {
+        let jobs = worked_example_jobs();
+        let skip = parse_skip_selectors(&strs(&["tag:heavy"]));
+        let c = compute_skip_cascade(&jobs, &skip);
+
+        // build matches tag:heavy directly; test depends on build.
+        assert_eq!(c.excluded.get("build"), Some(&SkipCause::Requested));
+        assert_eq!(
+            c.excluded.get("test"),
+            Some(&SkipCause::DependsOn("build".into()))
+        );
+        // install and lint are untouched (upstream / sibling).
+        assert!(!c.excluded.contains_key("install"));
+        assert!(!c.excluded.contains_key("lint"));
+        assert_eq!(c.excluded.len(), 2);
+    }
+
+    #[test]
+    fn cascade_immediate_parent_attribution() {
+        // test reports its immediate excluded dep (build), not the root (install).
+        let jobs = worked_example_jobs();
+        let skip = parse_skip_selectors(&strs(&["install"]));
+        let c = compute_skip_cascade(&jobs, &skip);
+        assert_eq!(
+            c.excluded.get("test"),
+            Some(&SkipCause::DependsOn("build".into()))
+        );
+    }
+
+    #[test]
+    fn cascade_diamond_is_deterministic() {
+        // `app` needs two directly-excluded jobs; declaration-order-first wins.
+        let jobs = vec![
+            JobDef {
+                name: Some("a".into()),
+                ..Default::default()
+            },
+            JobDef {
+                name: Some("b".into()),
+                ..Default::default()
+            },
+            JobDef {
+                name: Some("app".into()),
+                needs: Some(vec!["b".into(), "a".into()]),
+                ..Default::default()
+            },
+        ];
+        let skip = parse_skip_selectors(&strs(&["a", "b"]));
+        let c = compute_skip_cascade(&jobs, &skip);
+        // Seeds enqueued in declaration order: a, then b. `a` is processed
+        // first and claims `app`.
+        assert_eq!(
+            c.excluded.get("app"),
+            Some(&SkipCause::DependsOn("a".into()))
+        );
+    }
+
+    #[test]
+    fn cascade_unmatched_selectors_collected() {
+        let jobs = worked_example_jobs();
+        let skip = parse_skip_selectors(&strs(&["ghost", "tag:nope"]));
+        let c = compute_skip_cascade(&jobs, &skip);
+        assert!(c.excluded.is_empty());
+        assert!(c.unmatched.contains(&"ghost".to_string()));
+        assert!(c.unmatched.contains(&"tag:nope".to_string()));
+    }
+
+    #[test]
+    fn cascade_upstream_is_untouched() {
+        // Skipping a leaf (test) must not remove its upstream deps.
+        let jobs = worked_example_jobs();
+        let skip = parse_skip_selectors(&strs(&["test"]));
+        let c = compute_skip_cascade(&jobs, &skip);
+        assert_eq!(c.excluded.get("test"), Some(&SkipCause::Requested));
+        assert_eq!(c.excluded.len(), 1);
+        assert!(!c.excluded.contains_key("install"));
+        assert!(!c.excluded.contains_key("build"));
+        assert!(!c.excluded.contains_key("lint"));
+    }
+
+    #[test]
+    fn cause_reason_strings() {
+        assert_eq!(SkipCause::Requested.reason(), "requested (--skip-hooks)");
+        assert_eq!(
+            SkipCause::DependsOn("build".into()).reason(),
+            "depends on build (skipped)"
+        );
     }
 }

--- a/src/hooks/job_adapter.rs
+++ b/src/hooks/job_adapter.rs
@@ -1338,6 +1338,33 @@ mod tests {
     }
 
     #[test]
+    fn cascade_terminates_on_cyclic_needs() {
+        // A needs B, B needs A. Skipping `a` cascades to `b` (b needs a); when
+        // the BFS then rediscovers `a` via b's edge, the `excluded.contains_key`
+        // guard refuses to re-enqueue it, so the walk terminates. (A `needs:`
+        // cycle is later rejected by the DAG builder; the cascade runs first and
+        // must not hang on it.) The test completing — not hanging — is the
+        // cycle-safety proof the doc comment claims.
+        let jobs = vec![
+            JobDef {
+                name: Some("a".into()),
+                needs: Some(vec!["b".into()]),
+                ..Default::default()
+            },
+            JobDef {
+                name: Some("b".into()),
+                needs: Some(vec!["a".into()]),
+                ..Default::default()
+            },
+        ];
+        let skip = parse_skip_selectors(&strs(&["a"]));
+        let c = compute_skip_cascade(&jobs, &skip);
+        assert_eq!(c.excluded.get("a"), Some(&SkipCause::Requested));
+        assert_eq!(c.excluded.get("b"), Some(&SkipCause::DependsOn("a".into())));
+        assert_eq!(c.excluded.len(), 2);
+    }
+
+    #[test]
     fn cascade_unmatched_selectors_collected() {
         let jobs = worked_example_jobs();
         let skip = parse_skip_selectors(&strs(&["ghost", "tag:nope"]));

--- a/src/hooks/job_adapter.rs
+++ b/src/hooks/job_adapter.rs
@@ -24,6 +24,14 @@ pub struct SkippedJob {
     pub reason: String,
 }
 
+/// Resolve a job's effective `background:` flag: the job's own setting wins,
+/// then the hook-level default, then `false`. Centralizes the precedence rule
+/// shared by kept-job spec conversion ([`yaml_jobs_to_specs`]) and the
+/// `--skip-hooks` skip-attribution paths so it lives in exactly one place.
+pub fn resolve_background(job_background: Option<bool>, hook_background: Option<bool>) -> bool {
+    job_background.or(hook_background).unwrap_or(false)
+}
+
 /// Parsed `--skip-hooks` selectors.
 ///
 /// Built by [`parse_skip_selectors`] from the raw CLI tokens and carried on
@@ -39,12 +47,12 @@ pub struct SkipSelectors {
     /// Tags to skip (from `tag:<tag>` selectors).
     pub tags: Vec<String>,
     /// Hook types to skip wholesale (from bare hook-type names like
-    /// `worktree-post-create`). Each entry is a canonical
-    /// [`crate::hooks::HookType::yaml_name`]. Matched against the current
-    /// fire's hook name in the executor, where it short-circuits the whole
-    /// hook (like `all`, but scoped to one hook type). Does NOT feed
+    /// `worktree-post-create`), parsed into typed [`crate::hooks::HookType`]
+    /// values. Matched against the current fire's hook name in the executor
+    /// (via [`crate::hooks::HookType::yaml_name`]), where it short-circuits the
+    /// whole hook (like `all`, but scoped to one hook type). Does NOT feed
     /// [`compute_skip_cascade`] — it is a hook-level, not job-level, selector.
-    pub hook_types: Vec<String>,
+    pub hook_types: Vec<crate::hooks::HookType>,
     /// Original selector tokens, retained for no-match warning attribution.
     pub raw: Vec<String>,
 }
@@ -84,8 +92,8 @@ pub fn parse_skip_selectors(selectors: &[String]) -> SkipSelectors {
             out.names.push(name.to_string());
         } else if s == "all" || s == "*" {
             out.all = true;
-        } else if HookType::from_yaml_name(s).is_some() {
-            out.hook_types.push(s.to_string());
+        } else if let Some(ht) = HookType::from_yaml_name(s) {
+            out.hook_types.push(ht);
         } else {
             out.names.push(s.to_string());
         }
@@ -267,7 +275,7 @@ pub fn yaml_jobs_to_specs(
 
     for job in jobs {
         let name = job.name.clone().unwrap_or_else(|| "(unnamed)".to_string());
-        let declared_background = job.background.or(hook_background).unwrap_or(false);
+        let declared_background = resolve_background(job.background, hook_background);
 
         if job.group.is_some() {
             skipped.push(SkippedJob {
@@ -1188,13 +1196,13 @@ mod tests {
     fn parse_hook_type_name_is_reserved() {
         let s = parse_skip_selectors(&strs(&["worktree-post-create"]));
         assert!(!s.all);
-        assert_eq!(s.hook_types, vec!["worktree-post-create"]);
+        assert_eq!(s.hook_types, vec![crate::hooks::HookType::PostCreate]);
         assert!(s.names.is_empty());
         assert!(s.tags.is_empty());
         // post-clone and the other canonical names are reserved too.
         assert_eq!(
             parse_skip_selectors(&strs(&["post-clone"])).hook_types,
-            vec!["post-clone"]
+            vec![crate::hooks::HookType::PostClone]
         );
     }
 

--- a/src/hooks/yaml_executor/mod.rs
+++ b/src/hooks/yaml_executor/mod.rs
@@ -237,20 +237,20 @@ pub fn execute_yaml_hook_with_rc(
     if filter.skip.all {
         return Ok(HookResult::skipped("all hooks skipped by request"));
     }
-    // A hook-type selector (e.g. `--skip-hooks worktree-post-create`) skips the
-    // whole fire when it names *this* hook. A hook-type token that names a
-    // different hook (e.g. the worktree-pre-create fire of the same command, or
-    // a hook this command never fires) contributes nothing here and — unlike a
-    // job-name/tag miss — raises no warning: it is a valid hook name, just not
-    // this fire, so it never reaches `compute_skip_cascade`'s unmatched set.
-    if filter.skip.hook_types.iter().any(|h| h == hook_name) {
-        return Ok(HookResult::skipped(format!(
-            "hook '{hook_name}' skipped by request (--skip-hooks)"
-        )));
-    }
+
+    // A hook-type selector (`--skip-hooks worktree-post-create`) names *this*
+    // fire: skip every job in the hook. Unlike `all`, this is NOT a silent
+    // short-circuit — each job is routed into an attributed skip below and
+    // rendered/recorded exactly as if it had been named directly, so the hook
+    // still appears in the output with every job marked skipped. A hook-type
+    // token naming a *different* hook (the worktree-pre-create fire of the same
+    // command, or a hook this command never fires) leaves this false and is a
+    // silent no-op — it never reaches `compute_skip_cascade`'s unmatched set,
+    // so it raises no warning (it is a valid hook name, just not this fire).
+    let skip_whole_hook = filter.skip.hook_types.iter().any(|h| h == hook_name);
 
     // Filter out jobs matching exclude_tags
-    if let Some(ref exclude_tags) = hook_def.exclude_tags {
+    if !skip_whole_hook && let Some(ref exclude_tags) = hook_def.exclude_tags {
         jobs.retain(|job| {
             if let Some(ref tags) = job.tags {
                 !tags.iter().any(|t| exclude_tags.contains(t))
@@ -271,7 +271,19 @@ pub fn execute_yaml_hook_with_rc(
     // Unmatched selectors warn (the job runs) but never error — silent
     // no-match is more dangerous in the exclude direction.
     let mut requested_skips: Vec<crate::hooks::job_adapter::SkippedJob> = Vec::new();
-    if !filter.skip.is_empty() {
+    if skip_whole_hook {
+        // Whole-hook skip: every job becomes a direct `Requested` skip (same
+        // reason as a name match), then the job list is emptied so the fire
+        // flows through the `specs.is_empty()` render/record path below.
+        for job in &jobs {
+            requested_skips.push(crate::hooks::job_adapter::SkippedJob {
+                name: job.name.clone().unwrap_or_else(|| "(unnamed)".to_string()),
+                background: job.background.or(hook_def.background).unwrap_or(false),
+                reason: crate::hooks::job_adapter::SkipCause::Requested.reason(),
+            });
+        }
+        jobs.clear();
+    } else if !filter.skip.is_empty() {
         let cascade = crate::hooks::job_adapter::compute_skip_cascade(&jobs, &filter.skip);
         for sel in &cascade.unmatched {
             output.warning(&format!(
@@ -298,14 +310,16 @@ pub fn execute_yaml_hook_with_rc(
         }
     }
 
-    // Apply inclusion filters (from `hooks run --job` / `--tag`)
-    if let Some(ref name) = filter.only_job_name {
+    // Apply inclusion filters (from `hooks run --job` / `--tag`). Skipped when
+    // the whole hook is being skipped (jobs is already emptied) so the
+    // "no job matched" bails don't fire on the intentionally-cleared list.
+    if !skip_whole_hook && let Some(ref name) = filter.only_job_name {
         jobs.retain(|j| j.name.as_deref() == Some(name.as_str()));
         if jobs.is_empty() {
             anyhow::bail!("No job named '{name}' found in hook '{hook_name}'");
         }
     }
-    if !filter.only_tags.is_empty() {
+    if !skip_whole_hook && !filter.only_tags.is_empty() {
         jobs.retain(|job| {
             job.tags
                 .as_ref()
@@ -319,8 +333,10 @@ pub fn execute_yaml_hook_with_rc(
         }
     }
 
-    // Apply tracking filter when changed_attributes are present (move hooks)
-    if let Some(ref changed) = ctx.changed_attributes {
+    // Apply tracking filter when changed_attributes are present (move hooks).
+    // Skipped on a whole-hook skip so the emptied list doesn't divert into the
+    // "No jobs match changed attributes" return ahead of the skip render.
+    if !skip_whole_hook && let Some(ref changed) = ctx.changed_attributes {
         jobs = filter_tracked_jobs(&jobs, changed);
         if jobs.is_empty() {
             return Ok(HookResult::skipped("No jobs match changed attributes"));
@@ -1968,7 +1984,7 @@ mod tests {
     }
 
     #[test]
-    fn skip_hook_type_matching_this_fire_short_circuits() {
+    fn skip_hook_type_renders_every_job_as_skipped() {
         let hook_def = skip_example_hook();
         let (ctx, dir) = make_ctx_with_dir();
         let mut output = TestOutput::default();
@@ -1988,16 +2004,25 @@ mod tests {
             presenter: &presenter,
             repo_log: None,
         };
-        // hook_name == the selected hook type ⇒ whole fire skipped, no jobs run.
+        // hook_name == the selected hook type ⇒ the whole hook is skipped, but
+        // it is NOT a silent drop: every job renders as skipped with the same
+        // `requested` reason as a direct name skip (the user's mental model is
+        // "as if I marked each job"), and no job actually runs.
         let result =
             execute_yaml_hook_with_rc("worktree-post-create", &hook_def, &ctx, &mut output, &cfg)
                 .unwrap();
         assert!(result.skipped);
-        assert_eq!(
-            result.skip_reason.as_deref(),
-            Some("hook 'worktree-post-create' skipped by request (--skip-hooks)")
+        let events = recorder.events();
+        for job in ["install", "build", "test", "lint"] {
+            assert!(
+                events.contains(&format!("skipped:{job}:requested (--skip-hooks)")),
+                "expected {job} rendered as skipped, got: {events:?}"
+            );
+        }
+        assert!(
+            !events.iter().any(|e| e.starts_with("start:")),
+            "no job should execute on a whole-hook skip"
         );
-        assert!(!recorder.events().iter().any(|e| e.starts_with("start:")));
         assert!(
             output.warnings().is_empty(),
             "a matched hook-type selector must not warn, got: {:?}",

--- a/src/hooks/yaml_executor/mod.rs
+++ b/src/hooks/yaml_executor/mod.rs
@@ -237,6 +237,17 @@ pub fn execute_yaml_hook_with_rc(
     if filter.skip.all {
         return Ok(HookResult::skipped("all hooks skipped by request"));
     }
+    // A hook-type selector (e.g. `--skip-hooks worktree-post-create`) skips the
+    // whole fire when it names *this* hook. A hook-type token that names a
+    // different hook (e.g. the worktree-pre-create fire of the same command, or
+    // a hook this command never fires) contributes nothing here and — unlike a
+    // job-name/tag miss — raises no warning: it is a valid hook name, just not
+    // this fire, so it never reaches `compute_skip_cascade`'s unmatched set.
+    if filter.skip.hook_types.iter().any(|h| h == hook_name) {
+        return Ok(HookResult::skipped(format!(
+            "hook '{hook_name}' skipped by request (--skip-hooks)"
+        )));
+    }
 
     // Filter out jobs matching exclude_tags
     if let Some(ref exclude_tags) = hook_def.exclude_tags {
@@ -1952,6 +1963,84 @@ mod tests {
         assert!(
             output.warnings().iter().any(|w| w.contains("ghost")),
             "unmatched selector should warn, got: {:?}",
+            output.warnings()
+        );
+    }
+
+    #[test]
+    fn skip_hook_type_matching_this_fire_short_circuits() {
+        let hook_def = skip_example_hook();
+        let (ctx, dir) = make_ctx_with_dir();
+        let mut output = TestOutput::default();
+        let recorder = Arc::new(RecordingPresenter::default());
+        let presenter: Arc<dyn crate::executor::presenter::JobPresenter> = recorder.clone();
+        let filter = JobFilter {
+            skip: crate::hooks::job_adapter::parse_skip_selectors(&[
+                "worktree-post-create".to_string()
+            ]),
+            ..Default::default()
+        };
+        let cfg = HookExecutionContext {
+            source_dir: ".daft",
+            working_dir: dir.path(),
+            rc: None,
+            filter: &filter,
+            presenter: &presenter,
+            repo_log: None,
+        };
+        // hook_name == the selected hook type ⇒ whole fire skipped, no jobs run.
+        let result =
+            execute_yaml_hook_with_rc("worktree-post-create", &hook_def, &ctx, &mut output, &cfg)
+                .unwrap();
+        assert!(result.skipped);
+        assert_eq!(
+            result.skip_reason.as_deref(),
+            Some("hook 'worktree-post-create' skipped by request (--skip-hooks)")
+        );
+        assert!(!recorder.events().iter().any(|e| e.starts_with("start:")));
+        assert!(
+            output.warnings().is_empty(),
+            "a matched hook-type selector must not warn, got: {:?}",
+            output.warnings()
+        );
+    }
+
+    #[test]
+    fn skip_hook_type_naming_a_different_fire_runs_without_warning() {
+        // `--skip-hooks worktree-post-create` while the worktree-pre-create
+        // fire runs: the selector names a *valid* hook, just not this one, so
+        // every job runs and NO unmatched warning is emitted (the cross-fire
+        // case the per-fire warning must not flag).
+        let hook_def = skip_example_hook();
+        let (ctx, dir) = make_ctx_with_dir();
+        let mut output = TestOutput::default();
+        let recorder = Arc::new(RecordingPresenter::default());
+        let presenter: Arc<dyn crate::executor::presenter::JobPresenter> = recorder.clone();
+        let filter = JobFilter {
+            skip: crate::hooks::job_adapter::parse_skip_selectors(&[
+                "worktree-post-create".to_string()
+            ]),
+            ..Default::default()
+        };
+        let cfg = HookExecutionContext {
+            source_dir: ".daft",
+            working_dir: dir.path(),
+            rc: None,
+            filter: &filter,
+            presenter: &presenter,
+            repo_log: None,
+        };
+        let result =
+            execute_yaml_hook_with_rc("worktree-pre-create", &hook_def, &ctx, &mut output, &cfg)
+                .unwrap();
+        assert!(
+            !result.skipped,
+            "a non-matching hook-type selector is a no-op"
+        );
+        assert!(recorder.events().iter().any(|e| e.starts_with("start:")));
+        assert!(
+            output.warnings().is_empty(),
+            "a hook-type selector for a different fire must not warn, got: {:?}",
             output.warnings()
         );
     }

--- a/src/hooks/yaml_executor/mod.rs
+++ b/src/hooks/yaml_executor/mod.rs
@@ -65,13 +65,34 @@ impl ExecutionMode {
 
 /// Filter criteria for selecting specific jobs within a hook.
 ///
-/// Used by `hooks run` to restrict execution to a named job or jobs with specific tags.
+/// Two independent axes:
+/// - The **include** side (`only_job_name`, `only_tags`) is used by
+///   `hooks run` to restrict execution to a named job or tagged jobs. An empty
+///   include result is an error (`bail!`).
+/// - The **exclude** side (`skip`, from `--skip-hooks`) drops the matched jobs
+///   *plus their downstream dependents* (see
+///   [`crate::hooks::job_adapter::compute_skip_cascade`]) and reports them as
+///   attributed skips. An empty exclude result is a benign no-op (warn only).
 #[derive(Debug, Clone, Default)]
 pub struct JobFilter {
     /// Run only the job with this name.
     pub only_job_name: Option<String>,
     /// Run only jobs that have at least one of these tags.
     pub only_tags: Vec<String>,
+    /// `--skip-hooks` selectors: jobs (and their dependents) to exclude.
+    pub skip: crate::hooks::job_adapter::SkipSelectors,
+}
+
+impl JobFilter {
+    /// Build an exclude-only filter from raw `--skip-hooks` selector tokens.
+    /// Empty input yields the default (no-op) filter, so the common no-flag
+    /// path costs nothing.
+    pub fn skipping(selectors: &[String]) -> Self {
+        Self {
+            skip: crate::hooks::job_adapter::parse_skip_selectors(selectors),
+            ..Default::default()
+        }
+    }
 }
 
 /// Bundle of configuration values threaded into `execute_yaml_hook_with_rc`.
@@ -210,6 +231,13 @@ pub fn execute_yaml_hook_with_rc(
         return Ok(HookResult::skipped("No jobs defined"));
     }
 
+    // `--skip-hooks all` short-circuits the whole fire (the old --no-hooks
+    // path). The invocation meta was already written above, so this fire is
+    // still logged; we just run no jobs.
+    if filter.skip.all {
+        return Ok(HookResult::skipped("all hooks skipped by request"));
+    }
+
     // Filter out jobs matching exclude_tags
     if let Some(ref exclude_tags) = hook_def.exclude_tags {
         jobs.retain(|job| {
@@ -221,6 +249,41 @@ pub fn execute_yaml_hook_with_rc(
         });
         if jobs.is_empty() {
             return Ok(HookResult::skipped("All jobs excluded by tags"));
+        }
+    }
+
+    // Apply `--skip-hooks` exclusion: drop the matched jobs AND the transitive
+    // closure of jobs that `needs:` them (downstream dependents), routing each
+    // into an attributed skip. Runs while `needs:` is intact (before
+    // `yaml_jobs_to_specs`) so the cascade can walk the reverse-`needs` graph;
+    // this makes the adapter's needs-stripping a no-op for the exclude path.
+    // Unmatched selectors warn (the job runs) but never error — silent
+    // no-match is more dangerous in the exclude direction.
+    let mut requested_skips: Vec<crate::hooks::job_adapter::SkippedJob> = Vec::new();
+    if !filter.skip.is_empty() {
+        let cascade = crate::hooks::job_adapter::compute_skip_cascade(&jobs, &filter.skip);
+        for sel in &cascade.unmatched {
+            output.warning(&format!(
+                "--skip-hooks: no job or tag matched '{sel}' in hook '{hook_name}'"
+            ));
+        }
+        if !cascade.excluded.is_empty() {
+            jobs.retain(|job| {
+                let Some(name) = job.name.as_deref() else {
+                    return true;
+                };
+                match cascade.excluded.get(name) {
+                    None => true,
+                    Some(cause) => {
+                        requested_skips.push(crate::hooks::job_adapter::SkippedJob {
+                            name: name.to_string(),
+                            background: job.background.or(hook_def.background).unwrap_or(false),
+                            reason: cause.reason(),
+                        });
+                        false
+                    }
+                }
+            });
         }
     }
 
@@ -275,7 +338,7 @@ pub fn execute_yaml_hook_with_rc(
         hook_background: hook_def.background,
         repo_log,
     };
-    let (specs, skipped_jobs) = crate::hooks::job_adapter::yaml_jobs_to_specs(
+    let (specs, mut skipped_jobs) = crate::hooks::job_adapter::yaml_jobs_to_specs(
         &jobs,
         ctx,
         &hook_env,
@@ -283,6 +346,12 @@ pub fn execute_yaml_hook_with_rc(
         working_dir,
         &adapter,
     );
+
+    // Fold `--skip-hooks` exclusions into the skipped-job set so the
+    // persistence loop below records them (visible via `daft hooks jobs`)
+    // exactly like the adapter's own group/platform/condition skips. The
+    // separate `requested_skips` copy drives the live presenter render.
+    skipped_jobs.extend(requested_skips.iter().cloned());
 
     // Open the per-repo SQLite store once and reuse for both the
     // skipped-job persistence loop and the repo-policy write below.
@@ -370,6 +439,26 @@ pub fn execute_yaml_hook_with_rc(
     }
 
     if specs.is_empty() {
+        // When `--skip-hooks` emptied the survivor set (e.g. `--skip-hooks
+        // install` on a graph where everything reaches install), the jobs were
+        // deliberately excluded with per-job reasons — render them here so the
+        // skip is attributed, not silently swallowed by this early return. This
+        // is the only render site reached on the empty path (the post-header
+        // loop below never runs).
+        if !requested_skips.is_empty() {
+            let header_target = super::executor::header_target_for_ctx(ctx);
+            presenter.on_phase_start(hook_name, header_target);
+            for sj in &requested_skips {
+                presenter.on_job_skipped(
+                    &sj.name,
+                    &sj.reason,
+                    std::time::Duration::ZERO,
+                    false,
+                    None,
+                );
+            }
+            presenter.on_phase_complete(std::time::Duration::ZERO);
+        }
         return Ok(HookResult::skipped("All jobs skipped"));
     }
 
@@ -404,6 +493,15 @@ pub fn execute_yaml_hook_with_rc(
     // Use presenter for header and execution
     let header_target = super::executor::header_target_for_ctx(ctx);
     presenter.on_phase_start(hook_name, header_target);
+
+    // Render `--skip-hooks` exclusions as attributed skip lines under the hook
+    // header, before the surviving jobs run. (The empty-survivor case is
+    // handled at the `specs.is_empty()` early return above; these two render
+    // sites are mutually exclusive.)
+    for sj in &requested_skips {
+        presenter.on_job_skipped(&sj.name, &sj.reason, std::time::Duration::ZERO, false, None);
+    }
+
     let hook_start = std::time::Instant::now();
 
     // Execute foreground jobs via the generic runner
@@ -721,6 +819,7 @@ pub(crate) fn resolve_command(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::executor::presenter::NullPresenter;
     use crate::hooks::HookType;
     use crate::hooks::yaml_config::RunCommand;
     use crate::output::TestOutput;
@@ -1634,6 +1733,227 @@ mod tests {
             // SAFETY: see `NoBackgroundJobsEnv::set`.
             unsafe { std::env::remove_var("DAFT_NO_BACKGROUND_JOBS") };
         }
+    }
+
+    // ── --skip-hooks engine surfacing ───────────────────────────────────
+
+    /// Presenter that records the events the executor emits, so tests can
+    /// assert that skipped jobs surface live (with the right reason) rather
+    /// than being silently dropped. `NullPresenter` discards everything and
+    /// can't make these assertions.
+    #[derive(Default)]
+    struct RecordingPresenter {
+        events: std::sync::Mutex<Vec<String>>,
+    }
+
+    impl RecordingPresenter {
+        fn events(&self) -> Vec<String> {
+            self.events.lock().unwrap().clone()
+        }
+        fn push(&self, e: String) {
+            self.events.lock().unwrap().push(e);
+        }
+    }
+
+    impl crate::executor::presenter::JobPresenter for RecordingPresenter {
+        fn on_phase_start(&self, phase: &str, _target: Option<&str>) {
+            self.push(format!("phase_start:{phase}"));
+        }
+        fn on_job_start(&self, name: &str, _d: Option<&str>, _c: Option<&str>) {
+            self.push(format!("start:{name}"));
+        }
+        fn on_job_output(&self, _name: &str, _line: &str) {}
+        fn on_job_success(&self, name: &str, _dur: std::time::Duration) {
+            self.push(format!("success:{name}"));
+        }
+        fn on_job_failure(&self, name: &str, _dur: std::time::Duration) {
+            self.push(format!("failure:{name}"));
+        }
+        fn on_job_skipped(
+            &self,
+            name: &str,
+            reason: &str,
+            _dur: std::time::Duration,
+            _show_duration: bool,
+            _command_preview: Option<&str>,
+        ) {
+            self.push(format!("skipped:{name}:{reason}"));
+        }
+        fn on_job_cancelled(&self, name: &str, _dur: std::time::Duration) {
+            self.push(format!("cancelled:{name}"));
+        }
+        fn on_job_background(&self, name: &str, _d: Option<&str>) {
+            self.push(format!("background:{name}"));
+        }
+        fn on_message(&self, _msg: &str) {}
+        fn on_phase_complete(&self, _dur: std::time::Duration) {
+            self.push("phase_complete".to_string());
+        }
+        fn take_results(&self) -> Vec<crate::executor::JobResult> {
+            Vec::new()
+        }
+    }
+
+    /// The issue's worked-example hook: install / build(heavy) / test / lint.
+    /// Surviving jobs run `true` so the fire is hermetic.
+    fn skip_example_hook() -> HookDef {
+        HookDef {
+            jobs: Some(vec![
+                JobDef {
+                    name: Some("install".into()),
+                    run: Some(RunCommand::Simple("true".into())),
+                    ..Default::default()
+                },
+                JobDef {
+                    name: Some("build".into()),
+                    run: Some(RunCommand::Simple("true".into())),
+                    needs: Some(vec!["install".into()]),
+                    tags: Some(vec!["heavy".into()]),
+                    ..Default::default()
+                },
+                JobDef {
+                    name: Some("test".into()),
+                    run: Some(RunCommand::Simple("true".into())),
+                    needs: Some(vec!["build".into()]),
+                    ..Default::default()
+                },
+                JobDef {
+                    name: Some("lint".into()),
+                    run: Some(RunCommand::Simple("true".into())),
+                    needs: Some(vec!["install".into()]),
+                    ..Default::default()
+                },
+            ]),
+            // Sequential keeps the recorded event order deterministic.
+            parallel: Some(false),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn skip_all_short_circuits() {
+        let hook_def = skip_example_hook();
+        let (ctx, _dir) = make_ctx_with_dir();
+        let mut output = TestOutput::default();
+        let presenter: Arc<dyn crate::executor::presenter::JobPresenter> = NullPresenter::arc();
+        let filter = JobFilter {
+            skip: crate::hooks::job_adapter::parse_skip_selectors(&["all".to_string()]),
+            ..Default::default()
+        };
+        let cfg = HookExecutionContext {
+            source_dir: ".daft",
+            working_dir: _dir.path(),
+            rc: None,
+            filter: &filter,
+            presenter: &presenter,
+            repo_log: None,
+        };
+        let result =
+            execute_yaml_hook_with_rc("post-create", &hook_def, &ctx, &mut output, &cfg).unwrap();
+        assert!(result.skipped);
+        assert_eq!(
+            result.skip_reason.as_deref(),
+            Some("all hooks skipped by request")
+        );
+    }
+
+    #[test]
+    fn skip_name_cascade_empties_and_renders_each_reason() {
+        let hook_def = skip_example_hook();
+        let (ctx, dir) = make_ctx_with_dir();
+        let mut output = TestOutput::default();
+        let recorder = Arc::new(RecordingPresenter::default());
+        let presenter: Arc<dyn crate::executor::presenter::JobPresenter> = recorder.clone();
+        let filter = JobFilter {
+            skip: crate::hooks::job_adapter::parse_skip_selectors(&["install".to_string()]),
+            ..Default::default()
+        };
+        let cfg = HookExecutionContext {
+            source_dir: ".daft",
+            working_dir: dir.path(),
+            rc: None,
+            filter: &filter,
+            presenter: &presenter,
+            repo_log: None,
+        };
+        let result =
+            execute_yaml_hook_with_rc("post-create", &hook_def, &ctx, &mut output, &cfg).unwrap();
+
+        // Every job reaches install ⇒ all excluded ⇒ hook is skipped overall.
+        assert!(result.skipped);
+        let events = recorder.events();
+        // Each excluded job rendered with its attributed reason.
+        assert!(events.contains(&"skipped:install:requested (--skip-hooks)".to_string()));
+        assert!(events.contains(&"skipped:build:depends on install (skipped)".to_string()));
+        assert!(events.contains(&"skipped:test:depends on build (skipped)".to_string()));
+        assert!(events.contains(&"skipped:lint:depends on install (skipped)".to_string()));
+        // No job actually executed.
+        assert!(!events.iter().any(|e| e.starts_with("start:")));
+    }
+
+    #[test]
+    fn skip_tag_keeps_survivors_and_renders_skips() {
+        let hook_def = skip_example_hook();
+        let (ctx, dir) = make_ctx_with_dir();
+        let mut output = TestOutput::default();
+        let recorder = Arc::new(RecordingPresenter::default());
+        let presenter: Arc<dyn crate::executor::presenter::JobPresenter> = recorder.clone();
+        let filter = JobFilter {
+            skip: crate::hooks::job_adapter::parse_skip_selectors(&["tag:heavy".to_string()]),
+            ..Default::default()
+        };
+        let cfg = HookExecutionContext {
+            source_dir: ".daft",
+            working_dir: dir.path(),
+            rc: None,
+            filter: &filter,
+            presenter: &presenter,
+            repo_log: None,
+        };
+        let result =
+            execute_yaml_hook_with_rc("post-create", &hook_def, &ctx, &mut output, &cfg).unwrap();
+        assert!(!result.skipped, "install+lint still run");
+        let events = recorder.events();
+        // build + test excluded with reasons.
+        assert!(events.contains(&"skipped:build:requested (--skip-hooks)".to_string()));
+        assert!(events.contains(&"skipped:test:depends on build (skipped)".to_string()));
+        // install + lint executed.
+        assert!(events.contains(&"start:install".to_string()));
+        assert!(events.contains(&"start:lint".to_string()));
+        assert!(
+            !events
+                .iter()
+                .any(|e| e == "start:build" || e == "start:test")
+        );
+    }
+
+    #[test]
+    fn skip_unmatched_selector_warns_not_errors() {
+        let hook_def = skip_example_hook();
+        let (ctx, dir) = make_ctx_with_dir();
+        let mut output = TestOutput::default();
+        let presenter: Arc<dyn crate::executor::presenter::JobPresenter> = NullPresenter::arc();
+        let filter = JobFilter {
+            skip: crate::hooks::job_adapter::parse_skip_selectors(&["ghost".to_string()]),
+            ..Default::default()
+        };
+        let cfg = HookExecutionContext {
+            source_dir: ".daft",
+            working_dir: dir.path(),
+            rc: None,
+            filter: &filter,
+            presenter: &presenter,
+            repo_log: None,
+        };
+        // Must NOT error (contrast with the include path's bail!).
+        let result =
+            execute_yaml_hook_with_rc("post-create", &hook_def, &ctx, &mut output, &cfg).unwrap();
+        assert!(!result.skipped, "no real exclusion ⇒ all jobs run");
+        assert!(
+            output.warnings().iter().any(|w| w.contains("ghost")),
+            "unmatched selector should warn, got: {:?}",
+            output.warnings()
+        );
     }
 }
 

--- a/src/hooks/yaml_executor/mod.rs
+++ b/src/hooks/yaml_executor/mod.rs
@@ -247,99 +247,119 @@ pub fn execute_yaml_hook_with_rc(
     // command, or a hook this command never fires) leaves this false and is a
     // silent no-op — it never reaches `compute_skip_cascade`'s unmatched set,
     // so it raises no warning (it is a valid hook name, just not this fire).
-    let skip_whole_hook = filter.skip.hook_types.iter().any(|h| h == hook_name);
+    let skip_whole_hook = filter
+        .skip
+        .hook_types
+        .iter()
+        .any(|h| h.yaml_name() == hook_name);
 
-    // Filter out jobs matching exclude_tags
-    if !skip_whole_hook && let Some(ref exclude_tags) = hook_def.exclude_tags {
-        jobs.retain(|job| {
-            if let Some(ref tags) = job.tags {
-                !tags.iter().any(|t| exclude_tags.contains(t))
-            } else {
-                true
-            }
-        });
-        if jobs.is_empty() {
-            return Ok(HookResult::skipped("All jobs excluded by tags"));
-        }
-    }
-
-    // Apply `--skip-hooks` exclusion: drop the matched jobs AND the transitive
-    // closure of jobs that `needs:` them (downstream dependents), routing each
-    // into an attributed skip. Runs while `needs:` is intact (before
-    // `yaml_jobs_to_specs`) so the cascade can walk the reverse-`needs` graph;
-    // this makes the adapter's needs-stripping a no-op for the exclude path.
-    // Unmatched selectors warn (the job runs) but never error — silent
-    // no-match is more dangerous in the exclude direction.
+    // Resolve which jobs run and which are skipped (with attribution). A
+    // hook-type selector (`--skip-hooks worktree-post-create`) names *this*
+    // fire: every job is skipped wholesale and ALL include/exclude/tracking
+    // filters below are bypassed — the emptied job list would otherwise divert
+    // into a "no job matched" bail ahead of the skip render. `requested_skips`
+    // is declared before the branch so both render sites (the `specs.is_empty()`
+    // early return and the post-header loop) can read it regardless of which
+    // arm populated it.
     let mut requested_skips: Vec<crate::hooks::job_adapter::SkippedJob> = Vec::new();
     if skip_whole_hook {
         // Whole-hook skip: every job becomes a direct `Requested` skip (same
         // reason as a name match), then the job list is emptied so the fire
-        // flows through the `specs.is_empty()` render/record path below.
+        // flows through the `specs.is_empty()` render/record path below. Config
+        // `exclude_tags` is intentionally *not* applied here — a whole-hook skip
+        // reports every declared job, excluded-tag jobs included.
         for job in &jobs {
             requested_skips.push(crate::hooks::job_adapter::SkippedJob {
                 name: job.name.clone().unwrap_or_else(|| "(unnamed)".to_string()),
-                background: job.background.or(hook_def.background).unwrap_or(false),
+                background: crate::hooks::job_adapter::resolve_background(
+                    job.background,
+                    hook_def.background,
+                ),
                 reason: crate::hooks::job_adapter::SkipCause::Requested.reason(),
             });
         }
         jobs.clear();
-    } else if !filter.skip.is_empty() {
-        let cascade = crate::hooks::job_adapter::compute_skip_cascade(&jobs, &filter.skip);
-        for sel in &cascade.unmatched {
-            output.warning(&format!(
-                "--skip-hooks: no job or tag matched '{sel}' in hook '{hook_name}'"
-            ));
-        }
-        if !cascade.excluded.is_empty() {
+    } else {
+        // Filter out jobs matching config-level `exclude_tags`, before the
+        // cascade so excluded-tag jobs never seed it.
+        if let Some(ref exclude_tags) = hook_def.exclude_tags {
             jobs.retain(|job| {
-                let Some(name) = job.name.as_deref() else {
-                    return true;
-                };
-                match cascade.excluded.get(name) {
-                    None => true,
-                    Some(cause) => {
-                        requested_skips.push(crate::hooks::job_adapter::SkippedJob {
-                            name: name.to_string(),
-                            background: job.background.or(hook_def.background).unwrap_or(false),
-                            reason: cause.reason(),
-                        });
-                        false
-                    }
+                if let Some(ref tags) = job.tags {
+                    !tags.iter().any(|t| exclude_tags.contains(t))
+                } else {
+                    true
                 }
             });
+            if jobs.is_empty() {
+                return Ok(HookResult::skipped("All jobs excluded by tags"));
+            }
         }
-    }
 
-    // Apply inclusion filters (from `hooks run --job` / `--tag`). Skipped when
-    // the whole hook is being skipped (jobs is already emptied) so the
-    // "no job matched" bails don't fire on the intentionally-cleared list.
-    if !skip_whole_hook && let Some(ref name) = filter.only_job_name {
-        jobs.retain(|j| j.name.as_deref() == Some(name.as_str()));
-        if jobs.is_empty() {
-            anyhow::bail!("No job named '{name}' found in hook '{hook_name}'");
+        // Apply `--skip-hooks` exclusion: drop the matched jobs AND the
+        // transitive closure of jobs that `needs:` them (downstream
+        // dependents), routing each into an attributed skip. Runs while
+        // `needs:` is intact (before `yaml_jobs_to_specs`) so the cascade can
+        // walk the reverse-`needs` graph; this makes the adapter's
+        // needs-stripping a no-op for the exclude path. Unmatched selectors
+        // warn (the job runs) but never error — silent no-match is more
+        // dangerous in the exclude direction.
+        if !filter.skip.is_empty() {
+            let cascade = crate::hooks::job_adapter::compute_skip_cascade(&jobs, &filter.skip);
+            for sel in &cascade.unmatched {
+                output.warning(&format!(
+                    "--skip-hooks: no job or tag matched '{sel}' in hook '{hook_name}'"
+                ));
+            }
+            if !cascade.excluded.is_empty() {
+                jobs.retain(|job| {
+                    let Some(name) = job.name.as_deref() else {
+                        return true;
+                    };
+                    match cascade.excluded.get(name) {
+                        None => true,
+                        Some(cause) => {
+                            requested_skips.push(crate::hooks::job_adapter::SkippedJob {
+                                name: name.to_string(),
+                                background: crate::hooks::job_adapter::resolve_background(
+                                    job.background,
+                                    hook_def.background,
+                                ),
+                                reason: cause.reason(),
+                            });
+                            false
+                        }
+                    }
+                });
+            }
         }
-    }
-    if !skip_whole_hook && !filter.only_tags.is_empty() {
-        jobs.retain(|job| {
-            job.tags
-                .as_ref()
-                .is_some_and(|tags| tags.iter().any(|t| filter.only_tags.contains(t)))
-        });
-        if jobs.is_empty() {
-            anyhow::bail!(
-                "No jobs matching tags {:?} in hook '{hook_name}'",
-                filter.only_tags
-            );
-        }
-    }
 
-    // Apply tracking filter when changed_attributes are present (move hooks).
-    // Skipped on a whole-hook skip so the emptied list doesn't divert into the
-    // "No jobs match changed attributes" return ahead of the skip render.
-    if !skip_whole_hook && let Some(ref changed) = ctx.changed_attributes {
-        jobs = filter_tracked_jobs(&jobs, changed);
-        if jobs.is_empty() {
-            return Ok(HookResult::skipped("No jobs match changed attributes"));
+        // Apply inclusion filters (from `hooks run --job` / `--tag`).
+        if let Some(ref name) = filter.only_job_name {
+            jobs.retain(|j| j.name.as_deref() == Some(name.as_str()));
+            if jobs.is_empty() {
+                anyhow::bail!("No job named '{name}' found in hook '{hook_name}'");
+            }
+        }
+        if !filter.only_tags.is_empty() {
+            jobs.retain(|job| {
+                job.tags
+                    .as_ref()
+                    .is_some_and(|tags| tags.iter().any(|t| filter.only_tags.contains(t)))
+            });
+            if jobs.is_empty() {
+                anyhow::bail!(
+                    "No jobs matching tags {:?} in hook '{hook_name}'",
+                    filter.only_tags
+                );
+            }
+        }
+
+        // Apply tracking filter when changed_attributes are present (move hooks).
+        if let Some(ref changed) = ctx.changed_attributes {
+            jobs = filter_tracked_jobs(&jobs, changed);
+            if jobs.is_empty() {
+                return Ok(HookResult::skipped("No jobs match changed attributes"));
+            }
         }
     }
 

--- a/tests/integration/test_hooks.sh
+++ b/tests/integration/test_hooks.sh
@@ -111,7 +111,7 @@ test_hooks_list_command() {
 # Clone with Hooks Tests
 # ============================================================================
 
-# Test clone with --no-hooks flag
+# Test clone with --skip-hooks all (replaces the old --no-hooks flag)
 test_clone_no_hooks_flag() {
     local remote_repo=$(create_test_remote "test-clone-no-hooks" "main")
 
@@ -132,16 +132,16 @@ EOF
     ) >/dev/null 2>&1
     rm -rf "$temp_clone"
 
-    # Clone with --no-hooks
-    git-worktree-clone --layout contained --no-hooks "$remote_repo" || return 1
+    # Clone with --skip-hooks all
+    git-worktree-clone --layout contained --skip-hooks all "$remote_repo" || return 1
 
     # Verify the hook marker file was NOT created
     if [[ -f "test-clone-no-hooks/main/.hook-executed" ]]; then
-        log_error "--no-hooks flag did not prevent hook execution"
+        log_error "--skip-hooks all did not prevent hook execution"
         return 1
     fi
 
-    log_success "--no-hooks flag correctly prevents hook execution"
+    log_success "--skip-hooks all correctly prevents hook execution"
     return 0
 }
 
@@ -179,17 +179,17 @@ EOF
     return 0
 }
 
-# Test that --trust-hooks and --no-hooks are mutually exclusive
+# Test that --trust-hooks and --skip-hooks all are mutually exclusive
 test_clone_hooks_flags_exclusive() {
     local remote_repo=$(create_test_remote "test-clone-exclusive" "main")
 
     # Try to use both flags
-    if git-worktree-clone --layout contained --trust-hooks --no-hooks "$remote_repo" 2>&1; then
-        log_error "Should fail when both --trust-hooks and --no-hooks are specified"
+    if git-worktree-clone --layout contained --trust-hooks --skip-hooks all "$remote_repo" 2>&1; then
+        log_error "Should fail when both --trust-hooks and --skip-hooks all are specified"
         return 1
     fi
 
-    log_success "--trust-hooks and --no-hooks correctly reject being used together"
+    log_success "--trust-hooks and --skip-hooks all correctly reject being used together"
     return 0
 }
 

--- a/tests/manual/scenarios/hooks/flags-exclusive.yml
+++ b/tests/manual/scenarios/hooks/flags-exclusive.yml
@@ -1,5 +1,5 @@
 name: Hooks flags exclusive
-description: --no-hooks and --trust-hooks are mutually exclusive on clone
+description: --skip-hooks all and --trust-hooks are mutually exclusive on clone
 
 repos:
   - name: test-hooks-exclusive
@@ -15,7 +15,7 @@ repos:
 steps:
   - name: Clone with both flags fails
     run:
-      git-worktree-clone --trust-hooks --no-hooks --layout contained
+      git-worktree-clone --trust-hooks --skip-hooks all --layout contained
       $REMOTE_TEST_HOOKS_EXCLUSIVE 2>&1
     expect:
       exit_code: 1

--- a/tests/manual/scenarios/hooks/no-hooks-flag.yml
+++ b/tests/manual/scenarios/hooks/no-hooks-flag.yml
@@ -1,7 +1,8 @@
-name: Clone with --no-hooks flag
+name: Clone with --skip-hooks all
 description:
-  "The --no-hooks flag on clone prevents any hook execution, even if the
-  repository would otherwise be trusted."
+  "The --skip-hooks all selector on clone prevents any hook execution, even if
+  the repository would otherwise be trusted (the uniform replacement for the old
+  --no-hooks flag)."
 
 repos:
   - name: test-clone-no-hooks
@@ -20,9 +21,9 @@ repos:
           touch "$DAFT_WORKTREE_PATH/.hook-executed"
 
 steps:
-  - name: Clone with --no-hooks flag
+  - name: Clone with --skip-hooks all
     run:
-      git-worktree-clone --no-hooks --layout contained
+      git-worktree-clone --skip-hooks all --layout contained
       $REMOTE_TEST_CLONE_NO_HOOKS
     expect:
       exit_code: 0

--- a/tests/manual/scenarios/hooks/skip-hooks-by-hook-name.yml
+++ b/tests/manual/scenarios/hooks/skip-hooks-by-hook-name.yml
@@ -1,0 +1,72 @@
+name: --skip-hooks by hook name (per-hook, cross-fire)
+description:
+  "A bare hook-type name (`worktree-post-create`) skips that ONE hook wholesale
+  while leaving the command's other hooks running. The repo defines both a
+  worktree-pre-create and a worktree-post-create job; `--skip-hooks
+  worktree-post-create` on checkout must run pre-create (marker present) and
+  skip post-create (marker absent), and must NOT emit an unmatched-selector
+  warning for the pre-create fire (the cross-fire case: the selector names a
+  valid hook, just not that one). Regression for issue #616 hook-name selector."
+
+repos:
+  - name: test-skip-by-hook
+    default_branch: main
+    branches:
+      - name: main
+        files:
+          - path: README.md
+            content: "# skip by hook name"
+        commits:
+          - message: "Initial commit"
+      - name: feature/skip
+        from: main
+    daft_yml: |
+      hooks:
+        worktree-pre-create:
+          jobs:
+            - name: pre-marker
+              run: touch "$DAFT_PROJECT_ROOT/.ran-pre"
+        worktree-post-create:
+          jobs:
+            - name: post-marker
+              run: touch "$DAFT_PROJECT_ROOT/.ran-post"
+
+steps:
+  - name: Clone the repository
+    run: git-worktree-clone --layout contained $REMOTE_TEST_SKIP_BY_HOOK
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-skip-by-hook/main"
+
+  - name: Trust the repository
+    run: daft hooks trust --force 2>&1
+    cwd: "$WORK_DIR/test-skip-by-hook/main"
+    expect:
+      exit_code: 0
+
+  - name: Checkout with --skip-hooks worktree-post-create
+    run:
+      git-worktree-checkout feature/skip --skip-hooks worktree-post-create 2>&1
+    cwd: "$WORK_DIR/test-skip-by-hook/main"
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-skip-by-hook/feature/skip"
+      # The pre-create fire still runs; the post-create fire is skipped
+      # wholesale. A hook-type selector that doesn't match the *current* fire
+      # must NOT warn — proving the cross-fire no-op is silent.
+      output_not_contains:
+        - "no job or tag matched"
+
+  - name: Assert pre-create ran and post-create did not
+    run: |
+      ROOT="$WORK_DIR/test-skip-by-hook"
+      test -f "$ROOT/.ran-pre" && echo "PRE_RAN"
+      test ! -f "$ROOT/.ran-post" && echo "POST_SKIPPED"
+    cwd: "$WORK_DIR/test-skip-by-hook/main"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "PRE_RAN"
+        - "POST_SKIPPED"

--- a/tests/manual/scenarios/hooks/skip-hooks-by-hook-name.yml
+++ b/tests/manual/scenarios/hooks/skip-hooks-by-hook-name.yml
@@ -53,17 +53,18 @@ steps:
       exit_code: 0
       dirs_exist:
         - "$WORK_DIR/test-skip-by-hook/feature/skip"
-      # The pre-create fire still runs; the post-create fire is skipped
-      # wholesale — but it is SHOWN with its job marked skipped (and the
-      # attributed reason), not silently dropped. This is the visibility the
-      # whole-hook skip must preserve: the job appears as `(skip)`.
-      output_contains:
-        - "post-marker (skip)"
-        - "requested (--skip-hooks)"
       # A hook-type selector that doesn't match the *current* fire must NOT
-      # warn — proving the cross-fire no-op is silent.
+      # warn — proving the cross-fire no-op is silent (the selector names a
+      # valid hook, just not this one).
       output_not_contains:
         - "no job or tag matched"
+      # NOTE: we deliberately do NOT assert the per-job render text
+      # ("post-marker (skip)", "requested (--skip-hooks)") here. That reason
+      # line is only emitted in the non-compact hook output mode, which this
+      # non-TTY harness does not capture — see the same note in
+      # skip-hooks-cascade.yml. The whole-hook skip *behavior* is proved by the
+      # marker-file assertions in the next step; the presenter render is covered
+      # by the engine unit test `skip_hook_type_renders_every_job_as_skipped`.
 
   - name: Assert pre-create ran and post-create did not
     run: |

--- a/tests/manual/scenarios/hooks/skip-hooks-by-hook-name.yml
+++ b/tests/manual/scenarios/hooks/skip-hooks-by-hook-name.yml
@@ -54,8 +54,14 @@ steps:
       dirs_exist:
         - "$WORK_DIR/test-skip-by-hook/feature/skip"
       # The pre-create fire still runs; the post-create fire is skipped
-      # wholesale. A hook-type selector that doesn't match the *current* fire
-      # must NOT warn — proving the cross-fire no-op is silent.
+      # wholesale — but it is SHOWN with its job marked skipped (and the
+      # attributed reason), not silently dropped. This is the visibility the
+      # whole-hook skip must preserve: the job appears as `(skip)`.
+      output_contains:
+        - "post-marker (skip)"
+        - "requested (--skip-hooks)"
+      # A hook-type selector that doesn't match the *current* fire must NOT
+      # warn — proving the cross-fire no-op is silent.
       output_not_contains:
         - "no job or tag matched"
 

--- a/tests/manual/scenarios/hooks/skip-hooks-cascade.yml
+++ b/tests/manual/scenarios/hooks/skip-hooks-cascade.yml
@@ -1,0 +1,80 @@
+name: --skip-hooks cascade and attribution
+description:
+  "The --skip-hooks flag on a worktree-create command excludes the matched jobs
+  AND their downstream dependents (reverse-needs cascade), and reports each
+  excluded job as skipped with an attributed reason. Uses the issue #616 worked
+  example: install / build(tag heavy) / test(needs build) / lint(needs install).
+  `--skip-hooks tag:heavy` drops build + test; install + lint still run."
+
+repos:
+  - name: test-skip-hooks
+    default_branch: main
+    branches:
+      - name: main
+        files:
+          - path: README.md
+            content: "# skip-hooks cascade"
+        commits:
+          - message: "Initial commit"
+      - name: feature/skip
+        from: main
+    daft_yml: |
+      hooks:
+        worktree-post-create:
+          parallel: false
+          jobs:
+            - name: install
+              run: touch "$DAFT_WORKTREE_PATH/.ran-install"
+            - name: build
+              tags: [heavy]
+              needs: [install]
+              run: touch "$DAFT_WORKTREE_PATH/.ran-build"
+            - name: test
+              needs: [build]
+              run: touch "$DAFT_WORKTREE_PATH/.ran-test"
+            - name: lint
+              needs: [install]
+              run: touch "$DAFT_WORKTREE_PATH/.ran-lint"
+
+steps:
+  - name: Clone the repository
+    run: git-worktree-clone --layout contained $REMOTE_TEST_SKIP_HOOKS
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-skip-hooks/main"
+
+  - name: Trust the repository
+    run: daft hooks trust --force 2>&1
+    cwd: "$WORK_DIR/test-skip-hooks/main"
+    expect:
+      exit_code: 0
+
+  - name: Checkout feature branch with --skip-hooks tag:heavy
+    run: git-worktree-checkout feature/skip --skip-hooks tag:heavy 2>&1
+    cwd: "$WORK_DIR/test-skip-hooks/main"
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-skip-hooks/feature/skip"
+
+  # The reverse-needs cascade is proved by which marker files exist: build
+  # matched tag:heavy directly and test cascades (needs build), so neither
+  # runs; install and lint still run. (Attribution of the skip *reason* to the
+  # presenter is covered by the engine unit tests; the per-job reason line is
+  # only rendered in the non-compact hook output mode.)
+  - name: Assert kept jobs ran and skipped jobs did not
+    run: |
+      WT="$WORK_DIR/test-skip-hooks/feature/skip"
+      test -f "$WT/.ran-install" && echo "INSTALL_RAN"
+      test -f "$WT/.ran-lint" && echo "LINT_RAN"
+      test ! -f "$WT/.ran-build" && echo "BUILD_SKIPPED"
+      test ! -f "$WT/.ran-test" && echo "TEST_SKIPPED"
+    cwd: "$WORK_DIR/test-skip-hooks/main"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "INSTALL_RAN"
+        - "LINT_RAN"
+        - "BUILD_SKIPPED"
+        - "TEST_SKIPPED"


### PR DESCRIPTION
## Summary

Replaces the boolean `--no-hooks` with a value-driven, DAG-aware `--skip-hooks <SELECTOR>...` flag on every hook-firing command (`checkout`, `checkout-branch`, `go`, `start`, `clone`, `flow-adopt`). It gives a per-invocation lever to skip hooks wholesale or drop a subset of jobs **and everything that depends on them**, with each excluded job rendered as skipped (attributed reason) and recorded — never silently dropped.

Fixes #616

## Selector grammar

| Selector | Effect |
|---|---|
| `all` / `*` | skip the whole fire (the `--no-hooks` replacement; short-circuits, preserves trust gating) |
| `<hook>` (e.g. `worktree-post-create`) | skip that one hook wholesale; each job shown as skipped |
| `tag:<tag>` | skip tagged jobs **+ their reverse-`needs` dependents** |
| `<name>` (bare) | skip that job **+ its dependents** |
| `job:<name>` | escape hatch for a job literally named `all` / a hook-type |

Repeatable and comma-separated: `--skip-hooks tag:heavy,lint` or `--skip-hooks build --skip-hooks test`.

## Notable changes

- **`--no-hooks` removed** (no alias) — pre-1.0 clean cut; `--skip-hooks all` is the uniform replacement. Trust semantics preserved: `all` still gates config-load/trust; partial skips still imply trust on `--install`.
- **Cascade engine** (`compute_skip_cascade`): pure reverse-`needs` BFS, cycle-safe, deterministic immediate-parent attribution.
- **Surfaces**: shell completions (bash/zsh/fish) complete selector values from `daft.yml`; regenerated man pages; updated docs/SKILL; 2 new YAML scenarios + updated integration test.

## Test plan

- `mise run test:unit` — 1943 pass (cascade, parser, engine-render, clap-parse tests)
- `mise run clippy` / `mise run fmt:check` — clean
- `mise run test:manual hooks` — skip-hooks-cascade + skip-hooks-by-hook-name + flags-exclusive + no-hooks-flag all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)