### PR TITLE
ci: de-flake bg-output-silent test and extend artifact retention

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -412,7 +412,13 @@ jobs:
           path: |
             target/release/daft
             target/release/xtask
-          retention-days: 1
+          # 5 days (not 1): the integration-test jobs download this artifact
+          # rather than rebuild. Re-running only the failed jobs
+          # (`gh run rerun --failed`) does NOT re-run `build`, so with a 1-day
+          # window a re-run a couple of days later finds no artifact and fails at
+          # "Download binary" without running any test. 5 days covers a normal
+          # re-run window; a fresh full run always rebuilds regardless.
+          retention-days: 5
 
   # Integration tests (Linux only) — 4 parallel workers:
   # {default, gitoxide} x {bash, yaml}

--- a/tests/manual/scenarios/hooks/bg-output-silent.yml
+++ b/tests/manual/scenarios/hooks/bg-output-silent.yml
@@ -100,11 +100,23 @@ steps:
     run: |
       REPO_ID=$(cat "$WORK_DIR/test-bg-output-silent/.git/daft-id")
       JOBS_DIR="$HOME/.local/state/daft/jobs/$REPO_ID"
-      LOGS=$(find "$JOBS_DIR" -path '*silent-ok-job*' -name 'output.jsonl' 2>/dev/null)
+      # The log removal on silent success is best-effort and lands *after* the
+      # job's status flips out of `running` (which the previous step waited for),
+      # so poll for the file to disappear rather than checking once. A single
+      # check races the coordinator's cleanup under load and flakes. Bounded at
+      # 10 s (20 x 0.5 s), mirroring the settle-poll in the previous step.
+      for _ in $(seq 1 20); do
+        LOGS=$(find "$JOBS_DIR" -path '*silent-ok-job*' -name 'output.jsonl' 2>/dev/null)
+        if [ -z "$LOGS" ]; then
+          echo "OK_LOG_DELETED"
+          exit 0
+        fi
+        sleep 0.5
+      done
       echo "ok_logs_found:"
       printf '%s\n' "$LOGS"
-      [ -z "$LOGS" ] || { echo "ASSERTION_FAILED: silent-ok-job log was not deleted: $LOGS"; exit 1; }
-      echo "OK_LOG_DELETED"
+      echo "ASSERTION_FAILED: silent-ok-job log was not deleted within 10s: $LOGS"
+      exit 1
     expect:
       exit_code: 0
       output_contains:

--- a/tests/manual/scenarios/hooks/bg-output-silent.yml
+++ b/tests/manual/scenarios/hooks/bg-output-silent.yml
@@ -115,7 +115,7 @@ steps:
       done
       echo "ok_logs_found:"
       printf '%s\n' "$LOGS"
-      echo "ASSERTION_FAILED: silent-ok-job log was not deleted within 10s: $LOGS"
+      echo "ASSERTION_FAILED: silent-ok-job log was not deleted within 10s"
       exit 1
     expect:
       exit_code: 0


### PR DESCRIPTION
## What

Two CI-reliability fixes surfaced by Dependabot PR #634 (cargo deps), whose CI
failed twice for reasons unrelated to the dependency bump.

### 1. De-flake `hooks/bg-output-silent.yml` (step 4/6)

The step asserted the silent-success job's `output.jsonl` was deleted, but the
coordinator's best-effort log removal lands _after_ the job's status flips out
of `running` (which the preceding settle-poll waits for). A single `find` check
raced the cleanup under CI load and flaked, hopping integration-test matrix
cells run-to-run. It now polls for the file to disappear (bounded 10s),
mirroring the settle-poll in the preceding step.

### 2. Extend `daft-binary` artifact retention 1 → 5 days

The integration-test jobs download the `daft-binary` artifact built once by the
`build` job rather than rebuilding. With 1-day retention, re-running only the
failed jobs (`gh run rerun --failed`) a day or two later finds no artifact
(because `build` doesn't re-run) and fails at "Download binary" without running
a single test — a baffling non-signal. 5 days covers a normal re-run window; a
fresh full run always rebuilds regardless.

## Not included (separate follow-up)

The `core::worktree::merge::tests::squash_style_produces_single_commit_on_target`
unit-test flake is a separate, structural issue: `resolve_target(None)` reads
global process CWD, which cargo's parallel test threads can stomp, so in CI it
occasionally resolves the real (detached-HEAD) repo instead of the test's
tempdir. The fix (CWD isolation / explicit-target test refactor) needs care, and
a single green run can't validate a ~1/1900 flake, so it is intentionally
excluded here.

## Testing

- `bunx prettier@3.8.4 --check` on both files: clean.
- Changes are YAML-only (no `.rs`); CI runs the full build/lint/test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
