### PR TITLE
feat(hooks): contextual per-command notices when untrusted repos skip hooks, with trust + replay suggestions

### DIFF
--- a/.dep-age-allowlist
+++ b/.dep-age-allowlist
@@ -13,3 +13,9 @@
 # Example:
 #   # CVE-2026-XXXX patched in 0.2.4, no older fix available
 #   cargo:somecrate@0.2.4
+
+# why: soundness advisory in anyhow <=1.0.102 (dtolnay/anyhow#451) turns the
+# cargo-deny advisories gate red; 1.0.103 is the designated fix and is 6 days
+# old at time of bump — the same security exception Dependabot PRs get
+# automatically. Safe to remove after 2026-07-03.
+cargo:anyhow@1.0.103

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,6 +181,19 @@ invoked, then dispatches to the matching module in `src/commands/`. Symlinks
 like `git-worktree-clone → daft` enable Git subcommand discovery. Shortcut
 aliases (e.g., `gwtco`) are resolved in `src/shortcuts.rs` before routing.
 
+**Referring to the daft executable in output**: Runtime hints and suggested
+commands must render the executable the way the user invoked it —
+`daft hooks trust` for direct invocations (`daft`, `daft-go`, …),
+`git daft hooks trust` for git-style ones (`git daft`, `git worktree-checkout`,
+…). Use `daft::cli_label()` / `daft::daft_cmd(...)` (src/lib.rs); never hardcode
+`git daft` into a runtime string. Static text keeps the canonical `git daft`
+form: clap `about`/`long_about` (man pages are pre-generated from them) and
+`docs/` pages; SKILL.md uses the direct `daft` form (agents invoke the binary
+directly). Under `cfg!(test)` `cli_label()` always returns the canonical
+`git daft` — unit tests share one process, so argv-derived labels would flip
+assertions order-dependently; test the classification itself through
+`label_for_argv0`.
+
 **Shell integration**: `daft shell-init` generates shell wrappers that create a
 temp file and pass its path via `DAFT_CD_FILE`. When set, commands write the cd
 target to that file, and the wrapper reads it after the command finishes to `cd`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,9 +103,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"

--- a/SKILL.md
+++ b/SKILL.md
@@ -605,14 +605,17 @@ daft hooks dump         # Show fully merged configuration
 daft hooks run <type>   # Manually run a hook (bypasses trust)
 ```
 
-When a command skips hooks because the repo is untrusted, it prints one stderr
-warning naming the skipped hooks and suggesting `daft hooks trust` (suppressed
-by an explicit `--skip-hooks`). Each skip is recorded; a later
-`daft hooks trust` lists precise replay commands (`daft hooks run post-clone` /
-`daft hooks run worktree-post-create`) for the worktrees whose setup hooks never
-ran — run them inside each listed worktree. If an agent sees that warning,
-trusting and replaying is the way to get the worktree into its fully set-up
-state.
+When a command skips hooks because the repo is untrusted, it prints one plain
+stderr notice — e.g.
+`2 daft.yml hooks not run: worktree-pre-create, worktree-post-create — this repo isn't trusted.`
+— naming the skipped hooks and suggesting `daft hooks trust` (suppressed by an
+explicit `--skip-hooks`). It is an untagged notice, not a `warning:`, because an
+untrusted repo declining to run hooks is by design. Each skip is recorded; a
+later `daft hooks trust` lists precise replay commands
+(`daft hooks run post-clone` / `daft hooks run worktree-post-create`) for the
+worktrees whose setup hooks never ran — run them inside each listed worktree. If
+an agent sees that notice, trusting and replaying is the way to get the worktree
+into its fully set-up state.
 
 ### Manual Hook Execution
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -607,7 +607,7 @@ daft hooks run <type>   # Manually run a hook (bypasses trust)
 
 When a command skips hooks because the repo is untrusted, it prints one plain
 stderr notice — e.g.
-`2 daft.yml hooks not run: worktree-pre-create, worktree-post-create — this repo isn't trusted.`
+`Untrusted repo — 2 daft.yml hooks not run: worktree-pre-create, worktree-post-create`
 — naming the skipped hooks and suggesting `daft hooks trust` (suppressed by an
 explicit `--skip-hooks`). It is an untagged notice, not a `warning:`, because an
 untrusted repo declining to run hooks is by design. Each skip is recorded; a

--- a/SKILL.md
+++ b/SKILL.md
@@ -605,6 +605,15 @@ daft hooks dump         # Show fully merged configuration
 daft hooks run <type>   # Manually run a hook (bypasses trust)
 ```
 
+When a command skips hooks because the repo is untrusted, it prints one stderr
+warning naming the skipped hooks and suggesting `daft hooks trust` (suppressed
+by an explicit `--skip-hooks`). Each skip is recorded; a later
+`daft hooks trust` lists precise replay commands (`daft hooks run post-clone` /
+`daft hooks run worktree-post-create`) for the worktrees whose setup hooks never
+ran — run them inside each listed worktree. If an agent sees that warning,
+trusting and replaying is the way to get the worktree into its fully set-up
+state.
+
 ### Manual Hook Execution
 
 Run hooks on demand, bypassing trust checks (the user is explicitly invoking):

--- a/docs/about/troubleshooting.md
+++ b/docs/about/troubleshooting.md
@@ -24,15 +24,24 @@ Shell integration isn't installed. See
 [Shell integration](/getting-started/shell-integration) for the eval line to add
 to your shell config.
 
-## "daft.yml is untrusted; refusing to run hooks"
+## "hooks ... were NOT run — this repository isn't trusted"
 
-A `daft.yml` was added or changed. Trust the new contents:
+The repo defines hooks (`daft.yml` or `.daft/hooks/`) but hasn't been trusted,
+so daft skipped them. Trust it, then replay the setup that was skipped:
 
 ```bash
 git daft-hooks trust
+# trust prints the exact replay commands, e.g.:
+git daft-hooks run worktree-post-create   # inside each listed worktree
 ```
 
 This is intentional — see [Trust & security](/hooks/trust-and-security) for why.
+
+## My worktree is missing its hook side effects (env files, installs)
+
+It was probably created before the repo was trusted. Run `git daft-hooks trust`
+— it lists the worktrees whose setup hooks never ran and the
+`git daft-hooks run ...` commands to replay them.
 
 ## Hooks fire but I don't see their output
 

--- a/docs/about/troubleshooting.md
+++ b/docs/about/troubleshooting.md
@@ -24,7 +24,7 @@ Shell integration isn't installed. See
 [Shell integration](/getting-started/shell-integration) for the eval line to add
 to your shell config.
 
-## "hooks ... were NOT run — this repository isn't trusted"
+## "N hooks not run: ... — this repo isn't trusted"
 
 The repo defines hooks (`daft.yml` or `.daft/hooks/`) but hasn't been trusted,
 so daft skipped them. Trust it, then replay the setup that was skipped:

--- a/docs/about/troubleshooting.md
+++ b/docs/about/troubleshooting.md
@@ -24,7 +24,7 @@ Shell integration isn't installed. See
 [Shell integration](/getting-started/shell-integration) for the eval line to add
 to your shell config.
 
-## "N hooks not run: ... — this repo isn't trusted"
+## "Untrusted repo — N hooks not run: ..."
 
 The repo defines hooks (`daft.yml` or `.daft/hooks/`) but hasn't been trusted,
 so daft skipped them. Trust it, then replay the setup that was skipped:

--- a/docs/cli/daft-hooks.md
+++ b/docs/cli/daft-hooks.md
@@ -42,6 +42,10 @@ Grants full trust to the current repository, allowing hooks in
 Use 'git daft hooks prompt' instead if you want to be prompted before
 each hook execution.
 
+If hooks were skipped while the repository was untrusted, trusting
+lists the setup hooks that never ran and the exact
+'git daft hooks run' commands to replay them per worktree.
+
 Trust settings are stored in the daft config directory (trust.json)
 and persist across sessions.
 

--- a/docs/hooks/trust-and-security.md
+++ b/docs/hooks/trust-and-security.md
@@ -86,22 +86,23 @@ reference.
 ## Skipped hooks are never silent
 
 When a command would have run a hook but the repository isn't trusted, daft says
-so. Every command that fires lifecycle hooks — checkout, clone, merge, sync,
-prune, remove — prints one warning on stderr naming the hooks it skipped and the
-way forward:
+so. An untrusted repo skipping its hooks is the trust model working as designed,
+not a problem — so this is a plain notice, not a `warning:`. Every command that
+fires lifecycle hooks — checkout, clone, merge, sync, prune, remove — prints one
+notice on stderr naming the hooks it skipped and the way forward:
 
 ```
-warning: daft.yml defines hooks (worktree-pre-create, worktree-post-create) that were NOT run — this repository isn't trusted.
-         To run hooks here, trust this repository:  git daft hooks trust
-         Then replay this worktree's setup:         git daft hooks run worktree-post-create
+2 daft.yml hooks not run: worktree-pre-create, worktree-post-create — this repo isn't trusted.
+   To run them, trust this repo:       git daft hooks trust
+   Then replay this worktree's setup:  git daft hooks run worktree-post-create
 ```
 
-The warning covers both config shapes (`daft.yml` and `.daft/hooks/` scripts),
+The notice covers both config shapes (`daft.yml` and `.daft/hooks/` scripts),
 appears once per command no matter how many hooks were skipped, and never
 touches stdout, so shell integration and scripted output stay clean. Passing
 `--skip-hooks all` (or a hook-type selector naming the fire) suppresses it — an
-explicit opt-out is not a surprise worth warning about. The suggestion lines
-honor `DAFT_NO_HINTS=1`; the warning itself always prints.
+explicit opt-out is not a surprise worth reporting. The suggestion lines honor
+`DAFT_NO_HINTS=1`; the notice itself always prints.
 
 ### Replaying hooks you skipped
 

--- a/docs/hooks/trust-and-security.md
+++ b/docs/hooks/trust-and-security.md
@@ -92,10 +92,14 @@ fires lifecycle hooks — checkout, clone, merge, sync, prune, remove — prints
 notice on stderr naming the hooks it skipped and the way forward:
 
 ```
