### PR TITLE
feat(push): honor and report pre-push hooks at every daft push site

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -212,7 +212,7 @@ these as `git` subcommands (e.g., `daft worktree-checkout` is
 | `daft worktree-carry <targets>`                                                                                                                                              | Transfer uncommitted changes to one or more other worktrees                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | `daft worktree-fetch [targets]`                                                                                                                                              | Update worktree branches from remote (supports refspec syntax source:destination)                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | `daft worktree-branch -m <source> <new-branch>`                                                                                                                              | Rename a branch, move its worktree, and rename the remote branch                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-| `daft git-worktree-sync [-f] [-v\|-vv] [--rebase BRANCH [--autostash]] [--push [--force-with-lease]] [--include VALUE]... [--stat summary\|lines]`                           | Synchronize all worktrees: prune stale + update all + optional rebase + optional push (`-f`/`--prune-dirty` for dirty worktrees, `-v` hook details, `-vv` full sequential). By default, rebase and push apply only to branches you own (matching `git config user.email`). Use `--include` to add more branches: `unowned` for all, an email address for a teammate's branches, or a branch name for one specific branch.                                                                                                                     |
+| `daft git-worktree-sync [-f] [-v\|-vv] [--rebase BRANCH [--autostash]] [--push [--force-with-lease] [--no-verify]] [--include VALUE]... [--stat summary\|lines]`             | Synchronize all worktrees: prune stale + update all + optional rebase + optional push (`-f`/`--prune-dirty` for dirty worktrees, `-v` hook details, `-vv` full sequential). By default, rebase and push apply only to branches you own (matching `git config user.email`). Use `--include` to add more branches: `unowned` for all, an email address for a teammate's branches, or a branch name for one specific branch.                                                                                                                     |
 | `daft worktree-merge [SOURCE...] [--into <TARGET>] [--merge\|--squash\|--rebase\|--rebase-merge] [-s <STRAT>] [--adopt-target\|--no-adopt-target] [-y] [-r] [--set-default]` | Merge one or more source branches into a target worktree's branch. Without `--into`, the target is the current worktree. With `--into <target>`, merges into another worktree without changing directories. Multiple sources trigger octopus. `-r` removes the source worktree and branch after success. `--adopt-target` creates an ephemeral worktree when the target branch has no worktree. `--set-default` writes style and cleanup to `git config --local`. Finish with `daft worktree-merge --abort\|--continue\|--quit [<worktree>]`. |
 
 ### Adoption and Ejection
@@ -654,6 +654,18 @@ selector matching nothing warns and the run proceeds.
 (which is an inclusion filter). `--skip-hooks all` cannot be combined with
 `--trust-hooks`; a partial skip (`tag:`/`<job>`) still runs your own hooks and
 remains compatible with `--trust-hooks`.
+
+### Git pre-push Hooks on daft Pushes
+
+Separate from daft's own hooks: every daft-initiated `git push` honors the
+repo's git-level `pre-push` hook (native `.git/hooks` or `core.hooksPath`
+managers like lefthook/husky/pre-commit). The hook run is reported as a
+`pre-push` phase. A failing hook blocks the push and the command exits non-zero
+— any worktree it created or moved is still completed and usable, and the error
+names the manual recovery command. Pass `--no-verify` to the pushing command
+(`daft sync --push`, `daft start`/`go -b`, `daft rename`, `daft remove`,
+`daft multi-remote move`) to skip the hook for one invocation. `--skip-hooks`
+does NOT affect git-level hooks — it only filters daft's own jobs.
 
 ### Move Hooks
 

--- a/docs/cli/daft-multi-remote.md
+++ b/docs/cli/daft-multi-remote.md
@@ -155,6 +155,7 @@ daft multi-remote move [OPTIONS] <BRANCH>
 | `--set-upstream` | Also update the branch's upstream tracking to the new remote |  |
 | `--push` | Push the branch to the new remote |  |
 | `--delete-old` | Delete the branch from the old remote after pushing |  |
+| `--no-verify` | Skip the repo's pre-push hook on remote operations |  |
 | `--dry-run` | Preview changes without executing |  |
 | `-f, --force` | Skip confirmation |  |
 

--- a/docs/cli/git-worktree-branch-delete.md
+++ b/docs/cli/git-worktree-branch-delete.md
@@ -65,6 +65,7 @@ git worktree-branch-delete [OPTIONS] <BRANCHES>
 | `-D, --force` | Force deletion even if not fully merged |  |
 | `--local` | Only delete locally, keep remote branch |  |
 | `--remote` | Only delete the remote branch, keep local worktree and branch |  |
+| `--no-verify` | Skip the repo's pre-push hook when deleting the remote branch |  |
 | `-q, --quiet` | Operate quietly; suppress progress reporting |  |
 | `-v, --verbose` | Be verbose; show detailed progress |  |
 

--- a/docs/cli/git-worktree-branch.md
+++ b/docs/cli/git-worktree-branch.md
@@ -92,6 +92,7 @@ git worktree-branch [OPTIONS] [BRANCHES]
 | `--remote` | Only delete the remote branch, keep local worktree and branch |  |
 | `-m, --move` | Rename a branch and move its worktree |  |
 | `--no-remote` | Skip remote branch rename (only with -m) |  |
+| `--no-verify` | Skip the repo's pre-push hook on remote operations |  |
 | `--dry-run` | Preview changes without executing (only with -m) |  |
 | `-q, --quiet` | Operate quietly; suppress progress reporting |  |
 | `-v, --verbose` | Be verbose; show detailed progress |  |

--- a/docs/cli/git-worktree-checkout.md
+++ b/docs/cli/git-worktree-checkout.md
@@ -72,6 +72,7 @@ git worktree-checkout [OPTIONS] <BRANCH_NAME> [BASE_BRANCH_NAME]
 | `-s, --start` | Create a new worktree if the branch does not exist |  |
 | `-@, --at <PATH>` | Place the worktree at a specific path instead of using the layout template |  |
 | `--local` | Skip all remote operations (no fetch, no push) |  |
+| `--no-verify` | Skip the repo's pre-push hook on the automatic upstream push |  |
 | `--skip-hooks <SELECTOR>` | Skip hooks this run (all | <hook> | tag:<tag> | <job>); repeatable/comma-separated |  |
 
 ## Global Options

--- a/docs/cli/git-worktree-sync.md
+++ b/docs/cli/git-worktree-sync.md
@@ -51,6 +51,7 @@ git worktree-sync [OPTIONS]
 | `--autostash` | Automatically stash and unstash uncommitted changes before/after rebase |  |
 | `--push` | Push all branches to their remotes after syncing |  |
 | `--force-with-lease` | Use --force-with-lease when pushing (requires --push) |  |
+| `--no-verify` | Skip the repo's pre-push hook when pushing (requires --push) |  |
 | `--include <INCLUDE>` | Include additional branches in rebase/push (email, branch name, or 'unowned') |  |
 | `--stat <STAT>` | Statistics mode: summary or lines (default: from git config daft.sync.stat, or summary) |  |
 | `--columns <COLUMNS>` | Columns to display (comma-separated). Replace: branch,path,age. Modify defaults: +col,-col. Available: branch, path, size, base, changes, remote, age, annotation, owner, hash, last-commit |  |

--- a/docs/hooks/index.md
+++ b/docs/hooks/index.md
@@ -45,6 +45,16 @@ Two distinctions:
    _after_ code reaches the central repo; daft hooks run _before_. CI shifts
    left.
 
