### PR TITLE
docs: fix VitePress build broken by unclosed angle-bracket placeholders

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,16 @@ on:
       - "docs/**"
       - "Cargo.toml"
       - ".github/workflows/docs.yml"
+  # Build (without deploying) on PRs that touch the docs, so a broken VitePress
+  # build is caught before merge. This workflow previously only ran on push to
+  # master, so bad Markdown (e.g. unclosed angle-bracket placeholders parsed as
+  # Vue elements) reached master undetected and broke every deploy. The Deploy
+  # step below is gated to non-PR events.
+  pull_request:
+    paths:
+      - "docs/**"
+      - "Cargo.toml"
+      - ".github/workflows/docs.yml"
   workflow_dispatch:
 
 permissions:
@@ -38,7 +48,11 @@ jobs:
         working-directory: docs
         run: bunx vitepress build
 
+      # Deploy only on push to master and manual dispatch — never on PR builds,
+      # which validate the VitePress build without publishing. github.event_name
+      # is a trusted, GitHub-controlled value (no untrusted-input injection).
       - name: Deploy to Cloudflare Pages
+        if: github.event_name != 'pull_request'
         uses: cloudflare/wrangler-action@v4.0.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/docs/cli/daft-file.md
+++ b/docs/cli/daft-file.md
@@ -13,7 +13,7 @@ Merge SOURCE into TARGET. When the source is a worktree-root daft file with
 seed provenance (daft recorded what it wrote there), the merge is THREE-WAY
 against that seed: only keys the source genuinely refined move into the
 target, a key-level preview is printed first, and the target is backed up to
-<git-common-dir>/.daft/backups/file-merge/ before writing. Keys changed on
+`<git-common-dir>/.daft/backups/file-merge/` before writing. Keys changed on
 both sides are conflicts: pick a side at the interactive prompt, pass -y to
 take the source's values, or the command aborts non-zero listing the keys.
 

--- a/docs/cli/git-worktree-branch-delete.md
+++ b/docs/cli/git-worktree-branch-delete.md
@@ -35,7 +35,7 @@ branch that:
 
 Use -D (--force) to override these safety checks. Forcing DISCARDS refined
 untracked daft files — they are stashed under
-<git-common-dir>/.daft/discarded/<branch>/ and never merged into another
+`<git-common-dir>/.daft/discarded/<branch>/` and never merged into another
 worktree. For the default branch (e.g. main), --force removes its worktree
 only — the local branch ref and remote branch are always preserved.
 

--- a/docs/cli/git-worktree-branch.md
+++ b/docs/cli/git-worktree-branch.md
@@ -43,7 +43,7 @@ delete a branch that:
     consolidate with daft-file(1) merge, or answer the interactive prompt
 
 Use -D to override these safety checks. Forcing DISCARDS refined untracked
-daft files — they are stashed under <git-common-dir>/.daft/discarded/<branch>/
+daft files — they are stashed under `<git-common-dir>/.daft/discarded/<branch>/`
 and never merged into another worktree. For the default branch (e.g. main),
 -D removes its worktree only — the local branch ref and remote branch are
 always preserved.

--- a/docs/cli/git-worktree-checkout.md
+++ b/docs/cli/git-worktree-checkout.md
@@ -24,7 +24,7 @@ automatically. If the branch exists both locally and on the remote, the local
 branch is checked out and upstream tracking is configured.
 
 With -b, creates a new branch and a corresponding worktree in a single
-operation. The new branch is based on the current branch, or on <base-branch>
+operation. The new branch is based on the current branch, or on `<base-branch>`
 if specified. After creating the branch locally, it is pushed to the remote
 and upstream tracking is configured.
 

--- a/docs/cli/git-worktree-prune.md
+++ b/docs/cli/git-worktree-prune.md
@@ -29,7 +29,7 @@ warning. Worktrees whose untracked daft files (daft.yml / daft.local.yml)
 were refined since daft seeded them are also kept, with a pointer at
 daft-file(1) merge for consolidation. --force overrides both: unmerged
 branches are deleted and refined daft files are discarded to
-<git-common-dir>/.daft/discarded/<branch>/ — prune never writes another
+`<git-common-dir>/.daft/discarded/<branch>/` — prune never writes another
 worktree's files.
 
 If you are currently inside a worktree that is about to be pruned, the command