-2 daft.yml hooks not run: worktree-pre-create, worktree-post-create — this repo isn't trusted.
+Untrusted repo — 2 daft.yml hooks not run: worktree-pre-create, worktree-post-create
    To run them, trust this repo:       git daft hooks trust
    Then replay this worktree's setup:  git daft hooks run worktree-post-create
 ```
+
+The line reads general to specific — trust state, then the count, then the hook
+names — and on color terminals each part is styled by role: the state in bold,
+the hook names in daft's accent color, the suggested commands in cyan.
 
 The notice covers both config shapes (`daft.yml` and `.daft/hooks/` scripts),
 appears once per command no matter how many hooks were skipped, and never

--- a/docs/hooks/trust-and-security.md
+++ b/docs/hooks/trust-and-security.md
@@ -83,6 +83,46 @@ git daft hooks trust reset all
 See [`git daft-hooks`](/reference/cli/git-daft-hooks) for the full CLI
 reference.
 
+## Skipped hooks are never silent
+
+When a command would have run a hook but the repository isn't trusted, daft says
+so. Every command that fires lifecycle hooks — checkout, clone, merge, sync,
+prune, remove — prints one warning on stderr naming the hooks it skipped and the
+way forward:
+
+```
+warning: daft.yml defines hooks (worktree-pre-create, worktree-post-create) that were NOT run — this repository isn't trusted.
+         To run hooks here, trust this repository:  git daft hooks trust
+         Then replay this worktree's setup:         git daft hooks run worktree-post-create
+```
+
+The warning covers both config shapes (`daft.yml` and `.daft/hooks/` scripts),
+appears once per command no matter how many hooks were skipped, and never
+touches stdout, so shell integration and scripted output stay clean. Passing
+`--skip-hooks all` (or a hook-type selector naming the fire) suppresses it — an
+explicit opt-out is not a surprise worth warning about. The suggestion lines
+honor `DAFT_NO_HINTS=1`; the warning itself always prints.
+
+### Replaying hooks you skipped
+
+Each trust-skip is also recorded. When you later run `git daft hooks trust`,
+daft checks those records and lists the setup hooks that never ran, scoped to
+the worktrees that still exist:
+
+```
+Hooks were skipped here while the repository was untrusted. Replay them:
+  git daft hooks run post-clone               # in main
+  git daft hooks run worktree-post-create     # in feature/a, feature/b
+```
+
+Run the suggested command inside each listed worktree to apply the setup side
+effects (installs, symlinks, env files) retroactively. Only the idempotent setup
+hooks are suggested — `post-clone` and `worktree-post-create`. Pre-flight and
+removal hooks belong to operations that already happened, and merge hooks depend
+on per-merge environment variables, so replaying them would be meaningless or
+harmful. A record is cleared the moment the hook actually runs for that worktree
+(including via `hooks run`), so the suggestions stay accurate.
+
 ## Trust granularity
 
 Trust is granted at the **repository** level, identified by remote URL. There is

--- a/docs/hooks/trust-and-security.md
+++ b/docs/hooks/trust-and-security.md
@@ -99,7 +99,9 @@ Untrusted repo — 2 daft.yml hooks not run: worktree-pre-create, worktree-post-
 
 The line reads general to specific — trust state, then the count, then the hook
 names — and on color terminals each part is styled by role: the state in bold,
-the hook names in daft's accent color, the suggested commands in cyan.
+the hook names in daft's accent color, the suggested commands in cyan. The
+suggested commands also match how you invoked daft: `daft hooks trust` when you
+ran `daft` directly, `git daft hooks trust` when you went through git.
 
 The notice covers both config shapes (`daft.yml` and `.daft/hooks/` scripts),
 appears once per command no matter how many hooks were skipped, and never

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -73,3 +73,11 @@ pub fn argv() -> &'static [String] {
     ARGV.get()
         .expect("cli::install_and_apply must be called before cli::argv()")
 }
+
+/// Non-panicking [`argv`]: `None` before [`install_and_apply`] has run (unit
+/// tests, library embedders). Callers that must never crash on a missing
+/// install — e.g. cosmetic concerns like [`crate::cli_label`] — use this and
+/// pick a canonical fallback.
+pub fn try_argv() -> Option<&'static [String]> {
+    ARGV.get().map(Vec::as_slice)
+}

--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -791,23 +791,14 @@ fn run_checkout(
     }
 
     output.start_spinner("Preparing worktree...");
-    let (checkout_result, executor) = {
+    let checkout_result = {
         let mut bridge = CommandBridge::new(output, executor);
-        let r = checkout::execute(&params, git, &project_root, &mut bridge);
-        (r, bridge.into_executor())
+        checkout::execute(&params, git, &project_root, &mut bridge)
     };
     output.finish_spinner();
     let result = checkout_result?;
 
     render_checkout_result(&result, output);
-
-    // Show hooks notice if skipped due to trust
-    if result.post_hook_outcome.skipped
-        && let Some(reason) = &result.post_hook_outcome.skip_reason
-        && reason == "Repository not trusted"
-    {
-        executor.check_hooks_notice(&result.worktree_path, &result.git_dir, output);
-    }
 
     // Run exec commands (after hooks, before cd_path)
     let exec_result = crate::exec::run_exec_commands(&args.exec, output);
@@ -894,16 +885,15 @@ fn run_create_branch(
     if !push_hook_will_render {
         output.start_spinner("Creating worktree...");
     }
-    let (checkout_result, executor) = {
+    let checkout_result = {
         let mut bridge = CommandBridge::new(output, executor);
-        let r = checkout_branch::execute(
+        checkout_branch::execute(
             &params,
             git,
             &project_root,
             push_presenter.as_ref(),
             &mut bridge,
-        );
-        (r, bridge.into_executor())
+        )
     };
     if !push_hook_will_render {
         output.finish_spinner();
@@ -911,14 +901,6 @@ fn run_create_branch(
     let result = checkout_result?;
 
     render_create_result(&result, output);
-
-    // Show hooks notice if skipped due to trust
-    if result.post_hook_outcome.skipped
-        && let Some(reason) = &result.post_hook_outcome.skip_reason
-        && reason == "Repository not trusted"
-    {
-        executor.check_hooks_notice(&result.worktree_path, &result.git_dir, output);
-    }
 
     // Run exec commands (after hooks, before cd_path)
     let exec_result = crate::exec::run_exec_commands(&args.exec, output);

--- a/src/commands/clone.rs
+++ b/src/commands/clone.rs
@@ -1440,14 +1440,7 @@ fn run_post_clone_hook(
     .with_new_branch(false);
 
     let presenter = CliPresenter::auto(&HookOutputConfig::default());
-    let hook_result = executor.execute(&ctx, output, presenter)?;
-
-    if hook_result.skipped
-        && let Some(reason) = &hook_result.skip_reason
-        && reason == "Repository not trusted"
-    {
-        executor.check_hooks_notice(worktree_path, &result.git_dir, output);
-    }
+    executor.execute(&ctx, output, presenter)?;
 
     Ok(())
 }

--- a/src/commands/clone.rs
+++ b/src/commands/clone.rs
@@ -537,6 +537,11 @@ fn run_clone(args: &Args, settings: &DaftSettings, output: &mut dyn Output) -> R
 
     // Run hooks and exec only if a worktree was created
     if result.worktree_dir.is_some() {
+        // Surface untrusted-hook notices the multi-branch TUI deferred
+        // (TuiBridge buffers warnings) BEFORE the post-clone fire: the
+        // aggregated multi-worktree copy wins, and a post-clone Deny hit
+        // then dedups against it instead of replacing it.
+        crate::hooks::trust_skip::flush_pending_notice(&result.git_dir, output);
         run_post_clone_hook(args, &result, output)?;
         // For multi-branch TUI: hooks already ran inside TUI for all worktrees
         // (including the base). For everything else: run post-create hook for

--- a/src/commands/dump_store.rs
+++ b/src/commands/dump_store.rs
@@ -7,6 +7,8 @@
 //! - `visitor-seeds` — every visitor-config seed row for the repo, one
 //!   JSON object per line (`branch_slug`, `filename`, `content`,
 //!   timestamps).
+//! - `invocations` — every row in `invocations` for that repo, one JSON
+//!   object per line (includes the trust-skip records from #596).
 //!
 //! The output is JSON-serialized [`crate::coordinator::clean_policy::RepoPolicy`]
 //! (or `{}` when no row exists). Field names match the historical
@@ -23,23 +25,33 @@ use anyhow::{Context, Result, bail};
 pub fn run() -> Result<()> {
     let args: Vec<String> = crate::cli::argv().to_vec();
     let Some(table) = args.get(2) else {
-        bail!("usage: daft __dump-store <table>\n  tables: repo-policy, visitor-seeds");
+        bail!(
+            "usage: daft __dump-store <table>\n  tables: repo-policy, visitor-seeds, invocations"
+        );
     };
     match table.as_str() {
         "repo-policy" => dump_repo_policy(),
         "visitor-seeds" => dump_visitor_seeds(),
-        other => bail!("unknown table '{other}' (supported: repo-policy, visitor-seeds)"),
+        "invocations" => dump_invocations(),
+        other => {
+            bail!("unknown table '{other}' (supported: repo-policy, visitor-seeds, invocations)")
+        }
     }
 }
 
-fn dump_repo_policy() -> Result<()> {
-    use crate::coordinator::ports::JobsStorePort;
+fn open_store_for_cwd() -> Result<(String, crate::coordinator::adapters::SqliteJobsStore)> {
     let repo_hash = crate::core::repo_identity::compute_repo_id()
         .context("could not compute repo id for cwd")?;
     let state_base = crate::daft_state_dir().context("could not resolve daft state dir")?;
     let base = state_base.join("jobs").join(&repo_hash);
     let store = crate::coordinator::adapters::SqliteJobsStore::for_repo_base(&base)
         .context("open coordinator store")?;
+    Ok((repo_hash, store))
+}
+
+fn dump_repo_policy() -> Result<()> {
+    use crate::coordinator::ports::JobsStorePort;
+    let (repo_hash, store) = open_store_for_cwd()?;
     let policy = store.read_repo_policy(&repo_hash)?;
     let json = serde_json::to_string_pretty(&policy).context("serialize RepoPolicy")?;
     println!("{json}");
@@ -59,6 +71,31 @@ fn dump_visitor_seeds() -> Result<()> {
             "content": row.content,
             "seeded_at": row.seeded_at.to_rfc3339(),
             "updated_at": row.updated_at.to_rfc3339(),
+        });
+        println!("{json}");
+    }
+    Ok(())
+}
+
+fn dump_invocations() -> Result<()> {
+    let (repo_hash, store) = open_store_for_cwd()?;
+    // `__dump-store` is an application-boundary debug tool — the raw pool
+    // checkout is the sanctioned escape hatch for read paths the port
+    // doesn't (and shouldn't) surface.
+    let conn = store
+        .pool()
+        .reader()
+        .context("checkout store reader for dump")?;
+    let rows = crate::store::repos::InvocationsRepo::list_by_repo(&conn, &repo_hash)?;
+    for row in rows {
+        let json = serde_json::json!({
+            "invocation_id": row.invocation_id,
+            "trigger_command": row.trigger_command,
+            "hook_type": row.hook_type,
+            "worktree": row.worktree,
+            "created_at": row.created_at.to_rfc3339(),
+            "status": row.status,
+            "skip_reason": row.skip_reason,
         });
         println!("{json}");
     }

--- a/src/commands/flow_adopt.rs
+++ b/src/commands/flow_adopt.rs
@@ -247,14 +247,7 @@ fn run_post_adopt_hook(
     .with_new_branch(false);
 
     let presenter = CliPresenter::auto(&HookOutputConfig::default());
-    let hook_result = executor.execute(&ctx, output, presenter)?;
-
-    if hook_result.skipped
-        && let Some(reason) = &hook_result.skip_reason
-        && reason == "Repository not trusted"
-    {
-        executor.check_hooks_notice(&result.worktree_path, &result.git_dir, output);
-    }
+    executor.execute(&ctx, output, presenter)?;
 
     Ok(())
 }

--- a/src/commands/hooks/mod.rs
+++ b/src/commands/hooks/mod.rs
@@ -525,9 +525,10 @@ pub fn run() -> Result<()> {
         Some(HooksCommand::Run(run_args)) => run_cmd::cmd_run(&run_args, &mut output),
         None => {
             status::cmd_status(&args.path, false, &mut output)?;
-            output.info(&dim(
-                "Run `git daft hooks --help` to see all available commands.",
-            ));
+            output.info(&dim(&format!(
+                "Run `{}` to see all available commands.",
+                crate::daft_cmd("hooks --help")
+            )));
             Ok(())
         }
     }

--- a/src/commands/hooks/mod.rs
+++ b/src/commands/hooks/mod.rs
@@ -59,6 +59,13 @@ fn trust_long_about() -> String {
         ),
         "each hook execution.",
         "",
+        "If hooks were skipped while the repository was untrusted, trusting",
+        "lists the setup hooks that never ran and the exact",
+        &format!(
+            "'{}' commands to replay them per worktree.",
+            bold("git daft hooks run")
+        ),
+        "",
         "Trust settings are stored in the daft config directory (trust.json)",
         "and persist across sessions.",
     ]

--- a/src/commands/hooks/run_cmd.rs
+++ b/src/commands/hooks/run_cmd.rs
@@ -77,7 +77,7 @@ pub(super) fn cmd_run(args: &HooksRunArgs, output: &mut dyn Output) -> Result<()
         output.info(&format!(
             "  {} run `{}` to allow hooks to run automatically.",
             dim("Tip:"),
-            cyan("git daft hooks trust")
+            cyan(&crate::daft_cmd("hooks trust"))
         ));
         output.info("");
     }
@@ -298,7 +298,7 @@ fn cmd_run_list_hooks(
     output.info("");
     output.info(&format!(
         "Run a hook with: {}",
-        cyan("git daft hooks run <hook-type>")
+        cyan(&crate::daft_cmd("hooks run <hook-type>"))
     ));
 
     Ok(())

--- a/src/commands/hooks/status.rs
+++ b/src/commands/hooks/status.rs
@@ -197,7 +197,7 @@ pub(super) fn cmd_status(path: &Path, short: bool, output: &mut dyn Output) -> R
                 }
                 output.info(&format!(
                     "  Run '{}' to rename them.",
-                    cyan("git daft hooks migrate")
+                    cyan(&crate::daft_cmd("hooks migrate"))
                 ));
                 output.info(&format!(
                     "  {}",
@@ -221,28 +221,29 @@ pub(super) fn cmd_status(path: &Path, short: bool, output: &mut dyn Output) -> R
                     .to_string()
             };
 
+            let exe = crate::cli_label();
             match trust_level {
                 TrustLevel::Deny => {
                     output.info(&bold("To enable hooks:"));
                     output.info(&format!(
                         "  {}",
-                        cyan(&format!("git daft hooks trust {path_arg}"))
+                        cyan(&format!("{exe} hooks trust {path_arg}"))
                     ));
                     output.info(&format!(
                         "  {}",
-                        cyan(&format!("git daft hooks prompt {path_arg}"))
+                        cyan(&format!("{exe} hooks prompt {path_arg}"))
                     ));
                 }
                 TrustLevel::Prompt | TrustLevel::Allow => {
                     output.info(&bold("To revoke trust:"));
                     output.info(&format!(
                         "  {}  {}",
-                        cyan(&format!("git daft hooks deny {path_arg}")),
+                        cyan(&format!("{exe} hooks deny {path_arg}")),
                         dim("(explicitly deny)")
                     ));
                     output.info(&format!(
                         "  {}  {}",
-                        cyan(&format!("git daft hooks trust reset {path_arg}")),
+                        cyan(&format!("{exe} hooks trust reset {path_arg}")),
                         dim("(remove trust entry)")
                     ));
                 }

--- a/src/commands/hooks/trust.rs
+++ b/src/commands/hooks/trust.rs
@@ -95,11 +95,113 @@ pub(super) fn cmd_set_trust(
             output.result("Done.");
         }
 
+        if new_level == TrustLevel::Allow {
+            suggest_skipped_replays(&git_dir, project_root, output);
+        }
+
         Ok(())
     })();
 
     std::env::set_current_dir(&original_dir)?;
     result
+}
+
+/// One "replay this hook" line: the hook to run and the live branches whose
+/// recorded skip it would repair.
+#[derive(Debug, PartialEq, Eq)]
+struct ReplaySuggestion {
+    hook_type: String,
+    branches: Vec<String>,
+}
+
+/// Hooks worth suggesting a retroactive replay for. Only the idempotent
+/// setup hooks qualify: pre-* hooks prepare an operation that already
+/// happened, remove hooks tear down state (replaying one against a live
+/// worktree is harmful), and merge hooks template against `DAFT_MERGE_*`
+/// env that only the merge command injects.
+const REPLAYABLE_HOOKS: [&str; 2] = ["post-clone", "worktree-post-create"];
+
+/// Filter recorded skips down to actionable replay suggestions: replayable
+/// hook types only, branches that still have a live worktree, grouped per
+/// hook type in [`REPLAYABLE_HOOKS`] order.
+fn replay_suggestions(
+    rows: &[crate::store::models::InvocationRow],
+    live_branches: &std::collections::HashSet<String>,
+) -> Vec<ReplaySuggestion> {
+    use std::collections::BTreeSet;
+
+    REPLAYABLE_HOOKS
+        .iter()
+        .filter_map(|hook| {
+            let branches: BTreeSet<&str> = rows
+                .iter()
+                .filter(|r| r.hook_type == *hook && live_branches.contains(&r.worktree))
+                .map(|r| r.worktree.as_str())
+                .collect();
+            (!branches.is_empty()).then(|| ReplaySuggestion {
+                hook_type: hook.to_string(),
+                branches: branches.into_iter().map(String::from).collect(),
+            })
+        })
+        .collect()
+}
+
+/// After a trust grant, surface the hooks that were skipped while the
+/// repository was untrusted and offer the replay commands. Best-effort
+/// throughout — trusting must never fail because of the store.
+fn suggest_skipped_replays(git_dir: &Path, project_root: &Path, output: &mut dyn Output) {
+    use crate::coordinator::ports::JobsStorePort;
+    use crate::core::worktree::remove_repo::{RepoTarget, enumerate_worktrees};
+    use crate::store::paths::{COORDINATOR_DB, JOBS_SUBDIR};
+
+    let Ok(repo_hash) = crate::core::repo_identity::compute_repo_id_from_common_dir(git_dir) else {
+        return;
+    };
+    let Ok(state_base) = crate::daft_state_dir() else {
+        return;
+    };
+    // Existence check before opening: `for_repo_base` would create the
+    // per-repo state dir, and a repo with no hook history has none.
+    let base = state_base.join(JOBS_SUBDIR).join(&repo_hash);
+    if !base.join(COORDINATOR_DB).exists() {
+        return;
+    }
+    let Ok(store) = crate::coordinator::adapters::SqliteJobsStore::for_repo_base(&base) else {
+        return;
+    };
+    let Ok(rows) = store.list_skipped_invocations(&repo_hash) else {
+        return;
+    };
+    if rows.is_empty() {
+        return;
+    }
+
+    let target = RepoTarget {
+        bare_git_dir: git_dir.to_path_buf(),
+        project_root: project_root.to_path_buf(),
+    };
+    let Ok(entries) = enumerate_worktrees(&target, false) else {
+        return;
+    };
+    let live: std::collections::HashSet<String> =
+        entries.into_iter().filter_map(|e| e.branch).collect();
+
+    let suggestions = replay_suggestions(&rows, &live);
+    if suggestions.is_empty() {
+        return;
+    }
+
+    output.info("");
+    output.info(&bold(
+        "Hooks were skipped here while the repository was untrusted. Replay them:",
+    ));
+    for s in &suggestions {
+        output.info(&format!(
+            "  {}   {}",
+            cyan(&format!("git daft hooks run {}", s.hook_type)),
+            dim(&format!("# in {}", s.branches.join(", "))),
+        ));
+    }
 }
 
 /// Revoke trust for the repository at the given path.
@@ -462,4 +564,90 @@ pub(super) fn cmd_reset_trust_path(
 
     std::env::set_current_dir(&original_dir)?;
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::models::InvocationRow;
+    use crate::store::models::invocation::{INVOCATION_STATUS_SKIPPED, SKIP_REASON_UNTRUSTED};
+    use std::collections::HashSet;
+
+    fn skip_row(hook_type: &str, worktree: &str) -> InvocationRow {
+        InvocationRow {
+            repo_hash: "r".into(),
+            invocation_id: format!("{hook_type}-{worktree}"),
+            trigger_command: "checkout".into(),
+            hook_type: hook_type.into(),
+            worktree: worktree.into(),
+            created_at: chrono::Utc::now(),
+            coordinator_pid: None,
+            status: INVOCATION_STATUS_SKIPPED.into(),
+            skip_reason: Some(SKIP_REASON_UNTRUSTED.into()),
+        }
+    }
+
+    fn live(branches: &[&str]) -> HashSet<String> {
+        branches.iter().map(|b| b.to_string()).collect()
+    }
+
+    #[test]
+    fn suggests_only_replayable_hook_types() {
+        let rows = vec![
+            skip_row("worktree-pre-create", "feat/a"),
+            skip_row("worktree-post-create", "feat/a"),
+            skip_row("worktree-pre-remove", "feat/a"),
+            skip_row("worktree-post-remove", "feat/a"),
+            skip_row("pre-merge", "feat/a"),
+            skip_row("post-merge", "feat/a"),
+            skip_row("post-clone", "main"),
+        ];
+        let suggestions = replay_suggestions(&rows, &live(&["main", "feat/a"]));
+        assert_eq!(
+            suggestions,
+            vec![
+                ReplaySuggestion {
+                    hook_type: "post-clone".into(),
+                    branches: vec!["main".into()],
+                },
+                ReplaySuggestion {
+                    hook_type: "worktree-post-create".into(),
+                    branches: vec!["feat/a".into()],
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn excludes_branches_without_a_live_worktree() {
+        let rows = vec![
+            skip_row("worktree-post-create", "feat/alive"),
+            skip_row("worktree-post-create", "feat/removed"),
+        ];
+        let suggestions = replay_suggestions(&rows, &live(&["feat/alive"]));
+        assert_eq!(suggestions.len(), 1);
+        assert_eq!(suggestions[0].branches, vec!["feat/alive".to_string()]);
+    }
+
+    #[test]
+    fn groups_branches_per_hook_type_sorted_and_deduped() {
+        let rows = vec![
+            skip_row("worktree-post-create", "feat/b"),
+            skip_row("worktree-post-create", "feat/a"),
+            skip_row("worktree-post-create", "feat/a"),
+        ];
+        let suggestions = replay_suggestions(&rows, &live(&["feat/a", "feat/b"]));
+        assert_eq!(suggestions.len(), 1);
+        assert_eq!(
+            suggestions[0].branches,
+            vec!["feat/a".to_string(), "feat/b".to_string()]
+        );
+    }
+
+    #[test]
+    fn empty_when_nothing_actionable() {
+        assert!(replay_suggestions(&[], &live(&["main"])).is_empty());
+        let rows = vec![skip_row("worktree-pre-remove", "main")];
+        assert!(replay_suggestions(&rows, &live(&["main"])).is_empty());
+    }
 }

--- a/src/commands/hooks/trust.rs
+++ b/src/commands/hooks/trust.rs
@@ -195,10 +195,11 @@ fn suggest_skipped_replays(git_dir: &Path, project_root: &Path, output: &mut dyn
     output.info(&bold(
         "Hooks were skipped here while the repository was untrusted. Replay them:",
     ));
+    let exe = crate::cli_label();
     for s in &suggestions {
         output.info(&format!(
             "  {}   {}",
-            cyan(&format!("git daft hooks run {}", s.hook_type)),
+            cyan(&format!("{exe} hooks run {}", s.hook_type)),
             dim(&format!("# in {}", s.branches.join(", "))),
         ));
     }
@@ -365,7 +366,7 @@ pub(super) fn cmd_list(
             output.info(&dim("No trusted repositories."));
             output.info("");
             output.info(&bold("To trust a repository, cd into it and run:"));
-            output.info(&format!("  {}", cyan("git daft hooks trust")));
+            output.info(&format!("  {}", cyan(&crate::daft_cmd("hooks trust"))));
         }
         return Ok(());
     }

--- a/src/commands/multi_remote.rs
+++ b/src/commands/multi_remote.rs
@@ -480,12 +480,13 @@ fn cmd_status(emit_args: &EmitArgs) -> Result<()> {
     output.info("");
 
     // Commands
+    let exe = crate::cli_label();
     if settings.multi_remote_enabled {
         output.info("To disable multi-remote mode:");
-        output.info("  git daft multi-remote disable");
+        output.info(&format!("  {exe} multi-remote disable"));
     } else {
         output.info("To enable multi-remote mode:");
-        output.info("  git daft multi-remote enable");
+        output.info(&format!("  {exe} multi-remote enable"));
     }
 
     Ok(())
@@ -545,7 +546,8 @@ fn cmd_move(
     if !settings.multi_remote_enabled {
         anyhow::bail!(
             "Multi-remote mode is not enabled.\n\
-             Run 'git daft multi-remote enable' first, or use regular git commands."
+             Run '{}' first, or use regular git commands.",
+            crate::daft_cmd("multi-remote enable")
         );
     }
 

--- a/src/commands/prune.rs
+++ b/src/commands/prune.rs
@@ -561,6 +561,15 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
         .join()
         .map_err(|_| anyhow::anyhow!("DAG orchestrator thread panicked"))?;
 
+    // Surface untrusted-hook notices the TUI buffered (TuiBridge warnings
+    // never reach stderr). Before the deferred-branch removal below, so the
+    // aggregated copy wins and any live Deny hit there dedups against it.
+    {
+        let mut post_tui_output =
+            crate::output::CliOutput::new(crate::output::OutputConfig::new(false, false));
+        crate::hooks::trust_skip::flush_pending_notice(&git_dir, &mut post_tui_output);
+    }
+
     // ── Post-TUI: handle deferred branch (current worktree) ────────────
     sync_shared::handle_post_tui_deferred(
         &deferred_branch,

--- a/src/commands/repo/remove.rs
+++ b/src/commands/repo/remove.rs
@@ -292,6 +292,15 @@ fn run_sequential(
         }
     }
 
+    // Surface untrusted-hook notices buffered by the per-worktree removal
+    // tasks (they run hooks against a BufferingOutput). Must happen before
+    // the bare git dir — the notice registry key — is deleted below.
+    {
+        let mut notice_output =
+            crate::output::CliOutput::new(crate::output::OutputConfig::new(false, false));
+        crate::hooks::trust_skip::flush_pending_notice(&target.bare_git_dir, &mut notice_output);
+    }
+
     let (bare_status, bare_msg) = execute_remove_bare_task(target);
     let bare_line = match &bare_msg {
         TaskMessage::Removed => "removed".to_string(),
@@ -452,6 +461,13 @@ fn run_tui(
 
     let phases = vec![OperationPhase::RemoveRepo];
 
+    // The notice registry is keyed by the canonicalized git dir; canonicalize
+    // now, while the dir still exists — the DAG below deletes it.
+    let trust_notice_key = target
+        .bare_git_dir
+        .canonicalize()
+        .unwrap_or_else(|_| target.bare_git_dir.clone());
+
     let worktree_infos = build_tui_rows(worktrees);
 
     let dag = SyncDag::build_remove_repo(
@@ -571,6 +587,14 @@ fn run_tui(
     orchestrator
         .join()
         .map_err(|_| anyhow::anyhow!("DAG orchestrator thread panicked"))?;
+
+    // Surface untrusted-hook notices the TUI buffered (TuiBridge warnings
+    // never reach stderr).
+    {
+        let mut post_tui_output =
+            crate::output::CliOutput::new(crate::output::OutputConfig::new(false, false));
+        crate::hooks::trust_skip::flush_pending_notice(&trust_notice_key, &mut post_tui_output);
+    }
 
     if !completed.hook_summaries.is_empty() {
         eprintln!();

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -940,6 +940,15 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
         .join()
         .map_err(|_| anyhow::anyhow!("DAG orchestrator thread panicked"))?;
 
+    // Surface untrusted-hook notices the TUI buffered (TuiBridge warnings
+    // never reach stderr). Before the deferred-branch removal below, so the
+    // aggregated copy wins and any live Deny hit there dedups against it.
+    {
+        let mut post_tui_output =
+            crate::output::CliOutput::new(crate::output::OutputConfig::new(false, false));
+        crate::hooks::trust_skip::flush_pending_notice(&git_dir, &mut post_tui_output);
+    }
+
     // ── Post-TUI: handle deferred branch (current worktree) ────────────
     sync_shared::handle_post_tui_deferred(
         &deferred_branch,

--- a/src/coordinator/adapters/sqlite_store.rs
+++ b/src/coordinator/adapters/sqlite_store.rs
@@ -178,6 +178,49 @@ impl JobsStorePort for SqliteJobsStore {
         InvocationsRepo::get(&conn, repo_hash, invocation_id).map_err(anyhow::Error::from)
     }
 
+    fn record_skipped_invocation(&self, row: &InvocationRow) -> Result<()> {
+        // Delete-then-insert on the single writer checkout: the writer pool
+        // is sized 1, so the pair cannot interleave with another writer and
+        // the natural-key "at most one skipped row per (repo, hook, worktree)"
+        // invariant holds without a schema-level unique constraint.
+        let conn = self.pool.writer().context("checkout writer")?;
+        InvocationsRepo::delete_by_key_and_status(
+            &conn,
+            &row.repo_hash,
+            &row.hook_type,
+            &row.worktree,
+            crate::store::models::invocation::INVOCATION_STATUS_SKIPPED,
+        )?;
+        InvocationsRepo::upsert(&conn, row).map_err(anyhow::Error::from)
+    }
+
+    fn list_skipped_invocations(&self, repo_hash: &str) -> Result<Vec<InvocationRow>> {
+        let conn = self.pool.reader().context("checkout reader")?;
+        InvocationsRepo::list_by_repo_and_status(
+            &conn,
+            repo_hash,
+            crate::store::models::invocation::INVOCATION_STATUS_SKIPPED,
+        )
+        .map_err(anyhow::Error::from)
+    }
+
+    fn clear_skipped_invocations(
+        &self,
+        repo_hash: &str,
+        hook_type: &str,
+        worktree: &str,
+    ) -> Result<()> {
+        let conn = self.pool.writer().context("checkout writer")?;
+        InvocationsRepo::delete_by_key_and_status(
+            &conn,
+            repo_hash,
+            hook_type,
+            worktree,
+            crate::store::models::invocation::INVOCATION_STATUS_SKIPPED,
+        )?;
+        Ok(())
+    }
+
     fn upsert_job(&self, row: &JobRow) -> Result<()> {
         // Scrub secrets before they touch disk. This is the canonical
         // persistence boundary for job rows; every JobsStorePort write goes
@@ -333,6 +376,22 @@ mod tests {
             worktree: "feat/foo".into(),
             created_at: Utc::now(),
             coordinator_pid: Some(42),
+            status: crate::store::models::invocation::INVOCATION_STATUS_COMPLETED.into(),
+            skip_reason: None,
+        }
+    }
+
+    fn skipped_inv(id: &str, hook_type: &str, worktree: &str) -> InvocationRow {
+        InvocationRow {
+            repo_hash: "r".into(),
+            invocation_id: id.into(),
+            trigger_command: "checkout".into(),
+            hook_type: hook_type.into(),
+            worktree: worktree.into(),
+            created_at: Utc::now(),
+            coordinator_pid: None,
+            status: crate::store::models::invocation::INVOCATION_STATUS_SKIPPED.into(),
+            skip_reason: Some(crate::store::models::invocation::SKIP_REASON_UNTRUSTED.into()),
         }
     }
 
@@ -376,6 +435,72 @@ mod tests {
             back.env
         );
         assert_eq!(back.env.get("PATH"), Some(&"/usr/bin".to_string()));
+    }
+
+    #[test]
+    fn record_skipped_invocation_replaces_prior_row_for_same_key() {
+        let (_tmp, store) = fresh();
+        store
+            .record_skipped_invocation(&skipped_inv("inv-1", "worktree-post-create", "feat/a"))
+            .unwrap();
+        store
+            .record_skipped_invocation(&skipped_inv("inv-2", "worktree-post-create", "feat/a"))
+            .unwrap();
+        // A different worktree keeps its own row.
+        store
+            .record_skipped_invocation(&skipped_inv("inv-3", "worktree-post-create", "feat/b"))
+            .unwrap();
+
+        let rows = store.list_skipped_invocations("r").unwrap();
+        let mut ids: Vec<_> = rows.iter().map(|r| r.invocation_id.as_str()).collect();
+        ids.sort();
+        assert_eq!(ids, vec!["inv-2", "inv-3"]);
+    }
+
+    #[test]
+    fn list_skipped_invocations_excludes_completed_rows() {
+        let (_tmp, store) = fresh();
+        store.upsert_invocation(&sample_inv()).unwrap();
+        store
+            .record_skipped_invocation(&skipped_inv("inv-s", "post-clone", "main"))
+            .unwrap();
+        let rows = store.list_skipped_invocations("r").unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].invocation_id, "inv-s");
+        assert_eq!(
+            rows[0].skip_reason.as_deref(),
+            Some(crate::store::models::invocation::SKIP_REASON_UNTRUSTED)
+        );
+    }
+
+    #[test]
+    fn clear_skipped_invocations_deletes_only_the_matching_triple() {
+        let (_tmp, store) = fresh();
+        store
+            .record_skipped_invocation(&skipped_inv("inv-1", "worktree-post-create", "feat/a"))
+            .unwrap();
+        store
+            .record_skipped_invocation(&skipped_inv("inv-2", "worktree-pre-create", "feat/a"))
+            .unwrap();
+        store
+            .record_skipped_invocation(&skipped_inv("inv-3", "worktree-post-create", "feat/b"))
+            .unwrap();
+        // A completed row on the same natural key must survive the clear.
+        let mut done = sample_inv();
+        done.invocation_id = "inv-done".into();
+        done.hook_type = "worktree-post-create".into();
+        done.worktree = "feat/a".into();
+        store.upsert_invocation(&done).unwrap();
+
+        store
+            .clear_skipped_invocations("r", "worktree-post-create", "feat/a")
+            .unwrap();
+
+        let rows = store.list_skipped_invocations("r").unwrap();
+        let mut ids: Vec<_> = rows.iter().map(|r| r.invocation_id.as_str()).collect();
+        ids.sort();
+        assert_eq!(ids, vec!["inv-2", "inv-3"]);
+        assert!(store.get_invocation("r", "inv-done").unwrap().is_some());
     }
 
     #[test]

--- a/src/coordinator/adapters/sqlite_store.rs
+++ b/src/coordinator/adapters/sqlite_store.rs
@@ -179,19 +179,24 @@ impl JobsStorePort for SqliteJobsStore {
     }
 
     fn record_skipped_invocation(&self, row: &InvocationRow) -> Result<()> {
-        // Delete-then-insert on the single writer checkout: the writer pool
-        // is sized 1, so the pair cannot interleave with another writer and
-        // the natural-key "at most one skipped row per (repo, hook, worktree)"
-        // invariant holds without a schema-level unique constraint.
-        let conn = self.pool.writer().context("checkout writer")?;
-        InvocationsRepo::delete_by_key_and_status(
-            &conn,
-            &row.repo_hash,
-            &row.hook_type,
-            &row.worktree,
-            crate::store::models::invocation::INVOCATION_STATUS_SKIPPED,
-        )?;
-        InvocationsRepo::upsert(&conn, row).map_err(anyhow::Error::from)
+        // The delete+insert pair runs in one transaction so the natural-key
+        // "at most one skipped row per (repo, hook, worktree)" invariant
+        // holds across *processes*. The size-1 writer pool only serializes
+        // writers that share it; two concurrent daft commands on the same
+        // repo each hold their own pool, and unwrapped pairs from both can
+        // interleave and leave two skipped rows for one key.
+        let mut conn = self.pool.writer().context("checkout writer")?;
+        crate::store::repos::with_write_txn(&mut conn, |tx| {
+            InvocationsRepo::delete_by_key_and_status(
+                tx,
+                &row.repo_hash,
+                &row.hook_type,
+                &row.worktree,
+                crate::store::models::invocation::INVOCATION_STATUS_SKIPPED,
+            )?;
+            InvocationsRepo::upsert(tx, row)
+        })
+        .map_err(anyhow::Error::from)
     }
 
     fn list_skipped_invocations(&self, repo_hash: &str) -> Result<Vec<InvocationRow>> {
@@ -455,6 +460,63 @@ mod tests {
         let mut ids: Vec<_> = rows.iter().map(|r| r.invocation_id.as_str()).collect();
         ids.sort();
         assert_eq!(ids, vec!["inv-2", "inv-3"]);
+    }
+
+    #[test]
+    fn record_skipped_invocation_is_atomic_across_pools() {
+        // Two stores on one DB file stand in for two daft processes: each
+        // holds its own size-1 writer pool, so nothing but the transaction
+        // serializes the delete+insert pair. Only the *last* pairs on a key
+        // decide the end state, so a long hammer samples the race once —
+        // instead, many barrier-synced one-shot rounds, each on its own
+        // key, each an independent sample. With the transaction the
+        // invariant holds deterministically; without it, rounds interleave
+        // and leave two skipped rows for one natural key.
+        use std::sync::{Arc, Barrier};
+
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("db.sqlite");
+        let store_a = Arc::new(SqliteJobsStore::new(Pool::open(&path).unwrap()));
+        let store_b = Arc::new(SqliteJobsStore::new(Pool::open(&path).unwrap()));
+        let check = SqliteJobsStore::new(Pool::open(&path).unwrap());
+
+        for round in 0..200 {
+            let worktree = format!("feat/{round}");
+            let barrier = Arc::new(Barrier::new(2));
+            let spawn = |store: &Arc<SqliteJobsStore>, id: String| {
+                let store = Arc::clone(store);
+                let barrier = Arc::clone(&barrier);
+                let worktree = worktree.clone();
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    store
+                        .record_skipped_invocation(&skipped_inv(
+                            &id,
+                            "worktree-post-create",
+                            &worktree,
+                        ))
+                        .unwrap();
+                })
+            };
+            let a = spawn(&store_a, format!("a-{round}"));
+            let b = spawn(&store_b, format!("b-{round}"));
+            a.join().unwrap();
+            b.join().unwrap();
+
+            let rows: Vec<_> = check
+                .list_skipped_invocations("r")
+                .unwrap()
+                .into_iter()
+                .filter(|r| r.worktree == worktree)
+                .collect();
+            assert_eq!(
+                rows.len(),
+                1,
+                "round {round}: concurrent skip records for one (repo, hook, \
+                 worktree) key must collapse to a single row; got ids {:?}",
+                rows.iter().map(|r| &r.invocation_id).collect::<Vec<_>>()
+            );
+        }
     }
 
     #[test]

--- a/src/coordinator/domain/reconcile.rs
+++ b/src/coordinator/domain/reconcile.rs
@@ -90,6 +90,18 @@ mod tests {
             Ok(None)
         }
 
+        fn record_skipped_invocation(&self, _row: &InvocationRow) -> Result<()> {
+            Ok(())
+        }
+
+        fn list_skipped_invocations(&self, _r: &str) -> Result<Vec<InvocationRow>> {
+            Ok(Vec::new())
+        }
+
+        fn clear_skipped_invocations(&self, _r: &str, _h: &str, _w: &str) -> Result<()> {
+            Ok(())
+        }
+
         fn upsert_job(&self, row: &JobRow) -> Result<()> {
             let mut guard = self.jobs.lock().unwrap();
             if let Some(slot) = guard.iter_mut().find(|r| {

--- a/src/coordinator/ports/store.rs
+++ b/src/coordinator/ports/store.rs
@@ -20,6 +20,25 @@ pub trait JobsStorePort: Send + Sync {
     fn get_invocation(&self, repo_hash: &str, invocation_id: &str)
     -> Result<Option<InvocationRow>>;
 
+    /// Record a trust-skipped hook fire (#596). Replaces any prior skipped
+    /// row for the same `(repo_hash, hook_type, worktree)` natural key so
+    /// repeated skips do not accumulate — a skip row is advisory replay
+    /// state ("the most recent fire of this pair was blocked by trust"),
+    /// not an audit log.
+    fn record_skipped_invocation(&self, row: &InvocationRow) -> Result<()>;
+
+    /// All `status = 'skipped'` rows for a repo, oldest first.
+    fn list_skipped_invocations(&self, repo_hash: &str) -> Result<Vec<InvocationRow>>;
+
+    /// Delete skipped rows matching `(repo_hash, hook_type, worktree)`.
+    /// Called when the trust gate next passes for that pair.
+    fn clear_skipped_invocations(
+        &self,
+        repo_hash: &str,
+        hook_type: &str,
+        worktree: &str,
+    ) -> Result<()>;
+
     fn upsert_job(&self, row: &JobRow) -> Result<()>;
 
     fn get_job(&self, repo_hash: &str, invocation_id: &str, name: &str) -> Result<Option<JobRow>>;

--- a/src/core/progress.rs
+++ b/src/core/progress.rs
@@ -83,11 +83,6 @@ impl<'a> CommandBridge<'a> {
             output_config,
         }
     }
-
-    /// Consume the bridge and return the hook executor.
-    pub fn into_executor(self) -> HookExecutor {
-        self.executor
-    }
 }
 
 impl ProgressSink for CommandBridge<'_> {

--- a/src/core/tui_bridge.rs
+++ b/src/core/tui_bridge.rs
@@ -69,12 +69,12 @@ impl HookRunner for TuiBridge {
         match self.executor.execute(ctx, &mut self.output, presenter) {
             Ok(result) => {
                 if result.skipped {
-                    // TODO: When hooks are skipped due to TrustLevel::Prompt, surface a
-                    // post-TUI notice suggesting `git daft hooks trust`. Currently the
-                    // skip_reason is captured in HookOutcome but not surfaced to the user
-                    // in TUI mode. See spec: "Prompt Callbacks" section.
-                    // Skipped hooks (disabled, not trusted, etc.) produce no events —
-                    // the executor returns early before calling any presenter methods.
+                    // Trust-skipped hooks accumulate a pending notice in
+                    // `hooks::trust_skip` (the executor's Deny arm sees this
+                    // bridge's `BufferingOutput` and defers); the owning
+                    // command flushes it after the TUI exits. Skipped hooks
+                    // produce no events — the executor returns early before
+                    // calling any presenter methods.
                     return Ok(HookOutcome {
                         success: result.success,
                         skipped: true,

--- a/src/doctor/hooks_checks.rs
+++ b/src/doctor/hooks_checks.rs
@@ -199,7 +199,7 @@ pub fn check_deprecated_names(project_root: &Path) -> CheckResult {
             "Hook names",
             &format!("{} deprecated name(s)", deprecated.len()),
         )
-        .with_suggestion("Run 'git daft hooks migrate'")
+        .with_suggestion(&format!("Run '{}'", crate::daft_cmd("hooks migrate")))
         .with_fix(Box::new(move || fix_deprecated_names(&fix_project_root)))
         .with_dry_run_fix(Box::new(move || {
             dry_run_deprecated_names(&dry_project_root)
@@ -377,7 +377,10 @@ pub fn check_trust_level(git_common_dir: &Path) -> CheckResult {
         TrustLevel::Allow => CheckResult::pass("Trust level", "allow"),
         TrustLevel::Prompt => CheckResult::pass("Trust level", "prompt"),
         TrustLevel::Deny => CheckResult::warning("Trust level", "deny (hooks will not run)")
-            .with_suggestion("Run 'git daft hooks trust' to allow hook execution"),
+            .with_suggestion(&format!(
+                "Run '{}' to allow hook execution",
+                crate::daft_cmd("hooks trust")
+            )),
     }
 }
 

--- a/src/hooks/executor.rs
+++ b/src/hooks/executor.rs
@@ -3,14 +3,16 @@
 //! This module provides the `HookExecutor` which handles discovering,
 //! validating, and executing hooks with proper security checks.
 
+use super::trust_skip::{self, SkipSource};
 use super::yaml_config_loader;
 use super::yaml_executor::{self, JobFilter};
 use super::{
     DEPRECATED_HOOK_REMOVAL_VERSION, FailMode, HookConfig, HookContext, HookEnvironment, HookType,
-    HooksConfig, TrustDatabase, TrustLevel, find_hooks, list_hooks,
+    HooksConfig, TrustDatabase, TrustLevel, find_hooks,
 };
 use crate::executor::presenter::JobPresenter;
 use crate::output::Output;
+use crate::store::models::invocation::SKIP_REASON_PROMPT_UNAVAILABLE;
 use anyhow::Result;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -330,6 +332,19 @@ impl HookExecutor {
             let trust_level = self.get_verified_trust_level(&ctx.git_dir, output);
             match trust_level {
                 TrustLevel::Deny => {
+                    if !self.user_requested_skip(ctx.hook_type) {
+                        let configured_hooks: Vec<String> = yaml_config
+                            .hooks
+                            .keys()
+                            .filter(|name| HookType::from_yaml_name(name).is_some())
+                            .cloned()
+                            .collect();
+                        trust_skip::notify_and_record(
+                            ctx,
+                            SkipSource::Yaml { configured_hooks },
+                            output,
+                        );
+                    }
                     output.debug(&format!(
                         "Skipping {hook_name} YAML hooks: repository not trusted"
                     ));
@@ -344,14 +359,22 @@ impl HookExecutor {
                         }
                     } else {
                         output.warning(&format!(
-                            "YAML hooks exist but no permission callback configured. Skipping {hook_name}."
+                            "Repository trust is set to 'prompt' but no interactive prompt is available — skipping {hook_name}. Run 'git daft hooks trust' to allow hooks."
                         ));
+                        trust_skip::record_skip(ctx, SKIP_REASON_PROMPT_UNAVAILABLE);
                         return Ok(Some(HookResult::skipped("No permission callback")));
                     }
                 }
                 TrustLevel::Allow => {}
             }
         }
+
+        // The trust gate passed (Allow, prompt accepted, or explicit bypass):
+        // any "skipped while untrusted" record for this (hook, branch) pair
+        // is now stale — the upcoming fire supersedes it regardless of how
+        // that fire ends (failure and `skip:` conditions are post-trust
+        // outcomes, captured by job records instead).
+        trust_skip::clear_skips(ctx);
 
         let source_dir = yaml_config.source_dir.as_deref().unwrap_or(".daft");
         let rc = yaml_config.rc.as_deref();
@@ -435,6 +458,21 @@ impl HookExecutor {
             if has_project_hooks {
                 match trust_level {
                     TrustLevel::Deny => {
+                        if !self.user_requested_skip(ctx.hook_type) {
+                            let hook_files: Vec<String> = discovery
+                                .hooks
+                                .iter()
+                                .filter(|h| h.starts_with(hook_source_worktree))
+                                .filter_map(|p| p.file_name())
+                                .filter_map(|n| n.to_str())
+                                .map(String::from)
+                                .collect();
+                            trust_skip::notify_and_record(
+                                ctx,
+                                SkipSource::Scripts { hook_files },
+                                output,
+                            );
+                        }
                         output.debug(&format!(
                             "Skipping {} hooks: repository not trusted",
                             ctx.hook_type
@@ -452,6 +490,10 @@ impl HookExecutor {
                 }
             }
         }
+
+        // Trust gate passed (or only user-level hooks are involved): drop any
+        // stale "skipped while untrusted" record for this (hook, branch).
+        trust_skip::clear_skips(ctx);
 
         // Clear any active spinner — the presenter writes directly to stderr.
         output.finish_spinner();
@@ -524,9 +566,10 @@ impl HookExecutor {
         } else {
             // Default: don't execute without explicit permission
             output.warning(&format!(
-                "Hooks exist but no permission callback configured. Skipping {} hooks.",
+                "Repository trust is set to 'prompt' but no interactive prompt is available — skipping {} hooks. Run 'git daft hooks trust' to allow hooks.",
                 ctx.hook_type
             ));
+            trust_skip::record_skip(ctx, SKIP_REASON_PROMPT_UNAVAILABLE);
             false
         }
     }
@@ -565,28 +608,14 @@ impl HookExecutor {
         }
     }
 
-    /// Check if hooks exist for a worktree and display a notice if untrusted.
-    pub fn check_hooks_notice(
-        &self,
-        worktree_path: &Path,
-        git_dir: &Path,
-        output: &mut dyn Output,
-    ) {
-        let hooks = list_hooks(worktree_path);
-        if hooks.is_empty() {
-            return;
-        }
-
-        let trust_level = self.trust_db.get_trust_level(git_dir);
-        if trust_level == TrustLevel::Deny {
-            output.warning("This repository contains hooks in .daft/hooks/:");
-            for hook in &hooks {
-                output.list_item(hook.filename());
-            }
-            output.warning("");
-            output.warning("Hooks were NOT executed. To enable hooks for this repository:");
-            output.warning("  git daft hooks trust");
-        }
+    /// Whether the user explicitly asked to skip this whole hook fire
+    /// (`--skip-hooks all` or a hook-type selector naming it). An explicit
+    /// opt-out must not trigger the untrusted-hook notice or a replay
+    /// record: the hooks were not going to run regardless of trust. Partial
+    /// selectors (job names, tags) do NOT suppress — the remaining jobs
+    /// would have run if trusted, so the trust skip is still surprising.
+    fn user_requested_skip(&self, hook_type: HookType) -> bool {
+        self.job_filter.skip.all || self.job_filter.skip.hook_types.contains(&hook_type)
     }
 
     /// Get the trust level for a repository.
@@ -788,6 +817,37 @@ mod tests {
         assert_eq!(result.skip_reason, Some("No hook files found".to_string()));
     }
 
+    /// Build a context whose git dir exists (so the skip record can compute
+    /// a repo id) and whose state writes land in the test's tempdir.
+    fn test_ctx_with_state(
+        temp_dir: &Path,
+        worktree: &Path,
+        hook_type: HookType,
+        branch: &str,
+    ) -> HookContext {
+        let git_dir = temp_dir.join(".git");
+        fs::create_dir_all(&git_dir).unwrap();
+        HookContext::new(
+            hook_type, "checkout", temp_dir, &git_dir, "origin", worktree, worktree, branch,
+        )
+        .with_state_dir(temp_dir.join("state"))
+    }
+
+    /// Skip rows recorded for the context's repo, via the same store the
+    /// production write path uses.
+    fn skip_rows(ctx: &HookContext) -> Vec<crate::store::models::InvocationRow> {
+        use crate::coordinator::ports::JobsStorePort;
+        let repo_hash =
+            crate::core::repo_identity::compute_repo_id_from_common_dir(&ctx.git_dir).unwrap();
+        let state = ctx.state_dir.as_ref().unwrap();
+        let base = state.join("jobs").join(&repo_hash);
+        if !base.join("coordinator.db").exists() {
+            return Vec::new();
+        }
+        let store = crate::coordinator::adapters::SqliteJobsStore::for_repo_base(&base).unwrap();
+        store.list_skipped_invocations(&repo_hash).unwrap()
+    }
+
     #[test]
     fn test_executor_untrusted_repo() {
         let temp_dir = tempdir().unwrap();
@@ -800,16 +860,7 @@ mod tests {
         let executor = HookExecutor::with_trust_db(config, TrustDatabase::default());
         let mut output = TestOutput::default();
 
-        let ctx = HookContext::new(
-            HookType::PostCreate,
-            "checkout",
-            temp_dir.path(),
-            temp_dir.path().join(".git"),
-            "origin",
-            &worktree,
-            &worktree,
-            "main",
-        );
+        let ctx = test_ctx_with_state(temp_dir.path(), &worktree, HookType::PostCreate, "main");
 
         let presenter = NullPresenter::arc();
         let result = executor.execute(&ctx, &mut output, presenter).unwrap();
@@ -818,6 +869,132 @@ mod tests {
             result.skip_reason,
             Some("Repository not trusted".to_string())
         );
+
+        // The Deny arm warns (once) and records the skip.
+        let warnings = output.warnings();
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("worktree-post-create"));
+        let rows = skip_rows(&ctx);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].hook_type, "worktree-post-create");
+        assert_eq!(rows[0].worktree, "main");
+        assert_eq!(rows[0].skip_reason.as_deref(), Some("untrusted"));
+    }
+
+    #[test]
+    fn test_executor_untrusted_yaml_config_warns_and_records() {
+        let temp_dir = tempdir().unwrap();
+        let worktree = temp_dir.path().join("main");
+        fs::create_dir_all(&worktree).unwrap();
+        fs::write(
+            worktree.join("daft.yml"),
+            "hooks:\n  worktree-post-create:\n    jobs:\n      - name: setup\n        run: echo hi\n",
+        )
+        .unwrap();
+
+        let config = HooksConfig::default();
+        let executor = HookExecutor::with_trust_db(config, TrustDatabase::default());
+        let mut output = TestOutput::default();
+
+        let ctx = test_ctx_with_state(temp_dir.path(), &worktree, HookType::PostCreate, "main");
+
+        let presenter = NullPresenter::arc();
+        let result = executor.execute(&ctx, &mut output, presenter).unwrap();
+        assert!(result.skipped);
+        assert_eq!(
+            result.skip_reason,
+            Some("Repository not trusted".to_string())
+        );
+
+        let warnings = output.warnings();
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("daft.yml"));
+        assert!(warnings[0].contains("worktree-post-create"));
+        let rows = skip_rows(&ctx);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].skip_reason.as_deref(), Some("untrusted"));
+    }
+
+    #[test]
+    fn test_executor_user_requested_skip_suppresses_notice_and_record() {
+        let temp_dir = tempdir().unwrap();
+        let worktree = temp_dir.path().join("main");
+        fs::create_dir_all(&worktree).unwrap();
+
+        create_test_hook(&worktree, "worktree-post-create", "#!/bin/bash\necho test");
+
+        for selector in ["all", "worktree-post-create"] {
+            let config = HooksConfig::default();
+            let executor = HookExecutor::with_trust_db(config, TrustDatabase::default())
+                .with_job_filter(JobFilter::skipping(&[selector.to_string()]));
+            let mut output = TestOutput::default();
+
+            let ctx = test_ctx_with_state(temp_dir.path(), &worktree, HookType::PostCreate, "main");
+
+            let presenter = NullPresenter::arc();
+            let result = executor.execute(&ctx, &mut output, presenter).unwrap();
+            assert!(result.skipped, "selector {selector}: still trust-skipped");
+            assert!(
+                output.warnings().is_empty(),
+                "selector {selector}: explicit opt-out must not warn"
+            );
+            assert!(
+                skip_rows(&ctx).is_empty(),
+                "selector {selector}: explicit opt-out must not record"
+            );
+        }
+    }
+
+    #[test]
+    fn test_executor_bypass_trust_neither_warns_nor_records() {
+        let temp_dir = tempdir().unwrap();
+        let worktree = temp_dir.path().join("main");
+        fs::create_dir_all(&worktree).unwrap();
+
+        create_test_hook(&worktree, "worktree-post-create", "#!/bin/bash\necho test");
+
+        let config = HooksConfig::default();
+        let executor =
+            HookExecutor::with_trust_db(config, TrustDatabase::default()).with_bypass_trust(true);
+        let mut output = TestOutput::default();
+
+        let ctx = test_ctx_with_state(temp_dir.path(), &worktree, HookType::PostCreate, "main");
+
+        let presenter = NullPresenter::arc();
+        let result = executor.execute(&ctx, &mut output, presenter).unwrap();
+        assert!(result.success);
+        assert!(output.warnings().is_empty());
+        assert!(skip_rows(&ctx).is_empty());
+    }
+
+    #[test]
+    fn test_executor_trust_pass_clears_recorded_skip() {
+        let temp_dir = tempdir().unwrap();
+        let worktree = temp_dir.path().join("main");
+        fs::create_dir_all(&worktree).unwrap();
+
+        create_test_hook(&worktree, "worktree-post-create", "#!/bin/bash\necho test");
+
+        let ctx = test_ctx_with_state(temp_dir.path(), &worktree, HookType::PostCreate, "main");
+        let presenter = NullPresenter::arc();
+
+        // First run untrusted: records the skip.
+        let untrusted =
+            HookExecutor::with_trust_db(HooksConfig::default(), TrustDatabase::default());
+        let mut output = TestOutput::default();
+        untrusted
+            .execute(&ctx, &mut output, presenter.clone())
+            .unwrap();
+        assert_eq!(skip_rows(&ctx).len(), 1);
+
+        // Then trust and run again: the passing gate clears the record.
+        let mut trust_db = TrustDatabase::default();
+        trust_db.set_trust_level(&ctx.git_dir, TrustLevel::Allow);
+        let trusted = HookExecutor::with_trust_db(HooksConfig::default(), trust_db);
+        let mut output = TestOutput::default();
+        let result = trusted.execute(&ctx, &mut output, presenter).unwrap();
+        assert!(result.success);
+        assert!(skip_rows(&ctx).is_empty(), "trust pass clears the record");
     }
 
     #[test]
@@ -832,23 +1009,16 @@ mod tests {
             "#!/bin/bash\necho 'hook executed'",
         );
 
+        // Build the context first: it creates the git dir, which must exist
+        // before set_trust_level so both sides canonicalize identically.
+        let ctx = test_ctx_with_state(temp_dir.path(), &worktree, HookType::PostCreate, "main");
+
         let config = HooksConfig::default();
         let mut trust_db = TrustDatabase::default();
-        trust_db.set_trust_level(&temp_dir.path().join(".git"), TrustLevel::Allow);
+        trust_db.set_trust_level(&ctx.git_dir, TrustLevel::Allow);
 
         let executor = HookExecutor::with_trust_db(config, trust_db);
         let mut output = TestOutput::default();
-
-        let ctx = HookContext::new(
-            HookType::PostCreate,
-            "checkout",
-            temp_dir.path(),
-            temp_dir.path().join(".git"),
-            "origin",
-            &worktree,
-            &worktree,
-            "main",
-        );
 
         let presenter = NullPresenter::arc();
         let result = executor.execute(&ctx, &mut output, presenter).unwrap();

--- a/src/hooks/executor.rs
+++ b/src/hooks/executor.rs
@@ -870,10 +870,10 @@ mod tests {
             Some("Repository not trusted".to_string())
         );
 
-        // The Deny arm warns (once) and records the skip.
-        let warnings = output.warnings();
-        assert_eq!(warnings.len(), 1);
-        assert!(warnings[0].contains("worktree-post-create"));
+        // The Deny arm emits the notice (once) and records the skip.
+        let notices = output.notices();
+        assert_eq!(notices.len(), 1);
+        assert!(notices[0].contains("worktree-post-create"));
         let rows = skip_rows(&ctx);
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].hook_type, "worktree-post-create");
@@ -906,10 +906,10 @@ mod tests {
             Some("Repository not trusted".to_string())
         );
 
-        let warnings = output.warnings();
-        assert_eq!(warnings.len(), 1);
-        assert!(warnings[0].contains("daft.yml"));
-        assert!(warnings[0].contains("worktree-post-create"));
+        let notices = output.notices();
+        assert_eq!(notices.len(), 1);
+        assert!(notices[0].contains("daft.yml"));
+        assert!(notices[0].contains("worktree-post-create"));
         let rows = skip_rows(&ctx);
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].skip_reason.as_deref(), Some("untrusted"));
@@ -935,8 +935,8 @@ mod tests {
             let result = executor.execute(&ctx, &mut output, presenter).unwrap();
             assert!(result.skipped, "selector {selector}: still trust-skipped");
             assert!(
-                output.warnings().is_empty(),
-                "selector {selector}: explicit opt-out must not warn"
+                output.notices().is_empty() && output.warnings().is_empty(),
+                "selector {selector}: explicit opt-out must not notify"
             );
             assert!(
                 skip_rows(&ctx).is_empty(),
@@ -963,7 +963,7 @@ mod tests {
         let presenter = NullPresenter::arc();
         let result = executor.execute(&ctx, &mut output, presenter).unwrap();
         assert!(result.success);
-        assert!(output.warnings().is_empty());
+        assert!(output.notices().is_empty() && output.warnings().is_empty());
         assert!(skip_rows(&ctx).is_empty());
     }
 

--- a/src/hooks/executor.rs
+++ b/src/hooks/executor.rs
@@ -359,7 +359,8 @@ impl HookExecutor {
                         }
                     } else {
                         output.warning(&format!(
-                            "Repository trust is set to 'prompt' but no interactive prompt is available — skipping {hook_name}. Run 'git daft hooks trust' to allow hooks."
+                            "Repository trust is set to 'prompt' but no interactive prompt is available — skipping {hook_name}. Run '{}' to allow hooks.",
+                            crate::daft_cmd("hooks trust")
                         ));
                         trust_skip::record_skip(ctx, SKIP_REASON_PROMPT_UNAVAILABLE);
                         return Ok(Some(HookResult::skipped("No permission callback")));
@@ -417,20 +418,26 @@ impl HookExecutor {
         for warning in &discovery.deprecation_warnings {
             if warning.new_name_also_exists {
                 output.warning(&format!(
-                    "Both '{}' and '{}' exist in '{}'. Using '{}'; remove '{}' or run 'git daft hooks migrate'.",
+                    "Both '{}' and '{}' exist in '{}'. Using '{}'; remove '{}' or run '{}'.",
                     warning.new_name,
                     warning.old_name,
-                    warning.path.parent().unwrap_or(warning.path.as_path()).display(),
+                    warning
+                        .path
+                        .parent()
+                        .unwrap_or(warning.path.as_path())
+                        .display(),
                     warning.new_name,
                     warning.old_name,
+                    crate::daft_cmd("hooks migrate"),
                 ));
             } else {
                 output.warning(&format!(
-                    "Hook '{}' uses deprecated name '{}'. Rename to '{}' or run 'git daft hooks migrate'. \
+                    "Hook '{}' uses deprecated name '{}'. Rename to '{}' or run '{}'. \
                      Deprecated names will stop working in daft v{}.",
                     warning.path.display(),
                     warning.old_name,
                     warning.new_name,
+                    crate::daft_cmd("hooks migrate"),
                     DEPRECATED_HOOK_REMOVAL_VERSION
                 ));
             }
@@ -438,9 +445,10 @@ impl HookExecutor {
 
         if discovery.hooks.is_empty() {
             if !discovery.deprecation_warnings.is_empty() {
-                return Ok(HookResult::skipped(
-                    "Deprecated hook files found but not executed. Run 'git daft hooks migrate' to rename them.",
-                ));
+                return Ok(HookResult::skipped(format!(
+                    "Deprecated hook files found but not executed. Run '{}' to rename them.",
+                    crate::daft_cmd("hooks migrate")
+                )));
             }
             output.debug(&format!("No {} hooks found", ctx.hook_type));
             return Ok(HookResult::skipped("No hook files found"));
@@ -566,8 +574,9 @@ impl HookExecutor {
         } else {
             // Default: don't execute without explicit permission
             output.warning(&format!(
-                "Repository trust is set to 'prompt' but no interactive prompt is available — skipping {} hooks. Run 'git daft hooks trust' to allow hooks.",
-                ctx.hook_type
+                "Repository trust is set to 'prompt' but no interactive prompt is available — skipping {} hooks. Run '{}' to allow hooks.",
+                ctx.hook_type,
+                crate::daft_cmd("hooks trust")
             ));
             trust_skip::record_skip(ctx, SKIP_REASON_PROMPT_UNAVAILABLE);
             false
@@ -686,10 +695,11 @@ impl HookExecutor {
                 ));
                 output.warning(&format!("  Trusted remote: {stored_fingerprint}"));
                 output.warning(&format!("  Current remote: {url}"));
-                output.warning(
+                output.warning(&format!(
                     "A different repository may now be at this path. \
-                     Run 'git daft hooks trust' to re-trust.",
-                );
+                     Run '{}' to re-trust.",
+                    crate::daft_cmd("hooks trust")
+                ));
                 TrustLevel::Prompt
             }
             None => {

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -51,6 +51,7 @@ pub mod template;
 pub mod tracking;
 mod trust;
 mod trust_dto;
+pub mod trust_skip;
 pub mod visitor_propagation;
 pub mod visitor_seeds;
 pub mod yaml_config;

--- a/src/hooks/trust_skip.rs
+++ b/src/hooks/trust_skip.rs
@@ -122,7 +122,11 @@ pub fn notify_and_record(ctx: &HookContext, source: SkipSource, output: &mut dyn
         let state = reg.entry(key).or_default();
         if !state.displayed {
             if output.live_warnings() {
-                output.notice(&format_notice(&content, !crate::hints::hints_disabled()));
+                output.notice(&format_notice(
+                    &content,
+                    !crate::hints::hints_disabled(),
+                    notice_colors(),
+                ));
                 state.displayed = true;
             } else {
                 match &mut state.pending {
@@ -153,7 +157,11 @@ pub fn flush_pending_notice(git_dir: &Path, output: &mut dyn Output) {
         }
     };
     if let Some(content) = content {
-        output.notice(&format_notice(&content, !crate::hints::hints_disabled()));
+        output.notice(&format_notice(
+            &content,
+            !crate::hints::hints_disabled(),
+            notice_colors(),
+        ));
     }
 }
 
@@ -310,11 +318,40 @@ fn capped_hook_list(names: &BTreeSet<String>, more_word: &str) -> String {
     out
 }
 
-fn format_notice(content: &NoticeContent, show_hints: bool) -> String {
+/// Whether to style the notice. Requires a live color-capable stderr, and is
+/// forced off under both test harnesses: `cargo test` leaves fd 2 pointing at
+/// the developer's terminal even while capturing output (capture hooks the
+/// print machinery, not the fd), and the YAML runner sets `DAFT_TESTING` —
+/// either would otherwise leak ANSI codes into text assertions.
+fn notice_colors() -> bool {
+    !cfg!(test)
+        && std::env::var_os("DAFT_TESTING").is_none()
+        && crate::styles::colors_enabled_stderr()
+}
+
+fn format_notice(content: &NoticeContent, show_hints: bool, colorize: bool) -> String {
+    use crate::styles;
+
     // The notice is emitted via `Output::notice` — a plain stderr line with no
     // severity prefix — so the first line starts at column 0. Hint lines are
     // indented to read as subordinate to it.
     const INDENT: &str = "   ";
+    // Styling (when `colorize`): bold the count summary, dim the subordinate
+    // parts, cyan the runnable commands — cyan-for-commands matches the
+    // convention across the hooks command surfaces (status, trust, run) —
+    // and the accent orange for hook names, matching how the hook progress
+    // UI renders them when they do run.
+    let (bold, dim, cyan, accent, reset) = if colorize {
+        (
+            styles::BOLD,
+            styles::DIM,
+            styles::CYAN,
+            styles::ORANGE,
+            styles::RESET,
+        )
+    } else {
+        ("", "", "", "", "")
+    };
 
     let multi_branch = content.branches.len() > 1;
     let branch_clause = if multi_branch {
@@ -325,35 +362,35 @@ fn format_notice(content: &NoticeContent, show_hints: bool) -> String {
 
     // Lead with the count, then the names: "3 daft.yml hooks not run: a, b, c".
     let n = content.names.len();
-    let mut first = if content.legacy {
-        if n == 1 {
-            let name = content.names.iter().next().expect("len checked");
-            format!(
-                "1 .daft/hooks script not run{branch_clause}: {name} — this repo isn't trusted."
-            )
+    let (noun, names) = if content.legacy {
+        let noun = if n == 1 {
+            ".daft/hooks script"
         } else {
-            format!(
-                "{n} .daft/hooks scripts not run{branch_clause}: {} — this repo isn't trusted.",
-                capped_hook_list(&content.names, "scripts")
-            )
-        }
-    } else if n == 1 {
-        let name = content.names.iter().next().expect("len checked");
-        format!("1 daft.yml hook not run{branch_clause}: {name} — this repo isn't trusted.")
+            ".daft/hooks scripts"
+        };
+        (noun, capped_hook_list(&content.names, "scripts"))
     } else {
-        format!(
-            "{n} daft.yml hooks not run{branch_clause}: {} — this repo isn't trusted.",
-            capped_hook_list(&content.names, "hooks")
-        )
+        let noun = if n == 1 {
+            "daft.yml hook"
+        } else {
+            "daft.yml hooks"
+        };
+        (noun, capped_hook_list(&content.names, "hooks"))
     };
+    let head = format!("{n} {noun} not run{branch_clause}");
+    // Strictly general → specific: the trust state leads, then the
+    // consequence, then the names directly against the count they detail.
+    let mut out = format!("{bold}Untrusted repo{reset} — {head}: {accent}{names}{reset}");
 
     if show_hints {
         // Labels are padded to LABEL_W so both suggestion commands start at the
         // same column under the indent (LABEL_W spans the longest label below).
+        // Pad the plain label first, then wrap it in the (zero-width) style
+        // codes, so the alignment holds with and without color.
         const LABEL_W: usize = 34;
-        first.push_str(&format!(
-            "\n{INDENT}{:<LABEL_W$}  git daft hooks trust",
-            "To run them, trust this repo:"
+        let label = "To run them, trust this repo:";
+        out.push_str(&format!(
+            "\n{INDENT}{dim}{label:<LABEL_W$}{reset}  {cyan}git daft hooks trust{reset}"
         ));
         if let Some(replay) = &content.replay {
             let (label, suffix) = match (replay.as_str(), multi_branch) {
@@ -364,12 +401,17 @@ fn format_notice(content: &NoticeContent, show_hints: bool) -> String {
                 ),
                 (_, false) => ("Then replay this worktree's setup:", ""),
             };
-            first.push_str(&format!(
-                "\n{INDENT}{label:<LABEL_W$}  git daft hooks run {replay}{suffix}"
+            let suffix = if suffix.is_empty() {
+                String::new()
+            } else {
+                format!("{dim}{suffix}{reset}")
+            };
+            out.push_str(&format!(
+                "\n{INDENT}{dim}{label:<LABEL_W$}{reset}  {cyan}git daft hooks run {replay}{reset}{suffix}"
             ));
         }
     }
-    first
+    out
 }
 
 #[cfg(test)]
@@ -441,8 +483,8 @@ mod tests {
             legacy: false,
             replay: Some("worktree-post-create".to_string()),
         };
-        let msg = format_notice(&content, true);
-        assert!(msg.starts_with("2 daft.yml hooks not run: "));
+        let msg = format_notice(&content, true, false);
+        assert!(msg.starts_with("Untrusted repo — 2 daft.yml hooks not run: "));
         assert!(msg.contains("git daft hooks trust"));
         assert!(msg.contains("git daft hooks run worktree-post-create"));
         assert!(
@@ -561,15 +603,18 @@ mod tests {
             legacy: true,
             replay: None,
         };
-        let with_hints = format_notice(&content, true);
-        assert!(with_hints.starts_with("1 .daft/hooks script not run: worktree-pre-remove"));
+        let with_hints = format_notice(&content, true, false);
+        assert!(
+            with_hints
+                .starts_with("Untrusted repo — 1 .daft/hooks script not run: worktree-pre-remove")
+        );
         assert!(with_hints.contains("git daft hooks trust"));
         assert!(
             !with_hints.contains("hooks run"),
             "remove hooks get no replay line"
         );
 
-        let without = format_notice(&content, false);
+        let without = format_notice(&content, false, false);
         assert!(!without.contains("git daft hooks trust"));
         assert_eq!(without.lines().count(), 1);
     }
@@ -582,8 +627,65 @@ mod tests {
             legacy: false,
             replay: None,
         };
-        let msg = format_notice(&content, false);
+        let msg = format_notice(&content, false, false);
         assert!(msg.contains("and 2 more hooks"));
         assert!(!msg.contains("hook-5"));
+    }
+
+    #[test]
+    fn format_notice_leads_with_state_then_count_then_names() {
+        let content = NoticeContent {
+            names: BTreeSet::from([
+                "worktree-pre-create".to_string(),
+                "worktree-post-create".to_string(),
+            ]),
+            branches: BTreeSet::from(["feat/x".to_string()]),
+            legacy: false,
+            replay: None,
+        };
+        let msg = format_notice(&content, false, false);
+        assert_eq!(
+            msg,
+            "Untrusted repo — 2 daft.yml hooks not run: \
+             worktree-pre-create, worktree-post-create"
+        );
+    }
+
+    #[test]
+    fn format_notice_colorized_styles_parts_without_breaking_alignment() {
+        let content = NoticeContent {
+            names: BTreeSet::from(["worktree-post-create".to_string()]),
+            branches: BTreeSet::from(["feat/x".to_string()]),
+            legacy: false,
+            replay: Some("worktree-post-create".to_string()),
+        };
+        let strip = |s: &str| {
+            s.replace(crate::styles::BOLD, "")
+                .replace(crate::styles::DIM, "")
+                .replace(crate::styles::CYAN, "")
+                .replace(crate::styles::ORANGE, "")
+                .replace(crate::styles::RESET, "")
+        };
+
+        let plain = format_notice(&content, true, false);
+        let styled = format_notice(&content, true, true);
+        // Bold trust state leads the line.
+        assert!(styled.starts_with(crate::styles::BOLD));
+        // Commands are cyan, per the hooks-surface convention.
+        assert!(styled.contains(&format!(
+            "{}git daft hooks trust{}",
+            crate::styles::CYAN,
+            crate::styles::RESET
+        )));
+        // Hook names take the accent color the progress UI uses for them,
+        // distinct from the dim hint labels below.
+        assert!(styled.contains(&format!(
+            "{}worktree-post-create{}",
+            crate::styles::ORANGE,
+            crate::styles::RESET
+        )));
+        // Stripping the style codes must recover the plain rendering exactly —
+        // i.e. colors never move the aligned columns.
+        assert_eq!(strip(&styled), plain);
     }
 }

--- a/src/hooks/trust_skip.rs
+++ b/src/hooks/trust_skip.rs
@@ -285,6 +285,29 @@ fn capped_list(names: &BTreeSet<String>, more_word: &str) -> String {
     out
 }
 
+/// Like [`capped_list`], but hook names come out in lifecycle order
+/// (pre-create before post-create, …) rather than the set's alphabetical
+/// order, which reads backwards for hooks. Names that aren't lifecycle
+/// hooks (legacy script filenames with suffixes, deprecated names) keep
+/// their alphabetical position at the end.
+fn capped_hook_list(names: &BTreeSet<String>, more_word: &str) -> String {
+    let lifecycle_pos = |name: &str| {
+        HookType::from_yaml_name(name)
+            .and_then(|ht| HookType::all().iter().position(|h| *h == ht))
+            .unwrap_or(usize::MAX)
+    };
+    let mut ordered: Vec<&String> = names.iter().collect();
+    ordered.sort_by_key(|name| (lifecycle_pos(name), name.as_str()));
+
+    const CAP: usize = 4;
+    let shown: Vec<&str> = ordered.iter().take(CAP).map(|s| s.as_str()).collect();
+    let mut out = shown.join(", ");
+    if ordered.len() > CAP {
+        out.push_str(&format!(" and {} more {more_word}", ordered.len() - CAP));
+    }
+    out
+}
+
 fn format_notice(content: &NoticeContent, show_hints: bool) -> String {
     // Continuation lines align under the 9-char "warning: " prefix the CLI
     // output adds to the first line.
@@ -306,7 +329,7 @@ fn format_notice(content: &NoticeContent, show_hints: bool) -> String {
         } else {
             format!(
                 ".daft/hooks/ scripts ({}) were NOT run{branch_clause} — this repository isn't trusted.",
-                capped_list(&content.names, "scripts")
+                capped_hook_list(&content.names, "scripts")
             )
         }
     } else if content.names.len() == 1 {
@@ -317,7 +340,7 @@ fn format_notice(content: &NoticeContent, show_hints: bool) -> String {
     } else {
         format!(
             "daft.yml defines hooks ({}) that were NOT run{branch_clause} — this repository isn't trusted.",
-            capped_list(&content.names, "hooks")
+            capped_hook_list(&content.names, "hooks")
         )
     };
 

--- a/src/hooks/trust_skip.rs
+++ b/src/hooks/trust_skip.rs
@@ -1,0 +1,559 @@
+//! Untrusted-hook skip notices and replay records (#596).
+//!
+//! When the trust gate blocks a hook fire, two things must happen:
+//!
+//! 1. **Notice** — one contextual stderr warning per command invocation,
+//!    naming the skipped hooks and suggesting `git daft hooks trust`. The
+//!    notice is emitted here, from the executor's trust-Deny arms, so every
+//!    command and both config shapes (`daft.yml`, `.daft/hooks/`) are
+//!    covered centrally — no per-caller wiring to forget.
+//! 2. **Record** — a `status = 'skipped'` row in the `invocations` table so
+//!    `git daft hooks trust` can later suggest replaying exactly the hooks
+//!    that never ran. A row means "the most recent fire of this
+//!    (worktree, hook type) was blocked by trust"; it is deleted via
+//!    [`clear_skips`] the moment the gate next passes for that pair.
+//!
+//! # Once-per-command dedup
+//!
+//! "Once per command invocation" is tracked in a process-global registry
+//! keyed by git dir — one daft process is one command, and several commands
+//! construct multiple `HookExecutor`s per invocation (merge builds three;
+//! multi-branch clone builds one per satellite), so executor-instance state
+//! cannot dedupe.
+//!
+//! **Test contract:** there is deliberately no reset helper. Unit tests run
+//! in parallel threads sharing this registry; isolation comes from keying —
+//! every test must use a unique (tempdir) git dir and must never assert on
+//! global warning counts across git dirs.
+//!
+//! # TUI deferral
+//!
+//! In TUI mode the executor writes to a `BufferingOutput` whose warnings
+//! never reach the user. Emitting there would both hide the notice and mark
+//! it "shown", suppressing the one later chance at visibility. Instead,
+//! when [`Output::live_warnings`] is false the notice accumulates as
+//! pending state, and the command calls [`flush_pending_notice`] after the
+//! TUI exits to emit a single aggregated warning on the real stderr.
+
+use crate::coordinator::ports::JobsStorePort;
+use crate::hooks::HookContext;
+use crate::hooks::HookType;
+use crate::output::Output;
+use crate::store::models::InvocationRow;
+use crate::store::models::invocation::{INVOCATION_STATUS_SKIPPED, SKIP_REASON_UNTRUSTED};
+use std::collections::{BTreeSet, HashMap};
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock, PoisonError};
+
+/// Where the skipped hook definitions came from, with the names the notice
+/// should list.
+pub enum SkipSource {
+    /// YAML config. `configured_hooks` are the lifecycle hook names defined
+    /// in the loaded config (not just the one that fired), so a checkout
+    /// that skips both create hooks names both in its single notice.
+    Yaml { configured_hooks: Vec<String> },
+    /// Legacy `.daft/hooks/` scripts discovered for the current hook type.
+    Scripts { hook_files: Vec<String> },
+}
+
+#[derive(Default)]
+struct NoticeState {
+    /// A warning has reached a real stderr for this git dir.
+    displayed: bool,
+    /// Accumulated while the output was buffered (TUI mode).
+    pending: Option<NoticeContent>,
+}
+
+#[derive(Default, Clone)]
+struct NoticeContent {
+    /// Hook names to list (yaml names or script filenames).
+    names: BTreeSet<String>,
+    /// Branches the skips applied to. Empty for live notices (the branch is
+    /// obvious from command context); populated for aggregated TUI flushes.
+    branches: BTreeSet<String>,
+    /// All skips came from legacy scripts (wording switches to
+    /// `.daft/hooks/`). Any YAML skip flips this off.
+    legacy: bool,
+    /// Which `git daft hooks run <hook>` replay to suggest, if any.
+    replay: Option<String>,
+}
+
+impl NoticeContent {
+    fn merge(&mut self, other: NoticeContent) {
+        self.names.extend(other.names);
+        self.branches.extend(other.branches);
+        self.legacy = self.legacy && other.legacy;
+        // Post-create wins over post-clone: it is the per-worktree setup
+        // replay, which is what aggregated (multi-worktree) notices need.
+        self.replay = match (self.replay.take(), other.replay) {
+            (Some(a), Some(b)) => {
+                if a == "worktree-post-create" || b == "worktree-post-create" {
+                    Some("worktree-post-create".to_string())
+                } else {
+                    Some(a.max(b))
+                }
+            }
+            (a, b) => a.or(b),
+        };
+    }
+}
+
+fn registry() -> &'static Mutex<HashMap<PathBuf, NoticeState>> {
+    static REGISTRY: OnceLock<Mutex<HashMap<PathBuf, NoticeState>>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn registry_key(git_dir: &Path) -> PathBuf {
+    git_dir
+        .canonicalize()
+        .unwrap_or_else(|_| git_dir.to_path_buf())
+}
+
+/// Called from the executor's trust-Deny arms: emit (or defer) the
+/// once-per-command notice, then best-effort record the skip row. The
+/// warning never depends on the store write succeeding.
+pub fn notify_and_record(ctx: &HookContext, source: SkipSource, output: &mut dyn Output) {
+    let content = notice_content(ctx, &source);
+    let key = registry_key(&ctx.git_dir);
+    {
+        let mut reg = registry().lock().unwrap_or_else(PoisonError::into_inner);
+        let state = reg.entry(key).or_default();
+        if !state.displayed {
+            if output.live_warnings() {
+                output.warning(&format_notice(&content, !crate::hints::hints_disabled()));
+                state.displayed = true;
+            } else {
+                match &mut state.pending {
+                    Some(pending) => pending.merge(content),
+                    None => state.pending = Some(content),
+                }
+            }
+        }
+    }
+    record_skip(ctx, SKIP_REASON_UNTRUSTED);
+}
+
+/// Post-TUI flush: if skips were deferred for `git_dir` and no warning has
+/// reached a real stderr yet, emit one aggregated notice. No-op otherwise.
+pub fn flush_pending_notice(git_dir: &Path, output: &mut dyn Output) {
+    let key = registry_key(git_dir);
+    let content = {
+        let mut reg = registry().lock().unwrap_or_else(PoisonError::into_inner);
+        match reg.get_mut(&key) {
+            Some(state) if !state.displayed => {
+                let pending = state.pending.take();
+                if pending.is_some() {
+                    state.displayed = true;
+                }
+                pending
+            }
+            _ => None,
+        }
+    };
+    if let Some(content) = content {
+        output.warning(&format_notice(&content, !crate::hints::hints_disabled()));
+    }
+}
+
+/// Best-effort write of a `status = 'skipped'` invocation row. Failures are
+/// reported on raw stderr (same precedent as the yaml executor's
+/// invocation-meta write) — never via `output.warning`, which in TUI mode
+/// would vanish into the buffer and hide the degradation.
+pub fn record_skip(ctx: &HookContext, reason: &str) {
+    if let Err(e) = try_record_skip(ctx, reason) {
+        eprintln!(
+            "daft: failed to record skipped {} hook: {e}",
+            ctx.hook_type.yaml_name()
+        );
+    }
+}
+
+fn try_record_skip(ctx: &HookContext, reason: &str) -> anyhow::Result<()> {
+    // `create = true` always yields a store on success; the `else` arm is
+    // unreachable but must not panic on a best-effort path.
+    let Some(store) = open_store(ctx, true)? else {
+        return Ok(());
+    };
+    let repo_hash = repo_hash(ctx)?;
+    store.record_skipped_invocation(&InvocationRow {
+        repo_hash,
+        invocation_id: crate::coordinator::log_store::generate_invocation_id(),
+        trigger_command: ctx.command.clone(),
+        hook_type: ctx.hook_type.yaml_name().to_string(),
+        worktree: ctx.branch_name.clone(),
+        created_at: chrono::Utc::now(),
+        coordinator_pid: None,
+        status: INVOCATION_STATUS_SKIPPED.to_string(),
+        skip_reason: Some(reason.to_string()),
+    })
+}
+
+/// Best-effort delete of skip rows for `(repo, hook type, branch)`. Called
+/// by the executor whenever the trust gate passes (Allow, prompt accepted,
+/// or bypass) — the row's meaning is "the most recent fire was blocked",
+/// so a passing gate invalidates it even if the hook then fails or its
+/// `skip:` condition fires.
+pub fn clear_skips(ctx: &HookContext) {
+    if let Err(e) = try_clear_skips(ctx) {
+        eprintln!(
+            "daft: failed to clear skipped-{} records: {e}",
+            ctx.hook_type.yaml_name()
+        );
+    }
+}
+
+fn try_clear_skips(ctx: &HookContext) -> anyhow::Result<()> {
+    // No DB → no rows. Skipping early also avoids manufacturing per-repo
+    // state directories on every trusted hook fire of a fresh repo.
+    let Some(store) = open_store(ctx, false)? else {
+        return Ok(());
+    };
+    let repo_hash = repo_hash(ctx)?;
+    store.clear_skipped_invocations(&repo_hash, ctx.hook_type.yaml_name(), &ctx.branch_name)
+}
+
+fn repo_hash(ctx: &HookContext) -> anyhow::Result<String> {
+    crate::core::repo_identity::compute_repo_id_from_common_dir(&ctx.git_dir)
+}
+
+/// Open the per-repo store, honoring `ctx.state_dir` (tests) over
+/// `daft_state_dir()` (production). With `create = false`, returns
+/// `Ok(None)` when the DB file does not exist instead of creating it.
+fn open_store(
+    ctx: &HookContext,
+    create: bool,
+) -> anyhow::Result<Option<crate::coordinator::adapters::SqliteJobsStore>> {
+    use crate::coordinator::adapters::SqliteJobsStore;
+    use crate::store::paths::{COORDINATOR_DB, JOBS_SUBDIR};
+
+    let repo_hash = repo_hash(ctx)?;
+    let state_base = match &ctx.state_dir {
+        Some(p) => p.clone(),
+        None => crate::daft_state_dir()?,
+    };
+    if create {
+        // Canonical resolver: creates the per-repo dir and rejects
+        // symlink escapes.
+        let db_path = crate::store::paths::for_repo_under(&state_base, &repo_hash)?;
+        let base = db_path
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("coordinator DB path has no parent"))?;
+        Ok(Some(SqliteJobsStore::for_repo_base(base)?))
+    } else {
+        let base = state_base.join(JOBS_SUBDIR).join(&repo_hash);
+        if !base.join(COORDINATOR_DB).exists() {
+            return Ok(None);
+        }
+        Ok(Some(SqliteJobsStore::for_repo_base(&base)?))
+    }
+}
+
+fn notice_content(ctx: &HookContext, source: &SkipSource) -> NoticeContent {
+    let (names, legacy): (BTreeSet<String>, bool) = match source {
+        SkipSource::Yaml { configured_hooks } => {
+            (configured_hooks.iter().cloned().collect(), false)
+        }
+        SkipSource::Scripts { hook_files } => (hook_files.iter().cloned().collect(), true),
+    };
+    let replay = match ctx.hook_type {
+        HookType::PreCreate | HookType::PostCreate => names
+            .contains("worktree-post-create")
+            .then(|| "worktree-post-create".to_string()),
+        HookType::PostClone => names
+            .contains("post-clone")
+            .then(|| "post-clone".to_string()),
+        _ => None,
+    };
+    NoticeContent {
+        names,
+        // The branch is only named in aggregated (deferred) notices; a live
+        // notice prints inside the command that names the branch already.
+        branches: BTreeSet::from([ctx.branch_name.clone()]),
+        legacy,
+        replay,
+    }
+}
+
+/// Cap a name list at four entries, then "and N more".
+fn capped_list(names: &BTreeSet<String>, more_word: &str) -> String {
+    const CAP: usize = 4;
+    let shown: Vec<&str> = names.iter().take(CAP).map(String::as_str).collect();
+    let mut out = shown.join(", ");
+    if names.len() > CAP {
+        out.push_str(&format!(" and {} more {more_word}", names.len() - CAP));
+    }
+    out
+}
+
+fn format_notice(content: &NoticeContent, show_hints: bool) -> String {
+    // Continuation lines align under the 9-char "warning: " prefix the CLI
+    // output adds to the first line.
+    const INDENT: &str = "         ";
+
+    let multi_branch = content.branches.len() > 1;
+    let branch_clause = if multi_branch {
+        format!(" for {}", capped_list(&content.branches, "worktrees"))
+    } else {
+        String::new()
+    };
+
+    let mut first = if content.legacy {
+        if content.names.len() == 1 {
+            let name = content.names.iter().next().expect("len checked");
+            format!(
+                ".daft/hooks/{name} was NOT run{branch_clause} — this repository isn't trusted."
+            )
+        } else {
+            format!(
+                ".daft/hooks/ scripts ({}) were NOT run{branch_clause} — this repository isn't trusted.",
+                capped_list(&content.names, "scripts")
+            )
+        }
+    } else if content.names.len() == 1 {
+        let name = content.names.iter().next().expect("len checked");
+        format!(
+            "daft.yml defines a {name} hook that was NOT run{branch_clause} — this repository isn't trusted."
+        )
+    } else {
+        format!(
+            "daft.yml defines hooks ({}) that were NOT run{branch_clause} — this repository isn't trusted.",
+            capped_list(&content.names, "hooks")
+        )
+    };
+
+    if show_hints {
+        first.push_str(&format!(
+            "\n{INDENT}To run hooks here, trust this repository:  git daft hooks trust"
+        ));
+        if let Some(replay) = &content.replay {
+            let (label, suffix) = match (replay.as_str(), multi_branch) {
+                ("post-clone", _) => ("Then replay the clone's setup:           ", ""),
+                (_, true) => (
+                    "Then replay each worktree's setup:       ",
+                    "   (run inside each worktree)",
+                ),
+                (_, false) => ("Then replay this worktree's setup:       ", ""),
+            };
+            first.push_str(&format!(
+                "\n{INDENT}{label}git daft hooks run {replay}{suffix}"
+            ));
+        }
+    }
+    first
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::output::{BufferingOutput, TestOutput};
+    use tempfile::TempDir;
+
+    /// Each test gets a unique git dir (the registry key) and a private
+    /// state dir, per the module's test contract.
+    fn test_ctx(
+        git_dir: &Path,
+        state_dir: &Path,
+        hook_type: HookType,
+        branch: &str,
+    ) -> HookContext {
+        HookContext::new(
+            hook_type,
+            "checkout",
+            git_dir.parent().unwrap_or(git_dir),
+            git_dir,
+            "origin",
+            git_dir.parent().unwrap_or(git_dir),
+            git_dir.parent().unwrap_or(git_dir).join(branch),
+            branch,
+        )
+        .with_state_dir(state_dir)
+    }
+
+    fn yaml_source() -> SkipSource {
+        SkipSource::Yaml {
+            configured_hooks: vec![
+                "worktree-pre-create".to_string(),
+                "worktree-post-create".to_string(),
+            ],
+        }
+    }
+
+    #[test]
+    fn warns_once_per_git_dir_and_names_all_configured_hooks() {
+        let tmp = TempDir::new().unwrap();
+        let git_dir = tmp.path().join("repo/.git");
+        std::fs::create_dir_all(&git_dir).unwrap();
+        let state = tmp.path().join("state");
+
+        let mut output = TestOutput::new();
+        let pre = test_ctx(&git_dir, &state, HookType::PreCreate, "feat/x");
+        notify_and_record(&pre, yaml_source(), &mut output);
+        let post = test_ctx(&git_dir, &state, HookType::PostCreate, "feat/x");
+        notify_and_record(&post, yaml_source(), &mut output);
+
+        let warnings = output.warnings();
+        assert_eq!(warnings.len(), 1, "second Deny hit must be deduped");
+        // Hint lines depend on the ambient DAFT_NO_HINTS; assert only the
+        // env-independent first line here (hints are covered by the pure
+        // format tests below).
+        assert!(warnings[0].contains("worktree-pre-create"));
+        assert!(warnings[0].contains("worktree-post-create"));
+    }
+
+    #[test]
+    fn format_notice_yaml_multi_includes_trust_and_replay_hints() {
+        let content = NoticeContent {
+            names: BTreeSet::from([
+                "worktree-pre-create".to_string(),
+                "worktree-post-create".to_string(),
+            ]),
+            branches: BTreeSet::from(["feat/x".to_string()]),
+            legacy: false,
+            replay: Some("worktree-post-create".to_string()),
+        };
+        let msg = format_notice(&content, true);
+        assert!(msg.starts_with("daft.yml defines hooks ("));
+        assert!(msg.contains("git daft hooks trust"));
+        assert!(msg.contains("git daft hooks run worktree-post-create"));
+        assert!(
+            !msg.contains(" for feat/x"),
+            "single-branch notices do not name the branch"
+        );
+    }
+
+    #[test]
+    fn buffered_output_defers_until_flush_then_flushes_once() {
+        let tmp = TempDir::new().unwrap();
+        let git_dir = tmp.path().join("repo/.git");
+        std::fs::create_dir_all(&git_dir).unwrap();
+        let state = tmp.path().join("state");
+
+        let mut buffered = BufferingOutput::new();
+        let a = test_ctx(&git_dir, &state, HookType::PostCreate, "feat/a");
+        notify_and_record(&a, yaml_source(), &mut buffered);
+        let b = test_ctx(&git_dir, &state, HookType::PostCreate, "feat/b");
+        notify_and_record(&b, yaml_source(), &mut buffered);
+        assert!(
+            buffered.take_warnings().is_empty(),
+            "buffered sink must not receive the notice"
+        );
+
+        let mut real = TestOutput::new();
+        flush_pending_notice(&git_dir, &mut real);
+        let warnings = real.warnings();
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("feat/a"), "aggregate names branches");
+        assert!(warnings[0].contains("feat/b"));
+
+        let mut again = TestOutput::new();
+        flush_pending_notice(&git_dir, &mut again);
+        assert!(again.warnings().is_empty(), "flush is one-shot");
+    }
+
+    #[test]
+    fn live_warning_suppresses_later_flush() {
+        let tmp = TempDir::new().unwrap();
+        let git_dir = tmp.path().join("repo/.git");
+        std::fs::create_dir_all(&git_dir).unwrap();
+        let state = tmp.path().join("state");
+
+        let mut output = TestOutput::new();
+        let ctx = test_ctx(&git_dir, &state, HookType::PostClone, "main");
+        notify_and_record(
+            &ctx,
+            SkipSource::Yaml {
+                configured_hooks: vec!["post-clone".to_string()],
+            },
+            &mut output,
+        );
+        assert_eq!(output.warnings().len(), 1);
+
+        let mut after = TestOutput::new();
+        flush_pending_notice(&git_dir, &mut after);
+        assert!(after.warnings().is_empty());
+    }
+
+    #[test]
+    fn records_skip_row_and_clear_removes_it() {
+        use crate::coordinator::ports::JobsStorePort;
+
+        let tmp = TempDir::new().unwrap();
+        let git_dir = tmp.path().join("repo/.git");
+        std::fs::create_dir_all(&git_dir).unwrap();
+        let state = tmp.path().join("state");
+
+        let ctx = test_ctx(&git_dir, &state, HookType::PostCreate, "feat/x");
+        record_skip(&ctx, SKIP_REASON_UNTRUSTED);
+
+        let repo_hash =
+            crate::core::repo_identity::compute_repo_id_from_common_dir(&git_dir).unwrap();
+        let store = open_store(&ctx, false).unwrap().expect("db exists");
+        let rows = store.list_skipped_invocations(&repo_hash).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].hook_type, "worktree-post-create");
+        assert_eq!(rows[0].worktree, "feat/x");
+        assert_eq!(rows[0].trigger_command, "checkout");
+        assert_eq!(rows[0].skip_reason.as_deref(), Some(SKIP_REASON_UNTRUSTED));
+
+        // Repeated skip replaces, not accumulates.
+        record_skip(&ctx, SKIP_REASON_UNTRUSTED);
+        assert_eq!(store.list_skipped_invocations(&repo_hash).unwrap().len(), 1);
+
+        clear_skips(&ctx);
+        assert!(
+            store
+                .list_skipped_invocations(&repo_hash)
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn clear_without_db_is_a_silent_noop_and_creates_nothing() {
+        let tmp = TempDir::new().unwrap();
+        let git_dir = tmp.path().join("repo/.git");
+        std::fs::create_dir_all(&git_dir).unwrap();
+        let state = tmp.path().join("state");
+
+        let ctx = test_ctx(&git_dir, &state, HookType::PostCreate, "feat/x");
+        clear_skips(&ctx);
+        assert!(
+            !state.exists(),
+            "clear on a fresh repo must not manufacture state dirs"
+        );
+    }
+
+    #[test]
+    fn format_notice_legacy_single_and_hints_off() {
+        let content = NoticeContent {
+            names: BTreeSet::from(["worktree-pre-remove".to_string()]),
+            branches: BTreeSet::from(["feat/x".to_string()]),
+            legacy: true,
+            replay: None,
+        };
+        let with_hints = format_notice(&content, true);
+        assert!(with_hints.starts_with(".daft/hooks/worktree-pre-remove was NOT run"));
+        assert!(with_hints.contains("git daft hooks trust"));
+        assert!(
+            !with_hints.contains("hooks run"),
+            "remove hooks get no replay line"
+        );
+
+        let without = format_notice(&content, false);
+        assert!(!without.contains("git daft hooks trust"));
+        assert_eq!(without.lines().count(), 1);
+    }
+
+    #[test]
+    fn format_notice_caps_long_lists() {
+        let content = NoticeContent {
+            names: (1..=6).map(|i| format!("hook-{i}")).collect(),
+            branches: BTreeSet::new(),
+            legacy: false,
+            replay: None,
+        };
+        let msg = format_notice(&content, false);
+        assert!(msg.contains("and 2 more hooks"));
+        assert!(!msg.contains("hook-5"));
+    }
+}

--- a/src/hooks/trust_skip.rs
+++ b/src/hooks/trust_skip.rs
@@ -2,9 +2,11 @@
 //!
 //! When the trust gate blocks a hook fire, two things must happen:
 //!
-//! 1. **Notice** — one contextual stderr warning per command invocation,
-//!    naming the skipped hooks and suggesting `git daft hooks trust`. The
-//!    notice is emitted here, from the executor's trust-Deny arms, so every
+//! 1. **Notice** — one contextual stderr notice per command invocation
+//!    (via [`Output::notice`]: plain, untagged — an untrusted repo skipping
+//!    its hooks is by design, not a warning), naming the skipped hooks and
+//!    suggesting `git daft hooks trust`. The notice is emitted here, from the
+//!    executor's trust-Deny arms, so every
 //!    command and both config shapes (`daft.yml`, `.daft/hooks/`) are
 //!    covered centrally — no per-caller wiring to forget.
 //! 2. **Record** — a `status = 'skipped'` row in the `invocations` table so
@@ -24,16 +26,16 @@
 //! **Test contract:** there is deliberately no reset helper. Unit tests run
 //! in parallel threads sharing this registry; isolation comes from keying —
 //! every test must use a unique (tempdir) git dir and must never assert on
-//! global warning counts across git dirs.
+//! global notice counts across git dirs.
 //!
 //! # TUI deferral
 //!
-//! In TUI mode the executor writes to a `BufferingOutput` whose warnings
-//! never reach the user. Emitting there would both hide the notice and mark
+//! In TUI mode the executor writes to a `BufferingOutput` whose output
+//! never reaches the user. Emitting there would both hide the notice and mark
 //! it "shown", suppressing the one later chance at visibility. Instead,
 //! when [`Output::live_warnings`] is false the notice accumulates as
 //! pending state, and the command calls [`flush_pending_notice`] after the
-//! TUI exits to emit a single aggregated warning on the real stderr.
+//! TUI exits to emit a single aggregated notice on the real stderr.
 
 use crate::coordinator::ports::JobsStorePort;
 use crate::hooks::HookContext;
@@ -58,7 +60,7 @@ pub enum SkipSource {
 
 #[derive(Default)]
 struct NoticeState {
-    /// A warning has reached a real stderr for this git dir.
+    /// A notice has reached a real stderr for this git dir.
     displayed: bool,
     /// Accumulated while the output was buffered (TUI mode).
     pending: Option<NoticeContent>,
@@ -111,7 +113,7 @@ fn registry_key(git_dir: &Path) -> PathBuf {
 
 /// Called from the executor's trust-Deny arms: emit (or defer) the
 /// once-per-command notice, then best-effort record the skip row. The
-/// warning never depends on the store write succeeding.
+/// notice never depends on the store write succeeding.
 pub fn notify_and_record(ctx: &HookContext, source: SkipSource, output: &mut dyn Output) {
     let content = notice_content(ctx, &source);
     let key = registry_key(&ctx.git_dir);
@@ -120,7 +122,7 @@ pub fn notify_and_record(ctx: &HookContext, source: SkipSource, output: &mut dyn
         let state = reg.entry(key).or_default();
         if !state.displayed {
             if output.live_warnings() {
-                output.warning(&format_notice(&content, !crate::hints::hints_disabled()));
+                output.notice(&format_notice(&content, !crate::hints::hints_disabled()));
                 state.displayed = true;
             } else {
                 match &mut state.pending {
@@ -133,7 +135,7 @@ pub fn notify_and_record(ctx: &HookContext, source: SkipSource, output: &mut dyn
     record_skip(ctx, SKIP_REASON_UNTRUSTED);
 }
 
-/// Post-TUI flush: if skips were deferred for `git_dir` and no warning has
+/// Post-TUI flush: if skips were deferred for `git_dir` and no notice has
 /// reached a real stderr yet, emit one aggregated notice. No-op otherwise.
 pub fn flush_pending_notice(git_dir: &Path, output: &mut dyn Output) {
     let key = registry_key(git_dir);
@@ -151,13 +153,13 @@ pub fn flush_pending_notice(git_dir: &Path, output: &mut dyn Output) {
         }
     };
     if let Some(content) = content {
-        output.warning(&format_notice(&content, !crate::hints::hints_disabled()));
+        output.notice(&format_notice(&content, !crate::hints::hints_disabled()));
     }
 }
 
 /// Best-effort write of a `status = 'skipped'` invocation row. Failures are
 /// reported on raw stderr (same precedent as the yaml executor's
-/// invocation-meta write) — never via `output.warning`, which in TUI mode
+/// invocation-meta write) — never via `output.notice`, which in TUI mode
 /// would vanish into the buffer and hide the degradation.
 pub fn record_skip(ctx: &HookContext, reason: &str) {
     if let Err(e) = try_record_skip(ctx, reason) {
@@ -309,9 +311,10 @@ fn capped_hook_list(names: &BTreeSet<String>, more_word: &str) -> String {
 }
 
 fn format_notice(content: &NoticeContent, show_hints: bool) -> String {
-    // Continuation lines align under the 9-char "warning: " prefix the CLI
-    // output adds to the first line.
-    const INDENT: &str = "         ";
+    // The notice is emitted via `Output::notice` — a plain stderr line with no
+    // severity prefix — so the first line starts at column 0. Hint lines are
+    // indented to read as subordinate to it.
+    const INDENT: &str = "   ";
 
     let multi_branch = content.branches.len() > 1;
     let branch_clause = if multi_branch {
@@ -320,48 +323,49 @@ fn format_notice(content: &NoticeContent, show_hints: bool) -> String {
         String::new()
     };
 
+    // Lead with the count, then the names: "3 daft.yml hooks not run: a, b, c".
+    let n = content.names.len();
     let mut first = if content.legacy {
-        if content.names.len() == 1 {
+        if n == 1 {
             let name = content.names.iter().next().expect("len checked");
             format!(
-                ".daft/hooks/{name} was NOT run{branch_clause} — this repository isn't trusted."
+                "1 .daft/hooks script not run{branch_clause}: {name} — this repo isn't trusted."
             )
         } else {
             format!(
-                ".daft/hooks/ scripts ({}) were NOT run{branch_clause} — this repository isn't trusted.",
+                "{n} .daft/hooks scripts not run{branch_clause}: {} — this repo isn't trusted.",
                 capped_hook_list(&content.names, "scripts")
             )
         }
-    } else if content.names.len() == 1 {
+    } else if n == 1 {
         let name = content.names.iter().next().expect("len checked");
-        format!(
-            "daft.yml defines a {name} hook that was NOT run{branch_clause} — this repository isn't trusted."
-        )
+        format!("1 daft.yml hook not run{branch_clause}: {name} — this repo isn't trusted.")
     } else {
         format!(
-            "daft.yml defines hooks ({}) that were NOT run{branch_clause} — this repository isn't trusted.",
+            "{n} daft.yml hooks not run{branch_clause}: {} — this repo isn't trusted.",
             capped_hook_list(&content.names, "hooks")
         )
     };
 
     if show_hints {
+        // Labels are padded to LABEL_W so both suggestion commands start at the
+        // same column under the indent (LABEL_W spans the longest label below).
+        const LABEL_W: usize = 34;
         first.push_str(&format!(
-            "\n{INDENT}To run hooks here, trust this repository:  git daft hooks trust"
+            "\n{INDENT}{:<LABEL_W$}  git daft hooks trust",
+            "To run them, trust this repo:"
         ));
         if let Some(replay) = &content.replay {
-            // Labels are padded so both suggestion commands start at the
-            // same column (43 chars after the indent, matching the trust
-            // line above).
             let (label, suffix) = match (replay.as_str(), multi_branch) {
-                ("post-clone", _) => ("Then replay the clone's setup:             ", ""),
+                ("post-clone", _) => ("Then replay the clone's setup:", ""),
                 (_, true) => (
-                    "Then replay each worktree's setup:         ",
+                    "Then replay each worktree's setup:",
                     "   (run inside each worktree)",
                 ),
-                (_, false) => ("Then replay this worktree's setup:         ", ""),
+                (_, false) => ("Then replay this worktree's setup:", ""),
             };
             first.push_str(&format!(
-                "\n{INDENT}{label}git daft hooks run {replay}{suffix}"
+                "\n{INDENT}{label:<LABEL_W$}  git daft hooks run {replay}{suffix}"
             ));
         }
     }
@@ -405,7 +409,7 @@ mod tests {
     }
 
     #[test]
-    fn warns_once_per_git_dir_and_names_all_configured_hooks() {
+    fn notifies_once_per_git_dir_and_names_all_configured_hooks() {
         let tmp = TempDir::new().unwrap();
         let git_dir = tmp.path().join("repo/.git");
         std::fs::create_dir_all(&git_dir).unwrap();
@@ -417,13 +421,13 @@ mod tests {
         let post = test_ctx(&git_dir, &state, HookType::PostCreate, "feat/x");
         notify_and_record(&post, yaml_source(), &mut output);
 
-        let warnings = output.warnings();
-        assert_eq!(warnings.len(), 1, "second Deny hit must be deduped");
+        let notices = output.notices();
+        assert_eq!(notices.len(), 1, "second Deny hit must be deduped");
         // Hint lines depend on the ambient DAFT_NO_HINTS; assert only the
         // env-independent first line here (hints are covered by the pure
         // format tests below).
-        assert!(warnings[0].contains("worktree-pre-create"));
-        assert!(warnings[0].contains("worktree-post-create"));
+        assert!(notices[0].contains("worktree-pre-create"));
+        assert!(notices[0].contains("worktree-post-create"));
     }
 
     #[test]
@@ -438,7 +442,7 @@ mod tests {
             replay: Some("worktree-post-create".to_string()),
         };
         let msg = format_notice(&content, true);
-        assert!(msg.starts_with("daft.yml defines hooks ("));
+        assert!(msg.starts_with("2 daft.yml hooks not run: "));
         assert!(msg.contains("git daft hooks trust"));
         assert!(msg.contains("git daft hooks run worktree-post-create"));
         assert!(
@@ -466,18 +470,18 @@ mod tests {
 
         let mut real = TestOutput::new();
         flush_pending_notice(&git_dir, &mut real);
-        let warnings = real.warnings();
-        assert_eq!(warnings.len(), 1);
-        assert!(warnings[0].contains("feat/a"), "aggregate names branches");
-        assert!(warnings[0].contains("feat/b"));
+        let notices = real.notices();
+        assert_eq!(notices.len(), 1);
+        assert!(notices[0].contains("feat/a"), "aggregate names branches");
+        assert!(notices[0].contains("feat/b"));
 
         let mut again = TestOutput::new();
         flush_pending_notice(&git_dir, &mut again);
-        assert!(again.warnings().is_empty(), "flush is one-shot");
+        assert!(again.notices().is_empty(), "flush is one-shot");
     }
 
     #[test]
-    fn live_warning_suppresses_later_flush() {
+    fn live_notice_suppresses_later_flush() {
         let tmp = TempDir::new().unwrap();
         let git_dir = tmp.path().join("repo/.git");
         std::fs::create_dir_all(&git_dir).unwrap();
@@ -492,11 +496,11 @@ mod tests {
             },
             &mut output,
         );
-        assert_eq!(output.warnings().len(), 1);
+        assert_eq!(output.notices().len(), 1);
 
         let mut after = TestOutput::new();
         flush_pending_notice(&git_dir, &mut after);
-        assert!(after.warnings().is_empty());
+        assert!(after.notices().is_empty());
     }
 
     #[test]
@@ -558,7 +562,7 @@ mod tests {
             replay: None,
         };
         let with_hints = format_notice(&content, true);
-        assert!(with_hints.starts_with(".daft/hooks/worktree-pre-remove was NOT run"));
+        assert!(with_hints.starts_with("1 .daft/hooks script not run: worktree-pre-remove"));
         assert!(with_hints.contains("git daft hooks trust"));
         assert!(
             !with_hints.contains("hooks run"),

--- a/src/hooks/trust_skip.rs
+++ b/src/hooks/trust_skip.rs
@@ -388,9 +388,12 @@ fn format_notice(content: &NoticeContent, show_hints: bool, colorize: bool) -> S
         // Pad the plain label first, then wrap it in the (zero-width) style
         // codes, so the alignment holds with and without color.
         const LABEL_W: usize = 34;
+        // Render the executable the way the user invoked it (`daft` vs
+        // `git daft`), so the suggestion is copy-pasteable in their style.
+        let exe = crate::cli_label();
         let label = "To run them, trust this repo:";
         out.push_str(&format!(
-            "\n{INDENT}{dim}{label:<LABEL_W$}{reset}  {cyan}git daft hooks trust{reset}"
+            "\n{INDENT}{dim}{label:<LABEL_W$}{reset}  {cyan}{exe} hooks trust{reset}"
         ));
         if let Some(replay) = &content.replay {
             let (label, suffix) = match (replay.as_str(), multi_branch) {
@@ -407,7 +410,7 @@ fn format_notice(content: &NoticeContent, show_hints: bool, colorize: bool) -> S
                 format!("{dim}{suffix}{reset}")
             };
             out.push_str(&format!(
-                "\n{INDENT}{dim}{label:<LABEL_W$}{reset}  {cyan}git daft hooks run {replay}{reset}{suffix}"
+                "\n{INDENT}{dim}{label:<LABEL_W$}{reset}  {cyan}{exe} hooks run {replay}{reset}{suffix}"
             ));
         }
     }

--- a/src/hooks/trust_skip.rs
+++ b/src/hooks/trust_skip.rs
@@ -92,6 +92,10 @@ impl NoticeContent {
                 if a == "worktree-post-create" || b == "worktree-post-create" {
                     Some("worktree-post-create".to_string())
                 } else {
+                    // Both sides can only be "post-clone" here — replay is
+                    // populated from the two idempotent setup hooks only.
+                    // max() just keeps the pick deterministic if that set
+                    // ever grows.
                     Some(a.max(b))
                 }
             }

--- a/src/hooks/trust_skip.rs
+++ b/src/hooks/trust_skip.rs
@@ -349,13 +349,16 @@ fn format_notice(content: &NoticeContent, show_hints: bool) -> String {
             "\n{INDENT}To run hooks here, trust this repository:  git daft hooks trust"
         ));
         if let Some(replay) = &content.replay {
+            // Labels are padded so both suggestion commands start at the
+            // same column (43 chars after the indent, matching the trust
+            // line above).
             let (label, suffix) = match (replay.as_str(), multi_branch) {
-                ("post-clone", _) => ("Then replay the clone's setup:           ", ""),
+                ("post-clone", _) => ("Then replay the clone's setup:             ", ""),
                 (_, true) => (
-                    "Then replay each worktree's setup:       ",
+                    "Then replay each worktree's setup:         ",
                     "   (run inside each worktree)",
                 ),
-                (_, false) => ("Then replay this worktree's setup:       ", ""),
+                (_, false) => ("Then replay this worktree's setup:         ", ""),
             };
             first.push_str(&format!(
                 "\n{INDENT}{label}git daft hooks run {replay}{suffix}"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,47 @@ pub fn get_clap_args(expected_cmd: &str) -> Vec<String> {
     args.to_vec()
 }
 
+/// The daft executable as the user invoked it, for rendering suggested
+/// commands in user-facing output: `"daft"` when invoked directly (`daft`,
+/// `daft-go`, …), `"git daft"` when invoked through git (`git daft <verb>`,
+/// `git worktree-checkout`, …).
+///
+/// Returns the canonical `"git daft"` when argv isn't installed, and always
+/// under `cfg!(test)`: unit tests share one process, so the `daft-<hash>`
+/// test-binary name (or a test that installed argv) would otherwise flip
+/// other tests' expected hint strings order-dependently.
+pub fn cli_label() -> &'static str {
+    if cfg!(test) {
+        return "git daft";
+    }
+    cli::try_argv()
+        .and_then(|args| args.first())
+        .map(|argv0| label_for_argv0(argv0))
+        .unwrap_or("git daft")
+}
+
+/// Classify an argv\[0\] into the display label. `daft` and `daft-*`
+/// (`daft-go`, `daft-start`, …) are direct-style; everything else — `git-daft`,
+/// the `git-worktree-*` symlinks, shortcut symlinks, unknown names — renders
+/// git-style, which is also the canonical documented form.
+fn label_for_argv0(argv0: &str) -> &'static str {
+    let name = Path::new(argv0)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("");
+    if name == "daft" || name.starts_with("daft-") {
+        "daft"
+    } else {
+        "git daft"
+    }
+}
+
+/// Format a suggested daft invocation in the current invocation style:
+/// `daft_cmd("hooks trust")` → `daft hooks trust` or `git daft hooks trust`.
+pub fn daft_cmd(args: &str) -> String {
+    format!("{} {args}", cli_label())
+}
+
 /// Returns `true` if the given argv corresponds to an invocation that should
 /// skip startup-time background work (update checks, trust pruning, etc.).
 ///
@@ -261,6 +302,35 @@ mod tests {
     use super::*;
     use serial_test::serial;
     use std::path::PathBuf;
+
+    #[test]
+    fn label_for_argv0_direct_invocations() {
+        assert_eq!(label_for_argv0("daft"), "daft");
+        assert_eq!(label_for_argv0("/usr/local/bin/daft"), "daft");
+        assert_eq!(label_for_argv0("daft-go"), "daft");
+        assert_eq!(label_for_argv0("daft-start"), "daft");
+        assert_eq!(label_for_argv0("./target/debug/daft"), "daft");
+    }
+
+    #[test]
+    fn label_for_argv0_git_style_and_fallbacks() {
+        assert_eq!(label_for_argv0("git-daft"), "git daft");
+        assert_eq!(label_for_argv0("/usr/lib/git-core/git-daft"), "git daft");
+        assert_eq!(label_for_argv0("git-worktree-checkout"), "git daft");
+        assert_eq!(label_for_argv0("git-worktree-clone"), "git daft");
+        // Shortcut symlinks and unknown names render the canonical form.
+        assert_eq!(label_for_argv0("gwtco"), "git daft");
+        assert_eq!(label_for_argv0(""), "git daft");
+    }
+
+    #[test]
+    fn cli_label_is_canonical_in_tests() {
+        // Pins the cfg!(test) gate: in-process unit tests must always see the
+        // canonical label regardless of the test binary's name or any argv a
+        // sibling test installed.
+        assert_eq!(cli_label(), "git daft");
+        assert_eq!(daft_cmd("hooks trust"), "git daft hooks trust");
+    }
 
     #[test]
     #[serial]

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,11 +107,7 @@ fn main() -> Result<()> {
 
         // Main daft / git-daft command - check for subcommands
         "git-daft" | "daft" => {
-            let label = if resolved == "git-daft" {
-                "git daft"
-            } else {
-                "daft"
-            };
+            let label = daft::cli_label();
             // Check if a subcommand was provided
             let args = argv;
             if args.len() > 1 {

--- a/src/output/buffering.rs
+++ b/src/output/buffering.rs
@@ -79,6 +79,12 @@ impl Output for BufferingOutput {
     fn is_verbose(&self) -> bool {
         false
     }
+
+    fn live_warnings(&self) -> bool {
+        // Warnings land in the buffer, not in front of the user; callers
+        // that must guarantee visibility defer to a post-TUI flush.
+        false
+    }
 }
 
 #[cfg(test)]

--- a/src/output/buffering.rs
+++ b/src/output/buffering.rs
@@ -44,6 +44,14 @@ impl Output for BufferingOutput {
         self.warnings.push(msg.to_string());
     }
 
+    // No-op by design. The only `notice()` producer is the untrusted-hook
+    // notice, which detects TUI mode via `live_warnings() == false` and defers
+    // through its own registry — the post-TUI `flush_pending_notice` then emits
+    // on the real `CliOutput`. So a notice never reaches this buffer; capturing
+    // it here would double-handle it (and the buffer drains via `warning()`,
+    // which would re-tag it).
+    fn notice(&mut self, _msg: &str) {}
+
     fn error(&mut self, _msg: &str) {}
 
     fn debug(&mut self, _msg: &str) {}
@@ -115,6 +123,7 @@ mod tests {
         let mut output = BufferingOutput::new();
         output.info("info");
         output.success("success");
+        output.notice("notice");
         output.error("error");
         output.debug("debug");
         output.step("step");

--- a/src/output/cli.rs
+++ b/src/output/cli.rs
@@ -121,6 +121,13 @@ impl Output for CliOutput {
         }
     }
 
+    fn notice(&mut self, msg: &str) {
+        // A neutral fact, not a problem: no `warning:`/`error:` prefix, no
+        // color. Stays on stderr (out of stdout) and always shown, like a
+        // warning — quiet mode does not suppress it.
+        self.stderr_line(msg);
+    }
+
     fn error(&mut self, msg: &str) {
         // Errors are always shown (not affected by quiet mode)
         // Git-like format: lowercase prefix

--- a/src/output/cli.rs
+++ b/src/output/cli.rs
@@ -122,9 +122,10 @@ impl Output for CliOutput {
     }
 
     fn notice(&mut self, msg: &str) {
-        // A neutral fact, not a problem: no `warning:`/`error:` prefix, no
-        // color. Stays on stderr (out of stdout) and always shown, like a
-        // warning — quiet mode does not suppress it.
+        // A neutral fact, not a problem: no `warning:`/`error:` prefix, and
+        // no styling of its own — callers may pass pre-styled text, gated on
+        // a live color-capable stderr. Stays on stderr (out of stdout) and
+        // always shown, like a warning — quiet mode does not suppress it.
         self.stderr_line(msg);
     }
 

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -187,6 +187,17 @@ pub trait Output {
         let _ = self;
     }
 
+    /// Whether `warning()` reaches the user immediately (a real stderr).
+    ///
+    /// `BufferingOutput` (TUI mode, where ratatui owns the terminal) returns
+    /// `false`: its warnings land in a buffer, not in front of the user.
+    /// Callers that must guarantee a warning is *seen* — like the untrusted-
+    /// hook notice — use this to decide between emitting now and deferring
+    /// to a post-TUI flush.
+    fn live_warnings(&self) -> bool {
+        true
+    }
+
     // ─────────────────────────────────────────────────────────────────────────
     // Special Output
     // ─────────────────────────────────────────────────────────────────────────

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -106,7 +106,8 @@ pub trait Output {
     /// that are *not* problems (e.g. "this repo isn't trusted, so its hooks
     /// were skipped"). It stays on stderr (not stdout, so it never pollutes a
     /// command's machine-readable output) and ignores quiet mode (like a
-    /// warning, the user should still see it).
+    /// warning, the user should still see it). Implementations add no styling
+    /// of their own; callers may embed it (gated on a live stderr).
     fn notice(&mut self, msg: &str);
 
     /// Display an error message to stderr.

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -99,6 +99,16 @@ pub trait Output {
     /// Always shown (not affected by quiet mode).
     fn warning(&mut self, msg: &str);
 
+    /// Display a neutral notice to stderr — no severity prefix, always shown.
+    ///
+    /// Unlike [`warning`](Output::warning)/[`error`](Output::error), this adds
+    /// no `warning:`/`error:` tag: it is for by-design, informational facts
+    /// that are *not* problems (e.g. "this repo isn't trusted, so its hooks
+    /// were skipped"). It stays on stderr (not stdout, so it never pollutes a
+    /// command's machine-readable output) and ignores quiet mode (like a
+    /// warning, the user should still see it).
+    fn notice(&mut self, msg: &str);
+
     /// Display an error message to stderr.
     /// Always shown (not affected by quiet mode).
     fn error(&mut self, msg: &str);
@@ -187,11 +197,12 @@ pub trait Output {
         let _ = self;
     }
 
-    /// Whether `warning()` reaches the user immediately (a real stderr).
+    /// Whether stderr messages (`warning()`/`notice()`) reach the user
+    /// immediately (a real stderr).
     ///
     /// `BufferingOutput` (TUI mode, where ratatui owns the terminal) returns
-    /// `false`: its warnings land in a buffer, not in front of the user.
-    /// Callers that must guarantee a warning is *seen* — like the untrusted-
+    /// `false`: its output lands in a buffer, not in front of the user.
+    /// Callers that must guarantee a message is *seen* — like the untrusted-
     /// hook notice — use this to decide between emitting now and deferring
     /// to a post-TUI flush.
     fn live_warnings(&self) -> bool {

--- a/src/output/test.rs
+++ b/src/output/test.rs
@@ -14,6 +14,8 @@ pub enum OutputEntry {
     Success(String),
     /// Warning message
     Warning(String),
+    /// Neutral notice (stderr, no prefix, always shown)
+    Notice(String),
     /// Error message
     Error(String),
     /// Debug message
@@ -143,6 +145,17 @@ impl TestOutput {
             .collect()
     }
 
+    /// Get all notice messages.
+    pub fn notices(&self) -> Vec<&str> {
+        self.entries
+            .iter()
+            .filter_map(|e| match e {
+                OutputEntry::Notice(s) => Some(s.as_str()),
+                _ => None,
+            })
+            .collect()
+    }
+
     /// Get all error messages.
     pub fn errors(&self) -> Vec<&str> {
         self.entries
@@ -238,6 +251,11 @@ impl TestOutput {
         self.warnings().iter().any(|s| s.contains(substring))
     }
 
+    /// Check if any notice message contains the given substring.
+    pub fn has_notice(&self, substring: &str) -> bool {
+        self.notices().iter().any(|s| s.contains(substring))
+    }
+
     /// Check if any error message contains the given substring.
     pub fn has_error(&self, substring: &str) -> bool {
         self.errors().iter().any(|s| s.contains(substring))
@@ -310,6 +328,11 @@ impl Output for TestOutput {
     fn warning(&mut self, msg: &str) {
         // Warnings are always captured (not affected by quiet mode)
         self.entries.push(OutputEntry::Warning(msg.to_string()));
+    }
+
+    fn notice(&mut self, msg: &str) {
+        // Notices are always captured (not affected by quiet mode)
+        self.entries.push(OutputEntry::Notice(msg.to_string()));
     }
 
     fn error(&mut self, msg: &str) {

--- a/src/store/migrate.rs
+++ b/src/store/migrate.rs
@@ -22,6 +22,7 @@ pub fn migrations() -> Migrations<'static> {
     Migrations::new(vec![
         M::up(include_str!("migrations/001_initial.sql")),
         M::up(include_str!("migrations/002_visitor_seeds.sql")),
+        M::up(include_str!("migrations/003_invocation_status.sql")),
     ])
 }
 
@@ -32,7 +33,7 @@ pub fn current_version() -> i64 {
     // rusqlite_migration's version counter is `migrations.len() as u32` after
     // every migration is applied. We return that as i64 for consistency with
     // the on-disk `user_version` PRAGMA type.
-    2
+    3
 }
 
 /// Apply all pending migrations against `conn`. Refuses if the on-disk
@@ -105,6 +106,32 @@ mod tests {
             )
             .unwrap();
         assert_eq!(name, "visitor_seeds");
+    }
+
+    #[test]
+    fn invocations_table_gains_status_columns() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("db.sqlite");
+        let mut conn = connection::open_for_test(&path).unwrap();
+        run(&mut conn, &path).unwrap();
+        conn.execute(
+            "INSERT INTO invocations
+                 (repo_hash, invocation_id, trigger_command, hook_type, worktree,
+                  created_at, status, skip_reason)
+             VALUES ('r', 'i', 'checkout', 'worktree-post-create', 'feat/x',
+                     '2026-01-01T00:00:00Z', 'skipped', 'untrusted')",
+            [],
+        )
+        .unwrap();
+        let (status, reason): (String, Option<String>) = conn
+            .query_row(
+                "SELECT status, skip_reason FROM invocations WHERE repo_hash = 'r'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(status, "skipped");
+        assert_eq!(reason.as_deref(), Some("untrusted"));
     }
 
     #[test]

--- a/src/store/migrations/003_invocation_status.sql
+++ b/src/store/migrations/003_invocation_status.sql
@@ -1,0 +1,20 @@
+-- Trust-skipped hook fires (#596): record skips in `invocations` so daft can
+-- suggest replaying them after `git daft hooks trust`.
+--
+-- `status` mirrors the `jobs.status` lowercase-string convention:
+--   'completed'  default — the historical meaning of a row ("this fired");
+--                no production rows existed before this migration.
+--   'skipped'    the hook did not run; `skip_reason` says why.
+-- `skip_reason` is NULL unless skipped:
+--   'untrusted'           trust level Deny — blocked by the trust gate.
+--   'prompt-unavailable'  trust level Prompt with no interactive callback
+--                         (includes fingerprint-mismatch downgrades).
+--
+-- Skip rows are advisory replay state, not an audit log (the `jobs` table is
+-- the audit log): the writer keeps at most one skipped row per
+-- (repo_hash, hook_type, worktree) and deletes it when the trust gate next
+-- passes for that pair. No new index: the PK (repo_hash, invocation_id)
+-- prefix already serves the only query pattern (all skipped rows for a repo).
+
+ALTER TABLE invocations ADD COLUMN status TEXT NOT NULL DEFAULT 'completed';
+ALTER TABLE invocations ADD COLUMN skip_reason TEXT;

--- a/src/store/models/invocation.rs
+++ b/src/store/models/invocation.rs
@@ -1,6 +1,21 @@
 //! `invocations` row.
+//!
+//! `status` / `skip_reason` are free strings at the storage boundary (same
+//! convention as `jobs.status`); the constants below define the vocabulary
+//! at the edges so unknown values written by a newer daft still round-trip.
 
 use chrono::{DateTime, Utc};
+
+/// The hook fire ran (the historical meaning of an invocation row).
+pub const INVOCATION_STATUS_COMPLETED: &str = "completed";
+/// The hook fire did not run; `skip_reason` says why.
+pub const INVOCATION_STATUS_SKIPPED: &str = "skipped";
+
+/// Skipped because the repository's trust level is Deny.
+pub const SKIP_REASON_UNTRUSTED: &str = "untrusted";
+/// Skipped because trust level is Prompt and no interactive callback was
+/// available (includes fingerprint-mismatch downgrades).
+pub const SKIP_REASON_PROMPT_UNAVAILABLE: &str = "prompt-unavailable";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InvocationRow {
@@ -11,4 +26,6 @@ pub struct InvocationRow {
     pub worktree: String,
     pub created_at: DateTime<Utc>,
     pub coordinator_pid: Option<u32>,
+    pub status: String,
+    pub skip_reason: Option<String>,
 }

--- a/src/store/repos/invocations.rs
+++ b/src/store/repos/invocations.rs
@@ -12,14 +12,16 @@ impl InvocationsRepo {
     pub fn upsert(conn: &Connection, row: &InvocationRow) -> Result<()> {
         conn.execute(
             "INSERT INTO invocations
-                 (repo_hash, invocation_id, trigger_command, hook_type, worktree, created_at, coordinator_pid)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+                 (repo_hash, invocation_id, trigger_command, hook_type, worktree, created_at, coordinator_pid, status, skip_reason)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
              ON CONFLICT(repo_hash, invocation_id) DO UPDATE SET
                  trigger_command = excluded.trigger_command,
                  hook_type       = excluded.hook_type,
                  worktree        = excluded.worktree,
                  created_at      = excluded.created_at,
-                 coordinator_pid = excluded.coordinator_pid",
+                 coordinator_pid = excluded.coordinator_pid,
+                 status          = excluded.status,
+                 skip_reason     = excluded.skip_reason",
             params![
                 row.repo_hash,
                 row.invocation_id,
@@ -28,6 +30,8 @@ impl InvocationsRepo {
                 row.worktree,
                 row.created_at.to_rfc3339(),
                 row.coordinator_pid,
+                row.status,
+                row.skip_reason,
             ],
         )?;
         Ok(())
@@ -40,7 +44,7 @@ impl InvocationsRepo {
     ) -> Result<Option<InvocationRow>> {
         let row = conn
             .query_row(
-                "SELECT repo_hash, invocation_id, trigger_command, hook_type, worktree, created_at, coordinator_pid
+                "SELECT repo_hash, invocation_id, trigger_command, hook_type, worktree, created_at, coordinator_pid, status, skip_reason
                  FROM invocations
                  WHERE repo_hash = ?1 AND invocation_id = ?2",
                 params![repo_hash, invocation_id],
@@ -48,6 +52,41 @@ impl InvocationsRepo {
             )
             .optional()?;
         Ok(row)
+    }
+
+    /// All invocations for a repo with the given status, oldest first.
+    pub fn list_by_repo_and_status(
+        conn: &Connection,
+        repo_hash: &str,
+        status: &str,
+    ) -> Result<Vec<InvocationRow>> {
+        let mut stmt = conn.prepare(
+            "SELECT repo_hash, invocation_id, trigger_command, hook_type, worktree, created_at, coordinator_pid, status, skip_reason
+             FROM invocations
+             WHERE repo_hash = ?1 AND status = ?2
+             ORDER BY created_at ASC",
+        )?;
+        let rows = stmt
+            .query_map(params![repo_hash, status], row_to_invocation)?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(rows)
+    }
+
+    /// Delete rows matching the natural key `(repo, hook_type, worktree)`
+    /// and the given status. Returns the number of rows removed.
+    pub fn delete_by_key_and_status(
+        conn: &Connection,
+        repo_hash: &str,
+        hook_type: &str,
+        worktree: &str,
+        status: &str,
+    ) -> Result<usize> {
+        let n = conn.execute(
+            "DELETE FROM invocations
+             WHERE repo_hash = ?1 AND hook_type = ?2 AND worktree = ?3 AND status = ?4",
+            params![repo_hash, hook_type, worktree, status],
+        )?;
+        Ok(n)
     }
 }
 
@@ -62,6 +101,8 @@ fn row_to_invocation(row: &rusqlite::Row<'_>) -> rusqlite::Result<InvocationRow>
         worktree: row.get("worktree")?,
         created_at,
         coordinator_pid: row.get::<_, Option<u32>>("coordinator_pid")?,
+        status: row.get("status")?,
+        skip_reason: row.get::<_, Option<String>>("skip_reason")?,
     })
 }
 
@@ -123,6 +164,22 @@ mod tests {
             worktree: "feat/foo".into(),
             created_at: Utc::now(),
             coordinator_pid: Some(42),
+            status: crate::store::models::invocation::INVOCATION_STATUS_COMPLETED.into(),
+            skip_reason: None,
+        }
+    }
+
+    fn skipped_inv(id: &str, hook_type: &str, worktree: &str) -> InvocationRow {
+        InvocationRow {
+            repo_hash: "repohash".into(),
+            invocation_id: id.into(),
+            trigger_command: "checkout".into(),
+            hook_type: hook_type.into(),
+            worktree: worktree.into(),
+            created_at: Utc::now(),
+            coordinator_pid: None,
+            status: crate::store::models::invocation::INVOCATION_STATUS_SKIPPED.into(),
+            skip_reason: Some(crate::store::models::invocation::SKIP_REASON_UNTRUSTED.into()),
         }
     }
 
@@ -157,5 +214,84 @@ mod tests {
         let (_tmp, conn) = fresh_db();
         let back = InvocationsRepo::get(&conn, "missing", "missing").unwrap();
         assert!(back.is_none());
+    }
+
+    #[test]
+    fn list_by_status_filters_and_orders() {
+        let (_tmp, conn) = fresh_db();
+        InvocationsRepo::upsert(&conn, &sample_inv()).unwrap();
+        let mut older = skipped_inv("inv-2", "worktree-post-create", "feat/a");
+        older.created_at = Utc::now() - chrono::Duration::hours(1);
+        InvocationsRepo::upsert(&conn, &older).unwrap();
+        InvocationsRepo::upsert(&conn, &skipped_inv("inv-3", "post-clone", "main")).unwrap();
+
+        let skipped = InvocationsRepo::list_by_repo_and_status(
+            &conn,
+            "repohash",
+            crate::store::models::invocation::INVOCATION_STATUS_SKIPPED,
+        )
+        .unwrap();
+        assert_eq!(skipped.len(), 2);
+        // Oldest first; the completed sample row is excluded.
+        assert_eq!(skipped[0].invocation_id, "inv-2");
+        assert_eq!(skipped[1].invocation_id, "inv-3");
+
+        let other_repo = InvocationsRepo::list_by_repo_and_status(
+            &conn,
+            "elsewhere",
+            crate::store::models::invocation::INVOCATION_STATUS_SKIPPED,
+        )
+        .unwrap();
+        assert!(other_repo.is_empty());
+    }
+
+    #[test]
+    fn delete_by_key_and_status_scopes_tightly() {
+        let (_tmp, conn) = fresh_db();
+        InvocationsRepo::upsert(
+            &conn,
+            &skipped_inv("inv-1", "worktree-post-create", "feat/a"),
+        )
+        .unwrap();
+        InvocationsRepo::upsert(
+            &conn,
+            &skipped_inv("inv-2", "worktree-post-create", "feat/b"),
+        )
+        .unwrap();
+        InvocationsRepo::upsert(
+            &conn,
+            &skipped_inv("inv-3", "worktree-pre-create", "feat/a"),
+        )
+        .unwrap();
+        // Completed row sharing the same natural key must survive.
+        let mut done = sample_inv();
+        done.invocation_id = "inv-4".into();
+        done.hook_type = "worktree-post-create".into();
+        done.worktree = "feat/a".into();
+        InvocationsRepo::upsert(&conn, &done).unwrap();
+
+        let n = InvocationsRepo::delete_by_key_and_status(
+            &conn,
+            "repohash",
+            "worktree-post-create",
+            "feat/a",
+            crate::store::models::invocation::INVOCATION_STATUS_SKIPPED,
+        )
+        .unwrap();
+        assert_eq!(n, 1);
+
+        let remaining = InvocationsRepo::list_by_repo_and_status(
+            &conn,
+            "repohash",
+            crate::store::models::invocation::INVOCATION_STATUS_SKIPPED,
+        )
+        .unwrap();
+        let ids: Vec<_> = remaining.iter().map(|r| r.invocation_id.as_str()).collect();
+        assert_eq!(ids, vec!["inv-2", "inv-3"]);
+        assert!(
+            InvocationsRepo::get(&conn, "repohash", "inv-4")
+                .unwrap()
+                .is_some()
+        );
     }
 }

--- a/src/store/repos/invocations.rs
+++ b/src/store/repos/invocations.rs
@@ -54,6 +54,20 @@ impl InvocationsRepo {
         Ok(row)
     }
 
+    /// All invocations for a repo, oldest first.
+    pub fn list_by_repo(conn: &Connection, repo_hash: &str) -> Result<Vec<InvocationRow>> {
+        let mut stmt = conn.prepare(
+            "SELECT repo_hash, invocation_id, trigger_command, hook_type, worktree, created_at, coordinator_pid, status, skip_reason
+             FROM invocations
+             WHERE repo_hash = ?1
+             ORDER BY created_at ASC",
+        )?;
+        let rows = stmt
+            .query_map(params![repo_hash], row_to_invocation)?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(rows)
+    }
+
     /// All invocations for a repo with the given status, oldest first.
     pub fn list_by_repo_and_status(
         conn: &Connection,

--- a/src/store/repos/jobs.rs
+++ b/src/store/repos/jobs.rs
@@ -233,6 +233,8 @@ mod tests {
                 worktree: "feat/test".into(),
                 created_at: Utc::now(),
                 coordinator_pid: None,
+                status: crate::store::models::invocation::INVOCATION_STATUS_COMPLETED.into(),
+                skip_reason: None,
             },
         )
         .unwrap();

--- a/tests/manual/scenarios/hooks/replay-clears-skips.yml
+++ b/tests/manual/scenarios/hooks/replay-clears-skips.yml
@@ -1,0 +1,82 @@
+name: Replaying a skipped hook clears its record per worktree
+description:
+  "A skip record means 'this hook never ran for this worktree'. Replaying it via
+  hooks run must clear exactly that worktree's record: re-trusting then suggests
+  only the worktrees still missing their setup, and once all are replayed no
+  skipped rows remain in the store."
+
+repos:
+  - name: test-replay-clear
+    default_branch: main
+    branches:
+      - name: main
+        files:
+          - path: README.md
+            content: "# replay clear"
+        commits:
+          - message: "Initial commit"
+      - name: feature/replayed
+        from: main
+    daft_yml: |
+      hooks:
+        worktree-post-create:
+          jobs:
+            - name: post
+              run: touch "$DAFT_WORKTREE_PATH/.post-ran"
+
+steps:
+  - name: Clone the repository (records the base worktree's skip)
+    run: git-worktree-clone --layout contained $REMOTE_TEST_REPLAY_CLEAR
+    expect:
+      exit_code: 0
+
+  - name: Checkout while untrusted (records the feature worktree's skip)
+    run: git-worktree-checkout feature/replayed
+    cwd: "$WORK_DIR/test-replay-clear/main"
+    expect:
+      exit_code: 0
+
+  - name: Trust suggests replays for both worktrees
+    run: daft hooks trust --force
+    cwd: "$WORK_DIR/test-replay-clear/main"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "git daft hooks run worktree-post-create"
+        - "feature/replayed"
+
+  - name: Replay the hook inside the feature worktree
+    run: daft hooks run worktree-post-create
+    cwd: "$WORK_DIR/test-replay-clear/feature/replayed"
+    expect:
+      exit_code: 0
+      files_exist:
+        - "$WORK_DIR/test-replay-clear/feature/replayed/.post-ran"
+
+  - name: Re-trusting now suggests only the base worktree
+    run: |
+      daft hooks deny --force >/dev/null 2>&1
+      daft hooks trust --force
+    cwd: "$WORK_DIR/test-replay-clear/main"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "# in main"
+      output_not_contains:
+        - "feature/replayed"
+
+  - name: Replay the hook inside the base worktree
+    run: daft hooks run worktree-post-create
+    cwd: "$WORK_DIR/test-replay-clear/main"
+    expect:
+      exit_code: 0
+      files_exist:
+        - "$WORK_DIR/test-replay-clear/main/.post-ran"
+
+  - name: No skipped rows remain in the store
+    run: daft __dump-store invocations
+    cwd: "$WORK_DIR/test-replay-clear/main"
+    expect:
+      exit_code: 0
+      output_not_contains:
+        - '"status":"skipped"'

--- a/tests/manual/scenarios/hooks/replay-clears-skips.yml
+++ b/tests/manual/scenarios/hooks/replay-clears-skips.yml
@@ -36,14 +36,17 @@ steps:
     expect:
       exit_code: 0
 
-  - name: Trust suggests replays for both worktrees
+  - name: Trust suggests replays for both worktrees, in the invocation's style
     run: daft hooks trust --force
     cwd: "$WORK_DIR/test-replay-clear/main"
     expect:
       exit_code: 0
       output_contains:
-        - "git daft hooks run worktree-post-create"
+        - "daft hooks run worktree-post-create"
         - "feature/replayed"
+      output_not_contains:
+        # Invoked as `daft`, not `git daft` — suggestions must match.
+        - "git daft hooks run"
 
   - name: Replay the hook inside the feature worktree
     run: daft hooks run worktree-post-create

--- a/tests/manual/scenarios/hooks/skip-hooks-suppresses-untrusted-warning.yml
+++ b/tests/manual/scenarios/hooks/skip-hooks-suppresses-untrusted-warning.yml
@@ -1,0 +1,67 @@
+name: --skip-hooks suppresses the untrusted-hook warning
+description:
+  "When the user explicitly opted out of hooks (--skip-hooks all or a hook-type
+  selector naming the fire), the untrusted notice would be a nag — the hooks
+  were not going to run regardless of trust. No warning, and no replay record
+  either (trusting later must not suggest replays for fires the user skipped on
+  purpose)."
+
+repos:
+  - name: test-skip-suppress
+    default_branch: main
+    branches:
+      - name: main
+        files:
+          - path: README.md
+            content: "# skip suppress"
+        commits:
+          - message: "Initial commit"
+      - name: feature/skip-all
+        from: main
+      - name: feature/skip-type
+        from: main
+    daft_yml: |
+      hooks:
+        worktree-post-create:
+          jobs:
+            - name: post
+              run: touch "$DAFT_WORKTREE_PATH/.post-ran"
+
+steps:
+  - name: Clone the repository
+    run:
+      git-worktree-clone --layout contained --skip-hooks all
+      $REMOTE_TEST_SKIP_SUPPRESS
+    expect:
+      exit_code: 0
+      output_not_contains:
+        - "isn't trusted"
+
+  - name: Checkout with --skip-hooks all stays silent
+    run: git-worktree-checkout --skip-hooks all feature/skip-all
+    cwd: "$WORK_DIR/test-skip-suppress/main"
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-skip-suppress/feature/skip-all"
+      output_not_contains:
+        - "isn't trusted"
+
+  - name: Checkout with a hook-type selector stays silent
+    run:
+      git-worktree-checkout --skip-hooks worktree-post-create feature/skip-type
+    cwd: "$WORK_DIR/test-skip-suppress/main"
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-skip-suppress/feature/skip-type"
+      output_not_contains:
+        - "isn't trusted"
+
+  - name: Trusting suggests no replays (nothing was recorded)
+    run: daft hooks trust --force
+    cwd: "$WORK_DIR/test-skip-suppress/main"
+    expect:
+      exit_code: 0
+      output_not_contains:
+        - "Hooks were skipped here"

--- a/tests/manual/scenarios/hooks/skip-hooks-suppresses-untrusted-warning.yml
+++ b/tests/manual/scenarios/hooks/skip-hooks-suppresses-untrusted-warning.yml
@@ -35,7 +35,7 @@ steps:
     expect:
       exit_code: 0
       output_not_contains:
-        - "isn't trusted"
+        - "Untrusted repo"
 
   - name: Checkout with --skip-hooks all stays silent
     run: git-worktree-checkout --skip-hooks all feature/skip-all
@@ -45,7 +45,7 @@ steps:
       dirs_exist:
         - "$WORK_DIR/test-skip-suppress/feature/skip-all"
       output_not_contains:
-        - "isn't trusted"
+        - "Untrusted repo"
 
   - name: Checkout with a hook-type selector stays silent
     run:
@@ -56,7 +56,7 @@ steps:
       dirs_exist:
         - "$WORK_DIR/test-skip-suppress/feature/skip-type"
       output_not_contains:
-        - "isn't trusted"
+        - "Untrusted repo"
 
   - name: Trusting suggests no replays (nothing was recorded)
     run: daft hooks trust --force

--- a/tests/manual/scenarios/hooks/trust-suggests-replay.yml
+++ b/tests/manual/scenarios/hooks/trust-suggests-replay.yml
@@ -1,0 +1,54 @@
+name: Trusting suggests replaying previously skipped setup hooks
+description:
+  "Skips recorded while untrusted must turn into precise replay suggestions when
+  the repo is trusted: only the idempotent setup hooks (post-create here), never
+  pre-create, listing the affected worktrees."
+
+repos:
+  - name: test-replay-suggest
+    default_branch: main
+    branches:
+      - name: main
+        files:
+          - path: README.md
+            content: "# replay suggest"
+        commits:
+          - message: "Initial commit"
+      - name: feature/replay
+        from: main
+    daft_yml: |
+      hooks:
+        worktree-pre-create:
+          jobs:
+            - name: pre
+              run: echo pre
+        worktree-post-create:
+          jobs:
+            - name: post
+              run: touch "$DAFT_WORKTREE_PATH/.post-ran"
+
+steps:
+  - name: Clone the repository (records the base worktree's skip)
+    run: git-worktree-clone --layout contained $REMOTE_TEST_REPLAY_SUGGEST
+    expect:
+      exit_code: 0
+
+  - name: Checkout while untrusted (records the feature worktree's skips)
+    run: git-worktree-checkout feature/replay
+    cwd: "$WORK_DIR/test-replay-suggest/main"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "NOT run"
+
+  - name: Trusting suggests the post-create replay for both worktrees
+    run: daft hooks trust --force
+    cwd: "$WORK_DIR/test-replay-suggest/main"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "Hooks were skipped here while the repository was untrusted"
+        - "git daft hooks run worktree-post-create"
+        - "feature/replay"
+      output_not_contains:
+        - "hooks run worktree-pre-create"

--- a/tests/manual/scenarios/hooks/trust-suggests-replay.yml
+++ b/tests/manual/scenarios/hooks/trust-suggests-replay.yml
@@ -39,7 +39,7 @@ steps:
     expect:
       exit_code: 0
       output_contains:
-        - "hooks not run:"
+        - "Untrusted repo — 2 daft.yml hooks not run:"
 
   - name: Trusting suggests the post-create replay for both worktrees
     run: daft hooks trust --force

--- a/tests/manual/scenarios/hooks/trust-suggests-replay.yml
+++ b/tests/manual/scenarios/hooks/trust-suggests-replay.yml
@@ -48,7 +48,9 @@ steps:
       exit_code: 0
       output_contains:
         - "Hooks were skipped here while the repository was untrusted"
-        - "git daft hooks run worktree-post-create"
+        - "daft hooks run worktree-post-create"
         - "feature/replay"
       output_not_contains:
         - "hooks run worktree-pre-create"
+        # Invoked as `daft`, not `git daft` — suggestions must match.
+        - "git daft hooks run"

--- a/tests/manual/scenarios/hooks/trust-suggests-replay.yml
+++ b/tests/manual/scenarios/hooks/trust-suggests-replay.yml
@@ -39,7 +39,7 @@ steps:
     expect:
       exit_code: 0
       output_contains:
-        - "NOT run"
+        - "hooks not run:"
 
   - name: Trusting suggests the post-create replay for both worktrees
     run: daft hooks trust --force

--- a/tests/manual/scenarios/hooks/untrusted-warning-clone-multi-branch.yml
+++ b/tests/manual/scenarios/hooks/untrusted-warning-clone-multi-branch.yml
@@ -1,0 +1,47 @@
+name: Multi-branch clone emits exactly one untrusted-hook warning
+description:
+  "Multi-branch clone builds a fresh executor per satellite worktree; the
+  process-global notice registry must still collapse the trust skips into one
+  warning for the whole command. (Headless runs take the sequential satellite
+  path; the TUI path's deferred flush is unit-tested.)"
+
+repos:
+  - name: test-multi-untrusted
+    default_branch: main
+    branches:
+      - name: main
+        files:
+          - path: README.md
+            content: "# multi untrusted"
+        commits:
+          - message: "Initial commit"
+      - name: develop
+        from: main
+      - name: feature
+        from: main
+    daft_yml: |
+      hooks:
+        worktree-post-create:
+          jobs:
+            - name: post
+              run: touch "$DAFT_WORKTREE_PATH/.post-ran"
+
+steps:
+  - name: Multi-branch clone warns exactly once across all worktrees
+    run: |
+      git-worktree-clone --layout contained -b develop -b feature $REMOTE_TEST_MULTI_UNTRUSTED 2>&1 | grep -c "isn't trusted"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "1"
+
+  - name: Both satellite worktrees exist and no hook ran
+    run: "true"
+    cwd: "$WORK_DIR/test-multi-untrusted"
+    expect:
+      dirs_exist:
+        - "$WORK_DIR/test-multi-untrusted/develop"
+        - "$WORK_DIR/test-multi-untrusted/feature"
+      files_not_exist:
+        - "$WORK_DIR/test-multi-untrusted/develop/.post-ran"
+        - "$WORK_DIR/test-multi-untrusted/feature/.post-ran"

--- a/tests/manual/scenarios/hooks/untrusted-warning-clone-multi-branch.yml
+++ b/tests/manual/scenarios/hooks/untrusted-warning-clone-multi-branch.yml
@@ -29,7 +29,7 @@ repos:
 steps:
   - name: Multi-branch clone warns exactly once across all worktrees
     run: |
-      git-worktree-clone --layout contained -b develop -b feature $REMOTE_TEST_MULTI_UNTRUSTED 2>&1 | grep -c "isn't trusted"
+      git-worktree-clone --layout contained -b develop -b feature $REMOTE_TEST_MULTI_UNTRUSTED 2>&1 | grep -c "Untrusted repo"
     expect:
       exit_code: 0
       output_contains:

--- a/tests/manual/scenarios/hooks/untrusted-warning-clone-postclone.yml
+++ b/tests/manual/scenarios/hooks/untrusted-warning-clone-postclone.yml
@@ -30,6 +30,6 @@ steps:
       files_not_exist:
         - "$WORK_DIR/test-clone-untrusted/main/.clone-ran"
       output_contains:
-        - "daft.yml defines a post-clone hook that was NOT run"
+        - "1 daft.yml hook not run: post-clone"
         - "git daft hooks trust"
         - "git daft hooks run post-clone"

--- a/tests/manual/scenarios/hooks/untrusted-warning-clone-postclone.yml
+++ b/tests/manual/scenarios/hooks/untrusted-warning-clone-postclone.yml
@@ -1,0 +1,35 @@
+name: Untrusted post-clone hook warns at clone time
+description:
+  "Cloning a repo whose daft.yml defines post-clone must warn that the hook was
+  skipped and offer the trust command plus the post-clone replay."
+
+repos:
+  - name: test-clone-untrusted
+    default_branch: main
+    branches:
+      - name: main
+        files:
+          - path: README.md
+            content: "# clone untrusted"
+        commits:
+          - message: "Initial commit"
+    daft_yml: |
+      hooks:
+        post-clone:
+          jobs:
+            - name: bootstrap
+              run: touch "$DAFT_WORKTREE_PATH/.clone-ran"
+
+steps:
+  - name: Clone warns about the skipped post-clone hook
+    run: git-worktree-clone --layout contained $REMOTE_TEST_CLONE_UNTRUSTED
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-clone-untrusted/main"
+      files_not_exist:
+        - "$WORK_DIR/test-clone-untrusted/main/.clone-ran"
+      output_contains:
+        - "daft.yml defines a post-clone hook that was NOT run"
+        - "git daft hooks trust"
+        - "git daft hooks run post-clone"

--- a/tests/manual/scenarios/hooks/untrusted-warning-clone-postclone.yml
+++ b/tests/manual/scenarios/hooks/untrusted-warning-clone-postclone.yml
@@ -30,6 +30,6 @@ steps:
       files_not_exist:
         - "$WORK_DIR/test-clone-untrusted/main/.clone-ran"
       output_contains:
-        - "1 daft.yml hook not run: post-clone"
+        - "Untrusted repo — 1 daft.yml hook not run: post-clone"
         - "git daft hooks trust"
         - "git daft hooks run post-clone"

--- a/tests/manual/scenarios/hooks/untrusted-warning-remove.yml
+++ b/tests/manual/scenarios/hooks/untrusted-warning-remove.yml
@@ -52,7 +52,7 @@ steps:
     expect:
       exit_code: 0
       output_not_contains:
-        - "isn't trusted"
+        - "Untrusted repo"
 
   - name: Branch-delete warns about the skipped script hook
     run: git-worktree-branch-delete feature/doomed
@@ -60,7 +60,7 @@ steps:
     expect:
       exit_code: 0
       output_contains:
-        - "1 .daft/hooks script not run: worktree-pre-remove"
+        - "Untrusted repo — 1 .daft/hooks script not run: worktree-pre-remove"
         - "git daft hooks trust"
       output_not_contains:
         - "git daft hooks run"
@@ -82,7 +82,7 @@ steps:
     expect:
       exit_code: 0
       output_contains:
-        - "1 daft.yml hook not run: worktree-pre-remove"
+        - "Untrusted repo — 1 daft.yml hook not run: worktree-pre-remove"
         - "git daft hooks trust"
       output_not_contains:
         - "git daft hooks run"

--- a/tests/manual/scenarios/hooks/untrusted-warning-remove.yml
+++ b/tests/manual/scenarios/hooks/untrusted-warning-remove.yml
@@ -60,7 +60,7 @@ steps:
     expect:
       exit_code: 0
       output_contains:
-        - ".daft/hooks/worktree-pre-remove was NOT run"
+        - "1 .daft/hooks script not run: worktree-pre-remove"
         - "git daft hooks trust"
       output_not_contains:
         - "git daft hooks run"
@@ -82,7 +82,7 @@ steps:
     expect:
       exit_code: 0
       output_contains:
-        - "daft.yml defines a worktree-pre-remove hook that was NOT run"
+        - "1 daft.yml hook not run: worktree-pre-remove"
         - "git daft hooks trust"
       output_not_contains:
         - "git daft hooks run"

--- a/tests/manual/scenarios/hooks/untrusted-warning-remove.yml
+++ b/tests/manual/scenarios/hooks/untrusted-warning-remove.yml
@@ -1,0 +1,88 @@
+name: Untrusted remove hooks warn on branch-delete (both config shapes)
+description:
+  "branch-delete fires worktree-pre/post-remove through the executor but
+  previously emitted no untrusted notice at all. The centralized notice must
+  cover the remove path for both .daft/hooks/ scripts and daft.yml, and must not
+  offer a replay line (replaying remove hooks is harmful)."
+
+repos:
+  - name: test-remove-scripts
+    default_branch: main
+    branches:
+      - name: main
+        files:
+          - path: README.md
+            content: "# remove scripts"
+        commits:
+          - message: "Initial commit"
+      - name: feature/doomed
+        from: main
+    hook_scripts:
+      - name: worktree-pre-remove
+        content: |
+          #!/bin/bash
+          echo "$DAFT_BRANCH_NAME" >> "$DAFT_PROJECT_ROOT/.pre-remove-ran"
+  - name: test-remove-yaml
+    default_branch: main
+    branches:
+      - name: main
+        files:
+          - path: README.md
+            content: "# remove yaml"
+        commits:
+          - message: "Initial commit"
+      - name: feature/doomed
+        from: main
+    daft_yml: |
+      hooks:
+        worktree-pre-remove:
+          jobs:
+            - name: teardown
+              run: echo teardown
+
+steps:
+  - name: Clone the scripts repository
+    run: git-worktree-clone --layout contained $REMOTE_TEST_REMOVE_SCRIPTS
+    expect:
+      exit_code: 0
+
+  - name: Checkout is silent (no create hooks configured)
+    run: git-worktree-checkout feature/doomed
+    cwd: "$WORK_DIR/test-remove-scripts/main"
+    expect:
+      exit_code: 0
+      output_not_contains:
+        - "isn't trusted"
+
+  - name: Branch-delete warns about the skipped script hook
+    run: git-worktree-branch-delete feature/doomed
+    cwd: "$WORK_DIR/test-remove-scripts/main"
+    expect:
+      exit_code: 0
+      output_contains:
+        - ".daft/hooks/worktree-pre-remove was NOT run"
+        - "git daft hooks trust"
+      output_not_contains:
+        - "git daft hooks run"
+
+  - name: Clone the yaml repository
+    run: git-worktree-clone --layout contained $REMOTE_TEST_REMOVE_YAML
+    expect:
+      exit_code: 0
+
+  - name: Checkout the yaml repo worktree
+    run: git-worktree-checkout feature/doomed
+    cwd: "$WORK_DIR/test-remove-yaml/main"
+    expect:
+      exit_code: 0
+
+  - name: Branch-delete warns about the skipped daft.yml hook
+    run: git-worktree-branch-delete feature/doomed
+    cwd: "$WORK_DIR/test-remove-yaml/main"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "daft.yml defines a worktree-pre-remove hook that was NOT run"
+        - "git daft hooks trust"
+      output_not_contains:
+        - "git daft hooks run"

--- a/tests/manual/scenarios/hooks/untrusted-warning-stderr-only.yml
+++ b/tests/manual/scenarios/hooks/untrusted-warning-stderr-only.yml
@@ -50,4 +50,4 @@ steps:
       dirs_exist:
         - "$WORK_DIR/test-stderr-only/feature/loud"
       output_contains:
-        - "daft.yml defines a worktree-post-create hook that was NOT run"
+        - "1 daft.yml hook not run: worktree-post-create"

--- a/tests/manual/scenarios/hooks/untrusted-warning-stderr-only.yml
+++ b/tests/manual/scenarios/hooks/untrusted-warning-stderr-only.yml
@@ -1,0 +1,53 @@
+name: Untrusted-hook warning goes to stderr only
+description:
+  "The notice must never pollute stdout (the eval / DAFT_CD_FILE contract): with
+  stderr discarded the warning vanishes while the command still succeeds;
+  without redirection it is visible."
+
+repos:
+  - name: test-stderr-only
+    default_branch: main
+    branches:
+      - name: main
+        files:
+          - path: README.md
+            content: "# stderr only"
+        commits:
+          - message: "Initial commit"
+      - name: feature/quiet
+        from: main
+      - name: feature/loud
+        from: main
+    daft_yml: |
+      hooks:
+        worktree-post-create:
+          jobs:
+            - name: post
+              run: echo post
+
+steps:
+  - name: Clone the repository
+    run:
+      git-worktree-clone --layout contained $REMOTE_TEST_STDERR_ONLY 2>/dev/null
+    expect:
+      exit_code: 0
+
+  - name: With stderr discarded the warning disappears and checkout still works
+    run: git-worktree-checkout feature/quiet 2>/dev/null
+    cwd: "$WORK_DIR/test-stderr-only/main"
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-stderr-only/feature/quiet"
+      output_not_contains:
+        - "isn't trusted"
+
+  - name: Without redirection the warning is visible
+    run: git-worktree-checkout feature/loud
+    cwd: "$WORK_DIR/test-stderr-only/main"
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-stderr-only/feature/loud"
+      output_contains:
+        - "daft.yml defines a worktree-post-create hook that was NOT run"

--- a/tests/manual/scenarios/hooks/untrusted-warning-stderr-only.yml
+++ b/tests/manual/scenarios/hooks/untrusted-warning-stderr-only.yml
@@ -40,7 +40,7 @@ steps:
       dirs_exist:
         - "$WORK_DIR/test-stderr-only/feature/quiet"
       output_not_contains:
-        - "isn't trusted"
+        - "Untrusted repo"
 
   - name: Without redirection the warning is visible
     run: git-worktree-checkout feature/loud
@@ -50,4 +50,4 @@ steps:
       dirs_exist:
         - "$WORK_DIR/test-stderr-only/feature/loud"
       output_contains:
-        - "1 daft.yml hook not run: worktree-post-create"
+        - "Untrusted repo — 1 daft.yml hook not run: worktree-post-create"

--- a/tests/manual/scenarios/hooks/untrusted-warning-sync.yml
+++ b/tests/manual/scenarios/hooks/untrusted-warning-sync.yml
@@ -62,5 +62,5 @@ steps:
     expect:
       exit_code: 0
       output_contains:
-        - "1 daft.yml hook not run: worktree-pre-remove"
+        - "Untrusted repo — 1 daft.yml hook not run: worktree-pre-remove"
         - "git daft hooks trust"

--- a/tests/manual/scenarios/hooks/untrusted-warning-sync.yml
+++ b/tests/manual/scenarios/hooks/untrusted-warning-sync.yml
@@ -62,5 +62,5 @@ steps:
     expect:
       exit_code: 0
       output_contains:
-        - "daft.yml defines a worktree-pre-remove hook that was NOT run"
+        - "1 daft.yml hook not run: worktree-pre-remove"
         - "git daft hooks trust"

--- a/tests/manual/scenarios/hooks/untrusted-warning-sync.yml
+++ b/tests/manual/scenarios/hooks/untrusted-warning-sync.yml
@@ -1,0 +1,66 @@
+name: Untrusted remove hooks warn during sync's prune phase
+description:
+  "sync's prune phase fires worktree-pre/post-remove for branches deleted on the
+  remote, but previously emitted no untrusted notice. The centralized notice
+  must surface there too."
+
+repos:
+  - name: test-sync-untrusted
+    default_branch: main
+    branches:
+      - name: main
+        files:
+          - path: README.md
+            content: "# sync untrusted"
+        commits:
+          - message: "Initial commit"
+    daft_yml: |
+      hooks:
+        worktree-pre-remove:
+          jobs:
+            - name: teardown
+              run: echo teardown
+
+steps:
+  - name: Clone the repository
+    run: git-worktree-clone --layout contained $REMOTE_TEST_SYNC_UNTRUSTED
+    expect:
+      exit_code: 0
+
+  - name: Create a feature branch and push it to the remote
+    run: |
+      cd $WORK_DIR/test-sync-untrusted/main
+      git checkout -b feature/synced 2>/dev/null
+      echo content > synced.txt
+      git add synced.txt
+      git commit -m "Add synced content" 2>/dev/null
+      git push origin feature/synced 2>/dev/null
+      git checkout main 2>/dev/null
+    expect:
+      exit_code: 0
+
+  - name: Checkout the feature branch as a worktree
+    run: git-worktree-checkout feature/synced
+    cwd: "$WORK_DIR/test-sync-untrusted/main"
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-sync-untrusted/feature/synced"
+
+  - name: Delete the feature branch from the remote
+    run: |
+      temp=$(mktemp -d)
+      git clone $REMOTE_TEST_SYNC_UNTRUSTED "$temp" 2>/dev/null
+      cd "$temp" && git push origin --delete feature/synced 2>/dev/null
+      rm -rf "$temp"
+    expect:
+      exit_code: 0
+
+  - name: Sync warns about the skipped pre-remove hook while pruning
+    run: git-worktree-sync --force
+    cwd: "$WORK_DIR/test-sync-untrusted/main"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "daft.yml defines a worktree-pre-remove hook that was NOT run"
+        - "git daft hooks trust"

--- a/tests/manual/scenarios/hooks/untrusted-warning-yaml-checkout.yml
+++ b/tests/manual/scenarios/hooks/untrusted-warning-yaml-checkout.yml
@@ -1,0 +1,52 @@
+name: Untrusted daft.yml warns on checkout, naming all configured hooks
+description:
+  "A daft.yml-only repo previously skipped hooks in total silence (the old
+  notice only looked at .daft/hooks/). The centralized notice must fire once per
+  command, name every configured lifecycle hook, and suggest both the trust
+  command and the post-create replay."
+
+repos:
+  - name: test-yaml-untrusted
+    default_branch: main
+    branches:
+      - name: main
+        files:
+          - path: README.md
+            content: "# yaml untrusted"
+        commits:
+          - message: "Initial commit"
+      - name: feature/warned
+        from: main
+    daft_yml: |
+      hooks:
+        worktree-pre-create:
+          jobs:
+            - name: pre
+              run: touch "$DAFT_SOURCE_WORKTREE/.pre-ran"
+        worktree-post-create:
+          jobs:
+            - name: post
+              run: touch "$DAFT_WORKTREE_PATH/.post-ran"
+
+steps:
+  - name: Clone the repository
+    run: git-worktree-clone --layout contained $REMOTE_TEST_YAML_UNTRUSTED
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-yaml-untrusted/main"
+
+  - name: Checkout warns once, naming both configured hooks
+    run: git-worktree-checkout feature/warned
+    cwd: "$WORK_DIR/test-yaml-untrusted/main"
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-yaml-untrusted/feature/warned"
+      files_not_exist:
+        - "$WORK_DIR/test-yaml-untrusted/feature/warned/.post-ran"
+      output_contains:
+        - "daft.yml defines hooks (worktree-pre-create, worktree-post-create)
+          that were NOT run"
+        - "git daft hooks trust"
+        - "git daft hooks run worktree-post-create"

--- a/tests/manual/scenarios/hooks/untrusted-warning-yaml-checkout.yml
+++ b/tests/manual/scenarios/hooks/untrusted-warning-yaml-checkout.yml
@@ -46,6 +46,7 @@ steps:
       files_not_exist:
         - "$WORK_DIR/test-yaml-untrusted/feature/warned/.post-ran"
       output_contains:
-        - "2 daft.yml hooks not run: worktree-pre-create, worktree-post-create"
+        - "Untrusted repo — 2 daft.yml hooks not run: worktree-pre-create,
+          worktree-post-create"
         - "git daft hooks trust"
         - "git daft hooks run worktree-post-create"

--- a/tests/manual/scenarios/hooks/untrusted-warning-yaml-checkout.yml
+++ b/tests/manual/scenarios/hooks/untrusted-warning-yaml-checkout.yml
@@ -46,7 +46,6 @@ steps:
       files_not_exist:
         - "$WORK_DIR/test-yaml-untrusted/feature/warned/.post-ran"
       output_contains:
-        - "daft.yml defines hooks (worktree-pre-create, worktree-post-create)
-          that were NOT run"
+        - "2 daft.yml hooks not run: worktree-pre-create, worktree-post-create"
         - "git daft hooks trust"
         - "git daft hooks run worktree-post-create"

--- a/tests/manual/scenarios/hooks/untrusted.yml
+++ b/tests/manual/scenarios/hooks/untrusted.yml
@@ -29,7 +29,8 @@ steps:
       dirs_exist:
         - "$WORK_DIR/test-hooks-untrusted/main"
 
-  - name: Create worktree without trusting (hooks should NOT run)
+  - name:
+      Create worktree without trusting (hooks should NOT run, with a warning)
     run: git-worktree-checkout feature/test-hooks
     cwd: "$WORK_DIR/test-hooks-untrusted/main"
     expect:
@@ -38,3 +39,6 @@ steps:
         - "$WORK_DIR/test-hooks-untrusted/feature/test-hooks"
       files_not_exist:
         - "$WORK_DIR/test-hooks-untrusted/.hook-ran"
+      output_contains:
+        - ".daft/hooks/worktree-post-create was NOT run"
+        - "git daft hooks trust"

--- a/tests/manual/scenarios/hooks/untrusted.yml
+++ b/tests/manual/scenarios/hooks/untrusted.yml
@@ -29,8 +29,7 @@ steps:
       dirs_exist:
         - "$WORK_DIR/test-hooks-untrusted/main"
 
-  - name:
-      Create worktree without trusting (hooks should NOT run, with a warning)
+  - name: Create worktree without trusting (hooks should not run, with a notice)
     run: git-worktree-checkout feature/test-hooks
     cwd: "$WORK_DIR/test-hooks-untrusted/main"
     expect:
@@ -40,5 +39,5 @@ steps:
       files_not_exist:
         - "$WORK_DIR/test-hooks-untrusted/.hook-ran"
       output_contains:
-        - ".daft/hooks/worktree-post-create was NOT run"
+        - "1 .daft/hooks script not run: worktree-post-create"
         - "git daft hooks trust"

--- a/tests/manual/scenarios/hooks/untrusted.yml
+++ b/tests/manual/scenarios/hooks/untrusted.yml
@@ -39,5 +39,5 @@ steps:
       files_not_exist:
         - "$WORK_DIR/test-hooks-untrusted/.hook-ran"
       output_contains:
-        - "1 .daft/hooks script not run: worktree-post-create"
+        - "Untrusted repo — 1 .daft/hooks script not run: worktree-post-create"
         - "git daft hooks trust"


### PR DESCRIPTION
## Summary

When a repo defines hooks but isn't trusted, daft used to skip them either silently (`daft.yml` configs) or with inconsistent per-command warnings. This branch makes every trust-gated skip visible, calm, and actionable:

```
Untrusted repo — 2 daft.yml hooks not run: worktree-pre-create, worktree-post-create
   To run them, trust this repo:       git daft hooks trust
   Then replay this worktree's setup:  git daft hooks run worktree-post-create