+## daft and your existing git hooks
+
+daft's hooks do not replace git's own. Every daft-initiated `git push` honors
+the repository's `pre-push` hook — whether it lives in `.git/hooks` or is
+managed by lefthook, husky, or pre-commit via `core.hooksPath`. A failing
+pre-push gate blocks the push and fails the command; its run is reported as a
+`pre-push` phase on the same surface lifecycle hooks use. Pass `--no-verify` to
+any pushing command to skip it for one invocation. See
+[Git Hooks](/reference/configuration#git-hooks) for the details.
+
 ## Where to next
 
 - **Reference:** [Lifecycle hooks](/hooks/lifecycle) — types, triggers, env

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -324,10 +324,17 @@ git config daft.hooks.worktreePostCreate.failMode abort
 
 ## Git Hooks
 
-daft's push operations are structural -- they manage branch topology as a
-side-effect of worktree management, not as user-initiated code pushes. Because
-of this, daft passes `--no-verify` on all `git push` calls, skipping any
-`pre-push` hooks configured in the repository.
+Every daft-initiated `git push` honors the repository's `pre-push` hook --
+native `.git/hooks`, or hook managers registered through `core.hooksPath`
+(lefthook, husky, pre-commit). A pre-push secret scanner or test gate that fires
+on `git push` fires on daft's pushes too. The hook run is reported as a
+`pre-push` phase with the hook's output, using the same surface as daft's
+lifecycle hooks.
+
+Pass `--no-verify` to skip the hook for one invocation. Every command that can
+push accepts it: `daft sync --push`, `daft start` / `daft go -b` /
+`git worktree-checkout -b`, `daft rename`, `daft remove` /
+`git worktree-branch -d/-D`, and `daft multi-remote move`.
 
 Remote operations are disabled by default. When enabled (via
 `daft config remote-sync --on` or by setting the individual keys), this affects:
@@ -339,12 +346,16 @@ Remote operations are disabled by default. When enabled (via
 - **`daft multi-remote move --push`** -- pushes an existing branch to a new
   remote
 
-If a push fails (due to network issues, auth errors, or remote rejection rules),
-daft treats it as non-fatal: the local worktree and branch remain usable, and a
-warning is shown with the manual recovery command.
+Push failures are graded by the gate. When a `pre-push` hook is installed and
+the push fails, the command exits non-zero -- a gate saying no is a failure, not
+a warning (any worktree the command created or moved is still completed and
+usable, and the error names the manual recovery command). Without a hook, push
+failures (network issues, auth errors, remote rejection rules) stay non-fatal:
+the local worktree and branch remain usable and a warning is shown.
 
 Use `--local` on any worktree command to skip all remote operations for that
 invocation, regardless of config.
 
-::: tip This only applies to git's own hooks. daft's [lifecycle hooks](/hooks/)
-(configured in `daft.yml` or `.daft/hooks/`) are always executed normally. :::
+::: tip daft's [lifecycle hooks](/hooks/) (configured in `daft.yml` or
+`.daft/hooks/`) are separate from git's own hooks and are always executed
+normally. :::

--- a/man/daft-go.1
+++ b/man/daft-go.1
@@ -4,7 +4,7 @@
 .SH NAME
 daft go \- Open a worktree for an existing branch, or create one with \-b
 .SH SYNOPSIS
-\fBdaft go\fR [\fB\-b\fR|\fB\-\-create\-branch\fR] [\fB\-s\fR|\fB\-\-start\fR] [\fB\-c\fR|\fB\-\-carry\fR] [\fB\-\-no\-carry\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-\-no\-cd\fR] [\fB\-x\fR|\fB\-\-exec\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-@\fR|\fB\-\-at\fR] [\fB\-\-local\fR] [\fB\-\-skip\-hooks\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIBRANCH_NAME\fR> [\fIBASE_BRANCH_NAME\fR] 
+\fBdaft go\fR [\fB\-b\fR|\fB\-\-create\-branch\fR] [\fB\-s\fR|\fB\-\-start\fR] [\fB\-c\fR|\fB\-\-carry\fR] [\fB\-\-no\-carry\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-\-no\-cd\fR] [\fB\-x\fR|\fB\-\-exec\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-@\fR|\fB\-\-at\fR] [\fB\-\-local\fR] [\fB\-\-no\-verify\fR] [\fB\-\-skip\-hooks\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIBRANCH_NAME\fR> [\fIBASE_BRANCH_NAME\fR] 
 .SH DESCRIPTION
 .PP
 Opens a worktree for an existing local or remote branch. The worktree is
@@ -65,6 +65,9 @@ Place the worktree at a specific path instead of using the layout template
 .TP
 \fB\-\-local\fR
 Skip all remote operations (no fetch, no push)
+.TP
+\fB\-\-no\-verify\fR
+Skip the repo\*(Aqs pre\-push hook on the automatic upstream push
 .TP
 \fB\-\-skip\-hooks\fR \fI<SELECTOR>\fR
 Skip hooks when creating a worktree (all | <hook> | tag:<tag> | <job>); repeatable/comma\-separated

--- a/man/daft-remove.1
+++ b/man/daft-remove.1
@@ -4,7 +4,7 @@
 .SH NAME
 daft remove \- Delete branches and their worktrees
 .SH SYNOPSIS
-\fBdaft remove\fR [\fB\-f\fR|\fB\-\-force\fR] [\fB\-\-local\fR] [\fB\-\-remote\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIBRANCHES\fR> 
+\fBdaft remove\fR [\fB\-f\fR|\fB\-\-force\fR] [\fB\-\-local\fR] [\fB\-\-remote\fR] [\fB\-\-no\-verify\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIBRANCHES\fR> 
 .SH DESCRIPTION
 .PP
 Deletes one or more local branches along with their associated worktrees and
@@ -51,6 +51,9 @@ Only delete locally, keep remote branch
 .TP
 \fB\-\-remote\fR
 Only delete the remote branch, keep local worktree and branch
+.TP
+\fB\-\-no\-verify\fR
+Skip the repo\*(Aqs pre\-push hook when deleting the remote branch
 .TP
 \fB\-q\fR, \fB\-\-quiet\fR
 Operate quietly; suppress progress reporting

--- a/man/daft-rename.1
+++ b/man/daft-rename.1
@@ -4,7 +4,7 @@
 .SH NAME
 daft rename \- Rename a branch and move its worktree
 .SH SYNOPSIS
-\fBdaft rename\fR [\fB\-\-no\-remote\fR] [\fB\-\-dry\-run\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fISOURCE\fR> <\fINEW_BRANCH\fR> 
+\fBdaft rename\fR [\fB\-\-no\-remote\fR] [\fB\-\-no\-verify\fR] [\fB\-\-dry\-run\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fISOURCE\fR> <\fINEW_BRANCH\fR> 
 .SH DESCRIPTION
 .PP
 Renames a local branch and moves its associated worktree directory to match
@@ -23,6 +23,9 @@ Empty parent directories left behind by the move are automatically cleaned up.
 .TP
 \fB\-\-no\-remote\fR
 Skip remote branch rename
+.TP
+\fB\-\-no\-verify\fR
+Skip the repo\*(Aqs pre\-push hook on remote operations
 .TP
 \fB\-\-dry\-run\fR
 Preview changes without executing

--- a/man/daft-start.1
+++ b/man/daft-start.1
@@ -4,7 +4,7 @@
 .SH NAME
 daft start \- Create a new branch and worktree
 .SH SYNOPSIS
-\fBdaft start\fR [\fB\-c\fR|\fB\-\-carry\fR] [\fB\-\-no\-carry\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-\-no\-cd\fR] [\fB\-x\fR|\fB\-\-exec\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-@\fR|\fB\-\-at\fR] [\fB\-\-local\fR] [\fB\-\-skip\-hooks\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fINEW_BRANCH_NAME\fR> [\fIBASE_BRANCH_NAME\fR] 
+\fBdaft start\fR [\fB\-c\fR|\fB\-\-carry\fR] [\fB\-\-no\-carry\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-\-no\-cd\fR] [\fB\-x\fR|\fB\-\-exec\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-@\fR|\fB\-\-at\fR] [\fB\-\-local\fR] [\fB\-\-no\-verify\fR] [\fB\-\-skip\-hooks\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fINEW_BRANCH_NAME\fR> [\fIBASE_BRANCH_NAME\fR] 
 .SH DESCRIPTION
 .PP
 Creates a new branch and a corresponding worktree in a single operation. The
@@ -47,6 +47,9 @@ Place the worktree at a specific path instead of using the layout template
 .TP
 \fB\-\-local\fR
 Skip all remote operations (no fetch, no push)
+.TP
+\fB\-\-no\-verify\fR
+Skip the repo\*(Aqs pre\-push hook on the automatic upstream push
 .TP
 \fB\-\-skip\-hooks\fR \fI<SELECTOR>\fR
 Skip hooks this run (all | <hook> | tag:<tag> | <job>); repeatable/comma\-separated

--- a/man/daft-sync.1
+++ b/man/daft-sync.1
@@ -4,7 +4,7 @@
 .SH NAME
 daft\-sync \- Synchronize worktrees with remote (prune + update all)
 .SH SYNOPSIS
-\fBdaft\-sync\fR [\fB\-v\fR|\fB\-\-verbose\fR]... [\fB\-f\fR|\fB\-\-prune\-dirty\fR] [\fB\-\-rebase\fR] [\fB\-\-autostash\fR] [\fB\-\-push\fR] [\fB\-\-force\-with\-lease\fR] [\fB\-\-include\fR] [\fB\-\-stat\fR] [\fB\-\-columns\fR] [\fB\-\-sort\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] 
+\fBdaft\-sync\fR [\fB\-v\fR|\fB\-\-verbose\fR]... [\fB\-f\fR|\fB\-\-prune\-dirty\fR] [\fB\-\-rebase\fR] [\fB\-\-autostash\fR] [\fB\-\-push\fR] [\fB\-\-force\-with\-lease\fR] [\fB\-\-no\-verify\fR] [\fB\-\-include\fR] [\fB\-\-stat\fR] [\fB\-\-columns\fR] [\fB\-\-sort\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] 
 .SH DESCRIPTION
 .PP
 Synchronizes all worktrees with the remote in a single command.
@@ -46,6 +46,9 @@ Push all branches to their remotes after syncing
 .TP
 \fB\-\-force\-with\-lease\fR
 Use \-\-force\-with\-lease when pushing (requires \-\-push)
+.TP
+\fB\-\-no\-verify\fR
+Skip the repo\*(Aqs pre\-push hook when pushing (requires \-\-push)
 .TP
 \fB\-\-include\fR \fI<INCLUDE>\fR
 Include additional branches in rebase/push (email, branch name, or \*(Aqunowned\*(Aq)

--- a/man/git-worktree-branch-delete.1
+++ b/man/git-worktree-branch-delete.1
@@ -4,7 +4,7 @@
 .SH NAME
 git\-worktree\-branch\-delete \- Delete branches and their worktrees
 .SH SYNOPSIS
-\fBgit\-worktree\-branch\-delete\fR [\fB\-D\fR|\fB\-\-force\fR] [\fB\-\-local\fR] [\fB\-\-remote\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIBRANCHES\fR> 
+\fBgit\-worktree\-branch\-delete\fR [\fB\-D\fR|\fB\-\-force\fR] [\fB\-\-local\fR] [\fB\-\-remote\fR] [\fB\-\-no\-verify\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIBRANCHES\fR> 
 .SH DESCRIPTION
 .PP
 Deletes one or more local branches along with their associated worktrees and
@@ -48,6 +48,9 @@ Only delete locally, keep remote branch
 .TP
 \fB\-\-remote\fR
 Only delete the remote branch, keep local worktree and branch
+.TP
+\fB\-\-no\-verify\fR
+Skip the repo\*(Aqs pre\-push hook when deleting the remote branch
 .TP
 \fB\-q\fR, \fB\-\-quiet\fR
 Operate quietly; suppress progress reporting

--- a/man/git-worktree-branch.1
+++ b/man/git-worktree-branch.1
@@ -4,7 +4,7 @@
 .SH NAME
 git\-worktree\-branch \- Delete or rename branches and their worktrees
 .SH SYNOPSIS
-\fBgit\-worktree\-branch\fR [\fB\-d\fR|\fB\-\-delete\fR] [\fB\-D\fR|\fB\-\-force\fR] [\fB\-\-local\fR] [\fB\-\-remote\fR] [\fB\-m\fR|\fB\-\-move\fR] [\fB\-\-no\-remote\fR] [\fB\-\-dry\-run\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fIBRANCHES\fR] 
+\fBgit\-worktree\-branch\fR [\fB\-d\fR|\fB\-\-delete\fR] [\fB\-D\fR|\fB\-\-force\fR] [\fB\-\-local\fR] [\fB\-\-remote\fR] [\fB\-m\fR|\fB\-\-move\fR] [\fB\-\-no\-remote\fR] [\fB\-\-no\-verify\fR] [\fB\-\-dry\-run\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fIBRANCHES\fR] 
 .SH DESCRIPTION
 .PP
 Manage branches and their associated worktrees. Supports deletion (\-d/\-D)
@@ -80,6 +80,9 @@ Rename a branch and move its worktree
 .TP
 \fB\-\-no\-remote\fR
 Skip remote branch rename (only with \-m)
+.TP
+\fB\-\-no\-verify\fR
+Skip the repo\*(Aqs pre\-push hook on remote operations
 .TP
 \fB\-\-dry\-run\fR
 Preview changes without executing (only with \-m)

--- a/man/git-worktree-checkout.1
+++ b/man/git-worktree-checkout.1
@@ -4,7 +4,7 @@
 .SH NAME
 git\-worktree\-checkout \- Create a worktree for an existing branch, or a new branch with \-b
 .SH SYNOPSIS
-\fBgit\-worktree\-checkout\fR [\fB\-b\fR|\fB\-\-create\-branch\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-c\fR|\fB\-\-carry\fR] [\fB\-\-no\-carry\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-\-no\-cd\fR] [\fB\-x\fR|\fB\-\-exec\fR] [\fB\-s\fR|\fB\-\-start\fR] [\fB\-@\fR|\fB\-\-at\fR] [\fB\-\-local\fR] [\fB\-\-skip\-hooks\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIBRANCH_NAME\fR> [\fIBASE_BRANCH_NAME\fR] 
+\fBgit\-worktree\-checkout\fR [\fB\-b\fR|\fB\-\-create\-branch\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-c\fR|\fB\-\-carry\fR] [\fB\-\-no\-carry\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-\-no\-cd\fR] [\fB\-x\fR|\fB\-\-exec\fR] [\fB\-s\fR|\fB\-\-start\fR] [\fB\-@\fR|\fB\-\-at\fR] [\fB\-\-local\fR] [\fB\-\-no\-verify\fR] [\fB\-\-skip\-hooks\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIBRANCH_NAME\fR> [\fIBASE_BRANCH_NAME\fR] 
 .SH DESCRIPTION
 .PP
 Creates a new worktree for an existing local or remote branch. The worktree
@@ -69,6 +69,9 @@ Place the worktree at a specific path instead of using the layout template
 .TP
 \fB\-\-local\fR
 Skip all remote operations (no fetch, no push)
+.TP
+\fB\-\-no\-verify\fR
+Skip the repo\*(Aqs pre\-push hook on the automatic upstream push
 .TP
 \fB\-\-skip\-hooks\fR \fI<SELECTOR>\fR
 Skip hooks this run (all | <hook> | tag:<tag> | <job>); repeatable/comma\-separated

--- a/man/git-worktree-sync.1
+++ b/man/git-worktree-sync.1
@@ -4,7 +4,7 @@
 .SH NAME
 git\-worktree\-sync \- Synchronize worktrees with remote (prune + update all)
 .SH SYNOPSIS
-\fBgit\-worktree\-sync\fR [\fB\-v\fR|\fB\-\-verbose\fR]... [\fB\-f\fR|\fB\-\-prune\-dirty\fR] [\fB\-\-rebase\fR] [\fB\-\-autostash\fR] [\fB\-\-push\fR] [\fB\-\-force\-with\-lease\fR] [\fB\-\-include\fR] [\fB\-\-stat\fR] [\fB\-\-columns\fR] [\fB\-\-sort\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] 
+\fBgit\-worktree\-sync\fR [\fB\-v\fR|\fB\-\-verbose\fR]... [\fB\-f\fR|\fB\-\-prune\-dirty\fR] [\fB\-\-rebase\fR] [\fB\-\-autostash\fR] [\fB\-\-push\fR] [\fB\-\-force\-with\-lease\fR] [\fB\-\-no\-verify\fR] [\fB\-\-include\fR] [\fB\-\-stat\fR] [\fB\-\-columns\fR] [\fB\-\-sort\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] 
 .SH DESCRIPTION
 .PP
 Synchronizes all worktrees with the remote in a single command.
@@ -46,6 +46,9 @@ Push all branches to their remotes after syncing
 .TP
 \fB\-\-force\-with\-lease\fR
 Use \-\-force\-with\-lease when pushing (requires \-\-push)
+.TP
+\fB\-\-no\-verify\fR
+Skip the repo\*(Aqs pre\-push hook when pushing (requires \-\-push)
 .TP
 \fB\-\-include\fR \fI<INCLUDE>\fR
 Include additional branches in rebase/push (email, branch name, or \*(Aqunowned\*(Aq)

--- a/src/commands/branch_delete.rs
+++ b/src/commands/branch_delete.rs
@@ -65,6 +65,12 @@ pub struct Args {
     )]
     remote: bool,
 
+    #[arg(
+        long,
+        help = "Skip the repo's pre-push hook when deleting the remote branch"
+    )]
+    no_verify: bool,
+
     #[arg(short, long, help = "Operate quietly; suppress progress reporting")]
     quiet: bool,
 
@@ -107,6 +113,7 @@ fn run_branch_delete(args: &Args, output: &mut dyn Output, settings: &DaftSettin
         },
         remote_only: args.remote,
         keep_local_branch: false,
+        no_verify: args.no_verify,
         prune_cd_target: settings.prune_cd_target,
         command_label: "branch-delete".to_string(),
         skip_merge_validation: false,
@@ -123,7 +130,7 @@ fn run_branch_delete(args: &Args, output: &mut dyn Output, settings: &DaftSettin
     output.start_spinner("Deleting branches...");
     let exec_result = {
         let mut bridge = CommandBridge::new(output, executor);
-        branch_delete::execute(&params, &mut bridge)
+        branch_delete::execute(&params, None, &mut bridge)
     };
     output.finish_spinner();
     let result = exec_result?;

--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -23,6 +23,7 @@ use anyhow::Result;
 use clap::Parser;
 use std::io::IsTerminal;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 #[derive(Parser)]
 #[command(name = "git-worktree-checkout")]
@@ -123,6 +124,12 @@ pub struct Args {
 
     #[arg(long, help = "Skip all remote operations (no fetch, no push)")]
     local: bool,
+
+    #[arg(
+        long,
+        help = "Skip the repo's pre-push hook on the automatic upstream push"
+    )]
+    no_verify: bool,
 
     /// Skip hooks this run. Repeatable / comma-separated.
     /// Selectors: `all`, a hook name (`worktree-post-create`, …),
@@ -235,6 +242,12 @@ pub struct GoArgs {
     #[arg(long, help = "Skip all remote operations (no fetch, no push)")]
     local: bool,
 
+    #[arg(
+        long,
+        help = "Skip the repo's pre-push hook on the automatic upstream push"
+    )]
+    no_verify: bool,
+
     /// Skip hooks this run (only applies when `go` creates a worktree).
     /// Selectors: `all`, a hook name (`worktree-post-create`, …),
     /// `tag:<tag>`, or a job name (plus its dependents). See daft-hooks(1).
@@ -314,6 +327,12 @@ pub struct StartArgs {
     #[arg(long, help = "Skip all remote operations (no fetch, no push)")]
     local: bool,
 
+    #[arg(
+        long,
+        help = "Skip the repo's pre-push hook on the automatic upstream push"
+    )]
+    no_verify: bool,
+
     /// Skip hooks this run. Repeatable / comma-separated.
     /// Selectors: `all`, a hook name (`worktree-post-create`, …),
     /// `tag:<tag>`, or a job name (plus its dependents). See daft-hooks(1).
@@ -352,6 +371,7 @@ pub fn run_go() -> Result<()> {
         verbose: go_args.verbose,
         at: go_args.at,
         local: go_args.local,
+        no_verify: go_args.no_verify,
         skip_hooks: go_args.skip_hooks,
     };
     run_with_args(args)
@@ -377,6 +397,7 @@ pub fn run_start() -> Result<()> {
         verbose: start_args.verbose,
         at: start_args.at,
         local: start_args.local,
+        no_verify: start_args.no_verify,
         skip_hooks: start_args.skip_hooks,
     };
     run_with_args(args)
@@ -836,6 +857,7 @@ fn run_create_branch(
         } else {
             settings.checkout_push
         },
+        no_verify: args.no_verify,
         checkout_fetch: if args.local {
             false
         } else {
@@ -846,6 +868,7 @@ fn run_create_branch(
     };
 
     let hooks_config = crate::core::settings::load_hooks_config_with(git)?;
+    let hook_output_config = hooks_config.output.clone();
     let executor = HookExecutor::new(hooks_config)?.with_job_filter(
         crate::hooks::yaml_executor::JobFilter::skipping(&args.skip_hooks),
     );
@@ -854,13 +877,37 @@ fn run_create_branch(
         output.warning("[experimental] Using gitoxide backend for git operations");
     }
 
-    output.start_spinner("Creating worktree...");
+    // The pre-push hook run on the auto-upstream push renders phase/job
+    // output through this presenter — keep the spinner off when it will
+    // fire so the two don't fight over the terminal (#599).
+    let push_hook_will_render =
+        params.checkout_push && !params.no_verify && git.pre_push_hook_exists(&project_root);
+    let push_presenter: Option<Arc<dyn crate::executor::presenter::JobPresenter>> =
+        if push_hook_will_render {
+            let p: Arc<dyn crate::executor::presenter::JobPresenter> =
+                crate::executor::cli_presenter::CliPresenter::auto(&hook_output_config);
+            Some(p)
+        } else {
+            None
+        };
+
+    if !push_hook_will_render {
+        output.start_spinner("Creating worktree...");
+    }
     let (checkout_result, executor) = {
         let mut bridge = CommandBridge::new(output, executor);
-        let r = checkout_branch::execute(&params, git, &project_root, &mut bridge);
+        let r = checkout_branch::execute(
+            &params,
+            git,
+            &project_root,
+            push_presenter.as_ref(),
+            &mut bridge,
+        );
         (r, bridge.into_executor())
     };
-    output.finish_spinner();
+    if !push_hook_will_render {
+        output.finish_spinner();
+    }
     let result = checkout_result?;
 
     render_create_result(&result, output);

--- a/src/commands/clone.rs
+++ b/src/commands/clone.rs
@@ -1277,7 +1277,7 @@ fn create_satellite_worktrees_tui(
             eprintln!(
                 "  {}: {} {} ({}, {}ms)",
                 entry.branch_name,
-                entry.hook_type.filename(),
+                entry.hook_type.hook_name(),
                 status_word,
                 exit_str,
                 entry.duration.as_millis(),

--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -1180,6 +1180,7 @@ pub fn run() -> Result<()> {
                         delete_remote: settings.branch_delete_remote,
                         remote_only: false,
                         keep_local_branch,
+                        no_verify: false,
                         prune_cd_target: settings.prune_cd_target,
                         // Expose DAFT_COMMAND=merge so hook scripts can
                         // distinguish merge cleanup from standalone daft remove.
@@ -1191,7 +1192,11 @@ pub fn run() -> Result<()> {
                     let bd_result = {
                         let executor = HookExecutor::new(hooks_config.clone())?;
                         let mut bridge = CommandBridge::new(&mut output, executor);
-                        crate::core::worktree::branch_delete::execute(&bd_params, &mut bridge)?
+                        crate::core::worktree::branch_delete::execute(
+                            &bd_params,
+                            None,
+                            &mut bridge,
+                        )?
                     };
 
                     if !bd_result.validation_errors.is_empty() {

--- a/src/commands/multi_remote.rs
+++ b/src/commands/multi_remote.rs
@@ -4,8 +4,10 @@
 
 use crate::{
     core::OutputSink,
+    core::worktree::ports::NoopStageRunner,
+    core::worktree::push::{HookVerdict, PushAction, push_with_hooks},
     get_project_root,
-    git::{GitCommand, PushIo, PushOptions},
+    git::GitCommand,
     is_git_repository,
     multi_remote::{
         config::{set_multi_remote_default, set_multi_remote_enabled},
@@ -144,6 +146,9 @@ to match the new remote organization.
         #[arg(long, help = "Delete the branch from the old remote after pushing")]
         delete_old: bool,
 
+        #[arg(long, help = "Skip the repo's pre-push hook on remote operations")]
+        no_verify: bool,
+
         #[arg(long, help = "Preview changes without executing")]
         dry_run: bool,
 
@@ -172,9 +177,19 @@ pub fn run() -> Result<()> {
             set_upstream,
             push,
             delete_old,
+            no_verify,
             dry_run,
             force,
-        }) => cmd_move(&branch, &to, set_upstream, push, delete_old, dry_run, force),
+        }) => cmd_move(
+            &branch,
+            &to,
+            set_upstream,
+            push,
+            delete_old,
+            no_verify,
+            dry_run,
+            force,
+        ),
         None => cmd_status(&EmitArgs::default()), // Default to status
     }
 }
@@ -504,12 +519,14 @@ fn cmd_set_default(remote: &str) -> Result<()> {
 
 /// Move a worktree to a different remote folder.
 #[allow(clippy::fn_params_excessive_bools)]
+#[allow(clippy::too_many_arguments)]
 fn cmd_move(
     branch: &str,
     to_remote: &str,
     set_upstream: bool,
     push: bool,
     delete_old: bool,
+    no_verify: bool,
     dry_run: bool,
     skip_confirm: bool,
 ) -> Result<()> {
@@ -664,36 +681,96 @@ fn cmd_move(
         }
     }
 
+    // Remote pushes honor the repo's pre-push hook (#599); a failure with
+    // the hook in effect escalates after the move's local steps complete.
+    let push_presenter: Option<std::sync::Arc<dyn crate::executor::presenter::JobPresenter>> =
+        if (push || delete_old) && !no_verify && git.pre_push_hook_exists(&new_path) {
+            let p: std::sync::Arc<dyn crate::executor::presenter::JobPresenter> =
+                crate::executor::cli_presenter::CliPresenter::auto(
+                    &crate::settings::HookOutputConfig::default(),
+                );
+            Some(p)
+        } else {
+            None
+        };
+    let mut push_gate_error: Option<String> = None;
+
     // Push if requested
     if push {
         output.step(&format!("Pushing to {}...", to_remote));
 
-        let result = git
-            .push_set_upstream_from(to_remote, &branch_name, &new_path, &PushOptions::default())
-            .and_then(PushIo::into_result);
-
-        if let Err(e) = result {
-            output.warning(&format!("Failed to push: {}", e));
+        match push_with_hooks(
+            &git,
+            PushAction::SetUpstream {
+                remote: to_remote,
+                branch: &branch_name,
+            },
+            &new_path,
+            !no_verify,
+            &NoopStageRunner,
+            push_presenter.as_ref(),
+            None,
+        ) {
+            Ok(outcome) => {
+                if let Some(msg) = outcome.failure {
+                    if matches!(outcome.hook, HookVerdict::Rejected | HookVerdict::Passed) {
+                        push_gate_error = Some(format!(
+                            "Could not push '{to_remote}/{branch_name}' with the repo's \
+                             pre-push hook in effect: {msg}. The worktree was moved; push \
+                             manually with: git push --set-upstream {to_remote} {branch_name} \
+                             (or re-run with --no-verify)"
+                        ));
+                    } else {
+                        output.warning(&format!("Failed to push: {}", msg));
+                    }
+                }
+            }
+            Err(e) => {
+                output.warning(&format!("Failed to push: {}", e));
+            }
         }
     }
 
-    // Delete from old remote if requested
-    if delete_old && let Some(old_remote) = current_remote {
+    // Delete from old remote if requested (skipped if the push was gated —
+    // the same hook would gate this push too).
+    if delete_old
+        && push_gate_error.is_none()
+        && let Some(old_remote) = current_remote
+    {
         output.step(&format!(
             "Deleting from old remote {}/{}...",
             old_remote, branch_name
         ));
 
-        let result = git
-            .push_delete_from(
-                &old_remote,
-                &branch_name,
-                &new_path,
-                &PushOptions::default(),
-            )
-            .and_then(PushIo::into_result);
-        if let Err(e) = result {
-            output.warning(&format!("Failed to delete from old remote: {}", e));
+        match push_with_hooks(
+            &git,
+            PushAction::Delete {
+                remote: &old_remote,
+                branch: &branch_name,
+            },
+            &new_path,
+            !no_verify,
+            &NoopStageRunner,
+            push_presenter.as_ref(),
+            None,
+        ) {
+            Ok(outcome) => {
+                if let Some(msg) = outcome.failure {
+                    if matches!(outcome.hook, HookVerdict::Rejected | HookVerdict::Passed) {
+                        push_gate_error = Some(format!(
+                            "Could not delete '{old_remote}/{branch_name}' with the repo's \
+                             pre-push hook in effect: {msg}. Delete it manually with: \
+                             git push {old_remote} --delete {branch_name} (or re-run with \
+                             --no-verify)"
+                        ));
+                    } else {
+                        output.warning(&format!("Failed to delete from old remote: {}", msg));
+                    }
+                }
+            }
+            Err(e) => {
+                output.warning(&format!("Failed to delete from old remote: {}", e));
+            }
         }
     }
 
@@ -715,6 +792,12 @@ fn cmd_move(
     }
 
     output.result(&format!("Worktree moved to {}/{}", to_remote, branch_name));
+
+    // The move's local steps are complete — surface a deferred pre-push
+    // gate refusal as the command's failure (#599).
+    if let Some(message) = push_gate_error {
+        anyhow::bail!(message);
+    }
 
     Ok(())
 }

--- a/src/commands/multi_remote.rs
+++ b/src/commands/multi_remote.rs
@@ -714,11 +714,16 @@ fn cmd_move(
             Ok(outcome) => {
                 if let Some(msg) = outcome.failure {
                     if matches!(outcome.hook, HookVerdict::Rejected | HookVerdict::Passed) {
+                        let hint = if outcome.hook.no_verify_might_help() {
+                            " (or re-run with --no-verify to bypass the hook)"
+                        } else {
+                            ""
+                        };
                         push_gate_error = Some(format!(
-                            "Could not push '{to_remote}/{branch_name}' with the repo's \
-                             pre-push hook in effect: {msg}. The worktree was moved; push \
-                             manually with: git push --set-upstream {to_remote} {branch_name} \
-                             (or re-run with --no-verify)"
+                            "Could not push '{to_remote}/{branch_name}': {msg} ({}). \
+                             The worktree was moved; push manually with: \
+                             git push --set-upstream {to_remote} {branch_name}{hint}",
+                            outcome.hook.failure_cause(),
                         ));
                     } else {
                         output.warning(&format!("Failed to push: {}", msg));
@@ -757,11 +762,16 @@ fn cmd_move(
             Ok(outcome) => {
                 if let Some(msg) = outcome.failure {
                     if matches!(outcome.hook, HookVerdict::Rejected | HookVerdict::Passed) {
+                        let hint = if outcome.hook.no_verify_might_help() {
+                            " (or re-run with --no-verify to bypass the hook)"
+                        } else {
+                            ""
+                        };
                         push_gate_error = Some(format!(
-                            "Could not delete '{old_remote}/{branch_name}' with the repo's \
-                             pre-push hook in effect: {msg}. Delete it manually with: \
-                             git push {old_remote} --delete {branch_name} (or re-run with \
-                             --no-verify)"
+                            "Could not delete '{old_remote}/{branch_name}': {msg} ({}). \
+                             Delete it manually with: \
+                             git push {old_remote} --delete {branch_name}{hint}",
+                            outcome.hook.failure_cause(),
                         ));
                     } else {
                         output.warning(&format!("Failed to delete from old remote: {}", msg));

--- a/src/commands/multi_remote.rs
+++ b/src/commands/multi_remote.rs
@@ -5,7 +5,7 @@
 use crate::{
     core::OutputSink,
     get_project_root,
-    git::GitCommand,
+    git::{GitCommand, PushIo, PushOptions},
     is_git_repository,
     multi_remote::{
         config::{set_multi_remote_default, set_multi_remote_enabled},
@@ -668,12 +668,9 @@ fn cmd_move(
     if push {
         output.step(&format!("Pushing to {}...", to_remote));
 
-        let original_dir = std::env::current_dir()?;
-        std::env::set_current_dir(&new_path)?;
-
-        let result = git.push_set_upstream(to_remote, &branch_name);
-
-        std::env::set_current_dir(&original_dir)?;
+        let result = git
+            .push_set_upstream_from(to_remote, &branch_name, &new_path, &PushOptions::default())
+            .and_then(PushIo::into_result);
 
         if let Err(e) = result {
             output.warning(&format!("Failed to push: {}", e));
@@ -687,7 +684,14 @@ fn cmd_move(
             old_remote, branch_name
         ));
 
-        let result = delete_remote_branch(&git, &old_remote, &branch_name);
+        let result = git
+            .push_delete_from(
+                &old_remote,
+                &branch_name,
+                &new_path,
+                &PushOptions::default(),
+            )
+            .and_then(PushIo::into_result);
         if let Err(e) = result {
             output.warning(&format!("Failed to delete from old remote: {}", e));
         }
@@ -732,21 +736,4 @@ fn get_branch_name_for_worktree(
             .find(|e| e.path.as_path() == worktree_path)
             .and_then(|e| e.branch),
     )
-}
-
-/// Delete a branch from a remote.
-fn delete_remote_branch(_git: &GitCommand, remote: &str, branch: &str) -> Result<()> {
-    use std::process::Command;
-
-    let output = Command::new("git")
-        .args(["push", "--no-verify", remote, "--delete", branch])
-        .output()
-        .context("Failed to execute git push --delete")?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("Failed to delete remote branch: {}", stderr);
-    }
-
-    Ok(())
 }

--- a/src/commands/prune.rs
+++ b/src/commands/prune.rs
@@ -586,7 +586,7 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
             eprintln!(
                 "  {}: {} {} ({}, {}ms)",
                 entry.branch_name,
-                entry.hook_type.filename(),
+                entry.hook_type.hook_name(),
                 status_word,
                 exit_str,
                 entry.duration.as_millis(),

--- a/src/commands/repo/remove.rs
+++ b/src/commands/repo/remove.rs
@@ -584,7 +584,7 @@ fn run_tui(
             eprintln!(
                 "  {}: {} {} ({}, {}ms)",
                 entry.branch_name,
-                entry.hook_type.filename(),
+                entry.hook_type.hook_name(),
                 status_word,
                 exit_str,
                 entry.duration.as_millis()
@@ -610,7 +610,7 @@ struct HookSummary {
     branch_name: String,
     #[allow(dead_code)] // Held for symmetry; not yet used in summary output.
     success: bool,
-    hook_type: crate::hooks::HookType,
+    hook_type: crate::core::worktree::sync_dag::DagHookPhase,
     warned: bool,
     duration: std::time::Duration,
     exit_code: Option<i32>,
@@ -632,7 +632,7 @@ fn print_hook_summary(entries: &[HookSummary]) {
         eprintln!(
             "  {}: {} {} ({}, {}ms)",
             h.branch_name,
-            h.hook_type.filename(),
+            h.hook_type.hook_name(),
             status_word,
             exit_str,
             h.duration.as_millis()

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -626,6 +626,12 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
     let shared_push = args.push;
     let shared_force_with_lease = args.force_with_lease;
     let shared_no_verify = args.no_verify;
+    // One probe for the whole run — every worktree shares the repo's hooks
+    // dir, and DAG workers shouldn't each pay a subprocess for it (#599).
+    let shared_hook_present = shared_push
+        && GitCommand::new(true)
+            .with_gitoxide(settings.use_gitoxide)
+            .pre_push_hook_exists(&project_root);
 
     let deferred_branch: Arc<std::sync::Mutex<Option<String>>> =
         Arc::new(std::sync::Mutex::new(None));
@@ -837,6 +843,8 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
                             &shared_settings,
                             shared_force_with_lease,
                             shared_no_verify,
+                            shared_hook_present,
+                            &tx_for_tasks,
                             outcomes,
                         );
                         if status == TaskStatus::Succeeded {
@@ -957,7 +965,7 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
             eprintln!(
                 "  {}: {} {} ({}, {}ms)",
                 entry.branch_name,
-                entry.hook_type.filename(),
+                entry.hook_type.hook_name(),
                 status_word,
                 exit_str,
                 entry.duration.as_millis(),
@@ -1191,6 +1199,7 @@ fn execute_rebase_task(
 }
 
 /// Execute a single push task for a DAG worker.
+#[allow(clippy::too_many_arguments)]
 fn execute_push_task(
     branch_name: &str,
     worktree_path: Option<&PathBuf>,
@@ -1198,6 +1207,8 @@ fn execute_push_task(
     settings: &DaftSettings,
     force_with_lease: bool,
     no_verify: bool,
+    hook_present: bool,
+    tx: &std::sync::mpsc::Sender<sync_dag::DagEvent>,
     branch_outcomes: &HashSet<TaskOutcome>,
 ) -> (TaskStatus, TaskMessage, HashSet<TaskOutcome>) {
     // Push doesn't need the branch's worktree; any git dir works.
@@ -1228,6 +1239,22 @@ fn execute_push_task(
         no_verify,
     };
 
+    // Report the pre-push hook run as a phase on this branch's TUI row,
+    // mirroring how lifecycle hooks surface (#599). Existence-gated so
+    // hook-less repos emit nothing.
+    let presenter: Option<std::sync::Arc<dyn crate::executor::presenter::JobPresenter>> =
+        if hook_present && !no_verify {
+            let p: std::sync::Arc<dyn crate::executor::presenter::JobPresenter> =
+                crate::output::tui::TuiPresenter::new(
+                    tx.clone(),
+                    branch_name.to_string(),
+                    sync_dag::DagHookPhase::PrePush,
+                );
+            Some(p)
+        } else {
+            None
+        };
+
     let mut sink = NullSink;
     let result = push::push_single_worktree(
         &git,
@@ -1237,8 +1264,8 @@ fn execute_push_task(
         &params,
         &mut sink,
         &crate::core::worktree::ports::NoopStageRunner,
-        None,
-        None,
+        presenter.as_ref(),
+        Some(hook_present),
     );
 
     if result.no_upstream {

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -1296,7 +1296,7 @@ fn execute_push_task(
             .message
             .lines()
             .next()
-            .unwrap_or("push rejected by pre-push hook")
+            .unwrap_or(result.hook.failure_cause())
             .to_string();
         (
             TaskStatus::Failed,
@@ -1817,7 +1817,7 @@ fn run_push_phase(
     let gated = result.gated_failure_count();
     if gated > 0 {
         anyhow::bail!(
-            "{gated} push(es) failed with the repo's pre-push hook in effect \
+            "{gated} push(es) failed with the repo's pre-push hook honored \
              (re-run with --no-verify to bypass the hook)"
         );
     }

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -159,6 +159,13 @@ pub struct Args {
 
     #[arg(
         long,
+        requires = "push",
+        help = "Skip the repo's pre-push hook when pushing (requires --push)"
+    )]
+    no_verify: bool,
+
+    #[arg(
+        long,
         help = "Include additional branches in rebase/push (email, branch name, or 'unowned')"
     )]
     include: Vec<String>,
@@ -354,6 +361,7 @@ fn run_sequential(args: Args, settings: DaftSettings) -> Result<()> {
             &mut output,
             &settings,
             args.force_with_lease,
+            args.no_verify,
             &push_skip,
             &default_branch,
         )?;
@@ -617,6 +625,7 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
     let shared_rebase_branch: Arc<Option<String>> = Arc::new(args.rebase.clone());
     let shared_push = args.push;
     let shared_force_with_lease = args.force_with_lease;
+    let shared_no_verify = args.no_verify;
 
     let deferred_branch: Arc<std::sync::Mutex<Option<String>>> =
         Arc::new(std::sync::Mutex::new(None));
@@ -827,6 +836,7 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
                             &shared_project_root,
                             &shared_settings,
                             shared_force_with_lease,
+                            shared_no_verify,
                             outcomes,
                         );
                         if status == TaskStatus::Succeeded {
@@ -1187,6 +1197,7 @@ fn execute_push_task(
     project_root: &std::path::Path,
     settings: &DaftSettings,
     force_with_lease: bool,
+    no_verify: bool,
     branch_outcomes: &HashSet<TaskOutcome>,
 ) -> (TaskStatus, TaskMessage, HashSet<TaskOutcome>) {
     // Push doesn't need the branch's worktree; any git dir works.
@@ -1214,6 +1225,7 @@ fn execute_push_task(
     let params = push::PushParams {
         force_with_lease,
         remote_name: settings.remote.clone(),
+        no_verify,
     };
 
     let mut sink = NullSink;
@@ -1224,6 +1236,9 @@ fn execute_push_task(
         branch_name,
         &params,
         &mut sink,
+        &crate::core::worktree::ports::NoopStageRunner,
+        None,
+        None,
     );
 
     if result.no_upstream {
@@ -1244,9 +1259,26 @@ fn execute_push_task(
             TaskMessage::Pushed,
             branch_outcomes.clone(),
         )
+    } else if matches!(
+        result.hook,
+        push::HookVerdict::Rejected | push::HookVerdict::Passed
+    ) {
+        // A failed push with the pre-push gate in effect is a real failure
+        // (#599), not a divergence warning.
+        let first_line = result
+            .message
+            .lines()
+            .next()
+            .unwrap_or("push rejected by pre-push hook")
+            .to_string();
+        (
+            TaskStatus::Failed,
+            TaskMessage::Failed(first_line),
+            branch_outcomes.clone(),
+        )
     } else {
-        // Push failures are warnings, not hard failures — use Succeeded + Diverged
-        // so that check_tui_failures does not count them as Failed.
+        // Hook-less push failures stay warnings, not hard failures — use
+        // Succeeded + Diverged so check_tui_failures does not count them.
         (
             TaskStatus::Succeeded,
             TaskMessage::Diverged,
@@ -1693,6 +1725,7 @@ fn run_push_phase(
     output: &mut dyn Output,
     settings: &DaftSettings,
     force_with_lease: bool,
+    no_verify: bool,
     skip_branches: &HashSet<String>,
     base_branch: &str,
 ) -> Result<()> {
@@ -1706,14 +1739,42 @@ fn run_push_phase(
     let params = push::PushParams {
         force_with_lease,
         remote_name: wt_config.remote_name.clone(),
+        no_verify,
     };
 
-    output.start_spinner("Pushing branches...");
+    // When a pre-push hook will run, its reporting renders as phase/job
+    // output through the presenter — leave the spinner off so the two don't
+    // fight over the terminal (hook-less pushes keep the spinner as before).
+    let hook_present = git.pre_push_hook_exists(&project_root);
+    let presenter: Option<Arc<dyn crate::executor::presenter::JobPresenter>> =
+        if hook_present && !no_verify {
+            let p: Arc<dyn crate::executor::presenter::JobPresenter> =
+                crate::executor::cli_presenter::CliPresenter::auto(
+                    &crate::settings::HookOutputConfig::default(),
+                );
+            Some(p)
+        } else {
+            None
+        };
+
+    if presenter.is_none() {
+        output.start_spinner("Pushing branches...");
+    }
     let exec_result = {
         let mut sink = OutputSink(output);
-        push::execute(&params, &git, &project_root, &mut sink, skip_branches)
+        push::execute(
+            &params,
+            &git,
+            &project_root,
+            &mut sink,
+            skip_branches,
+            &crate::core::worktree::ports::NoopStageRunner,
+            presenter.as_ref(),
+        )
     };
-    output.finish_spinner();
+    if presenter.is_none() {
+        output.finish_spinner();
+    }
     let result = exec_result?;
 
     render_push_result(&result, output, base_branch);
@@ -1723,6 +1784,15 @@ fn run_push_phase(
             "{} branch(es) failed to push",
             result.failed_count()
         ));
+    }
+
+    // A pre-push gate saying no must surface as a failure, not a warning.
+    let gated = result.gated_failure_count();
+    if gated > 0 {
+        anyhow::bail!(
+            "{gated} push(es) failed with the repo's pre-push hook in effect \
+             (re-run with --no-verify to bypass the hook)"
+        );
     }
 
     Ok(())

--- a/src/commands/sync_shared.rs
+++ b/src/commands/sync_shared.rs
@@ -552,7 +552,7 @@ fn run_remove_hook_best_effort(
         // can surface it. Mirrors `TuiBridge::run_hook`.
         let _ = tx.send(DagEvent::HookCompleted {
             branch_name: label.to_string(),
-            hook_type,
+            hook_type: hook_type.into(),
             success: false,
             warned: false,
             duration: std::time::Duration::ZERO,

--- a/src/commands/worktree_branch.rs
+++ b/src/commands/worktree_branch.rs
@@ -4,6 +4,7 @@ use crate::{
         CommandBridge,
         worktree::{branch_delete, rename},
     },
+    git::GitCommand,
     git::should_show_gitoxide_notice,
     hooks::HookExecutor,
     is_git_repository,
@@ -112,6 +113,9 @@ pub struct Args {
     )]
     no_remote: bool,
 
+    #[arg(long, help = "Skip the repo's pre-push hook on remote operations")]
+    no_verify: bool,
+
     #[arg(
         long,
         help = "Preview changes without executing (only with -m)",
@@ -195,6 +199,12 @@ pub struct RemoveArgs {
     )]
     remote: bool,
 
+    #[arg(
+        long,
+        help = "Skip the repo's pre-push hook when deleting the remote branch"
+    )]
+    no_verify: bool,
+
     #[arg(short, long, help = "Operate quietly; suppress progress reporting")]
     quiet: bool,
 
@@ -229,6 +239,7 @@ pub fn run_remove() -> Result<()> {
         remove_args.local,
         remove_args.remote,
         "-f/--force",
+        remove_args.no_verify,
         &mut output,
         &settings,
     )
@@ -339,6 +350,9 @@ pub struct RenameArgs {
     #[arg(long, help = "Skip remote branch rename")]
     no_remote: bool,
 
+    #[arg(long, help = "Skip the repo's pre-push hook on remote operations")]
+    no_verify: bool,
+
     #[arg(long, help = "Preview changes without executing")]
     dry_run: bool,
 
@@ -379,6 +393,7 @@ pub fn run_rename() -> Result<()> {
         &rename_args.source,
         &rename_args.new_branch,
         rename_args.no_remote,
+        rename_args.no_verify,
         rename_args.dry_run,
         rename_args.verbose,
         &mut output,
@@ -423,6 +438,7 @@ fn run_with_args(args: Args) -> Result<()> {
             &args.branches[0],
             &args.branches[1],
             args.no_remote,
+            args.no_verify,
             args.dry_run,
             args.verbose,
             &mut output,
@@ -443,6 +459,7 @@ fn run_with_args(args: Args) -> Result<()> {
             args.local,
             args.remote,
             "-D/--force",
+            args.no_verify,
             &mut output,
             &settings,
         )?;
@@ -458,6 +475,7 @@ fn run_branch_delete(
     local_only: bool,
     remote_only: bool,
     force_flag_label: &str,
+    no_verify: bool,
     output: &mut dyn Output,
     settings: &DaftSettings,
 ) -> Result<()> {
@@ -476,6 +494,7 @@ fn run_branch_delete(
         },
         remote_only,
         keep_local_branch: false,
+        no_verify,
         prune_cd_target: settings.prune_cd_target,
         command_label: "branch-delete".to_string(),
         skip_merge_validation: false,
@@ -483,18 +502,40 @@ fn run_branch_delete(
     };
 
     let hooks_config = crate::core::settings::load_hooks_config()?;
+    let hook_output_config = hooks_config.output.clone();
     let executor = HookExecutor::new(hooks_config)?;
 
     if should_show_gitoxide_notice(settings.use_gitoxide) {
         output.warning("[experimental] Using gitoxide backend for git operations");
     }
 
-    output.start_spinner("Deleting branches...");
+    // The pre-push hook run on the remote-branch delete renders through
+    // this presenter — keep the spinner off when it will fire (#599).
+    let probe_git = GitCommand::new(quiet).with_gitoxide(settings.use_gitoxide);
+    let push_hook_will_render = params.delete_remote
+        && !params.no_verify
+        && std::env::current_dir()
+            .map(|cwd| probe_git.pre_push_hook_exists(&cwd))
+            .unwrap_or(false);
+    let push_presenter: Option<std::sync::Arc<dyn crate::executor::presenter::JobPresenter>> =
+        if push_hook_will_render {
+            let p: std::sync::Arc<dyn crate::executor::presenter::JobPresenter> =
+                crate::executor::cli_presenter::CliPresenter::auto(&hook_output_config);
+            Some(p)
+        } else {
+            None
+        };
+
+    if !push_hook_will_render {
+        output.start_spinner("Deleting branches...");
+    }
     let exec_result = {
         let mut bridge = CommandBridge::new(output, executor);
-        branch_delete::execute(&params, &mut bridge)
+        branch_delete::execute(&params, push_presenter.as_ref(), &mut bridge)
     };
-    output.finish_spinner();
+    if !push_hook_will_render {
+        output.finish_spinner();
+    }
     let result = exec_result?;
 
     // Handle validation errors
@@ -551,10 +592,12 @@ fn run_branch_delete(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_rename_inner(
     source: &str,
     new_branch: &str,
     no_remote: bool,
+    no_verify: bool,
     dry_run: bool,
     verbose: bool,
     output: &mut dyn Output,
@@ -570,6 +613,7 @@ fn run_rename_inner(
         remote_name: settings.remote.clone(),
         multi_remote_enabled: settings.multi_remote_enabled,
         multi_remote_default: settings.multi_remote_default.clone(),
+        no_verify,
     };
 
     if should_show_gitoxide_notice(settings.use_gitoxide) {
@@ -582,13 +626,31 @@ fn run_rename_inner(
     }
     let executor = HookExecutor::new(hooks_config.clone())?;
 
-    if !params.dry_run {
+    // The pre-push hook run on the remote rename renders through this
+    // presenter — keep the spinner off when it will fire (#599).
+    let probe_git = GitCommand::new(output.is_quiet()).with_gitoxide(settings.use_gitoxide);
+    let push_hook_will_render = !params.dry_run
+        && !params.no_remote
+        && !params.no_verify
+        && std::env::current_dir()
+            .map(|cwd| probe_git.pre_push_hook_exists(&cwd))
+            .unwrap_or(false);
+    let push_presenter: Option<std::sync::Arc<dyn crate::executor::presenter::JobPresenter>> =
+        if push_hook_will_render {
+            let p: std::sync::Arc<dyn crate::executor::presenter::JobPresenter> =
+                crate::executor::cli_presenter::CliPresenter::auto(&hooks_config.output);
+            Some(p)
+        } else {
+            None
+        };
+
+    if !params.dry_run && !push_hook_will_render {
         output.start_spinner("Renaming branch...");
     }
     let exec_result = {
         let mut bridge =
             CommandBridge::with_output_config(output, executor, hooks_config.output.clone());
-        rename::execute(&params, &mut bridge)
+        rename::execute(&params, push_presenter.as_ref(), &mut bridge)
     };
     output.finish_spinner();
     let result = exec_result?;
@@ -627,6 +689,12 @@ fn run_rename_inner(
         && let Ok(cd_file) = std::env::var(CD_FILE_ENV)
     {
         std::fs::write(&cd_file, cd_target.to_string_lossy().as_bytes()).ok();
+    }
+
+    // The worktree moved and the shell has been re-pointed — now surface a
+    // deferred pre-push gate refusal as the command's failure (#599).
+    if let Some(message) = result.push_gate_error {
+        anyhow::bail!(message);
     }
 
     Ok(())

--- a/src/core/tui_bridge.rs
+++ b/src/core/tui_bridge.rs
@@ -97,7 +97,7 @@ impl HookRunner for TuiBridge {
                 // it). Manually send HookCompleted so the TUI can show the failure.
                 let _ = self.sender.send(DagEvent::HookCompleted {
                     branch_name: self.branch_name.clone(),
-                    hook_type,
+                    hook_type: hook_type.into(),
                     success: false,
                     warned: false,
                     duration: std::time::Duration::ZERO,

--- a/src/core/worktree/branch_delete.rs
+++ b/src/core/worktree/branch_delete.rs
@@ -6,7 +6,7 @@ use crate::core::{
     ConflictSide, ConsolidationChoice, ConsolidationPrompter, ConsolidationRequest, HookRunner,
     ProgressSink, RefinedFileSummary,
 };
-use crate::git::GitCommand;
+use crate::git::{GitCommand, PushIo, PushOptions};
 use crate::hooks::visitor_seeds::{self, FileClass, SeedsContext};
 use crate::hooks::{HookContext, HookType, RemovalReason};
 use crate::remote::get_default_branch_local;
@@ -1017,8 +1017,20 @@ fn delete_single_branch(
             "Deleting remote branch {}/{}...",
             remote, remote_branch
         ));
-        match ctx.git.push_delete(remote, remote_branch) {
-            Ok(()) => {
+        // Run from the branch's worktree when it still exists (Step 3 removes
+        // it later) so the repo's pre-push hook fires there; otherwise any
+        // directory inside the repo works for a remote delete.
+        let push_cwd = branch
+            .worktree_path
+            .as_deref()
+            .filter(|p| p.is_dir())
+            .unwrap_or(&ctx.project_root);
+        match ctx
+            .git
+            .push_delete_from(remote, remote_branch, push_cwd, &PushOptions::default())
+            .and_then(PushIo::into_result)
+        {
+            Ok(_) => {
                 result.remote_deleted = true;
                 sink.on_step(&format!(
                     "Remote branch {}/{} deleted",

--- a/src/core/worktree/branch_delete.rs
+++ b/src/core/worktree/branch_delete.rs
@@ -2,11 +2,14 @@
 //!
 //! Deletes branches and their associated worktrees.
 
+use crate::core::worktree::ports::NoopStageRunner;
+use crate::core::worktree::push::{PushAction, push_with_hooks};
 use crate::core::{
     ConflictSide, ConsolidationChoice, ConsolidationPrompter, ConsolidationRequest, HookRunner,
     ProgressSink, RefinedFileSummary,
 };
-use crate::git::{GitCommand, PushIo, PushOptions};
+use crate::executor::presenter::JobPresenter;
+use crate::git::GitCommand;
 use crate::hooks::visitor_seeds::{self, FileClass, SeedsContext};
 use crate::hooks::{HookContext, HookType, RemovalReason};
 use crate::remote::get_default_branch_local;
@@ -15,6 +18,7 @@ use crate::{get_git_common_dir, get_project_root};
 use anyhow::{Context, Result};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 /// Input parameters for the branch-delete operation.
 pub struct BranchDeleteParams {
@@ -38,6 +42,9 @@ pub struct BranchDeleteParams {
     /// (without `-b`) to remove a source worktree while keeping the local
     /// branch ref intact.
     pub keep_local_branch: bool,
+    /// Skip the repo's pre-push hook when deleting the remote branch
+    /// (`--no-verify`).
+    pub no_verify: bool,
     /// Where to cd after deleting the current worktree.
     pub prune_cd_target: PruneCdTarget,
     /// Label exposed to hook scripts as `DAFT_COMMAND`. Defaults to
@@ -120,6 +127,10 @@ struct BranchDeleteContext<'a> {
     remote_name: String,
     source_worktree: PathBuf,
     default_branch: String,
+    /// Skip the repo's pre-push hook on the remote-branch delete.
+    no_verify: bool,
+    /// Reports the pre-push hook run on the remote-branch delete (#599).
+    presenter: Option<&'a Arc<dyn JobPresenter>>,
 }
 
 /// Validated branch ready for deletion.
@@ -164,8 +175,12 @@ enum ResolveResult {
 // ── Public API ─────────────────────────────────────────────────────────────
 
 /// Execute the branch-delete operation.
+///
+/// `presenter` reports the pre-push hook run on remote-branch deletes
+/// (#599); pass `None` to skip that reporting (the hook is still honored).
 pub fn execute(
     params: &BranchDeleteParams,
+    presenter: Option<&Arc<dyn JobPresenter>>,
     sink: &mut (impl ProgressSink + HookRunner + ConsolidationPrompter),
 ) -> Result<BranchDeleteResult> {
     let git = GitCommand::new(params.is_quiet).with_gitoxide(params.use_gitoxide);
@@ -181,6 +196,8 @@ pub fn execute(
         remote_name: params.remote_name.clone(),
         source_worktree: std::env::current_dir()?,
         default_branch,
+        no_verify: params.no_verify,
+        presenter,
     };
 
     // Parse worktree list once upfront into a map: branch_name -> worktree_path
@@ -1025,10 +1042,19 @@ fn delete_single_branch(
             .as_deref()
             .filter(|p| p.is_dir())
             .unwrap_or(&ctx.project_root);
-        match ctx
-            .git
-            .push_delete_from(remote, remote_branch, push_cwd, &PushOptions::default())
-            .and_then(PushIo::into_result)
+        match push_with_hooks(
+            ctx.git,
+            PushAction::Delete {
+                remote,
+                branch: remote_branch,
+            },
+            push_cwd,
+            !ctx.no_verify,
+            &NoopStageRunner,
+            ctx.presenter,
+            None,
+        )
+        .and_then(crate::core::worktree::push::PushOutcome::into_result)
         {
             Ok(_) => {
                 result.remote_deleted = true;
@@ -1567,6 +1593,7 @@ mod tests {
             delete_remote: false,
             remote_only: false,
             keep_local_branch: true,
+            no_verify: false,
             prune_cd_target: crate::settings::PruneCdTarget::Root,
             command_label: "branch-delete".to_string(),
             skip_merge_validation: false,
@@ -1575,7 +1602,7 @@ mod tests {
         let mut output = TestOutput::new();
         let executor = HookExecutor::new(HooksConfig::default()).unwrap();
         let mut bridge = CommandBridge::new(&mut output, executor);
-        let result = execute(&params, &mut bridge).expect("keep_local_branch should succeed");
+        let result = execute(&params, None, &mut bridge).expect("keep_local_branch should succeed");
 
         assert_eq!(result.deletions.len(), 1);
         assert!(
@@ -1633,6 +1660,7 @@ mod tests {
             delete_remote: false,
             remote_only: false,
             keep_local_branch: true,
+            no_verify: false,
             prune_cd_target: crate::settings::PruneCdTarget::Root,
             command_label: "branch-delete".to_string(),
             skip_merge_validation: false,
@@ -1641,7 +1669,7 @@ mod tests {
         let mut output = TestOutput::new();
         let executor = HookExecutor::new(HooksConfig::default()).unwrap();
         let mut bridge = CommandBridge::new(&mut output, executor);
-        let result = execute(&params, &mut bridge).unwrap();
+        let result = execute(&params, None, &mut bridge).unwrap();
 
         assert!(
             result.validation_errors.is_empty(),
@@ -1698,6 +1726,7 @@ mod tests {
             delete_remote: false,
             remote_only: false,
             keep_local_branch: true,
+            no_verify: false,
             prune_cd_target: crate::settings::PruneCdTarget::Root,
             command_label: "merge".to_string(),
             skip_merge_validation: false,
@@ -1712,7 +1741,7 @@ mod tests {
         trust_db.set_trust_level(&canonical_git_dir, crate::hooks::TrustLevel::Allow);
         let executor = HookExecutor::with_trust_db(HooksConfig::default(), trust_db);
         let mut bridge = CommandBridge::new(&mut output, executor);
-        let bd_result = execute(&params, &mut bridge).unwrap();
+        let bd_result = execute(&params, None, &mut bridge).unwrap();
         assert!(
             bd_result.validation_errors.is_empty(),
             "unexpected validation errors: {:?}",
@@ -1851,13 +1880,14 @@ mod tests {
             delete_remote: false,
             remote_only: false,
             keep_local_branch: false,
+            no_verify: false,
             prune_cd_target: crate::settings::PruneCdTarget::Root,
             command_label: "branch-delete".to_string(),
             skip_merge_validation: false,
             force_flag_label: "-D/--force".to_string(),
         };
         let mut bridge = ScriptedBridge::aborting();
-        let result = execute(&params, &mut bridge).unwrap();
+        let result = execute(&params, None, &mut bridge).unwrap();
 
         assert!(
             !result.validation_errors.is_empty(),
@@ -1939,13 +1969,14 @@ mod tests {
             delete_remote: false,
             remote_only: false,
             keep_local_branch: false,
+            no_verify: false,
             prune_cd_target: crate::settings::PruneCdTarget::Root,
             command_label: "branch-delete".to_string(),
             skip_merge_validation: false,
             force_flag_label: "-D/--force".to_string(),
         };
         let mut bridge = ScriptedBridge::aborting();
-        let result = execute(&params, &mut bridge).unwrap();
+        let result = execute(&params, None, &mut bridge).unwrap();
 
         assert!(
             result.validation_errors.is_empty(),
@@ -2039,6 +2070,7 @@ mod tests {
             delete_remote: false,
             remote_only: false,
             keep_local_branch: false,
+            no_verify: false,
             prune_cd_target: crate::settings::PruneCdTarget::Root,
             command_label: "branch-delete".to_string(),
             skip_merge_validation: false,
@@ -2048,7 +2080,7 @@ mod tests {
             choice: crate::core::ConsolidationChoice::Consolidate,
             side: crate::core::ConflictSide::Abort,
         };
-        let result = execute(&params, &mut bridge).unwrap();
+        let result = execute(&params, None, &mut bridge).unwrap();
 
         assert!(
             result.validation_errors.is_empty(),

--- a/src/core/worktree/checkout_branch.rs
+++ b/src/core/worktree/checkout_branch.rs
@@ -5,7 +5,7 @@
 use crate::config::git::{COMMITS_AHEAD_THRESHOLD, DEFAULT_COMMIT_COUNT};
 use crate::core::layout::{Layout, auto_gitignore_if_needed};
 use crate::core::{HookOutcome, HookRunner, ProgressSink};
-use crate::git::GitCommand;
+use crate::git::{GitCommand, PushIo, PushOptions};
 use crate::hooks::{HookContext, HookType};
 use crate::multi_remote::path::{
     build_template_context, calculate_worktree_path, resolve_remote_for_branch,
@@ -180,7 +180,7 @@ pub fn execute(
     let (stash_applied, stash_conflict) = apply_stash(stash_created, git, sink);
 
     // Push and set upstream
-    let (push_set, push_skipped) = push_if_enabled(params, git, sink);
+    let (push_set, push_skipped) = push_if_enabled(params, git, &worktree_path, sink);
 
     // Propagate in-scope untracked daft files from source worktree to the new
     // worktree, so that user post-create hooks can read them.
@@ -539,9 +539,13 @@ fn apply_stash(
 }
 
 /// Push and set upstream tracking if the setting is enabled.
+///
+/// Runs the push from the new worktree so the repo's `pre-push` hook fires
+/// in the branch being pushed.
 fn push_if_enabled(
     params: &CheckoutBranchParams,
     git: &GitCommand,
+    worktree_path: &Path,
     sink: &mut impl ProgressSink,
 ) -> (bool, bool) {
     if !params.checkout_push {
@@ -554,7 +558,16 @@ fn push_if_enabled(
         params.remote_name, params.new_branch_name
     ));
 
-    if let Err(e) = git.push_set_upstream(&params.remote_name, &params.new_branch_name) {
+    let result = git
+        .push_set_upstream_from(
+            &params.remote_name,
+            &params.new_branch_name,
+            worktree_path,
+            &PushOptions::default(),
+        )
+        .and_then(PushIo::into_result);
+
+    if let Err(e) = result {
         sink.on_warning(&format!(
             "Could not push '{}' to '{}': {}. The worktree is ready locally. Push manually with: git push -u {} {}",
             params.new_branch_name, params.remote_name, e,

--- a/src/core/worktree/checkout_branch.rs
+++ b/src/core/worktree/checkout_branch.rs
@@ -608,19 +608,26 @@ fn push_if_enabled(
             Some(msg) => {
                 let gated = matches!(outcome.hook, HookVerdict::Rejected | HookVerdict::Passed);
                 if gated {
+                    let hint = if outcome.hook.no_verify_might_help() {
+                        " (or re-run with --no-verify to bypass the hook)"
+                    } else {
+                        ""
+                    };
                     return (
                         false,
                         false,
                         Some(format!(
-                            "Could not push '{}' to '{}' with the repo's pre-push hook in effect: {}. \
-                             The worktree was created and is ready at '{}'. Fix the hook failure and \
-                             push manually with: git push -u {} {} (or re-run with --no-verify)",
+                            "Could not push '{}' to '{}': {} ({}). \
+                             The worktree was created and is ready at '{}'. \
+                             Push manually with: git push -u {} {}{}",
                             params.new_branch_name,
                             params.remote_name,
                             msg,
+                            outcome.hook.failure_cause(),
                             worktree_path.display(),
                             params.remote_name,
                             params.new_branch_name,
+                            hint,
                         )),
                     );
                 }

--- a/src/core/worktree/checkout_branch.rs
+++ b/src/core/worktree/checkout_branch.rs
@@ -4,8 +4,11 @@
 
 use crate::config::git::{COMMITS_AHEAD_THRESHOLD, DEFAULT_COMMIT_COUNT};
 use crate::core::layout::{Layout, auto_gitignore_if_needed};
+use crate::core::worktree::ports::NoopStageRunner;
+use crate::core::worktree::push::{HookVerdict, PushAction, push_with_hooks};
 use crate::core::{HookOutcome, HookRunner, ProgressSink};
-use crate::git::{GitCommand, PushIo, PushOptions};
+use crate::executor::presenter::JobPresenter;
+use crate::git::GitCommand;
 use crate::hooks::{HookContext, HookType};
 use crate::multi_remote::path::{
     build_template_context, calculate_worktree_path, resolve_remote_for_branch,
@@ -13,6 +16,7 @@ use crate::multi_remote::path::{
 use crate::utils::*;
 use anyhow::Result;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 /// Input parameters for the checkout-branch operation.
 pub struct CheckoutBranchParams {
@@ -36,6 +40,8 @@ pub struct CheckoutBranchParams {
     pub checkout_branch_carry: bool,
     /// Whether to push and set upstream (from settings).
     pub checkout_push: bool,
+    /// Skip the repo's pre-push hook on the upstream push (`--no-verify`).
+    pub no_verify: bool,
     /// Whether to fetch from remote before creating the worktree.
     pub checkout_fetch: bool,
     /// Optional layout for computing the worktree path.
@@ -61,10 +67,14 @@ pub struct CheckoutBranchResult {
 }
 
 /// Execute the checkout-branch operation.
+///
+/// `presenter` reports the pre-push hook run on the automatic upstream push
+/// (#599); pass `None` to skip that reporting (the hook is still honored).
 pub fn execute(
     params: &CheckoutBranchParams,
     git: &GitCommand,
     project_root: &Path,
+    presenter: Option<&Arc<dyn JobPresenter>>,
     sink: &mut (impl ProgressSink + HookRunner),
 ) -> Result<CheckoutBranchResult> {
     validate_branch_name(&params.new_branch_name)?;
@@ -179,8 +189,12 @@ pub fn execute(
     // Apply stashed changes
     let (stash_applied, stash_conflict) = apply_stash(stash_created, git, sink);
 
-    // Push and set upstream
-    let (push_set, push_skipped) = push_if_enabled(params, git, &worktree_path, sink);
+    // Push and set upstream. A pre-push gate refusal is deferred, not an
+    // immediate bail: the worktree must still be fully initialized
+    // (propagation, shared links, post-create hooks) before the command
+    // fails, so the user is left with a usable worktree.
+    let (push_set, push_skipped, push_gate_error) =
+        push_if_enabled(params, git, &worktree_path, presenter, sink);
 
     // Propagate in-scope untracked daft files from source worktree to the new
     // worktree, so that user post-create hooks can read them.
@@ -244,6 +258,12 @@ pub fn execute(
     .with_base_branch(&base_branch);
 
     let post_hook_outcome = sink.run_hook(&post_hook_ctx)?;
+
+    // The worktree is fully set up — now surface a deferred pre-push gate
+    // refusal as the command's failure (#599 acceptance: non-zero exit).
+    if let Some(message) = push_gate_error {
+        anyhow::bail!(message);
+    }
 
     Ok(CheckoutBranchResult {
         new_branch_name: params.new_branch_name.clone(),
@@ -542,15 +562,20 @@ fn apply_stash(
 ///
 /// Runs the push from the new worktree so the repo's `pre-push` hook fires
 /// in the branch being pushed.
+/// Returns `(push_set, push_skipped, gate_error)`. A push failure with the
+/// repo's pre-push hook in effect escalates via `gate_error` (the caller
+/// fails the command after finishing worktree setup, #599); hook-less or
+/// bypassed failures keep the legacy warn-and-continue behavior.
 fn push_if_enabled(
     params: &CheckoutBranchParams,
     git: &GitCommand,
     worktree_path: &Path,
+    presenter: Option<&Arc<dyn JobPresenter>>,
     sink: &mut impl ProgressSink,
-) -> (bool, bool) {
+) -> (bool, bool, Option<String>) {
     if !params.checkout_push {
         sink.on_step("Skipping push (disabled in config)");
-        return (false, true);
+        return (false, true, None);
     }
 
     sink.on_step(&format!(
@@ -558,27 +583,57 @@ fn push_if_enabled(
         params.remote_name, params.new_branch_name
     ));
 
-    let result = git
-        .push_set_upstream_from(
-            &params.remote_name,
-            &params.new_branch_name,
-            worktree_path,
-            &PushOptions::default(),
-        )
-        .and_then(PushIo::into_result);
+    let result = push_with_hooks(
+        git,
+        PushAction::SetUpstream {
+            remote: &params.remote_name,
+            branch: &params.new_branch_name,
+        },
+        worktree_path,
+        !params.no_verify,
+        &NoopStageRunner,
+        presenter,
+        None,
+    );
 
-    if let Err(e) = result {
-        sink.on_warning(&format!(
-            "Could not push '{}' to '{}': {}. The worktree is ready locally. Push manually with: git push -u {} {}",
-            params.new_branch_name, params.remote_name, e,
-            params.remote_name, params.new_branch_name
-        ));
-        (false, false)
-    } else {
-        sink.on_step(&format!(
-            "Push to '{}' and upstream tracking set successfully",
-            params.remote_name
-        ));
-        (true, false)
-    }
+    let failure = match result {
+        Ok(outcome) => match outcome.failure {
+            None => {
+                sink.on_step(&format!(
+                    "Push to '{}' and upstream tracking set successfully",
+                    params.remote_name
+                ));
+                return (true, false, None);
+            }
+            Some(msg) => {
+                let gated = matches!(outcome.hook, HookVerdict::Rejected | HookVerdict::Passed);
+                if gated {
+                    return (
+                        false,
+                        false,
+                        Some(format!(
+                            "Could not push '{}' to '{}' with the repo's pre-push hook in effect: {}. \
+                             The worktree was created and is ready at '{}'. Fix the hook failure and \
+                             push manually with: git push -u {} {} (or re-run with --no-verify)",
+                            params.new_branch_name,
+                            params.remote_name,
+                            msg,
+                            worktree_path.display(),
+                            params.remote_name,
+                            params.new_branch_name,
+                        )),
+                    );
+                }
+                msg
+            }
+        },
+        Err(e) => format!("{e}"),
+    };
+
+    sink.on_warning(&format!(
+        "Could not push '{}' to '{}': {}. The worktree is ready locally. Push manually with: git push -u {} {}",
+        params.new_branch_name, params.remote_name, failure,
+        params.remote_name, params.new_branch_name
+    ));
+    (false, false, None)
 }

--- a/src/core/worktree/mod.rs
+++ b/src/core/worktree/mod.rs
@@ -28,6 +28,7 @@ pub mod merge;
 pub mod merge_set_default;
 pub mod merged;
 pub mod porcelain;
+pub mod ports;
 pub mod previous;
 pub mod prune;
 pub mod push;

--- a/src/core/worktree/ports.rs
+++ b/src/core/worktree/ports.rs
@@ -1,0 +1,96 @@
+//! Ports owned by the worktree subsystem.
+//!
+//! Consumer-owns-port (see ARCHITECTURE.md "Hexagonal at subsystem
+//! boundaries"): the traits here describe what worktree operations need from
+//! the outside world, in the worktree subsystem's own vocabulary. Adapters
+//! live with their implementing subsystem. This is the first port outside
+//! `src/coordinator/` and follows the same shape.
+
+use crate::executor::presenter::JobPresenter;
+use anyhow::Result;
+use std::path::Path;
+use std::sync::Arc;
+
+/// One ref a push is updating, in the exact shape git feeds a `pre-push`
+/// hook on stdin: `<local-ref> <local-oid> <remote-ref> <remote-oid>` per
+/// line. Deletes use `(delete)` and the zero oid on the local side; refs
+/// new to the remote use the zero oid on the remote side.
+#[derive(Debug, Clone)]
+pub struct PushRef {
+    pub local_ref: String,
+    pub local_oid: String,
+    pub remote_ref: String,
+    pub remote_oid: String,
+}
+
+/// Result of running a daft-managed hook stage.
+#[derive(Debug, Clone)]
+pub struct StageOutcome {
+    /// Whether the stage completed successfully (gates the push).
+    pub success: bool,
+    /// Whether the stage was skipped rather than run.
+    pub skipped: bool,
+    /// Reason for skipping or failing, if any.
+    pub reason: Option<String>,
+}
+
+/// Port for daft-managed hook stages around git operations (issue #599
+/// declares it; #468 implements it).
+///
+/// A "stage" is a named gate like `pre-push`. When an adapter manages a
+/// stage, daft runs the stage itself (with per-job reporting through the
+/// presenter) and then performs the git operation with git's own hook
+/// dispatch suppressed, so a foreign incumbent hook is never double-fired —
+/// chaining it is the adapter's job. When no adapter manages the stage,
+/// callers fall back to Path A: git dispatches whatever `pre-push` hook is
+/// installed (native, lefthook, husky, pre-commit) as one opaque subprocess.
+///
+/// Trust gating lives behind this port too: an adapter must answer `false`
+/// for repos whose daft config is untrusted, degrading to Path A (git still
+/// runs the repo's own hooks; daft's stage is skipped).
+pub trait StageRunner {
+    /// Whether daft manages the given stage for the repo seen from
+    /// `repo_cwd` (a directory inside the repo — normally the worktree the
+    /// operation runs in; the adapter resolves git dirs itself).
+    ///
+    /// Called on every push, so implementations must stay cheap: stat-level
+    /// probes only, no subprocess spawns.
+    fn manages_stage(&self, stage: &str, repo_cwd: &Path) -> bool;
+
+    /// Run the stage. `worktree_cwd` is the worktree the triggering
+    /// operation targets; `refs` pins what the push is about to update.
+    /// Reporting flows through `presenter` (same surface lifecycle hooks
+    /// use), giving per-job fidelity that Path A's single opaque subprocess
+    /// cannot.
+    fn run_stage(
+        &self,
+        stage: &str,
+        worktree_cwd: Option<&Path>,
+        refs: &[PushRef],
+        presenter: Arc<dyn JobPresenter>,
+    ) -> Result<StageOutcome>;
+}
+
+/// The adapter used until #468 ships: daft manages no stages, so every push
+/// takes Path A. Mirrors the `NoopHookRunner` pattern in `core/mod.rs`.
+pub struct NoopStageRunner;
+
+impl StageRunner for NoopStageRunner {
+    fn manages_stage(&self, _stage: &str, _repo_cwd: &Path) -> bool {
+        false
+    }
+
+    fn run_stage(
+        &self,
+        _stage: &str,
+        _worktree_cwd: Option<&Path>,
+        _refs: &[PushRef],
+        _presenter: Arc<dyn JobPresenter>,
+    ) -> Result<StageOutcome> {
+        Ok(StageOutcome {
+            success: true,
+            skipped: true,
+            reason: Some("no stage runner configured".to_string()),
+        })
+    }
+}

--- a/src/core/worktree/push.rs
+++ b/src/core/worktree/push.rs
@@ -1,16 +1,22 @@
 //! Core logic for pushing worktree branches to their remotes.
 //!
 //! Used by `daft sync --push` to push all branches to their remote
-//! tracking branches after updating/rebasing.
+//! tracking branches after updating/rebasing, and home of
+//! [`push_with_hooks`] — the shared composition every daft push site
+//! routes through to honor and report `pre-push` hooks (#599).
 
 use crate::core::ProgressSink;
 use crate::core::worktree::fetch;
+use crate::core::worktree::ports::{PushRef, StageRunner};
+use crate::executor::presenter::JobPresenter;
 use crate::git::push_porcelain::parse_push_report;
-use crate::git::{GitCommand, PushIo, PushOptions};
+use crate::git::{GitCommand, PushIo, PushOptions, PushStream};
 use crate::utils::*;
 use anyhow::Result;
 use std::collections::HashSet;
 use std::path::Path;
+use std::sync::Arc;
+use std::time::Instant;
 
 /// Input parameters for the push operation.
 pub struct PushParams {
@@ -61,6 +67,318 @@ impl PushResult {
             .filter(|r| !r.success && !r.no_upstream)
             .count()
     }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// push_with_hooks — the shared seam every daft push site routes through
+// ─────────────────────────────────────────────────────────────────────────
+
+/// A daft-initiated push, named by intent. [`push_with_hooks`] dispatches to
+/// the matching `GitCommand` primitive.
+#[derive(Debug, Clone, Copy)]
+pub enum PushAction<'a> {
+    /// `git push --set-upstream <remote> <branch>`
+    SetUpstream { remote: &'a str, branch: &'a str },
+    /// `git push <remote> <branch>` (optionally `--force-with-lease`)
+    Sync {
+        remote: &'a str,
+        branch: &'a str,
+        force_with_lease: bool,
+    },
+    /// `git push <remote> --delete <branch>`
+    Delete { remote: &'a str, branch: &'a str },
+}
+
+impl PushAction<'_> {
+    fn branch(&self) -> &str {
+        match self {
+            PushAction::SetUpstream { branch, .. }
+            | PushAction::Sync { branch, .. }
+            | PushAction::Delete { branch, .. } => branch,
+        }
+    }
+
+    fn is_delete(&self) -> bool {
+        matches!(self, PushAction::Delete { .. })
+    }
+
+    fn remote(&self) -> &str {
+        match self {
+            PushAction::SetUpstream { remote, .. }
+            | PushAction::Sync { remote, .. }
+            | PushAction::Delete { remote, .. } => remote,
+        }
+    }
+
+    /// Human preview of the underlying git command (verbose job display).
+    fn preview(&self) -> String {
+        match self {
+            PushAction::SetUpstream { remote, branch } => {
+                format!("git push --set-upstream {remote} {branch}")
+            }
+            PushAction::Sync {
+                remote,
+                branch,
+                force_with_lease: false,
+            } => format!("git push {remote} {branch}"),
+            PushAction::Sync {
+                remote,
+                branch,
+                force_with_lease: true,
+            } => format!("git push --force-with-lease {remote} {branch}"),
+            PushAction::Delete { remote, branch } => {
+                format!("git push {remote} --delete {branch}")
+            }
+        }
+    }
+
+    fn run(&self, git: &GitCommand, cwd: &Path, opts: &PushOptions) -> Result<PushIo> {
+        match *self {
+            PushAction::SetUpstream { remote, branch } => {
+                git.push_set_upstream_from(remote, branch, cwd, opts)
+            }
+            PushAction::Sync {
+                remote,
+                branch,
+                force_with_lease,
+            } => git.push_from(remote, branch, cwd, force_with_lease, opts),
+            PushAction::Delete { remote, branch } => {
+                git.push_delete_from(remote, branch, cwd, opts)
+            }
+        }
+    }
+}
+
+/// Coarse verdict on the `pre-push` gate for one push.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HookVerdict {
+    /// No pre-push hook is installed; the push ran ungated.
+    NoHook,
+    /// A hook is installed and the push got past it (the push itself may
+    /// still have failed further along, e.g. non-fast-forward).
+    Passed,
+    /// The push failed before any ref was negotiated with a hook installed —
+    /// the local gate (or pre-negotiation transport) refused it.
+    Rejected,
+    /// The caller passed `--no-verify`; the installed hook was bypassed.
+    Bypassed,
+}
+
+/// Caller-facing result of [`push_with_hooks`]. `Err` from the function is
+/// reserved for spawn-level problems; a push that ran and failed lands here
+/// in `failure` so call sites can grade severity (warn vs abort) by verdict.
+#[derive(Debug)]
+pub struct PushOutcome {
+    /// Every pushed ref was already up to date (porcelain `=`).
+    pub up_to_date: bool,
+    pub hook: HookVerdict,
+    /// `Some(message)` when the push failed.
+    pub failure: Option<String>,
+}
+
+impl PushOutcome {
+    pub fn success(&self) -> bool {
+        self.failure.is_none()
+    }
+
+    pub fn hook_rejected(&self) -> bool {
+        self.hook == HookVerdict::Rejected
+    }
+
+    /// Collapse into the legacy contract: bail with the failure message.
+    pub fn into_result(self) -> Result<Self> {
+        match self.failure {
+            None => Ok(self),
+            Some(msg) => Err(anyhow::anyhow!(msg)),
+        }
+    }
+}
+
+/// Run one daft push with the repo's `pre-push` stage honored and reported.
+///
+/// Two paths (#599):
+/// - **Path B** — `stage.manages_stage("pre-push", cwd)`: daft runs its own
+///   stage (per-job reporting via `presenter`), then pushes with git's hook
+///   dispatch suppressed so an incumbent hook is not double-fired. Until
+///   #468 ships a real adapter, `NoopStageRunner` never takes this path.
+/// - **Path A** — otherwise: the push runs with hooks honored; git itself
+///   dispatches whatever `pre-push` hook is installed (native, lefthook,
+///   husky, pre-commit) as one opaque subprocess. When a hook exists and a
+///   presenter is given, the run is reported as a single synthetic
+///   `pre-push` phase + job carrying the teed git output — existence-gated
+///   so hook-less repos render nothing extra.
+///
+/// `verify: false` is the explicit `--no-verify` opt-out (the old behavior).
+/// `hook_present` short-circuits the existence probe when the caller
+/// already resolved it (e.g. once per repo for sync's many worktrees).
+pub fn push_with_hooks(
+    git: &GitCommand,
+    action: PushAction<'_>,
+    cwd: &Path,
+    verify: bool,
+    stage: &dyn StageRunner,
+    presenter: Option<&Arc<dyn JobPresenter>>,
+    hook_present: Option<bool>,
+) -> Result<PushOutcome> {
+    let hook_present = hook_present.unwrap_or_else(|| git.pre_push_hook_exists(cwd));
+
+    // Explicit opt-out: push with git's hook dispatch suppressed.
+    if !verify {
+        let io = action.run(
+            git,
+            cwd,
+            &PushOptions {
+                verify: false,
+                on_output: None,
+            },
+        )?;
+        return Ok(collapse(io, hook_present, true));
+    }
+
+    // Path B — daft owns the stage (#468 adapters; Noop never gets here).
+    if stage.manages_stage("pre-push", cwd) {
+        let refs = compute_push_refs(cwd, &action);
+        let stage_presenter = presenter
+            .map(Arc::clone)
+            .unwrap_or_else(|| crate::executor::presenter::NullPresenter::arc());
+        let outcome = stage.run_stage("pre-push", Some(cwd), &refs, stage_presenter)?;
+        if !outcome.success {
+            return Ok(PushOutcome {
+                up_to_date: false,
+                hook: HookVerdict::Rejected,
+                failure: Some(
+                    outcome
+                        .reason
+                        .unwrap_or_else(|| "pre-push stage failed".to_string()),
+                ),
+            });
+        }
+        // Stage passed: push without letting git re-fire the incumbent.
+        let io = action.run(
+            git,
+            cwd,
+            &PushOptions {
+                verify: false,
+                on_output: None,
+            },
+        )?;
+        let mut collapsed = collapse(io, hook_present, false);
+        if collapsed.hook == HookVerdict::Bypassed || collapsed.hook == HookVerdict::NoHook {
+            collapsed.hook = HookVerdict::Passed;
+        }
+        return Ok(collapsed);
+    }
+
+    // Path A — git dispatches the hook; report the opaque run when present.
+    match presenter {
+        Some(presenter) if hook_present => {
+            presenter.on_phase_start("pre-push", Some(action.branch()));
+            presenter.on_job_start("pre-push", None, Some(&action.preview()));
+            let started = Instant::now();
+            let tee = |_stream: PushStream, line: &str| {
+                presenter.on_job_output("pre-push", line);
+            };
+            let result = action.run(
+                git,
+                cwd,
+                &PushOptions {
+                    verify: true,
+                    on_output: Some(&tee),
+                },
+            );
+            let elapsed = started.elapsed();
+            match &result {
+                Ok(io) if io.success => presenter.on_job_success("pre-push", elapsed),
+                _ => presenter.on_job_failure("pre-push", elapsed),
+            }
+            presenter.on_phase_complete(elapsed);
+            Ok(collapse(result?, true, false))
+        }
+        _ => {
+            let io = action.run(git, cwd, &PushOptions::default())?;
+            Ok(collapse(io, hook_present, false))
+        }
+    }
+}
+
+/// Fold a finished push subprocess into the caller-facing outcome.
+fn collapse(io: PushIo, hook_present: bool, bypassed: bool) -> PushOutcome {
+    let report = parse_push_report(&io.stdout);
+    let hook = if !hook_present {
+        HookVerdict::NoHook
+    } else if bypassed {
+        HookVerdict::Bypassed
+    } else if !io.success && !report.has_ref_lines() {
+        // The push died before any ref was negotiated (E0: a pre-push
+        // refusal emits zero porcelain ref lines) — the gate said no.
+        HookVerdict::Rejected
+    } else {
+        HookVerdict::Passed
+    };
+
+    if io.success {
+        PushOutcome {
+            up_to_date: report.all_up_to_date(),
+            hook,
+            failure: None,
+        }
+    } else {
+        let stderr = io.stderr.trim();
+        let message = if stderr.is_empty() {
+            "Git push failed".to_string()
+        } else {
+            format!("Git push failed: {stderr}")
+        };
+        PushOutcome {
+            up_to_date: false,
+            hook,
+            failure: Some(message),
+        }
+    }
+}
+
+/// Best-effort construction of the refs a push will update, in the 4-field
+/// shape git feeds a `pre-push` hook (Path B's `run_stage` input). The zero
+/// oid is the protocol's "unknown/absent" on either side.
+fn compute_push_refs(cwd: &Path, action: &PushAction<'_>) -> Vec<PushRef> {
+    let branch_ref = format!("refs/heads/{}", action.branch());
+    let tracking_ref = format!("refs/remotes/{}/{}", action.remote(), action.branch());
+    let local_oid = rev_parse_oid(cwd, &branch_ref);
+    let remote_oid = rev_parse_oid(cwd, &tracking_ref);
+
+    if action.is_delete() {
+        vec![PushRef {
+            local_ref: "(delete)".to_string(),
+            local_oid: zero_oid_like(remote_oid.as_deref()),
+            remote_ref: branch_ref,
+            remote_oid: remote_oid.unwrap_or_else(|| zero_oid_like(None)),
+        }]
+    } else {
+        vec![PushRef {
+            local_ref: branch_ref.clone(),
+            local_oid: local_oid.clone().unwrap_or_else(|| zero_oid_like(None)),
+            remote_ref: branch_ref,
+            remote_oid: remote_oid.unwrap_or_else(|| zero_oid_like(local_oid.as_deref())),
+        }]
+    }
+}
+
+fn rev_parse_oid(cwd: &Path, refname: &str) -> Option<String> {
+    let mut cmd = git_command_at(cwd);
+    cmd.args(["rev-parse", "--verify", "--quiet", refname]);
+    cmd.stdin(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+    let output = cmd.output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let oid = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!oid.is_empty()).then_some(oid)
+}
+
+/// Zero oid sized to match its counterpart (SHA-1 vs SHA-256 repos).
+fn zero_oid_like(counterpart: Option<&str>) -> String {
+    "0".repeat(counterpart.map_or(40, str::len))
 }
 
 /// Execute the push operation across all worktrees (sequential path).
@@ -186,5 +504,457 @@ pub fn push_single_worktree(
                 ..Default::default()
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::worktree::ports::{NoopStageRunner, StageOutcome};
+    use std::process::Stdio;
+    use std::sync::Mutex;
+    use std::time::Duration;
+
+    // ── Pure collapse() classification ──────────────────────────────────
+
+    fn io(success: bool, stdout: &str, stderr: &str) -> PushIo {
+        PushIo {
+            success,
+            stdout: stdout.to_string(),
+            stderr: stderr.to_string(),
+        }
+    }
+
+    const UP_TO_DATE: &str = "To /tmp/r.git\n=\trefs/heads/b:refs/heads/b\t[up to date]\nDone\n";
+    const PUSHED: &str = "To /tmp/r.git\n \trefs/heads/b:refs/heads/b\ta..b\nDone\n";
+    const NON_FF: &str =
+        "To /tmp/r.git\n!\trefs/heads/b:refs/heads/b\t[rejected] (non-fast-forward)\nDone\n";
+
+    #[test]
+    fn collapse_success_without_hook() {
+        let outcome = collapse(io(true, PUSHED, ""), false, false);
+        assert!(outcome.success());
+        assert!(!outcome.up_to_date);
+        assert_eq!(outcome.hook, HookVerdict::NoHook);
+    }
+
+    #[test]
+    fn collapse_up_to_date_with_passing_hook() {
+        let outcome = collapse(io(true, UP_TO_DATE, ""), true, false);
+        assert!(outcome.success());
+        assert!(outcome.up_to_date);
+        assert_eq!(outcome.hook, HookVerdict::Passed);
+    }
+
+    #[test]
+    fn collapse_gate_refusal_is_rejected() {
+        // Hook refusals die before ref negotiation: no porcelain ref lines.
+        let outcome = collapse(io(false, "HOOK NOISE\n", "HOOK SAYS NO\n"), true, false);
+        assert!(!outcome.success());
+        assert_eq!(outcome.hook, HookVerdict::Rejected);
+        assert!(outcome.failure.unwrap().contains("HOOK SAYS NO"));
+    }
+
+    #[test]
+    fn collapse_non_ff_failure_means_hook_passed() {
+        let outcome = collapse(io(false, NON_FF, "error: failed to push\n"), true, false);
+        assert!(!outcome.success());
+        assert_eq!(outcome.hook, HookVerdict::Passed);
+    }
+
+    #[test]
+    fn collapse_bypass_wins_over_rejection_shape() {
+        let outcome = collapse(io(true, PUSHED, ""), true, true);
+        assert_eq!(outcome.hook, HookVerdict::Bypassed);
+    }
+
+    // ── Recording fakes (reconcile.rs fake-adapter shape) ───────────────
+
+    #[derive(Default)]
+    struct RecordingPresenter {
+        events: Mutex<Vec<String>>,
+    }
+
+    impl RecordingPresenter {
+        fn arc() -> Arc<Self> {
+            Arc::new(Self::default())
+        }
+
+        fn events(&self) -> Vec<String> {
+            self.events.lock().unwrap().clone()
+        }
+
+        fn push(&self, event: String) {
+            self.events.lock().unwrap().push(event);
+        }
+    }
+
+    impl JobPresenter for RecordingPresenter {
+        fn on_phase_start(&self, phase_name: &str, target: Option<&str>) {
+            self.push(format!(
+                "phase_start:{phase_name}:{}",
+                target.unwrap_or("-")
+            ));
+        }
+        fn on_job_start(&self, name: &str, _d: Option<&str>, _c: Option<&str>) {
+            self.push(format!("job_start:{name}"));
+        }
+        fn on_job_output(&self, name: &str, line: &str) {
+            self.push(format!("job_output:{name}:{line}"));
+        }
+        fn on_job_success(&self, name: &str, _duration: Duration) {
+            self.push(format!("job_success:{name}"));
+        }
+        fn on_job_failure(&self, name: &str, _duration: Duration) {
+            self.push(format!("job_failure:{name}"));
+        }
+        fn on_job_skipped(&self, name: &str, _r: &str, _d: Duration, _s: bool, _c: Option<&str>) {
+            self.push(format!("job_skipped:{name}"));
+        }
+        fn on_job_cancelled(&self, name: &str, _duration: Duration) {
+            self.push(format!("job_cancelled:{name}"));
+        }
+        fn on_job_background(&self, name: &str, _description: Option<&str>) {
+            self.push(format!("job_background:{name}"));
+        }
+        fn on_message(&self, msg: &str) {
+            self.push(format!("message:{msg}"));
+        }
+        fn on_phase_complete(&self, _total_duration: Duration) {
+            self.push("phase_complete".to_string());
+        }
+        fn take_results(&self) -> Vec<crate::executor::JobResult> {
+            Vec::new()
+        }
+    }
+
+    /// Fake Path-B adapter: manages `pre-push`, records calls, returns a
+    /// scripted verdict.
+    struct FakeStageRunner {
+        succeed: bool,
+        calls: Mutex<Vec<(String, Vec<PushRef>)>>,
+    }
+
+    impl FakeStageRunner {
+        fn new(succeed: bool) -> Self {
+            Self {
+                succeed,
+                calls: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    impl StageRunner for FakeStageRunner {
+        fn manages_stage(&self, stage: &str, _repo_cwd: &Path) -> bool {
+            stage == "pre-push"
+        }
+
+        fn run_stage(
+            &self,
+            stage: &str,
+            _worktree_cwd: Option<&Path>,
+            refs: &[PushRef],
+            _presenter: Arc<dyn JobPresenter>,
+        ) -> Result<StageOutcome> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push((stage.to_string(), refs.to_vec()));
+            Ok(StageOutcome {
+                success: self.succeed,
+                skipped: false,
+                reason: (!self.succeed).then(|| "stage job failed".to_string()),
+            })
+        }
+    }
+
+    // ── End-to-end against real git in isolated temp repos ──────────────
+
+    struct TestRepo {
+        _dir: tempfile::TempDir,
+        work: std::path::PathBuf,
+        remote: std::path::PathBuf,
+    }
+
+    fn git_in(dir: &Path, args: &[&str]) -> std::process::Output {
+        let mut cmd = git_command_at(dir);
+        cmd.args(args)
+            .envs([
+                ("GIT_AUTHOR_NAME", "Test"),
+                ("GIT_AUTHOR_EMAIL", "test@test.com"),
+                ("GIT_COMMITTER_NAME", "Test"),
+                ("GIT_COMMITTER_EMAIL", "test@test.com"),
+            ])
+            .stdin(Stdio::null());
+        cmd.output().expect("git invocation failed")
+    }
+
+    fn assert_git(dir: &Path, args: &[&str]) {
+        let out = git_in(dir, args);
+        assert!(
+            out.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    /// Local bare remote + one-commit clone on branch `main`.
+    fn test_repo() -> TestRepo {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let remote = dir.path().join("remote.git");
+        let work = dir.path().join("work");
+        std::fs::create_dir_all(&remote).unwrap();
+        assert_git(&remote, &["init", "--bare", "--quiet", "."]);
+        std::fs::create_dir_all(&work).unwrap();
+        assert_git(&work, &["init", "--quiet", "-b", "main", "."]);
+        assert_git(
+            &work,
+            &["remote", "add", "origin", remote.to_str().unwrap()],
+        );
+        std::fs::write(work.join("a.txt"), "hi\n").unwrap();
+        assert_git(&work, &["add", "a.txt"]);
+        assert_git(&work, &["commit", "--quiet", "-m", "init"]);
+        TestRepo {
+            _dir: dir,
+            work,
+            remote,
+        }
+    }
+
+    fn install_pre_push(repo: &TestRepo, script: &str) {
+        let hooks = repo.work.join(".git/hooks");
+        std::fs::create_dir_all(&hooks).unwrap();
+        let hook = hooks.join("pre-push");
+        std::fs::write(&hook, script).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&hook, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+    }
+
+    fn remote_has_branch(repo: &TestRepo, branch: &str) -> bool {
+        let out = git_in(
+            &repo.remote,
+            &["show-ref", "--verify", &format!("refs/heads/{branch}")],
+        );
+        out.status.success()
+    }
+
+    fn sync_main<'a>() -> PushAction<'a> {
+        PushAction::Sync {
+            remote: "origin",
+            branch: "main",
+            force_with_lease: false,
+        }
+    }
+
+    #[test]
+    fn failing_hook_rejects_push_and_reports_synthetic_job() {
+        let repo = test_repo();
+        install_pre_push(&repo, "#!/bin/sh\necho \"GATE SAYS NO\" >&2\nexit 1\n");
+        let git = GitCommand::new(false);
+        let presenter = RecordingPresenter::arc();
+        let presenter_dyn: Arc<dyn JobPresenter> = presenter.clone();
+
+        let outcome = push_with_hooks(
+            &git,
+            sync_main(),
+            &repo.work,
+            true,
+            &NoopStageRunner,
+            Some(&presenter_dyn),
+            None,
+        )
+        .unwrap();
+
+        assert!(!outcome.success());
+        assert_eq!(outcome.hook, HookVerdict::Rejected);
+        assert!(outcome.failure.as_deref().unwrap().contains("GATE SAYS NO"));
+        assert!(!remote_has_branch(&repo, "main"), "push must be blocked");
+
+        let events = presenter.events();
+        assert_eq!(events.first().unwrap(), "phase_start:pre-push:main");
+        assert!(events.contains(&"job_start:pre-push".to_string()));
+        assert!(
+            events
+                .iter()
+                .any(|e| e.starts_with("job_output:pre-push:") && e.contains("GATE SAYS NO")),
+            "hook stderr must be teed through the presenter: {events:?}"
+        );
+        assert!(events.contains(&"job_failure:pre-push".to_string()));
+        assert_eq!(events.last().unwrap(), "phase_complete");
+    }
+
+    #[test]
+    fn passing_hook_allows_push_and_reports_success() {
+        let repo = test_repo();
+        install_pre_push(&repo, "#!/bin/sh\necho \"gate ok\"\nexit 0\n");
+        let git = GitCommand::new(false);
+        let presenter = RecordingPresenter::arc();
+        let presenter_dyn: Arc<dyn JobPresenter> = presenter.clone();
+
+        let outcome = push_with_hooks(
+            &git,
+            sync_main(),
+            &repo.work,
+            true,
+            &NoopStageRunner,
+            Some(&presenter_dyn),
+            None,
+        )
+        .unwrap();
+
+        assert!(outcome.success(), "failure: {:?}", outcome.failure);
+        assert_eq!(outcome.hook, HookVerdict::Passed);
+        assert!(!outcome.up_to_date);
+        assert!(remote_has_branch(&repo, "main"));
+        let events = presenter.events();
+        assert!(events.contains(&"job_success:pre-push".to_string()));
+    }
+
+    #[test]
+    fn no_verify_bypasses_failing_hook_without_phase() {
+        let repo = test_repo();
+        install_pre_push(&repo, "#!/bin/sh\nexit 1\n");
+        let git = GitCommand::new(false);
+        let presenter = RecordingPresenter::arc();
+        let presenter_dyn: Arc<dyn JobPresenter> = presenter.clone();
+
+        let outcome = push_with_hooks(
+            &git,
+            sync_main(),
+            &repo.work,
+            false, // --no-verify passthrough
+            &NoopStageRunner,
+            Some(&presenter_dyn),
+            None,
+        )
+        .unwrap();
+
+        assert!(outcome.success());
+        assert_eq!(outcome.hook, HookVerdict::Bypassed);
+        assert!(remote_has_branch(&repo, "main"));
+        assert!(
+            presenter.events().is_empty(),
+            "bypassed pushes render no synthetic phase"
+        );
+    }
+
+    #[test]
+    fn hookless_repo_renders_no_phase() {
+        let repo = test_repo();
+        let git = GitCommand::new(false);
+        let presenter = RecordingPresenter::arc();
+        let presenter_dyn: Arc<dyn JobPresenter> = presenter.clone();
+
+        let outcome = push_with_hooks(
+            &git,
+            sync_main(),
+            &repo.work,
+            true,
+            &NoopStageRunner,
+            Some(&presenter_dyn),
+            None,
+        )
+        .unwrap();
+
+        assert!(outcome.success());
+        assert_eq!(outcome.hook, HookVerdict::NoHook);
+        assert!(
+            presenter.events().is_empty(),
+            "existence gate must suppress the synthetic phase"
+        );
+    }
+
+    #[test]
+    fn up_to_date_detection_survives_hook_reporting() {
+        let repo = test_repo();
+        install_pre_push(&repo, "#!/bin/sh\nexit 0\n");
+        let git = GitCommand::new(false);
+
+        let first = push_with_hooks(
+            &git,
+            sync_main(),
+            &repo.work,
+            true,
+            &NoopStageRunner,
+            None,
+            None,
+        )
+        .unwrap();
+        assert!(first.success() && !first.up_to_date);
+
+        let second = push_with_hooks(
+            &git,
+            sync_main(),
+            &repo.work,
+            true,
+            &NoopStageRunner,
+            None,
+            None,
+        )
+        .unwrap();
+        assert!(second.success());
+        assert!(second.up_to_date, "second push must classify as up-to-date");
+    }
+
+    #[test]
+    fn managing_stage_runner_failure_blocks_push() {
+        let repo = test_repo();
+        let git = GitCommand::new(false);
+        let runner = FakeStageRunner::new(false);
+
+        let outcome =
+            push_with_hooks(&git, sync_main(), &repo.work, true, &runner, None, None).unwrap();
+
+        assert!(!outcome.success());
+        assert_eq!(outcome.hook, HookVerdict::Rejected);
+        assert!(
+            !remote_has_branch(&repo, "main"),
+            "stage failure gates the push"
+        );
+
+        let calls = runner.calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        let (stage, refs) = &calls[0];
+        assert_eq!(stage, "pre-push");
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].local_ref, "refs/heads/main");
+        assert_ne!(refs[0].local_oid, zero_oid_like(None));
+        assert_eq!(refs[0].remote_oid, zero_oid_like(None), "new remote ref");
+    }
+
+    #[test]
+    fn managing_stage_runner_success_pushes_without_refiring_incumbent() {
+        let repo = test_repo();
+        // A failing native hook proves Path B suppresses git's dispatch:
+        // if git re-fired it, the push would be rejected.
+        install_pre_push(&repo, "#!/bin/sh\nexit 1\n");
+        let git = GitCommand::new(false);
+        let runner = FakeStageRunner::new(true);
+
+        let outcome =
+            push_with_hooks(&git, sync_main(), &repo.work, true, &runner, None, None).unwrap();
+
+        assert!(outcome.success(), "failure: {:?}", outcome.failure);
+        assert_eq!(outcome.hook, HookVerdict::Passed);
+        assert!(remote_has_branch(&repo, "main"));
+    }
+
+    #[test]
+    fn delete_action_builds_delete_shaped_refs() {
+        let repo = test_repo();
+        let refs = compute_push_refs(
+            &repo.work,
+            &PushAction::Delete {
+                remote: "origin",
+                branch: "main",
+            },
+        );
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].local_ref, "(delete)");
+        assert_eq!(refs[0].remote_ref, "refs/heads/main");
+        assert_eq!(refs[0].local_oid, zero_oid_like(None));
     }
 }

--- a/src/core/worktree/push.rs
+++ b/src/core/worktree/push.rs
@@ -24,6 +24,8 @@ pub struct PushParams {
     pub force_with_lease: bool,
     /// Name of the remote (e.g. "origin").
     pub remote_name: String,
+    /// Skip the repo's pre-push hook (`--no-verify` passthrough).
+    pub no_verify: bool,
 }
 
 /// Result of pushing a single worktree branch.
@@ -36,6 +38,8 @@ pub struct WorktreePushResult {
     pub up_to_date: bool,
     /// Branch has no remote tracking branch.
     pub no_upstream: bool,
+    /// Verdict on the repo's pre-push gate for this push.
+    pub hook: HookVerdict,
     pub message: String,
 }
 
@@ -65,6 +69,21 @@ impl PushResult {
         self.results
             .iter()
             .filter(|r| !r.success && !r.no_upstream)
+            .count()
+    }
+
+    /// Failures that happened with a pre-push hook installed and honored.
+    /// These escalate to a non-zero exit (#599): a gate saying no must not
+    /// be reduced to a warning. Hook-less or `--no-verify` failures keep the
+    /// legacy warn-and-continue ergonomics.
+    pub fn gated_failure_count(&self) -> usize {
+        self.results
+            .iter()
+            .filter(|r| {
+                !r.success
+                    && !r.no_upstream
+                    && matches!(r.hook, HookVerdict::Rejected | HookVerdict::Passed)
+            })
             .count()
     }
 }
@@ -150,9 +169,10 @@ impl PushAction<'_> {
 }
 
 /// Coarse verdict on the `pre-push` gate for one push.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum HookVerdict {
     /// No pre-push hook is installed; the push ran ungated.
+    #[default]
     NoHook,
     /// A hook is installed and the push got past it (the push itself may
     /// still have failed further along, e.g. non-fast-forward).
@@ -388,9 +408,14 @@ pub fn execute(
     project_root: &Path,
     progress: &mut dyn ProgressSink,
     exclude_branches: &HashSet<String>,
+    stage: &dyn StageRunner,
+    presenter: Option<&Arc<dyn JobPresenter>>,
 ) -> Result<PushResult> {
     let original_dir = get_current_directory()?;
     let worktrees = fetch::get_all_worktrees_with_branches(git)?;
+
+    // All worktrees share one hooks dir — probe once for the whole pass.
+    let hook_present = git.pre_push_hook_exists(project_root);
 
     let mut results: Vec<WorktreePushResult> = Vec::new();
 
@@ -408,7 +433,17 @@ pub fn execute(
 
         progress.on_step(&format!("Pushing '{worktree_name}'"));
 
-        let result = push_single_worktree(git, path, &worktree_name, branch, params, progress);
+        let result = push_single_worktree(
+            git,
+            path,
+            &worktree_name,
+            branch,
+            params,
+            progress,
+            stage,
+            presenter,
+            Some(hook_present),
+        );
         results.push(result);
     }
 
@@ -424,6 +459,10 @@ pub fn execute(
 ///
 /// Checks for an upstream tracking remote first; skips if none is set.
 /// Uses an explicit working directory for thread-safe parallel execution.
+///
+/// `hook_present` short-circuits the per-push hook probe when the caller
+/// already resolved it for the repo (all worktrees share one hooks dir).
+#[allow(clippy::too_many_arguments)]
 pub fn push_single_worktree(
     git: &GitCommand,
     worktree_path: &Path,
@@ -431,6 +470,9 @@ pub fn push_single_worktree(
     branch_name: &str,
     params: &PushParams,
     progress: &mut dyn ProgressSink,
+    stage: &dyn StageRunner,
+    presenter: Option<&Arc<dyn JobPresenter>>,
+    hook_present: Option<bool>,
 ) -> WorktreePushResult {
     // Verify directory exists
     if !worktree_path.is_dir() {
@@ -468,30 +510,47 @@ pub fn push_single_worktree(
         Ok(Some(_)) => {}
     }
 
-    // Run git push with explicit working directory (thread-safe)
-    match git
-        .push_from(
-            &params.remote_name,
-            branch_name,
-            worktree_path,
-            params.force_with_lease,
-            &PushOptions::default(),
-        )
-        .and_then(PushIo::into_result)
-    {
-        Ok(io) => {
-            let up_to_date = parse_push_report(&io.stdout).all_up_to_date();
-            WorktreePushResult {
-                worktree_name: worktree_name.to_string(),
-                branch_name: branch_name.to_string(),
-                success: true,
-                up_to_date,
-                message: if up_to_date {
-                    "Already up to date".to_string()
-                } else {
-                    "Pushed successfully".to_string()
+    let action = PushAction::Sync {
+        remote: &params.remote_name,
+        branch: branch_name,
+        force_with_lease: params.force_with_lease,
+    };
+
+    match push_with_hooks(
+        git,
+        action,
+        worktree_path,
+        !params.no_verify,
+        stage,
+        presenter,
+        hook_present,
+    ) {
+        Ok(outcome) => {
+            let hook = outcome.hook;
+            match outcome.failure {
+                None => WorktreePushResult {
+                    worktree_name: worktree_name.to_string(),
+                    branch_name: branch_name.to_string(),
+                    success: true,
+                    up_to_date: outcome.up_to_date,
+                    hook,
+                    message: if outcome.up_to_date {
+                        "Already up to date".to_string()
+                    } else {
+                        "Pushed successfully".to_string()
+                    },
+                    ..Default::default()
                 },
-                ..Default::default()
+                Some(msg) => {
+                    progress.on_warning(&format!("Failed to push '{worktree_name}': {msg}"));
+                    WorktreePushResult {
+                        worktree_name: worktree_name.to_string(),
+                        branch_name: branch_name.to_string(),
+                        hook,
+                        message: msg,
+                        ..Default::default()
+                    }
+                }
             }
         }
         Err(e) => {

--- a/src/core/worktree/push.rs
+++ b/src/core/worktree/push.rs
@@ -5,7 +5,8 @@
 
 use crate::core::ProgressSink;
 use crate::core::worktree::fetch;
-use crate::git::GitCommand;
+use crate::git::push_porcelain::parse_push_report;
+use crate::git::{GitCommand, PushIo, PushOptions};
 use crate::utils::*;
 use anyhow::Result;
 use std::collections::HashSet;
@@ -150,15 +151,18 @@ pub fn push_single_worktree(
     }
 
     // Run git push with explicit working directory (thread-safe)
-    match git.push_from(
-        &params.remote_name,
-        branch_name,
-        worktree_path,
-        params.force_with_lease,
-    ) {
-        Ok(output) => {
-            let up_to_date = output.contains("Everything up-to-date")
-                || output.contains("everything up-to-date");
+    match git
+        .push_from(
+            &params.remote_name,
+            branch_name,
+            worktree_path,
+            params.force_with_lease,
+            &PushOptions::default(),
+        )
+        .and_then(PushIo::into_result)
+    {
+        Ok(io) => {
+            let up_to_date = parse_push_report(&io.stdout).all_up_to_date();
             WorktreePushResult {
                 worktree_name: worktree_name.to_string(),
                 branch_name: branch_name.to_string(),

--- a/src/core/worktree/push.rs
+++ b/src/core/worktree/push.rs
@@ -184,6 +184,40 @@ pub enum HookVerdict {
     Bypassed,
 }
 
+impl HookVerdict {
+    /// Honest, one-line cause for a *failed* gated push, framed to what daft
+    /// can actually observe on Path A — git's hook dispatch is opaque, so daft
+    /// only sees whether any ref was negotiated before the push died:
+    /// - `Rejected`: nothing was negotiated. The repo's pre-push hook refusing
+    ///   the push produces this, but so does a pre-negotiation transport error
+    ///   (unreachable remote, auth). #599 deliberately does not parse
+    ///   locale-dependent stderr to tell them apart, so the message names both
+    ///   rather than asserting the hook is to blame.
+    /// - `Passed`: refs were negotiated, so the hook accepted the push; the
+    ///   remote rejected it downstream (non-fast-forward, permissions).
+    ///
+    /// The underlying git error travels separately (in `PushOutcome::failure`)
+    /// and carries the real diagnostic; this only frames it.
+    pub fn failure_cause(self) -> &'static str {
+        match self {
+            HookVerdict::Rejected => {
+                "the repo's pre-push hook may have blocked it, or the remote was unreachable"
+            }
+            HookVerdict::Passed => "the pre-push hook passed but the remote rejected the push",
+            HookVerdict::Bypassed | HookVerdict::NoHook => "the push failed",
+        }
+    }
+
+    /// Whether re-running with `--no-verify` could plausibly let the push
+    /// through. Only when the push never negotiated a ref (`Rejected`) is a
+    /// local pre-push hook a candidate cause; a `Passed` push already cleared
+    /// the hook, so bypassing it would not change a downstream remote
+    /// rejection.
+    pub fn no_verify_might_help(self) -> bool {
+        matches!(self, HookVerdict::Rejected)
+    }
+}
+
 /// Caller-facing result of [`push_with_hooks`]. `Err` from the function is
 /// reserved for spawn-level problems; a push that ran and failed lands here
 /// in `failure` so call sites can grade severity (warn vs abort) by verdict.
@@ -307,6 +341,12 @@ pub fn push_with_hooks(
                 },
             );
             let elapsed = started.elapsed();
+            // The synthetic job tracks the whole `git push` subprocess, so a
+            // failure here marks `pre-push: ✗` even when the hook passed and
+            // the push died later (non-fast-forward, transport). That coarse
+            // attribution is the accepted Path A tradeoff — git's hook dispatch
+            // is opaque, so daft can't pin the failure on the hook specifically.
+            // The caller-facing message disambiguates via `HookVerdict`.
             match &result {
                 Ok(io) if io.success => presenter.on_job_success("pre-push", elapsed),
                 _ => presenter.on_job_failure("pre-push", elapsed),
@@ -625,6 +665,44 @@ mod tests {
     fn collapse_bypass_wins_over_rejection_shape() {
         let outcome = collapse(io(true, PUSHED, ""), true, true);
         assert_eq!(outcome.hook, HookVerdict::Bypassed);
+    }
+
+    #[test]
+    fn failure_cause_does_not_blame_the_hook_for_a_rejected_push() {
+        // A `Rejected` push died before ref negotiation — that is the hook OR a
+        // transport error, and daft must not assert the hook is to blame (the
+        // review's Medium finding). The phrasing names both possibilities.
+        let cause = HookVerdict::Rejected.failure_cause();
+        assert!(
+            cause.contains("pre-push hook"),
+            "names the hook as a candidate"
+        );
+        assert!(
+            cause.contains("unreachable"),
+            "also names transport failure so a network error isn't blamed on the hook: {cause}"
+        );
+    }
+
+    #[test]
+    fn failure_cause_for_passed_blames_the_remote_not_the_hook() {
+        // A `Passed` push cleared the hook; a downstream failure is the remote's
+        // (non-fast-forward, perms). The message must not imply the hook rejected.
+        let cause = HookVerdict::Passed.failure_cause();
+        assert!(cause.contains("passed"), "states the hook passed");
+        assert!(
+            cause.contains("remote rejected"),
+            "attributes the failure to the remote"
+        );
+    }
+
+    #[test]
+    fn no_verify_hint_only_offered_when_the_hook_is_a_candidate() {
+        // `--no-verify` bypasses the local hook, so it only helps a `Rejected`
+        // push; a `Passed`-then-failed push would fail the same way bypassed.
+        assert!(HookVerdict::Rejected.no_verify_might_help());
+        assert!(!HookVerdict::Passed.no_verify_might_help());
+        assert!(!HookVerdict::NoHook.no_verify_might_help());
+        assert!(!HookVerdict::Bypassed.no_verify_might_help());
     }
 
     // ── Recording fakes (reconcile.rs fake-adapter shape) ───────────────

--- a/src/core/worktree/rename.rs
+++ b/src/core/worktree/rename.rs
@@ -7,7 +7,7 @@ use crate::core::multi_remote::path::{
     calculate_worktree_path, extract_remote_from_path, resolve_remote_for_branch,
 };
 use crate::core::{HookRunner, ProgressSink};
-use crate::git::GitCommand;
+use crate::git::{GitCommand, PushIo, PushOptions};
 use crate::hooks::move_hooks::{MoveHookParams, run_setup_hooks, run_teardown_hooks};
 use crate::hooks::tracking::TrackedAttribute;
 use crate::{get_git_common_dir, get_project_root};
@@ -256,15 +256,31 @@ pub fn execute(
                     "Pushing '{}/{}' to remote...",
                     remote, params.new_branch
                 ));
-                match git.push_set_upstream_from(remote, &params.new_branch, &new_path) {
-                    Ok(()) => {
+                match git
+                    .push_set_upstream_from(
+                        remote,
+                        &params.new_branch,
+                        &new_path,
+                        &PushOptions::default(),
+                    )
+                    .and_then(PushIo::into_result)
+                {
+                    Ok(_) => {
                         // Delete old remote branch.
                         sink.on_step(&format!(
                             "Deleting old remote branch '{}/{}'...",
                             remote, old_branch
                         ));
-                        match git.push_delete(remote, &old_branch) {
-                            Ok(()) => {
+                        match git
+                            .push_delete_from(
+                                remote,
+                                &old_branch,
+                                &new_path,
+                                &PushOptions::default(),
+                            )
+                            .and_then(PushIo::into_result)
+                        {
+                            Ok(_) => {
                                 remote_renamed = true;
                                 sink.on_step("Remote branch renamed successfully");
                             }

--- a/src/core/worktree/rename.rs
+++ b/src/core/worktree/rename.rs
@@ -6,14 +6,18 @@
 use crate::core::multi_remote::path::{
     calculate_worktree_path, extract_remote_from_path, resolve_remote_for_branch,
 };
+use crate::core::worktree::ports::NoopStageRunner;
+use crate::core::worktree::push::{HookVerdict, PushAction, push_with_hooks};
 use crate::core::{HookRunner, ProgressSink};
-use crate::git::{GitCommand, PushIo, PushOptions};
+use crate::executor::presenter::JobPresenter;
+use crate::git::GitCommand;
 use crate::hooks::move_hooks::{MoveHookParams, run_setup_hooks, run_teardown_hooks};
 use crate::hooks::tracking::TrackedAttribute;
 use crate::{get_git_common_dir, get_project_root};
 use anyhow::{Context, Result};
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 /// Input parameters for the rename operation.
 pub struct RenameParams {
@@ -35,6 +39,8 @@ pub struct RenameParams {
     pub multi_remote_enabled: bool,
     /// Default remote for multi-remote mode.
     pub multi_remote_default: String,
+    /// Skip the repo's pre-push hook on remote operations (`--no-verify`).
+    pub no_verify: bool,
 }
 
 /// Result of a rename operation.
@@ -59,6 +65,11 @@ pub struct RenameResult {
     pub dry_run: bool,
     /// Non-fatal warnings collected during the operation.
     pub warnings: Vec<String>,
+    /// A push failure with the repo's pre-push hook in effect. The command
+    /// layer fails with this AFTER writing the cd redirect — the worktree
+    /// moved, so the shell must be re-pointed even when the command errors
+    /// (#599).
+    pub push_gate_error: Option<String>,
 }
 
 use super::porcelain::{WorktreeListEntry, parse_worktree_list_porcelain};
@@ -68,6 +79,7 @@ use super::porcelain::{WorktreeListEntry, parse_worktree_list_porcelain};
 /// Execute the rename operation.
 pub fn execute(
     params: &RenameParams,
+    presenter: Option<&Arc<dyn JobPresenter>>,
     sink: &mut (impl ProgressSink + HookRunner),
 ) -> Result<RenameResult> {
     let git = GitCommand::new(params.is_quiet).with_gitoxide(params.use_gitoxide);
@@ -175,6 +187,7 @@ pub fn execute(
             cd_target,
             dry_run: true,
             warnings: Vec::new(),
+            push_gate_error: None,
         });
     }
 
@@ -240,7 +253,11 @@ pub fn execute(
     run_setup_hooks(&move_params, sink);
 
     // Step 7: Remote operations (if applicable and not --no-remote).
+    // A push failure with the repo's pre-push hook in effect escalates to a
+    // command failure (#599) — deferred so the remaining local steps still
+    // run and the rename is left in a consistent, fully-reported state.
     let mut remote_renamed = false;
+    let mut push_gate_error: Option<String> = None;
     if !params.no_remote {
         let remote =
             resolve_remote_for_branch(&git, &params.new_branch, None, &params.remote_name).ok();
@@ -256,47 +273,66 @@ pub fn execute(
                     "Pushing '{}/{}' to remote...",
                     remote, params.new_branch
                 ));
-                match git
-                    .push_set_upstream_from(
+                match run_remote_rename_push(
+                    &git,
+                    PushAction::SetUpstream {
                         remote,
-                        &params.new_branch,
-                        &new_path,
-                        &PushOptions::default(),
-                    )
-                    .and_then(PushIo::into_result)
-                {
-                    Ok(_) => {
+                        branch: &params.new_branch,
+                    },
+                    &new_path,
+                    params,
+                    presenter,
+                ) {
+                    Ok(()) => {
                         // Delete old remote branch.
                         sink.on_step(&format!(
                             "Deleting old remote branch '{}/{}'...",
                             remote, old_branch
                         ));
-                        match git
-                            .push_delete_from(
+                        match run_remote_rename_push(
+                            &git,
+                            PushAction::Delete {
                                 remote,
-                                &old_branch,
-                                &new_path,
-                                &PushOptions::default(),
-                            )
-                            .and_then(PushIo::into_result)
-                        {
-                            Ok(_) => {
+                                branch: &old_branch,
+                            },
+                            &new_path,
+                            params,
+                            presenter,
+                        ) {
+                            Ok(()) => {
                                 remote_renamed = true;
                                 sink.on_step("Remote branch renamed successfully");
                             }
-                            Err(e) => {
+                            Err(PushFailure::Gated(msg)) => {
+                                push_gate_error = Some(format!(
+                                    "Could not delete old remote branch '{remote}/{old_branch}' \
+                                     with the repo's pre-push hook in effect: {msg}. The branch \
+                                     was renamed locally and '{remote}/{}' was pushed; delete the \
+                                     old remote branch manually with: git push {remote} --delete \
+                                     {old_branch} (or re-run with --no-verify)",
+                                    params.new_branch
+                                ));
+                            }
+                            Err(PushFailure::Other(e)) => {
                                 warnings.push(format!(
-                                    "Failed to delete old remote branch '{}/{}': {e}",
-                                    remote, old_branch
+                                    "Failed to delete old remote branch '{remote}/{old_branch}': {e}"
                                 ));
                                 sink.on_warning(&format!(
-                                    "Could not delete old remote branch '{}/{}': {e}",
-                                    remote, old_branch
+                                    "Could not delete old remote branch '{remote}/{old_branch}': {e}"
                                 ));
                             }
                         }
                     }
-                    Err(e) => {
+                    Err(PushFailure::Gated(msg)) => {
+                        push_gate_error = Some(format!(
+                            "Could not push '{remote}/{}' with the repo's pre-push hook in \
+                             effect: {msg}. The branch was renamed locally; the remote still \
+                             has '{old_branch}'. Fix the hook failure and push manually with: \
+                             git push --set-upstream {remote} {} (or re-run with --no-verify)",
+                            params.new_branch, params.new_branch
+                        ));
+                    }
+                    Err(PushFailure::Other(e)) => {
                         warnings.push(format!("Failed to push new branch to remote: {e}"));
                         sink.on_warning(&format!(
                             "Could not push new branch to '{}/{}': {e}",
@@ -329,7 +365,49 @@ pub fn execute(
         cd_target,
         dry_run: false,
         warnings,
+        push_gate_error,
     })
+}
+
+// ── Remote push helpers ────────────────────────────────────────────────────
+
+/// How a remote push failed, graded for #599 escalation.
+enum PushFailure {
+    /// Failed with the repo's pre-push hook in effect — escalates to a
+    /// command failure.
+    Gated(String),
+    /// Any other failure — legacy warn-and-continue.
+    Other(String),
+}
+
+fn run_remote_rename_push(
+    git: &GitCommand,
+    action: PushAction<'_>,
+    cwd: &Path,
+    params: &RenameParams,
+    presenter: Option<&Arc<dyn JobPresenter>>,
+) -> std::result::Result<(), PushFailure> {
+    match push_with_hooks(
+        git,
+        action,
+        cwd,
+        !params.no_verify,
+        &NoopStageRunner,
+        presenter,
+        None,
+    ) {
+        Ok(outcome) => match outcome.failure {
+            None => Ok(()),
+            Some(msg) => {
+                if matches!(outcome.hook, HookVerdict::Rejected | HookVerdict::Passed) {
+                    Err(PushFailure::Gated(msg))
+                } else {
+                    Err(PushFailure::Other(msg))
+                }
+            }
+        },
+        Err(e) => Err(PushFailure::Other(format!("{e}"))),
+    }
 }
 
 // ── Source resolution ──────────────────────────────────────────────────────

--- a/src/core/worktree/rename.rs
+++ b/src/core/worktree/rename.rs
@@ -303,14 +303,19 @@ pub fn execute(
                                 remote_renamed = true;
                                 sink.on_step("Remote branch renamed successfully");
                             }
-                            Err(PushFailure::Gated(msg)) => {
+                            Err(PushFailure::Gated(msg, verdict)) => {
+                                let hint = if verdict.no_verify_might_help() {
+                                    " (or re-run with --no-verify to bypass the hook)"
+                                } else {
+                                    ""
+                                };
                                 push_gate_error = Some(format!(
-                                    "Could not delete old remote branch '{remote}/{old_branch}' \
-                                     with the repo's pre-push hook in effect: {msg}. The branch \
-                                     was renamed locally and '{remote}/{}' was pushed; delete the \
-                                     old remote branch manually with: git push {remote} --delete \
-                                     {old_branch} (or re-run with --no-verify)",
-                                    params.new_branch
+                                    "Could not delete old remote branch '{remote}/{old_branch}': \
+                                     {msg} ({cause}). The branch was renamed locally and \
+                                     '{remote}/{new}' was pushed; delete the old remote branch \
+                                     manually with: git push {remote} --delete {old_branch}{hint}",
+                                    new = params.new_branch,
+                                    cause = verdict.failure_cause(),
                                 ));
                             }
                             Err(PushFailure::Other(e)) => {
@@ -323,13 +328,19 @@ pub fn execute(
                             }
                         }
                     }
-                    Err(PushFailure::Gated(msg)) => {
+                    Err(PushFailure::Gated(msg, verdict)) => {
+                        let hint = if verdict.no_verify_might_help() {
+                            " (or re-run with --no-verify to bypass the hook)"
+                        } else {
+                            ""
+                        };
                         push_gate_error = Some(format!(
-                            "Could not push '{remote}/{}' with the repo's pre-push hook in \
-                             effect: {msg}. The branch was renamed locally; the remote still \
-                             has '{old_branch}'. Fix the hook failure and push manually with: \
-                             git push --set-upstream {remote} {} (or re-run with --no-verify)",
-                            params.new_branch, params.new_branch
+                            "Could not push '{remote}/{new}': {msg} ({cause}). \
+                             The branch was renamed locally; the remote still has \
+                             '{old_branch}'. Push manually with: \
+                             git push --set-upstream {remote} {new}{hint}",
+                            new = params.new_branch,
+                            cause = verdict.failure_cause(),
                         ));
                     }
                     Err(PushFailure::Other(e)) => {
@@ -373,9 +384,11 @@ pub fn execute(
 
 /// How a remote push failed, graded for #599 escalation.
 enum PushFailure {
-    /// Failed with the repo's pre-push hook in effect — escalates to a
-    /// command failure.
-    Gated(String),
+    /// Failed while the repo's pre-push hook was honored — escalates to a
+    /// command failure. Carries the git error and the verdict so the message
+    /// can name the cause accurately (hook refusal vs downstream reject)
+    /// instead of always blaming the hook.
+    Gated(String, HookVerdict),
     /// Any other failure — legacy warn-and-continue.
     Other(String),
 }
@@ -400,7 +413,7 @@ fn run_remote_rename_push(
             None => Ok(()),
             Some(msg) => {
                 if matches!(outcome.hook, HookVerdict::Rejected | HookVerdict::Passed) {
-                    Err(PushFailure::Gated(msg))
+                    Err(PushFailure::Gated(msg, outcome.hook))
                 } else {
                     Err(PushFailure::Other(msg))
                 }

--- a/src/core/worktree/sync_dag.rs
+++ b/src/core/worktree/sync_dag.rs
@@ -497,6 +497,46 @@ impl PatchSource {
     }
 }
 
+/// The hook phase a `DagEvent` hook/job event belongs to: a lifecycle hook
+/// run by daft, or the synthetic `pre-push` stage reported around a hooked
+/// git push (#599). `HookType` stays closed — the pre-push stage is not a
+/// daft lifecycle hook, just a reported phase.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DagHookPhase {
+    Lifecycle(HookType),
+    PrePush,
+}
+
+impl DagHookPhase {
+    /// Short status-column label (kept narrow for the table layout).
+    pub fn label(&self) -> &'static str {
+        match self {
+            DagHookPhase::Lifecycle(HookType::PreRemove) => "pre-remove",
+            DagHookPhase::Lifecycle(HookType::PostRemove) => "post-remove",
+            DagHookPhase::Lifecycle(HookType::PreCreate) => "pre-create",
+            DagHookPhase::Lifecycle(HookType::PostCreate) => "post-create",
+            DagHookPhase::Lifecycle(HookType::PostClone) => "post-clone",
+            DagHookPhase::Lifecycle(HookType::PreMerge) => "pre-merge",
+            DagHookPhase::Lifecycle(HookType::PostMerge) => "post-merge",
+            DagHookPhase::PrePush => "pre-push",
+        }
+    }
+
+    /// Canonical hook name for summaries (matches `HookType::filename`).
+    pub fn hook_name(&self) -> &'static str {
+        match self {
+            DagHookPhase::Lifecycle(hook_type) => hook_type.filename(),
+            DagHookPhase::PrePush => "pre-push",
+        }
+    }
+}
+
+impl From<HookType> for DagHookPhase {
+    fn from(hook_type: HookType) -> Self {
+        DagHookPhase::Lifecycle(hook_type)
+    }
+}
+
 /// Message sent from worker threads to the renderer.
 #[derive(Debug, Clone)]
 pub enum DagEvent {
@@ -518,12 +558,12 @@ pub enum DagEvent {
     /// A hook started running for a branch.
     HookStarted {
         branch_name: String,
-        hook_type: HookType,
+        hook_type: DagHookPhase,
     },
     /// A hook completed for a branch.
     HookCompleted {
         branch_name: String,
-        hook_type: HookType,
+        hook_type: DagHookPhase,
         success: bool,
         /// Non-zero exit with FailMode::Warn.
         warned: bool,
@@ -536,13 +576,13 @@ pub enum DagEvent {
     /// A job started running within a hook.
     JobStarted {
         branch_name: String,
-        hook_type: HookType,
+        hook_type: DagHookPhase,
         job_name: String,
     },
     /// A job completed within a hook.
     JobCompleted {
         branch_name: String,
-        hook_type: HookType,
+        hook_type: DagHookPhase,
         job_name: String,
         status: JobCompletionStatus,
         duration: Duration,

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -5,10 +5,13 @@ mod branch;
 mod clone;
 mod config;
 pub(crate) mod oxide;
+pub mod push_porcelain;
 mod refs;
 mod remote;
 mod stash;
 mod worktree;
+
+pub use remote::{PushIo, PushOptions, PushOutputTee, PushStream};
 
 static GITOXIDE_NOTICE: Once = Once::new();
 

--- a/src/git/push_porcelain.rs
+++ b/src/git/push_porcelain.rs
@@ -1,0 +1,189 @@
+//! Pure parser for `git push --porcelain` stdout.
+//!
+//! Porcelain ref-status lines have the machine-stable shape
+//! `<flag>\t<from>:<to>\t<summary>`, bracketed by `To <url>` and `Done`.
+//! Other content interleaves on stdout — a pre-push hook's own stdout, and
+//! `--set-upstream`'s "branch '…' set up to track …" notice — so parsing keys
+//! strictly on the flag + tab structure and ignores everything else.
+//!
+//! `--quiet` suppresses the ref-status lines entirely (only `Done` remains),
+//! which would make every push look like a hook-gated abort. `run_push` never
+//! passes `--quiet` for this reason; quietness is a display concern handled by
+//! the capture/tee layer above.
+
+/// Status flag of a single pushed ref, per the `git push --porcelain` format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RefStatusFlag {
+    /// ` ` — successfully pushed fast-forward.
+    FastForward,
+    /// `+` — successful forced update.
+    Forced,
+    /// `*` — successfully pushed new ref.
+    New,
+    /// `-` — successfully deleted ref.
+    Deleted,
+    /// `=` — ref was already up to date and did not need pushing.
+    UpToDate,
+    /// `!` — ref was rejected or failed to push.
+    Rejected,
+}
+
+impl RefStatusFlag {
+    fn from_char(c: char) -> Option<Self> {
+        match c {
+            ' ' => Some(Self::FastForward),
+            '+' => Some(Self::Forced),
+            '*' => Some(Self::New),
+            '-' => Some(Self::Deleted),
+            '=' => Some(Self::UpToDate),
+            '!' => Some(Self::Rejected),
+            _ => None,
+        }
+    }
+}
+
+/// One parsed `<flag>\t<from>:<to>\t<summary>` line.
+#[derive(Debug, Clone)]
+pub struct RefStatus {
+    pub flag: RefStatusFlag,
+    /// The `<from>:<to>` refspec as printed (deletes have an empty `<from>`).
+    pub refspec: String,
+    /// Human summary: `[up to date]`, `[new branch]`, `<old>..<new>`, …
+    pub summary: String,
+}
+
+/// Parsed report of a `git push --porcelain` run.
+#[derive(Debug, Clone, Default)]
+pub struct PushReport {
+    pub refs: Vec<RefStatus>,
+}
+
+impl PushReport {
+    /// Every pushed ref was already up to date (and at least one ref line was
+    /// seen). Replaces the locale-fragile `"Everything up-to-date"` stderr grep.
+    pub fn all_up_to_date(&self) -> bool {
+        !self.refs.is_empty() && self.refs.iter().all(|r| r.flag == RefStatusFlag::UpToDate)
+    }
+
+    /// Whether any ref-status line was emitted at all. A failed push with NO
+    /// ref lines never reached ref negotiation — the signature of a local
+    /// gate (pre-push hook) refusal or a transport failure.
+    pub fn has_ref_lines(&self) -> bool {
+        !self.refs.is_empty()
+    }
+}
+
+/// Parse the stdout of a `git push --porcelain` invocation.
+pub fn parse_push_report(stdout: &str) -> PushReport {
+    let refs = stdout
+        .lines()
+        .filter_map(|line| {
+            let mut chars = line.chars();
+            let flag = RefStatusFlag::from_char(chars.next()?)?;
+            let rest = chars.as_str().strip_prefix('\t')?;
+            let (refspec, summary) = rest.split_once('\t')?;
+            // Real refspecs are `<from>:<to>`; deletes print `:refs/...`.
+            // The colon requirement filters stray tab-bearing hook output.
+            if !refspec.contains(':') {
+                return None;
+            }
+            Some(RefStatus {
+                flag,
+                refspec: refspec.to_string(),
+                summary: summary.to_string(),
+            })
+        })
+        .collect();
+
+    PushReport { refs }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Fixtures captured from git 2.x in scratch repos (issue #599, step E0).
+
+    #[test]
+    fn fast_forward_update() {
+        let out = "To /tmp/remote.git\n \trefs/heads/feature:refs/heads/feature\ta59a2e2..f33e772\nDone\n";
+        let report = parse_push_report(out);
+        assert_eq!(report.refs.len(), 1);
+        assert_eq!(report.refs[0].flag, RefStatusFlag::FastForward);
+        assert_eq!(
+            report.refs[0].refspec,
+            "refs/heads/feature:refs/heads/feature"
+        );
+        assert!(!report.all_up_to_date());
+        assert!(report.has_ref_lines());
+    }
+
+    #[test]
+    fn up_to_date() {
+        let out =
+            "To /tmp/remote.git\n=\trefs/heads/feature:refs/heads/feature\t[up to date]\nDone\n";
+        let report = parse_push_report(out);
+        assert!(report.all_up_to_date());
+    }
+
+    #[test]
+    fn new_branch_with_set_upstream_notice() {
+        // --set-upstream interleaves a non-porcelain notice on stdout.
+        let out = "To /tmp/remote.git\n*\trefs/heads/feature:refs/heads/feature\t[new branch]\nbranch 'feature' set up to track 'origin/feature'.\nDone\n";
+        let report = parse_push_report(out);
+        assert_eq!(report.refs.len(), 1);
+        assert_eq!(report.refs[0].flag, RefStatusFlag::New);
+        assert!(!report.all_up_to_date());
+    }
+
+    #[test]
+    fn delete_has_empty_from() {
+        let out = "To /tmp/remote.git\n-\t:refs/heads/feature\t[deleted]\nDone\n";
+        let report = parse_push_report(out);
+        assert_eq!(report.refs.len(), 1);
+        assert_eq!(report.refs[0].flag, RefStatusFlag::Deleted);
+        assert_eq!(report.refs[0].refspec, ":refs/heads/feature");
+    }
+
+    #[test]
+    fn forced_update_with_hook_stdout_noise() {
+        // A passing pre-push hook's stdout interleaves before the report.
+        let out = "hook stdout line\nTo /tmp/remote.git\n+\trefs/heads/feature:refs/heads/feature\t82ec994...851c641 (forced update)\nDone\n";
+        let report = parse_push_report(out);
+        assert_eq!(report.refs.len(), 1);
+        assert_eq!(report.refs[0].flag, RefStatusFlag::Forced);
+    }
+
+    #[test]
+    fn rejected_non_fast_forward() {
+        let out = "To /tmp/remote.git\n!\trefs/heads/feature:refs/heads/feature\t[rejected] (non-fast-forward)\nDone\n";
+        let report = parse_push_report(out);
+        assert_eq!(report.refs.len(), 1);
+        assert_eq!(report.refs[0].flag, RefStatusFlag::Rejected);
+        assert!(!report.all_up_to_date());
+    }
+
+    #[test]
+    fn hook_rejection_yields_no_ref_lines() {
+        // A failing pre-push hook aborts before ref negotiation: stdout holds
+        // only the hook's own noise — no To/ref/Done lines at all.
+        let report = parse_push_report("HOOK STDOUT NOISE\n");
+        assert!(!report.has_ref_lines());
+        assert!(!report.all_up_to_date());
+    }
+
+    #[test]
+    fn empty_output() {
+        let report = parse_push_report("");
+        assert!(!report.has_ref_lines());
+        assert!(!report.all_up_to_date());
+    }
+
+    #[test]
+    fn hook_noise_with_tabs_is_not_a_ref_line() {
+        // Tab-bearing hook output without the flag+refspec shape is ignored.
+        let out = "x\tnot-a-refspec\twhatever\n \tno-colon-here\tsummary\n";
+        let report = parse_push_report(out);
+        assert!(!report.has_ref_lines());
+    }
+}

--- a/src/git/remote.rs
+++ b/src/git/remote.rs
@@ -1,9 +1,104 @@
 use super::GitCommand;
 use super::oxide;
 use crate::styles;
+use crate::utils::git_command_at;
 use anyhow::{Context, Result};
-use std::path::Path;
+use std::io::{BufRead, BufReader, Read};
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+
+/// Which pipe a teed `git push` output line arrived on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PushStream {
+    Stdout,
+    Stderr,
+}
+
+/// Tee sink for live `git push` output lines (called from the pipe-drain
+/// threads, hence `Sync`).
+pub type PushOutputTee = dyn Fn(PushStream, &str) + Sync;
+
+/// Options threaded through every push primitive into [`GitCommand::run_push`].
+pub struct PushOptions<'a> {
+    /// When `false`, pass `--no-verify` so git skips the repo's `pre-push`
+    /// hook. Defaults to `true`: daft honors the hook (issue #599).
+    pub verify: bool,
+    /// Tee sink: every output line is forwarded here as it arrives, in
+    /// addition to being captured in [`PushIo`]. Keeps the git layer free of
+    /// presenter types — the composition layer bridges this to `JobPresenter`.
+    pub on_output: Option<&'a PushOutputTee>,
+}
+
+impl Default for PushOptions<'_> {
+    fn default() -> Self {
+        Self {
+            verify: true,
+            on_output: None,
+        }
+    }
+}
+
+/// Captured result of a `git push` subprocess.
+///
+/// `Err` from the push primitives means the subprocess could not be spawned;
+/// a push that ran and failed (hook rejection, non-fast-forward, transport)
+/// is `Ok` with `success: false` so callers can inspect both streams before
+/// deciding severity.
+#[derive(Debug)]
+pub struct PushIo {
+    pub success: bool,
+    /// Captured stdout: `--porcelain` ref-status lines plus any pre-push hook
+    /// stdout (parse with [`crate::git::push_porcelain::parse_push_report`]).
+    pub stdout: String,
+    /// Captured stderr: hook stderr, transport errors, git diagnostics.
+    pub stderr: String,
+}
+
+impl PushIo {
+    /// Collapse into the legacy contract: bail with stderr when the push
+    /// failed. For call sites that keep today's coarse error handling.
+    pub fn into_result(self) -> Result<Self> {
+        if self.success {
+            Ok(self)
+        } else {
+            anyhow::bail!("Git push failed: {}", self.stderr);
+        }
+    }
+}
+
+/// A regular file with at least one executable bit set (git's own criterion
+/// for whether a hook runs; a non-executable hook file is ignored).
+fn is_executable_file(path: &Path) -> bool {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::metadata(path)
+            .map(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
+            .unwrap_or(false)
+    }
+    #[cfg(not(unix))]
+    {
+        path.is_file()
+    }
+}
+
+/// Drain one pipe of the push subprocess line-by-line, teeing each line to
+/// `on_output` (when set) and accumulating the full stream.
+fn drain_push_pipe<R: Read>(
+    pipe: R,
+    stream: PushStream,
+    on_output: Option<&PushOutputTee>,
+) -> String {
+    let mut captured = String::new();
+    for line in BufReader::new(pipe).lines().map_while(Result::ok) {
+        if let Some(tee) = on_output {
+            tee(stream, &line);
+        }
+        captured.push_str(&line);
+        captured.push('\n');
+    }
+    captured
+}
 
 impl GitCommand {
     pub fn fetch(&self, remote: &str, prune: bool) -> Result<()> {
@@ -46,18 +141,91 @@ impl GitCommand {
         Ok(())
     }
 
-    pub fn push_set_upstream(&self, remote: &str, branch: &str) -> Result<()> {
-        let output = Command::new("git")
-            .args(["push", "--no-verify", "--set-upstream", remote, branch])
-            .output()
-            .context("Failed to execute git push command")?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            anyhow::bail!("Git push failed: {}", stderr);
+    /// Shared seam for every daft-initiated `git push` (issue #599).
+    ///
+    /// - Runs via [`git_command_at`] so `-C <cwd>` is authoritative even when
+    ///   daft itself runs inside a git hook (inherited `GIT_DIR` is scrubbed),
+    ///   and so the repo's `pre-push` hook fires in the right worktree.
+    /// - Always passes `--porcelain`: the machine-stable ref-status report on
+    ///   stdout is what callers parse (see `push_porcelain`). Never passes
+    ///   `--quiet` — it suppresses those ref-status lines; quietness is a
+    ///   display decision made by the capture/tee layer above.
+    /// - `--no-verify` is added only when `opts.verify` is `false`. This is
+    ///   the single place that literal may appear (grep-gated by test).
+    fn run_push(&self, push_args: &[&str], cwd: &Path, opts: &PushOptions) -> Result<PushIo> {
+        let mut cmd = git_command_at(cwd);
+        cmd.args(["push", "--porcelain"]);
+        if !opts.verify {
+            cmd.arg("--no-verify");
         }
+        cmd.args(push_args);
+        cmd.stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
 
-        Ok(())
+        let mut child = cmd.spawn().context("Failed to execute git push command")?;
+        let stdout_pipe = child
+            .stdout
+            .take()
+            .context("Failed to capture git push stdout")?;
+        let stderr_pipe = child
+            .stderr
+            .take()
+            .context("Failed to capture git push stderr")?;
+
+        // Thread-per-pipe drain (the executor/command.rs pattern): both pipes
+        // are read concurrently so neither can fill and deadlock the child.
+        // Scoped threads let the tee closure borrow from the caller.
+        let (stdout, stderr) = std::thread::scope(|scope| {
+            let out =
+                scope.spawn(|| drain_push_pipe(stdout_pipe, PushStream::Stdout, opts.on_output));
+            let err =
+                scope.spawn(|| drain_push_pipe(stderr_pipe, PushStream::Stderr, opts.on_output));
+            (
+                out.join().unwrap_or_default(),
+                err.join().unwrap_or_default(),
+            )
+        });
+
+        let status = child
+            .wait()
+            .context("Failed to wait for git push command")?;
+
+        Ok(PushIo {
+            success: status.success(),
+            stdout,
+            stderr,
+        })
+    }
+
+    /// Whether the repo (as seen from `cwd`) has an executable `pre-push`
+    /// hook installed — native or via `core.hooksPath` (lefthook, husky,
+    /// pre-commit all register through one of those two mechanisms).
+    ///
+    /// Used to existence-gate the synthetic `pre-push` reporting phase so a
+    /// hook-less repo never renders a hollow phase header.
+    pub fn pre_push_hook_exists(&self, cwd: &Path) -> bool {
+        let mut cmd = git_command_at(cwd);
+        cmd.args(["rev-parse", "--git-path", "hooks"]);
+        cmd.stdin(Stdio::null()).stderr(Stdio::null());
+        let Ok(output) = cmd.output() else {
+            return false;
+        };
+        if !output.status.success() {
+            return false;
+        }
+        let raw = String::from_utf8_lossy(&output.stdout);
+        let rel = raw.trim();
+        if rel.is_empty() {
+            return false;
+        }
+        // `--git-path` prints relative to git's cwd (our `-C <cwd>`).
+        let hooks_dir = if Path::new(rel).is_absolute() {
+            PathBuf::from(rel)
+        } else {
+            cwd.join(rel)
+        };
+        is_executable_file(&hooks_dir.join("pre-push"))
     }
 
     /// Push a branch and set upstream, running from a specific directory.
@@ -65,20 +233,10 @@ impl GitCommand {
         &self,
         remote: &str,
         branch: &str,
-        cwd: &std::path::Path,
-    ) -> Result<()> {
-        let output = Command::new("git")
-            .args(["push", "--no-verify", "--set-upstream", remote, branch])
-            .current_dir(cwd)
-            .output()
-            .context("Failed to execute git push command")?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            anyhow::bail!("Git push failed: {}", stderr);
-        }
-
-        Ok(())
+        cwd: &Path,
+        opts: &PushOptions,
+    ) -> Result<PushIo> {
+        self.run_push(&["--set-upstream", remote, branch], cwd, opts)
     }
 
     pub fn set_upstream(&self, remote: &str, branch: &str) -> Result<()> {
@@ -99,52 +257,31 @@ impl GitCommand {
     /// Push a branch from a specific directory, optionally with --force-with-lease.
     ///
     /// Required for parallel workers where `set_current_dir` would race.
-    /// Returns the combined stderr on success (for detecting "Everything up-to-date").
     pub fn push_from(
         &self,
         remote: &str,
         branch: &str,
-        cwd: &std::path::Path,
+        cwd: &Path,
         force_with_lease: bool,
-    ) -> Result<String> {
-        let mut cmd = Command::new("git");
-        cmd.args(["push", "--no-verify", remote, branch]);
-        cmd.current_dir(cwd);
-
+        opts: &PushOptions,
+    ) -> Result<PushIo> {
         if force_with_lease {
-            cmd.arg("--force-with-lease");
+            self.run_push(&["--force-with-lease", remote, branch], cwd, opts)
+        } else {
+            self.run_push(&[remote, branch], cwd, opts)
         }
-
-        let output = cmd.output().context("Failed to execute git push command")?;
-
-        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-
-        if !output.status.success() {
-            anyhow::bail!("Git push failed: {}", stderr);
-        }
-
-        Ok(stderr)
     }
 
-    /// Delete a remote branch via `git push <remote> --delete <branch>`.
-    pub fn push_delete(&self, remote: &str, branch: &str) -> Result<()> {
-        let mut cmd = Command::new("git");
-        cmd.args(["push", "--no-verify", remote, "--delete", branch]);
-
-        if self.quiet {
-            cmd.arg("--quiet");
-        }
-
-        let output = cmd
-            .output()
-            .context("Failed to execute git push --delete command")?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            anyhow::bail!("Git push --delete failed: {}", stderr);
-        }
-
-        Ok(())
+    /// Delete a remote branch via `git push <remote> --delete <branch>`,
+    /// running from a specific directory.
+    pub fn push_delete_from(
+        &self,
+        remote: &str,
+        branch: &str,
+        cwd: &Path,
+        opts: &PushOptions,
+    ) -> Result<PushIo> {
+        self.run_push(&[remote, "--delete", branch], cwd, opts)
     }
 
     /// Pull from remote with specified arguments
@@ -489,5 +626,76 @@ impl GitCommand {
                     .map(|s| s.to_string())
             })
             .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    fn rs_files_under(dir: &Path, acc: &mut Vec<std::path::PathBuf>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                rs_files_under(&path, acc);
+            } else if path.extension().is_some_and(|e| e == "rs") {
+                acc.push(path);
+            }
+        }
+    }
+
+    /// #599 grep-gate: the no-verify push flag may appear only in
+    /// `run_push`'s verify toggle. Every push must route through that seam —
+    /// no primitive, call site, or raw `Command` may hardcode the bypass.
+    #[test]
+    fn no_verify_literal_only_in_run_push() {
+        // Assembled at runtime so this test doesn't match itself. The
+        // surrounding quotes keep git's unrelated no-verify-signatures
+        // completion strings out of scope: only the exact quoted flag
+        // literal is gated.
+        let needle = format!("\"--no-{}\"", "verify");
+        let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let mut files = Vec::new();
+        rs_files_under(&src, &mut files);
+        assert!(
+            files.len() > 100,
+            "src/ walk looks broken ({} files)",
+            files.len()
+        );
+
+        let this_file = Path::new(file!())
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap();
+        let mut offenders = Vec::new();
+        let mut in_run_push_file = 0usize;
+        for file in &files {
+            let Ok(content) = std::fs::read_to_string(file) else {
+                continue;
+            };
+            let count = content.matches(&needle).count();
+            if count == 0 {
+                continue;
+            }
+            if file.file_name().and_then(|n| n.to_str()) == Some(this_file)
+                && file.parent().is_some_and(|p| p.ends_with("git"))
+            {
+                in_run_push_file = count;
+            } else {
+                offenders.push(file.display().to_string());
+            }
+        }
+
+        assert!(
+            offenders.is_empty(),
+            "the no-verify push flag must only appear inside run_push (src/git/remote.rs); found in: {offenders:?}"
+        );
+        assert_eq!(
+            in_run_push_file, 1,
+            "expected exactly one no-verify occurrence in remote.rs (run_push's toggle)"
+        );
     }
 }

--- a/src/git/remote.rs
+++ b/src/git/remote.rs
@@ -15,8 +15,8 @@ pub enum PushStream {
 }
 
 /// Tee sink for live `git push` output lines (called from the pipe-drain
-/// threads, hence `Sync`).
-pub type PushOutputTee = dyn Fn(PushStream, &str) + Sync;
+/// threads, hence `Sync`; lifetime-parametric so callers can borrow).
+pub type PushOutputTee<'a> = dyn Fn(PushStream, &str) + Sync + 'a;
 
 /// Options threaded through every push primitive into [`GitCommand::run_push`].
 pub struct PushOptions<'a> {
@@ -26,7 +26,7 @@ pub struct PushOptions<'a> {
     /// Tee sink: every output line is forwarded here as it arrives, in
     /// addition to being captured in [`PushIo`]. Keeps the git layer free of
     /// presenter types — the composition layer bridges this to `JobPresenter`.
-    pub on_output: Option<&'a PushOutputTee>,
+    pub on_output: Option<&'a PushOutputTee<'a>>,
 }
 
 impl Default for PushOptions<'_> {
@@ -87,7 +87,7 @@ fn is_executable_file(path: &Path) -> bool {
 fn drain_push_pipe<R: Read>(
     pipe: R,
     stream: PushStream,
-    on_output: Option<&PushOutputTee>,
+    on_output: Option<&PushOutputTee<'_>>,
 ) -> String {
     let mut captured = String::new();
     for line in BufReader::new(pipe).lines().map_while(Result::ok) {

--- a/src/output/tui/presenter.rs
+++ b/src/output/tui/presenter.rs
@@ -9,10 +9,9 @@
 //!
 //! [`CliPresenter`]: crate::executor::cli_presenter::CliPresenter
 
-use crate::core::worktree::sync_dag::{DagEvent, JobCompletionStatus};
+use crate::core::worktree::sync_dag::{DagEvent, DagHookPhase, JobCompletionStatus};
 use crate::executor::JobResult;
 use crate::executor::presenter::JobPresenter;
-use crate::hooks::HookType;
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -28,7 +27,7 @@ pub struct TuiPresenter {
     /// Which branch this presenter is scoped to.
     branch_name: String,
     /// Which hook phase this presenter is scoped to.
-    hook_type: HookType,
+    hook_type: DagHookPhase,
     /// When the phase started, for computing duration.
     start: Mutex<Option<Instant>>,
     /// Whether any job has failed during this phase.
@@ -48,12 +47,12 @@ impl TuiPresenter {
     pub fn new(
         sender: mpsc::Sender<DagEvent>,
         branch_name: impl Into<String>,
-        hook_type: HookType,
+        hook_type: impl Into<DagHookPhase>,
     ) -> Arc<Self> {
         Arc::new(Self {
             sender,
             branch_name: branch_name.into(),
-            hook_type,
+            hook_type: hook_type.into(),
             start: Mutex::new(None),
             has_failure: Mutex::new(false),
             output: Mutex::new(String::new()),
@@ -200,6 +199,7 @@ impl JobPresenter for TuiPresenter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::hooks::HookType;
 
     #[test]
     fn tui_presenter_is_send_sync() {
@@ -229,7 +229,7 @@ mod tests {
                 hook_type,
             } => {
                 assert_eq!(branch_name, "feat/login");
-                assert_eq!(hook_type, HookType::PostCreate);
+                assert_eq!(hook_type, HookType::PostCreate.into());
             }
             other => panic!("expected HookStarted, got {other:?}"),
         }
@@ -261,7 +261,7 @@ mod tests {
                 output,
             } => {
                 assert_eq!(branch_name, "main");
-                assert_eq!(hook_type, HookType::PostClone);
+                assert_eq!(hook_type, HookType::PostClone.into());
                 assert!(success);
                 assert!(!warned);
                 // Duration should be non-negative (close to zero in tests).
@@ -364,7 +364,7 @@ mod tests {
                 job_name,
             } => {
                 assert_eq!(branch_name, "main");
-                assert_eq!(hook_type, HookType::PostCreate);
+                assert_eq!(hook_type, HookType::PostCreate.into());
                 assert_eq!(job_name, "build");
             }
             other => panic!("expected JobStarted, got {other:?}"),

--- a/src/output/tui/render.rs
+++ b/src/output/tui/render.rs
@@ -918,7 +918,7 @@ fn render_status_cell(wt: &super::state::WorktreeRow, tick: usize) -> Cell<'stat
 fn format_hook_line(sub: &super::state::HookSubRow, prefix: &str, tick: usize) -> Line<'static> {
     use super::state::HookSubStatus;
 
-    let name = sub.hook_type.filename();
+    let name = sub.hook_type.hook_name();
     let status_span = match &sub.status {
         HookSubStatus::Running => {
             let spinner = SPINNER_FRAMES[tick % SPINNER_FRAMES.len()];

--- a/src/output/tui/state.rs
+++ b/src/output/tui/state.rs
@@ -2,9 +2,8 @@ use crate::core::sort::SortSpec;
 use crate::core::worktree::info_field::FieldSet;
 use crate::core::worktree::list::{EntryKind, Stat, WorktreeInfo};
 use crate::core::worktree::sync_dag::{
-    DagEvent, JobCompletionStatus, OperationPhase, TaskMessage, TaskStatus,
+    DagEvent, DagHookPhase, JobCompletionStatus, OperationPhase, TaskMessage, TaskStatus,
 };
-use crate::hooks::HookType;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -63,7 +62,7 @@ pub enum HookSubStatus {
 /// A hook sub-row displayed beneath a worktree row in -v mode.
 #[derive(Debug, Clone)]
 pub struct HookSubRow {
-    pub hook_type: HookType,
+    pub hook_type: DagHookPhase,
     pub status: HookSubStatus,
     pub job_sub_rows: Vec<JobSubRow>,
 }
@@ -88,7 +87,7 @@ pub struct JobSubRow {
 #[derive(Debug, Clone)]
 pub struct HookSummaryEntry {
     pub branch_name: String,
-    pub hook_type: HookType,
+    pub hook_type: DagHookPhase,
     pub success: bool,
     pub warned: bool,
     pub duration: Duration,
@@ -302,18 +301,9 @@ impl TuiState {
                 let show_sub_rows = self.show_hook_sub_rows;
                 if let Some(row) = self.find_row_mut(branch_name) {
                     // Update status label to show current hook phase.
-                    // Use short labels to stay within STATUS_MAX_WIDTH and avoid
+                    // Short labels stay within STATUS_MAX_WIDTH and avoid
                     // column width jumps in the table layout.
-                    let label = match hook_type {
-                        HookType::PreRemove => "pre-remove",
-                        HookType::PostRemove => "post-remove",
-                        HookType::PreCreate => "pre-create",
-                        HookType::PostCreate => "post-create",
-                        HookType::PostClone => "post-clone",
-                        HookType::PreMerge => "pre-merge",
-                        HookType::PostMerge => "post-merge",
-                    };
-                    row.status = WorktreeStatus::Active(label.to_string());
+                    row.status = WorktreeStatus::Active(hook_type.label().to_string());
                     // Add sub-row if in verbose TUI mode
                     if show_sub_rows {
                         row.hook_sub_rows.push(HookSubRow {
@@ -527,6 +517,7 @@ impl TuiState {
 mod tests {
     use super::*;
     use crate::core::worktree::sync_dag::*;
+    use crate::hooks::HookType;
 
     fn make_test_state() -> TuiState {
         let phases = vec![
@@ -1037,7 +1028,7 @@ mod tests {
         let mut state = make_test_state();
         state.apply_event(&DagEvent::HookStarted {
             branch_name: "feat/old".into(),
-            hook_type: HookType::PreRemove,
+            hook_type: HookType::PreRemove.into(),
         });
         let row = state
             .live
@@ -1053,7 +1044,7 @@ mod tests {
         let mut state = make_test_state();
         state.apply_event(&DagEvent::HookCompleted {
             branch_name: "feat/old".into(),
-            hook_type: HookType::PreRemove,
+            hook_type: HookType::PreRemove.into(),
             success: false,
             warned: true,
             duration: Duration::from_millis(100),
@@ -1078,7 +1069,7 @@ mod tests {
         let mut state = make_test_state();
         state.apply_event(&DagEvent::HookCompleted {
             branch_name: "master".into(),
-            hook_type: HookType::PostRemove,
+            hook_type: HookType::PostRemove.into(),
             success: true,
             warned: false,
             duration: Duration::from_millis(50),
@@ -1103,7 +1094,7 @@ mod tests {
 
         state.apply_event(&DagEvent::HookStarted {
             branch_name: "feat/a".into(),
-            hook_type: HookType::PostRemove,
+            hook_type: HookType::PostRemove.into(),
         });
 
         {
@@ -1114,14 +1105,14 @@ mod tests {
                 .find(|w| w.info.name == "feat/a")
                 .unwrap();
             assert_eq!(row.hook_sub_rows.len(), 1);
-            assert_eq!(row.hook_sub_rows[0].hook_type, HookType::PostRemove);
+            assert_eq!(row.hook_sub_rows[0].hook_type, HookType::PostRemove.into());
             assert_eq!(row.hook_sub_rows[0].status, HookSubStatus::Running);
         }
 
         let dur = Duration::from_millis(200);
         state.apply_event(&DagEvent::HookCompleted {
             branch_name: "feat/a".into(),
-            hook_type: HookType::PostRemove,
+            hook_type: HookType::PostRemove.into(),
             success: true,
             warned: false,
             duration: dur,
@@ -1148,11 +1139,11 @@ mod tests {
 
         state.apply_event(&DagEvent::HookStarted {
             branch_name: "feat/a".into(),
-            hook_type: HookType::PostCreate,
+            hook_type: HookType::PostCreate.into(),
         });
         state.apply_event(&DagEvent::JobStarted {
             branch_name: "feat/a".into(),
-            hook_type: HookType::PostCreate,
+            hook_type: HookType::PostCreate.into(),
             job_name: "build".into(),
         });
 
@@ -1177,16 +1168,16 @@ mod tests {
 
         state.apply_event(&DagEvent::HookStarted {
             branch_name: "feat/a".into(),
-            hook_type: HookType::PostCreate,
+            hook_type: HookType::PostCreate.into(),
         });
         state.apply_event(&DagEvent::JobStarted {
             branch_name: "feat/a".into(),
-            hook_type: HookType::PostCreate,
+            hook_type: HookType::PostCreate.into(),
             job_name: "build".into(),
         });
         state.apply_event(&DagEvent::JobCompleted {
             branch_name: "feat/a".into(),
-            hook_type: HookType::PostCreate,
+            hook_type: HookType::PostCreate.into(),
             job_name: "build".into(),
             status: JobCompletionStatus::Succeeded,
             duration: Duration::from_millis(150),
@@ -1211,21 +1202,21 @@ mod tests {
 
         state.apply_event(&DagEvent::HookStarted {
             branch_name: "feat/a".into(),
-            hook_type: HookType::PreRemove,
+            hook_type: HookType::PreRemove.into(),
         });
         state.apply_event(&DagEvent::JobStarted {
             branch_name: "feat/a".into(),
-            hook_type: HookType::PreRemove,
+            hook_type: HookType::PreRemove.into(),
             job_name: "cleanup".into(),
         });
         state.apply_event(&DagEvent::JobStarted {
             branch_name: "feat/a".into(),
-            hook_type: HookType::PreRemove,
+            hook_type: HookType::PreRemove.into(),
             job_name: "notify".into(),
         });
         state.apply_event(&DagEvent::JobCompleted {
             branch_name: "feat/a".into(),
-            hook_type: HookType::PreRemove,
+            hook_type: HookType::PreRemove.into(),
             job_name: "cleanup".into(),
             status: JobCompletionStatus::Succeeded,
             duration: Duration::from_millis(100),
@@ -1233,7 +1224,7 @@ mod tests {
         });
         state.apply_event(&DagEvent::JobCompleted {
             branch_name: "feat/a".into(),
-            hook_type: HookType::PreRemove,
+            hook_type: HookType::PreRemove.into(),
             job_name: "notify".into(),
             status: JobCompletionStatus::Failed,
             duration: Duration::from_millis(200),
@@ -1410,11 +1401,11 @@ mod tests {
 
         state.apply_event(&DagEvent::HookStarted {
             branch_name: "feat/a".into(),
-            hook_type: HookType::PostCreate,
+            hook_type: HookType::PostCreate.into(),
         });
         state.apply_event(&DagEvent::JobStarted {
             branch_name: "feat/a".into(),
-            hook_type: HookType::PostCreate,
+            hook_type: HookType::PostCreate.into(),
             job_name: "build".into(),
         });
 

--- a/tests/manual/scenarios/push-hooks/branch-delete-remote-rejected.yml
+++ b/tests/manual/scenarios/push-hooks/branch-delete-remote-rejected.yml
@@ -1,0 +1,54 @@
+name: branch-delete's remote delete is gated by the pre-push hook
+description:
+  "A failing pre-push hook gates the remote-branch delete (remote deletes are
+  pushes too): the command reports the failure and exits non-zero, and the
+  remote branch survives. --no-verify bypasses the gate."
+
+repos:
+  - name: delete-gate-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone the repository
+    run: git-worktree-clone --layout contained $REMOTE_DELETE_GATE_REPO
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/delete-gate-repo/main"
+
+  - name: Install a failing pre-push hook via core.hooksPath
+    run: |
+      mkdir -p $WORK_DIR/test-hooks
+      printf '#!/bin/sh\necho "GATE SAYS NO" >&2\nexit 1\n' > $WORK_DIR/test-hooks/pre-push
+      chmod +x $WORK_DIR/test-hooks/pre-push
+      git config core.hooksPath $WORK_DIR/test-hooks
+    cwd: "$WORK_DIR/delete-gate-repo/main"
+    expect: { exit_code: 0 }
+
+  - name: Remote-only delete is rejected by the hook
+    run: git-worktree-branch -d feature/test-feature --remote 2>&1
+    cwd: "$WORK_DIR/delete-gate-repo/main"
+    expect:
+      exit_code: 1
+      output_contains:
+        - "GATE SAYS NO"
+
+  - name: The remote branch survived
+    run: git ls-remote --heads origin feature/test-feature
+    cwd: "$WORK_DIR/delete-gate-repo/main"
+    expect:
+      exit_code: 0
+      output_contains: ["feature/test-feature"]
+
+  - name: --no-verify deletes the remote branch through the failing hook
+    run: git-worktree-branch -d feature/test-feature --remote --no-verify 2>&1
+    cwd: "$WORK_DIR/delete-gate-repo/main"
+    expect:
+      exit_code: 0
+
+  - name: The remote branch is gone
+    run: git ls-remote --heads origin 2>/dev/null
+    cwd: "$WORK_DIR/delete-gate-repo/main"
+    expect:
+      exit_code: 0
+      output_not_contains: ["feature/test-feature"]

--- a/tests/manual/scenarios/push-hooks/checkout-branch-autopush-rejected.yml
+++ b/tests/manual/scenarios/push-hooks/checkout-branch-autopush-rejected.yml
@@ -1,0 +1,65 @@
+name: checkout -b auto-upstream push is gated by the pre-push hook
+description:
+  "With daft.checkout.push enabled, a failing pre-push hook gates the automatic
+  upstream push: the worktree is still created and fully set up, the command
+  exits non-zero with a created-but-rejected message, and the branch never
+  reaches the remote."
+
+repos:
+  - name: autopush-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone the repository
+    run: git-worktree-clone --layout contained $REMOTE_AUTOPUSH_REPO
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/autopush-repo/main"
+
+  - name: Enable the automatic upstream push
+    run: git config daft.checkout.push true
+    cwd: "$WORK_DIR/autopush-repo/main"
+    expect: { exit_code: 0 }
+
+  - name: Install a failing pre-push hook via core.hooksPath
+    run: |
+      mkdir -p $WORK_DIR/test-hooks
+      printf '#!/bin/sh\necho "GATE SAYS NO" >&2\nexit 1\n' > $WORK_DIR/test-hooks/pre-push
+      chmod +x $WORK_DIR/test-hooks/pre-push
+      git config core.hooksPath $WORK_DIR/test-hooks
+    cwd: "$WORK_DIR/autopush-repo/main"
+    expect: { exit_code: 0 }
+
+  - name: Creating a branch fails on the gated push but keeps the worktree
+    run: git-worktree-checkout -b feat-gated 2>&1
+    cwd: "$WORK_DIR/autopush-repo/main"
+    expect:
+      exit_code: 1
+      output_contains:
+        - "pre-push hook in effect"
+        - "ready at"
+      dirs_exist:
+        - "$WORK_DIR/autopush-repo/feat-gated"
+
+  - name: The branch never reached the remote
+    run: git ls-remote --heads origin feat-gated
+    cwd: "$WORK_DIR/autopush-repo/main"
+    expect:
+      exit_code: 0
+      output_not_contains: ["feat-gated"]
+
+  - name: --no-verify lets the same creation push through
+    run: git-worktree-checkout -b feat-bypassed --no-verify 2>&1
+    cwd: "$WORK_DIR/autopush-repo/main"
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/autopush-repo/feat-bypassed"
+
+  - name: The bypassed branch reached the remote
+    run: git ls-remote --heads origin feat-bypassed
+    cwd: "$WORK_DIR/autopush-repo/main"
+    expect:
+      exit_code: 0
+      output_contains: ["feat-bypassed"]

--- a/tests/manual/scenarios/push-hooks/checkout-branch-autopush-rejected.yml
+++ b/tests/manual/scenarios/push-hooks/checkout-branch-autopush-rejected.yml
@@ -37,8 +37,9 @@ steps:
     expect:
       exit_code: 1
       output_contains:
-        - "pre-push hook in effect"
+        - "pre-push hook"
         - "ready at"
+        - "--no-verify"
       dirs_exist:
         - "$WORK_DIR/autopush-repo/feat-gated"
 

--- a/tests/manual/scenarios/push-hooks/rename-remote-rejected.yml
+++ b/tests/manual/scenarios/push-hooks/rename-remote-rejected.yml
@@ -39,7 +39,8 @@ steps:
     expect:
       exit_code: 1
       output_contains:
-        - "pre-push hook in effect"
+        - "pre-push hook"
+        - "--no-verify"
       dirs_exist:
         - "$WORK_DIR/rename-gate-repo/feature/renamed"
 

--- a/tests/manual/scenarios/push-hooks/rename-remote-rejected.yml
+++ b/tests/manual/scenarios/push-hooks/rename-remote-rejected.yml
@@ -1,0 +1,59 @@
+name: rename's remote update is gated by the pre-push hook
+description:
+  "A failing pre-push hook gates daft rename's remote operations: the local
+  rename and worktree move complete, the command exits non-zero with the
+  gated-push message, and the remote still has the old branch name."
+
+repos:
+  - name: rename-gate-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone the repository
+    run: git-worktree-clone --layout contained $REMOTE_RENAME_GATE_REPO
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/rename-gate-repo/main"
+
+  - name: Checkout the feature branch
+    run: git-worktree-checkout feature/test-feature
+    cwd: "$WORK_DIR/rename-gate-repo/main"
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/rename-gate-repo/feature/test-feature"
+
+  - name: Install a failing pre-push hook via core.hooksPath
+    run: |
+      mkdir -p $WORK_DIR/test-hooks
+      printf '#!/bin/sh\necho "GATE SAYS NO" >&2\nexit 1\n' > $WORK_DIR/test-hooks/pre-push
+      chmod +x $WORK_DIR/test-hooks/pre-push
+      git config core.hooksPath $WORK_DIR/test-hooks
+    cwd: "$WORK_DIR/rename-gate-repo/main"
+    expect: { exit_code: 0 }
+
+  - name: Rename completes locally but fails on the gated remote push
+    run: daft rename feature/test-feature feature/renamed 2>&1
+    cwd: "$WORK_DIR/rename-gate-repo/main"
+    expect:
+      exit_code: 1
+      output_contains:
+        - "pre-push hook in effect"
+      dirs_exist:
+        - "$WORK_DIR/rename-gate-repo/feature/renamed"
+
+  - name: The local branch was renamed
+    run: git branch --list feature/renamed
+    cwd: "$WORK_DIR/rename-gate-repo/main"
+    expect:
+      exit_code: 0
+      output_contains: ["feature/renamed"]
+
+  - name: The remote still has the old name and not the new one
+    run: git ls-remote --heads origin 2>/dev/null
+    cwd: "$WORK_DIR/rename-gate-repo/main"
+    expect:
+      exit_code: 0
+      output_contains: ["feature/test-feature"]
+      output_not_contains: ["feature/renamed"]

--- a/tests/manual/scenarios/push-hooks/sync-push-no-verify-bypasses.yml
+++ b/tests/manual/scenarios/push-hooks/sync-push-no-verify-bypasses.yml
@@ -1,0 +1,65 @@
+name: sync --push --no-verify bypasses a failing pre-push hook
+description:
+  "--no-verify restores the old bypass behavior: a failing pre-push hook is
+  skipped, the push succeeds, and no synthetic pre-push phase is rendered."
+
+repos:
+  - name: push-bypass-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone the repository
+    run: git-worktree-clone --layout contained $REMOTE_PUSH_BYPASS_REPO
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/push-bypass-repo/main"
+
+  - name: Set local identity so the feature branch is owned
+    run: |
+      git config user.email "me@example.com"
+      git config user.name "Me Testuser"
+    cwd: "$WORK_DIR/push-bypass-repo/main"
+    expect: { exit_code: 0 }
+
+  - name: Checkout the feature branch
+    run: git-worktree-checkout feature/test-feature
+    cwd: "$WORK_DIR/push-bypass-repo/main"
+    expect: { exit_code: 0 }
+
+  - name: Commit an owned change on the feature branch
+    run: |
+      echo "owned change" > owned.txt
+      git add owned.txt
+      GIT_AUTHOR_EMAIL="me@example.com" GIT_COMMITTER_EMAIL="me@example.com" \
+        git commit -m "Owned commit"
+    cwd: "$WORK_DIR/push-bypass-repo/feature/test-feature"
+    expect: { exit_code: 0 }
+
+  - name: Install a failing pre-push hook via core.hooksPath
+    run: |
+      mkdir -p $WORK_DIR/test-hooks
+      printf '#!/bin/sh\necho "GATE SAYS NO" >&2\nexit 1\n' > $WORK_DIR/test-hooks/pre-push
+      chmod +x $WORK_DIR/test-hooks/pre-push
+      git config core.hooksPath $WORK_DIR/test-hooks
+    cwd: "$WORK_DIR/push-bypass-repo/feature/test-feature"
+    expect: { exit_code: 0 }
+
+  - name: sync --push --no-verify bypasses the hook and pushes
+    run: git-worktree-sync --push --no-verify 2>&1
+    cwd: "$WORK_DIR/push-bypass-repo/feature/test-feature"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "pushed feature/test-feature"
+      output_not_contains:
+        - "GATE SAYS NO"
+
+  - name: The remote branch was updated despite the failing hook
+    run: |
+      git fetch origin 2>/dev/null
+      git rev-list --count origin/feature/test-feature..feature/test-feature
+    cwd: "$WORK_DIR/push-bypass-repo/feature/test-feature"
+    expect:
+      exit_code: 0
+      output_contains: ["0"]

--- a/tests/manual/scenarios/push-hooks/sync-push-passing-and-up-to-date.yml
+++ b/tests/manual/scenarios/push-hooks/sync-push-passing-and-up-to-date.yml
@@ -1,0 +1,78 @@
+name: sync --push with a passing pre-push hook pushes and detects up-to-date
+description:
+  "A passing pre-push hook lets `sync --push` through (reported as a successful
+  pre-push phase), and a second run still classifies the branch as up to date —
+  the porcelain-based detection survives the hook-honoring stdio change (#599
+  regression)."
+
+repos:
+  - name: push-pass-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone the repository
+    run: git-worktree-clone --layout contained $REMOTE_PUSH_PASS_REPO
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/push-pass-repo/main"
+
+  - name: Set local identity so the feature branch is owned
+    run: |
+      git config user.email "me@example.com"
+      git config user.name "Me Testuser"
+    cwd: "$WORK_DIR/push-pass-repo/main"
+    expect: { exit_code: 0 }
+
+  - name: Checkout the feature branch
+    run: git-worktree-checkout feature/test-feature
+    cwd: "$WORK_DIR/push-pass-repo/main"
+    expect: { exit_code: 0 }
+
+  - name: Commit an owned change on the feature branch
+    run: |
+      echo "owned change" > owned.txt
+      git add owned.txt
+      GIT_AUTHOR_EMAIL="me@example.com" GIT_COMMITTER_EMAIL="me@example.com" \
+        git commit -m "Owned commit"
+    cwd: "$WORK_DIR/push-pass-repo/feature/test-feature"
+    expect: { exit_code: 0 }
+
+  - name: Install a passing pre-push hook via core.hooksPath
+    run: |
+      mkdir -p $WORK_DIR/test-hooks
+      printf '#!/bin/sh\necho "checks ok"\nexit 0\n' > $WORK_DIR/test-hooks/pre-push
+      chmod +x $WORK_DIR/test-hooks/pre-push
+      git config core.hooksPath $WORK_DIR/test-hooks
+    cwd: "$WORK_DIR/push-pass-repo/feature/test-feature"
+    expect: { exit_code: 0 }
+
+  - name: sync --push goes through the hook and pushes
+    # The synthetic pre-push phase markup is suppressed under DAFT_TESTING
+    # (same as lifecycle-hook rendering); its presence is covered by unit
+    # tests against a recording presenter.
+    run: git-worktree-sync --push 2>&1
+    cwd: "$WORK_DIR/push-pass-repo/feature/test-feature"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "pushed feature/test-feature"
+
+  - name: The remote branch was updated
+    run: |
+      git fetch origin 2>/dev/null
+      git rev-list --count origin/feature/test-feature..feature/test-feature
+    cwd: "$WORK_DIR/push-pass-repo/feature/test-feature"
+    expect:
+      exit_code: 0
+      output_contains: ["0"]
+
+  - name: A second sync --push detects up-to-date (porcelain regression)
+    run: git-worktree-sync --push 2>&1
+    cwd: "$WORK_DIR/push-pass-repo/feature/test-feature"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "up to date"
+      output_not_contains:
+        - "pushed feature/test-feature"

--- a/tests/manual/scenarios/push-hooks/sync-push-rejected.yml
+++ b/tests/manual/scenarios/push-hooks/sync-push-rejected.yml
@@ -1,0 +1,69 @@
+name: sync --push aborts when the repo's pre-push hook rejects
+description:
+  "A failing pre-push hook (installed via core.hooksPath, the lefthook/husky
+  mechanism) gates `sync --push`: the push is blocked, the hook's output is
+  reported under a synthetic pre-push phase, and the command exits non-zero."
+
+repos:
+  - name: push-gate-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone the repository
+    run: git-worktree-clone --layout contained $REMOTE_PUSH_GATE_REPO
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/push-gate-repo/main"
+
+  - name: Set local identity so the feature branch is owned
+    run: |
+      git config user.email "me@example.com"
+      git config user.name "Me Testuser"
+    cwd: "$WORK_DIR/push-gate-repo/main"
+    expect: { exit_code: 0 }
+
+  - name: Checkout the feature branch
+    run: git-worktree-checkout feature/test-feature
+    cwd: "$WORK_DIR/push-gate-repo/main"
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/push-gate-repo/feature/test-feature"
+
+  - name: Commit an owned change on the feature branch
+    run: |
+      echo "owned change" > owned.txt
+      git add owned.txt
+      GIT_AUTHOR_EMAIL="me@example.com" GIT_COMMITTER_EMAIL="me@example.com" \
+        git commit -m "Owned commit"
+    cwd: "$WORK_DIR/push-gate-repo/feature/test-feature"
+    expect: { exit_code: 0 }
+
+  - name: Install a failing pre-push hook via core.hooksPath
+    run: |
+      mkdir -p $WORK_DIR/test-hooks
+      printf '#!/bin/sh\necho "GATE SAYS NO" >&2\nexit 1\n' > $WORK_DIR/test-hooks/pre-push
+      chmod +x $WORK_DIR/test-hooks/pre-push
+      git config core.hooksPath $WORK_DIR/test-hooks
+    cwd: "$WORK_DIR/push-gate-repo/feature/test-feature"
+    expect: { exit_code: 0 }
+
+  - name: sync --push is rejected by the hook and exits non-zero
+    run: git-worktree-sync --push 2>&1
+    cwd: "$WORK_DIR/push-gate-repo/feature/test-feature"
+    expect:
+      exit_code: 1
+      output_contains:
+        - "pre-push"
+        - "GATE SAYS NO"
+        - "pre-push hook in effect"
+
+  - name: The remote branch was not updated
+    run: |
+      git fetch origin 2>/dev/null
+      git rev-list --count origin/feature/test-feature..feature/test-feature
+    cwd: "$WORK_DIR/push-gate-repo/feature/test-feature"
+    expect:
+      exit_code: 0
+      output_contains: ["1"]

--- a/tests/manual/scenarios/push-hooks/sync-push-rejected.yml
+++ b/tests/manual/scenarios/push-hooks/sync-push-rejected.yml
@@ -57,7 +57,7 @@ steps:
       output_contains:
         - "pre-push"
         - "GATE SAYS NO"
-        - "pre-push hook in effect"
+        - "pre-push hook honored"
 
   - name: The remote branch was not updated
     run: |


### PR DESCRIPTION
Fixes #599.

## What

Every daft-initiated push hardcoded `--no-verify`, silently bypassing the
repository's `pre-push` hook — native `.git/hooks`, lefthook, husky, and
pre-commit-framework alike. A developer with a pre-push test-gate or
secret-scanner got it on `git push` but never on a daft push, so daft could not
honestly claim to be a drop-in for hook-managed repos.

This flips the default from **always bypass** to **honor**: git now runs
`pre-push` and gates the push on its exit code at all six push sites — plus a
hand-rolled bypass that lived outside the primitives in `multi_remote.rs`. The
hook's run is reported through the same `JobPresenter` surface daft already uses
for lifecycle hooks, and `--no-verify` is preserved as an explicit
per-invocation opt-out.

It ships entirely on **Path A**: git dispatches the hook as one opaque
subprocess, daft tees its output and reports a single synthetic `pre-push`
phase. The `StageRunner` port that #468 will implement (daft-owned hook stages
with per-job fidelity) is **declared** here behind a Noop adapter, so this PR
carries zero #468 code while leaving the exact seam #468 plugs into.

## Highlights

### The shared seam (`src/git/remote.rs`)

- One private `run_push(args, cwd, opts) -> PushIo` funnels every push. The
  `--no-verify` literal now appears in exactly one place in the codebase, gated
  on `!opts.verify` — a `#[test]` grep-gate walks `src/` and fails the build if
  it leaks anywhere else.
- Always passes `--porcelain`; streams stdout+stderr through a thread-per-pipe
  tee (mirroring `src/executor/command.rs`) so output is both forwarded live to
  the presenter and fully captured for parsing.
- The three primitives became cwd-mandatory (`push_set_upstream_from`,
  `push_from`, `push_delete_from`) so native hooks fire in the correct worktree;
  the two no-cwd variants are deleted (pre-1.0 clean cut). New error contract:
  `Err` = spawn/IO failure only; a rejected push is
  `Ok(PushIo { success: false, .. })` so the composition layer classifies before
  deciding severity.
- The raw `multi_remote.rs` bypass and its `set_current_dir`/restore dance are
  gone — it routes through `push_delete_from` with an explicit cwd.
- New `pre_push_hook_exists(cwd)` resolves `core.hooksPath` (so lefthook / husky
  / pre-commit installs are detected, not just `.git/hooks`) and checks the
  executable bit.

### Pure porcelain parser (`src/git/push_porcelain.rs`)

- `parse_push_report(stdout) -> PushReport` replaces the locale-fragile
  `"Everything up-to-date"` stderr grep. A hook rejection emits zero porcelain
  ref lines — that is the gate signature. Pure function, nine unit tests against
  fixtures captured from real `git push --porcelain` runs.

### Composition (`src/core/worktree/push.rs`)

- `push_with_hooks(...)` is the single entry point. `--no-verify` ⇒ `Bypassed`;
  `manages_stage` ⇒ Path B (run the stage, then push with `verify=false` so git
  does not double-fire the hook); otherwise Path A (existence-gated synthetic
  `pre-push` phase with teed output). Collapses to a coarse
  `PushOutcome { up_to_date, hook: HookVerdict, failure }` that every caller
  branches on regardless of path.

### The `StageRunner` port (`src/core/worktree/ports.rs`)

- First port outside `src/coordinator/` (consumer-owns-port, `dyn` + sync per
  ARCHITECTURE.md). Ships with `NoopStageRunner` whose `manages_stage` returns
  `false`, so everything runs Path A today and #599 compiles and ships with zero
  #468 code. The port pins git's four-field pre-push stdin via `PushRef`.

### Reporting (CLI + TUI)

- Path A drives `CliPresenter` / `TuiPresenter` **directly** around the teed
  subprocess: one `on_phase_start("pre-push")` → one job carrying git's output →
  `on_phase_complete`. Same `JobPresenter` trait and renderers as lifecycle
  hooks — it simply drives them directly rather than through `HookExecutor`
  (a native/lefthook subprocess has no `HookContext`/`HookType`/daft job).
- The phase is **existence-gated**: a plain push with no hook shows no hollow
  header.
- TUI sync gains `DagHookPhase { Lifecycle(HookType), PrePush }` — the DAG event
  label is generalized; the closed `HookType` enum is untouched (explicit
  non-goal: no `HookType::PrePush`).

### Per-site semantics — the one deliberate behavior change

The hook always gates the push. **When a pre-push hook exists and `verify` is
on, a failed push is now an error (non-zero exit), not a warning** — a gate
saying NO must not be reduced to a warning. With no hook present (or with
`--no-verify`), the old warn-and-continue ergonomics are preserved, so the
offline UX is intact. Escalation bails are **deferred** until after worktree
setup / cd-redirect completes, so the user's shell still lands in the new
worktree even when the gated push then fails the command.

| Site | Before, on push failure | After #599 |
|---|---|---|
| `sync --push` | counted → non-zero | unchanged |
| checkout-branch auto-upstream | warn + continue | hook present ⇒ error (worktree kept + set up) |
| rename (push new name / delete old) | warn + continue | hook present ⇒ error |
| branch-delete `--remote` | recorded → non-zero | unchanged |
| multi-remote move `--push` / delete-old | warn + continue | hook present ⇒ error |

### `--no-verify` passthrough

- Added to `sync`, `checkout` (`-b` / `go` / `start`), `rename`,
  `worktree-branch` (+ `remove`), `branch-delete`, and `multi-remote move`.
  Threads to `verify = !no_verify`. Man pages + CLI reference docs regenerated.

## The up_to_date fork (resolved, not regressed)

The issue flagged a real design fork: you cannot switch to `Stdio::inherit()` to
surface hook output without emptying the captured string `sync` parses for
up-to-date, which would mislabel up-to-date branches as "Pushed successfully."
Resolved with option (b) from the issue — `--porcelain` + tee. Porcelain puts a
locale-stable verdict on **stdout** (`=\t<refspec>\t[up to date]`) while the
hook's output stays on its own streams and is teed for visibility. A second
`sync --push` after a passing push still classifies the branch as up-to-date
(covered by a dedicated scenario).

## #468 design appendix — the two-axis Path-B model (behind `StageRunner`, not built here)

The pluggable hook-runner architecture asked for in scoping lives entirely
behind the `StageRunner` port, so it costs this PR nothing:

- **Outer axis** — per repo: managed **and** trusted ⇒ Path B (daft owns the
  stage); otherwise ⇒ Path A (git dispatches). Trust gates only daft's own stage;
  it cannot gate git's native dispatch, so an untrusted repo degrades to Path A
  and the push still proceeds with the native/lefthook hook firing.
- **Inner axis** — inside Path B: a config-template plugin (a drop-in
  configuration file describing how to detect/parse/run a new runner) ⇒ a
  compiled-Rust plugin (the speed fallback when a template would be too slow) ⇒
  an opaque single-job fallback. Repo-supplied runner templates carry arbitrary
  invoke strings — the same trust surface as `daft.yml` hooks — so #468 must
  trust-gate them.

#468 supplies the real adapter; the seam already calls
`manages_stage("pre-push", repo_cwd)` and runs `run_stage(...)` before pushing
with `verify=false` (avoiding a double-fire). #600 consumes the same seam, adding
only branch→worktree resolution.

## Testing

- Unit: **1976 / 0**, clippy zero-warnings, fmt clean, man pages up-to-date.
- New unit coverage: the pure porcelain parser (9 tests), and `push_with_hooks`
  end-to-end against real temp-repo hooks with a recording presenter and a fake
  managing `StageRunner` (13 tests) — failing hook rejects and reports, passing
  hook pushes, `--no-verify` bypasses without emitting a phase, a hookless repo
  renders nothing, up-to-date survives, and Path B blocks on stage failure / does
  not re-fire on success.
- Six new YAML scenarios under `tests/manual/scenarios/push-hooks/` install a
  hook via `core.hooksPath` against the `standard-remote` fixture and assert the
  gate at each surface: `sync --push` rejected, sync passing + up-to-date
  regression, `--no-verify` bypass, checkout-branch auto-upstream rejected,
  rename remote rejected, branch-delete `--remote` rejected.
- Neighboring scenario suites re-run green (sync, branch-delete, checkout,
  rename).

## Note

Implementing the multi-remote move scenario surfaced a **pre-existing** bug:
`daft multi-remote enable` fails in the `contained` layout (it tries
`git worktree move` on the container root → "is a main working tree"). It is
unrelated to this change and deserves its own issue; site 6's gating is covered
by unit tests and shares the rename path's exact code, so no YAML scenario is
gated on that bug.