--- a/man/daft-file.1
+++ b/man/daft-file.1
@@ -10,7 +10,7 @@ Merge SOURCE into TARGET. When the source is a worktree\-root daft file with
 seed provenance (daft recorded what it wrote there), the merge is THREE\-WAY
 against that seed: only keys the source genuinely refined move into the
 target, a key\-level preview is printed first, and the target is backed up to
-<git\-common\-dir>/.daft/backups/file\-merge/ before writing. Keys changed on
+`<git\-common\-dir>/.daft/backups/file\-merge/` before writing. Keys changed on
 both sides are conflicts: pick a side at the interactive prompt, pass \-y to
 take the source\*(Aqs values, or the command aborts non\-zero listing the keys.
 .PP

--- a/man/daft-go.1
+++ b/man/daft-go.1
@@ -22,7 +22,7 @@ Use \*(Aq\-\*(Aq as the branch name to switch to the previous worktree, similar 
 \*(Aqcd \-\*(Aq. Repeated \*(Aqdaft go \-\*(Aq toggles between the two most recent worktrees.
 .PP
 With \-b, creates a new branch and worktree in a single operation. The new
-branch is based on the current branch, or on <base\-branch> if specified.
+branch is based on the current branch, or on `<base\-branch>` if specified.
 Prefer \*(Aqdaft start\*(Aq for creating new branches.
 .PP
 With \-s (\-\-start), if the specified branch does not exist locally or on the

--- a/man/daft-prune.1
+++ b/man/daft-prune.1
@@ -23,7 +23,7 @@ warning. Worktrees whose untracked daft files (daft.yml / daft.local.yml)
 were refined since daft seeded them are also kept, with a pointer at
 daft\-file(1) merge for consolidation. \-\-force overrides both: unmerged
 branches are deleted and refined daft files are discarded to
-<git\-common\-dir>/.daft/discarded/<branch>/ — prune never writes another
+`<git\-common\-dir>/.daft/discarded/<branch>/` — prune never writes another
 worktree\*(Aqs files.
 .PP
 If you are currently inside a worktree that is about to be pruned, the command

--- a/man/daft-remove.1
+++ b/man/daft-remove.1
@@ -30,7 +30,7 @@ branch that:
     consolidate with daft\-file(1) merge, or answer the interactive prompt
 .PP
 Use \-f to override these safety checks. Forcing DISCARDS refined untracked
-daft files — they are stashed under <git\-common\-dir>/.daft/discarded/<branch>/
+daft files — they are stashed under `<git\-common\-dir>/.daft/discarded/<branch>/`
 and never merged into another worktree. For the default branch (e.g. main),
 \-f removes its worktree only — the local branch ref and remote branch are
 always preserved.

--- a/man/daft-start.1
+++ b/man/daft-start.1
@@ -11,7 +11,7 @@ Creates a new branch and a corresponding worktree in a single operation. The
 worktree is placed at the project root level as a sibling to other worktrees,
 using the branch name as the directory name.
 .PP
-The new branch is based on the current branch, or on <base\-branch> if
+The new branch is based on the current branch, or on `<base\-branch>` if
 specified. After creating the branch locally, it is pushed to the remote and
 upstream tracking is configured (unless disabled via daft.checkoutBranch.push).
 .PP

--- a/man/git-worktree-branch-delete.1
+++ b/man/git-worktree-branch-delete.1
@@ -28,7 +28,7 @@ branch that:
 .PP
 Use \-D (\-\-force) to override these safety checks. Forcing DISCARDS refined
 untracked daft files — they are stashed under
-<git\-common\-dir>/.daft/discarded/<branch>/ and never merged into another
+`<git\-common\-dir>/.daft/discarded/<branch>/` and never merged into another
 worktree. For the default branch (e.g. main), \-\-force removes its worktree
 only — the local branch ref and remote branch are always preserved.
 .PP

--- a/man/git-worktree-branch.1
+++ b/man/git-worktree-branch.1
@@ -35,7 +35,7 @@ delete a branch that:
     consolidate with daft\-file(1) merge, or answer the interactive prompt
 .PP
 Use \-D to override these safety checks. Forcing DISCARDS refined untracked
-daft files — they are stashed under <git\-common\-dir>/.daft/discarded/<branch>/
+daft files — they are stashed under `<git\-common\-dir>/.daft/discarded/<branch>/`
 and never merged into another worktree. For the default branch (e.g. main),
 \-D removes its worktree only — the local branch ref and remote branch are
 always preserved.

--- a/man/git-worktree-checkout.1
+++ b/man/git-worktree-checkout.1
@@ -16,7 +16,7 @@ automatically. If the branch exists both locally and on the remote, the local
 branch is checked out and upstream tracking is configured.
 .PP
 With \-b, creates a new branch and a corresponding worktree in a single
-operation. The new branch is based on the current branch, or on <base\-branch>
+operation. The new branch is based on the current branch, or on `<base\-branch>`
 if specified. After creating the branch locally, it is pushed to the remote
 and upstream tracking is configured.
 .PP

--- a/man/git-worktree-prune.1
+++ b/man/git-worktree-prune.1
@@ -23,7 +23,7 @@ warning. Worktrees whose untracked daft files (daft.yml / daft.local.yml)
 were refined since daft seeded them are also kept, with a pointer at
 daft\-file(1) merge for consolidation. \-\-force overrides both: unmerged
 branches are deleted and refined daft files are discarded to
-<git\-common\-dir>/.daft/discarded/<branch>/ — prune never writes another
+`<git\-common\-dir>/.daft/discarded/<branch>/` — prune never writes another
 worktree\*(Aqs files.
 .PP
 If you are currently inside a worktree that is about to be pruned, the command

--- a/src/commands/branch_delete.rs
+++ b/src/commands/branch_delete.rs
@@ -37,7 +37,7 @@ branch that:
 
 Use -D (--force) to override these safety checks. Forcing DISCARDS refined
 untracked daft files — they are stashed under
-<git-common-dir>/.daft/discarded/<branch>/ and never merged into another
+`<git-common-dir>/.daft/discarded/<branch>/` and never merged into another
 worktree. For the default branch (e.g. main), --force removes its worktree
 only — the local branch ref and remote branch are always preserved.
 

--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -39,7 +39,7 @@ automatically. If the branch exists both locally and on the remote, the local
 branch is checked out and upstream tracking is configured.
 
 With -b, creates a new branch and a corresponding worktree in a single
-operation. The new branch is based on the current branch, or on <base-branch>
+operation. The new branch is based on the current branch, or on `<base-branch>`
 if specified. After creating the branch locally, it is pushed to the remote
 and upstream tracking is configured.
 
@@ -165,7 +165,7 @@ Use '-' as the branch name to switch to the previous worktree, similar to
 'cd -'. Repeated 'daft go -' toggles between the two most recent worktrees.
 
 With -b, creates a new branch and worktree in a single operation. The new
-branch is based on the current branch, or on <base-branch> if specified.
+branch is based on the current branch, or on `<base-branch>` if specified.
 Prefer 'daft start' for creating new branches.
 
 With -s (--start), if the specified branch does not exist locally or on the
@@ -271,7 +271,7 @@ Creates a new branch and a corresponding worktree in a single operation. The
 worktree is placed at the project root level as a sibling to other worktrees,
 using the branch name as the directory name.
 
-The new branch is based on the current branch, or on <base-branch> if
+The new branch is based on the current branch, or on `<base-branch>` if
 specified. After creating the branch locally, it is pushed to the remote and
 upstream tracking is configured (unless disabled via daft.checkoutBranch.push).
 

--- a/src/commands/file/merge.rs
+++ b/src/commands/file/merge.rs
@@ -32,7 +32,7 @@ Merge SOURCE into TARGET. When the source is a worktree-root daft file with\n\
 seed provenance (daft recorded what it wrote there), the merge is THREE-WAY\n\
 against that seed: only keys the source genuinely refined move into the\n\
 target, a key-level preview is printed first, and the target is backed up to\n\
-<git-common-dir>/.daft/backups/file-merge/ before writing. Keys changed on\n\
+`<git-common-dir>/.daft/backups/file-merge/` before writing. Keys changed on\n\
 both sides are conflicts: pick a side at the interactive prompt, pass -y to\n\
 take the source's values, or the command aborts non-zero listing the keys.\n\
 \n\

--- a/src/commands/prune.rs
+++ b/src/commands/prune.rs
@@ -54,7 +54,7 @@ warning. Worktrees whose untracked daft files (daft.yml / daft.local.yml)
 were refined since daft seeded them are also kept, with a pointer at
 daft-file(1) merge for consolidation. --force overrides both: unmerged
 branches are deleted and refined daft files are discarded to
-<git-common-dir>/.daft/discarded/<branch>/ — prune never writes another
+`<git-common-dir>/.daft/discarded/<branch>/` — prune never writes another
 worktree's files.
 
 If you are currently inside a worktree that is about to be pruned, the command

--- a/src/commands/worktree_branch.rs
+++ b/src/commands/worktree_branch.rs
@@ -48,7 +48,7 @@ delete a branch that:
     consolidate with daft-file(1) merge, or answer the interactive prompt
 
 Use -D to override these safety checks. Forcing DISCARDS refined untracked
-daft files — they are stashed under <git-common-dir>/.daft/discarded/<branch>/
+daft files — they are stashed under `<git-common-dir>/.daft/discarded/<branch>/`
 and never merged into another worktree. For the default branch (e.g. main),
 -D removes its worktree only — the local branch ref and remote branch are
 always preserved.
@@ -166,7 +166,7 @@ branch that:
     consolidate with daft-file(1) merge, or answer the interactive prompt
 
 Use -f to override these safety checks. Forcing DISCARDS refined untracked
-daft files — they are stashed under <git-common-dir>/.daft/discarded/<branch>/
+daft files — they are stashed under `<git-common-dir>/.daft/discarded/<branch>/`
 and never merged into another worktree. For the default branch (e.g. main),
 -f removes its worktree only — the local branch ref and remote branch are
 always preserved.


### PR DESCRIPTION
## Problem

The **Deploy Docs** workflow has failed on every push to `master` since #629
(2026-06-20); the last green run was 2026-06-12. VitePress compiles each
Markdown page as a Vue SFC template, so bare angle-bracket placeholders such as
`<git-common-dir>` and `<branch>` written in prose are parsed as unclosed HTML
elements and abort the build:

```
[vite:vue] cli/git-worktree-prune.md (24:34): Element is missing end tag.
```

#629 added prose describing the `--force` discard path to several commands using
bare `<...>` placeholders, instead of the backtick-wrapped convention the same
help strings already use elsewhere (e.g. `` `git pull` `` in `git-worktree-fetch`).

## Why it stayed hidden

`docs.yml` only ran on push to `master` — never on pull requests — so the bad
Markdown passed PR CI and only broke once merged, on the live deploy.

## Fix

The `docs/cli/*.md` pages are **generated** from clap help text
(`xtask gen-cli-docs`), so editing the Markdown directly would be clobbered on
the next release. The fix is at the source:

1. **Backtick the placeholders in the clap `long_about`/`help` strings**
   (`prune`, `branch-delete`, `worktree-branch`, `checkout`, `file merge`) — this
   is correct authoring consistent with the existing backtick convention. Man
   pages and CLI docs are regenerated (`mise run man:gen`, `mise run docs:cli:gen`);
   the diff is backtick-only.
2. **Add a `pull_request` build guard to `docs.yml`** that builds (without
   deploying) the docs on PRs touching `docs/**`, so this class of breakage is
   caught before merge. The Deploy step is gated to non-PR events
   (`if: github.event_name != 'pull_request'`), so PRs never publish and fork
   PRs never see the Cloudflare secrets.

Because this PR touches `docs/**` and `docs.yml`, the new `pull_request` trigger
runs on this very PR — validating the fix here.

## Verification

- `cd docs && bunx vitepress build` — **green** (was failing on `master`).
- Pre-commit gates pass: `verify-man`, `verify-cli-docs`, `clippy`,
  `prettier-format`.
- `mise run fmt` / `mise run clippy` / `mise run test:unit` — all pass.
- No binary behavior change (help-text wording + docs tooling only), so `docs:`
  type / no release bump.

Fixes #640