```

### What's in here

- **One notice per command invocation**, centralized at the executor's trust gates so every command (checkout, clone, merge, sync, prune, remove) and both config shapes (`daft.yml`, `.daft/hooks/`) are covered with no per-caller wiring. TUI commands defer the notice through a process-global registry keyed by git dir and flush it to the real stderr after the TUI exits.
- **A notice, not a warning.** Emitted via a new `Output::notice` channel — stderr, no severity tag, shown even under `--quiet` — because an untrusted repo declining to run its hooks is the security model working as designed, not a problem. The line reads general → specific (trust state, count, hook names) and is styled by role on color terminals: bold state, hook names in the accent orange the hook progress UI already uses for them, suggested commands in cyan. Styling is applied after padding, so stripping the codes recovers the plain rendering byte-for-byte.
- **Skips are recorded** (`invocations` table, migration 002) so a later `git daft hooks trust` suggests replaying exactly the setup hooks that never ran, scoped per worktree. Replaying a hook clears its record; only idempotent setup hooks (`post-clone`, `worktree-post-create`) are ever suggested.
- **Executable-name parity.** Suggested commands render the way daft was invoked — `daft hooks trust` for direct invocations, `git daft hooks trust` through git — via new `cli_label()`/`daft_cmd()` helpers swept across all runtime hints (hooks notice, prompt-unavailable/migrate/re-trust warnings, `hooks status`/`trust`/`run`, multi-remote, doctor). Static clap help and man pages keep the canonical git form; a CLAUDE.md guideline prevents regressions.
- Docs: trust-and-security page (never-silent section, replay section), troubleshooting entry, and SKILL.md updated.

### Verification

- 2027 unit tests pass; clippy clean with zero warnings.
- Full manual YAML suite: **647 scenarios / 2540 steps, 0 failures**, including 10 scenarios pinning this feature: per-command notice coverage, the stderr-only channel contract, exactly-once emission across multi-branch clone, `--skip-hooks` suppression (with no replay records), replay suggestion precision and clearing, and invocation-style parity for suggestions.

Fixes #596

🤖 Generated with [Claude Code](https://claude.com/claude-code)
