### PR TITLE
fix: detect multi-commit squash merges in the gone-branch merge verifier

### DIFF
--- a/src/core/worktree/merged.rs
+++ b/src/core/worktree/merged.rs
@@ -128,15 +128,14 @@ mod tests {
     use super::*;
     use serial_test::serial;
     use std::path::{Path, PathBuf};
-    use std::process::{Command as ShellCommand, Stdio};
+    use std::process::Stdio;
 
     /// Test-only helper: run `git` quietly in `path` and panic if it fails.
+    /// Routed through `git_command_at` so all inherited `GIT_*` vars are
+    /// cleared (per the project's test-hygiene rule), not just GIT_DIR.
     fn git_ok(path: &Path, args: &[&str]) {
-        let status = ShellCommand::new("git")
+        let status = crate::utils::git_command_at(path)
             .args(args)
-            .current_dir(path)
-            .env_remove("GIT_DIR")
-            .env_remove("GIT_WORK_TREE")
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .status()

--- a/src/core/worktree/merged.rs
+++ b/src/core/worktree/merged.rs
@@ -39,8 +39,21 @@ pub fn is_branch_merged(
 
 /// Check whether `branch` has been merged into `target`.
 ///
-/// Two-step: `merge-base --is-ancestor` detects regular merges; `git cherry`
-/// detects squash merges (all lines start with `-`).
+/// Three checks, cheapest first:
+///
+/// 1. `merge-base --is-ancestor` — regular and fast-forward merges.
+/// 2. `git cherry` — per-commit patch-id equivalence (all lines `-`).
+///    Catches rebase merges and single-commit squashes, but NOT a
+///    multi-commit branch squashed into one target commit: no individual
+///    commit's patch-id matches the combined squash commit (#662).
+/// 3. Cumulative-diff squash probe — a synthetic commit of the branch's
+///    whole tree parented at the merge base represents the branch's total
+///    diff as one commit; `git cherry` on that finds the squash commit.
+///
+/// Known remaining gap: a squash commit whose diff was altered during the
+/// merge (conflict resolution, maintainer edits) matches no probe and is
+/// still reported unmerged — deliberate, since every check here must be
+/// conservative: reporting "merged" is what authorizes deleting the branch.
 pub fn is_branch_merged_into(git: &GitCommand, branch: &str, target: &str) -> Result<bool> {
     // Step 1: Check if branch is an ancestor of the target (regular merge)
     let is_ancestor = git
@@ -64,6 +77,204 @@ pub fn is_branch_merged_into(git: &GitCommand, branch: &str, target: &str) -> Re
     }
 
     // All lines must start with `-` for the branch to be considered squash-merged
-    let all_merged = lines.iter().all(|line| line.starts_with('-'));
-    Ok(all_merged)
+    if lines.iter().all(|line| line.starts_with('-')) {
+        return Ok(true);
+    }
+
+    // Step 3: Multi-commit squash probe.
+    squash_probe(git, branch, target)
+}
+
+/// Detect a squash merge of a multi-commit branch.
+///
+/// Synthesizes an unreferenced commit wrapping `branch`'s tree, parented at
+/// the merge base with `target` — its diff is exactly the branch's
+/// cumulative diff since forking. If `git cherry` finds a patch-equivalent
+/// commit on `target`, the branch's combined work landed as one squash
+/// commit. The probe object stays dangling and is swept by `git gc`; it is
+/// only created after the cheaper ancestor and per-commit checks failed.
+fn squash_probe(git: &GitCommand, branch: &str, target: &str) -> Result<bool> {
+    let Some(base) = git
+        .merge_base(target, branch)
+        .context("squash probe merge-base failed")?
+    else {
+        // Unrelated histories cannot have been squash-merged.
+        return Ok(false);
+    };
+
+    let tree = git
+        .rev_parse(&format!("{branch}^{{tree}}"))
+        .context("squash probe tree lookup failed")?;
+    let synthetic = git
+        .commit_tree(&tree, &base, "daft squash-merge probe")
+        .context("squash probe commit failed")?;
+
+    let cherry_output = git
+        .cherry(target, &synthetic)
+        .context("squash probe cherry failed")?;
+
+    // Exactly one line is expected (the synthetic commit). `-` means a
+    // patch-equivalent commit exists on the target. A missing or `+` line —
+    // including the empty-diff case where the branch has no net change —
+    // conservatively stays "not merged".
+    Ok(cherry_output
+        .lines()
+        .next()
+        .is_some_and(|line| line.starts_with('-')))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use std::path::{Path, PathBuf};
+    use std::process::{Command as ShellCommand, Stdio};
+
+    /// Test-only helper: run `git` quietly in `path` and panic if it fails.
+    fn git_ok(path: &Path, args: &[&str]) {
+        let status = ShellCommand::new("git")
+            .args(args)
+            .current_dir(path)
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .unwrap();
+        assert!(
+            status.success(),
+            "git {args:?} failed in {}",
+            path.display()
+        );
+    }
+
+    /// RAII helper: saves the current working directory on construction and
+    /// restores it on drop. Tests that call `std::env::set_current_dir` use
+    /// this to avoid leaving cwd pointing at a deleted tempdir for the next
+    /// test (which would panic in `std::env::current_dir`).
+    struct CwdGuard {
+        original: PathBuf,
+    }
+
+    impl CwdGuard {
+        fn new() -> Self {
+            Self {
+                original: std::env::current_dir().expect("cwd readable at test start"),
+            }
+        }
+    }
+
+    impl Drop for CwdGuard {
+        fn drop(&mut self) {
+            if std::env::set_current_dir(&self.original).is_err() {
+                let _ = std::env::set_current_dir(std::env::temp_dir());
+            }
+        }
+    }
+
+    fn init_repo(path: &Path) {
+        git_ok(path, &["init", "-q", "-b", "main"]);
+        // Local config so git subprocesses have an identity without touching
+        // global config.
+        git_ok(path, &["config", "--local", "user.name", "Test"]);
+        git_ok(path, &["config", "--local", "user.email", "test@test.com"]);
+        git_ok(path, &["commit", "--allow-empty", "-q", "-m", "init"]);
+    }
+
+    /// Checkout `branch`, write `content` to `file`, stage and commit it.
+    fn add_commit(path: &Path, branch: &str, file: &str, content: &str) {
+        git_ok(path, &["checkout", "-q", branch]);
+        std::fs::write(path.join(file), content).unwrap();
+        git_ok(path, &["add", file]);
+        git_ok(path, &["commit", "-q", "-m", &format!("add {file}")]);
+    }
+
+    /// Run `is_branch_merged_into` with the process cwd inside `path`
+    /// (the GitCommand subprocess helpers resolve the repo from cwd).
+    fn merged_into(path: &Path, branch: &str, target: &str) -> bool {
+        let _guard = CwdGuard::new();
+        std::env::set_current_dir(path).unwrap();
+        let git = GitCommand::new(true);
+        is_branch_merged_into(&git, branch, target).unwrap()
+    }
+
+    /// Regression test for #662: a branch of N>1 commits squash-merged into
+    /// the target has no per-commit patch-id match (`git cherry` shows every
+    /// commit as `+`), so the cherry check alone misclassifies it as
+    /// unmerged. The cumulative-diff probe must detect it.
+    #[test]
+    #[serial]
+    fn multi_commit_squash_detected_as_merged() {
+        let tmp = tempfile::tempdir().unwrap();
+        init_repo(tmp.path());
+        git_ok(tmp.path(), &["checkout", "-q", "-b", "feat"]);
+        add_commit(tmp.path(), "feat", "a.txt", "a");
+        add_commit(tmp.path(), "feat", "b.txt", "b");
+        git_ok(tmp.path(), &["checkout", "-q", "main"]);
+        git_ok(tmp.path(), &["merge", "--squash", "feat"]);
+        git_ok(tmp.path(), &["commit", "-q", "-m", "feat squashed (#1)"]);
+
+        assert!(
+            merged_into(tmp.path(), "feat", "main"),
+            "multi-commit squash-merged branch must be detected as merged"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn single_commit_squash_still_detected() {
+        let tmp = tempfile::tempdir().unwrap();
+        init_repo(tmp.path());
+        git_ok(tmp.path(), &["checkout", "-q", "-b", "feat"]);
+        add_commit(tmp.path(), "feat", "a.txt", "a");
+        git_ok(tmp.path(), &["checkout", "-q", "main"]);
+        git_ok(tmp.path(), &["merge", "--squash", "feat"]);
+        git_ok(tmp.path(), &["commit", "-q", "-m", "feat squashed (#2)"]);
+
+        assert!(merged_into(tmp.path(), "feat", "main"));
+    }
+
+    #[test]
+    #[serial]
+    fn regular_merge_still_detected() {
+        let tmp = tempfile::tempdir().unwrap();
+        init_repo(tmp.path());
+        git_ok(tmp.path(), &["checkout", "-q", "-b", "feat"]);
+        add_commit(tmp.path(), "feat", "a.txt", "a");
+        add_commit(tmp.path(), "feat", "b.txt", "b");
+        git_ok(tmp.path(), &["checkout", "-q", "main"]);
+        git_ok(tmp.path(), &["merge", "-q", "--no-ff", "--no-edit", "feat"]);
+
+        assert!(merged_into(tmp.path(), "feat", "main"));
+    }
+
+    #[test]
+    #[serial]
+    fn unmerged_branch_stays_unmerged() {
+        let tmp = tempfile::tempdir().unwrap();
+        init_repo(tmp.path());
+        git_ok(tmp.path(), &["checkout", "-q", "-b", "feat"]);
+        add_commit(tmp.path(), "feat", "a.txt", "a");
+        add_commit(tmp.path(), "feat", "b.txt", "b");
+        // Advance main independently so the branches genuinely diverge.
+        add_commit(tmp.path(), "main", "other.txt", "other");
+
+        assert!(
+            !merged_into(tmp.path(), "feat", "main"),
+            "unmerged work must never be reported as merged"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn unrelated_histories_not_merged() {
+        let tmp = tempfile::tempdir().unwrap();
+        init_repo(tmp.path());
+        git_ok(tmp.path(), &["checkout", "-q", "--orphan", "lonely"]);
+        std::fs::write(tmp.path().join("l.txt"), "l").unwrap();
+        git_ok(tmp.path(), &["add", "l.txt"]);
+        git_ok(tmp.path(), &["commit", "-q", "-m", "orphan work"]);
+
+        assert!(!merged_into(tmp.path(), "lonely", "main"));
+    }
 }

--- a/src/git/refs.rs
+++ b/src/git/refs.rs
@@ -217,6 +217,58 @@ impl GitCommand {
         Ok(output.status.success())
     }
 
+    /// Resolve the merge base of two revisions.
+    ///
+    /// Returns `Ok(None)` when the revisions share no common ancestor
+    /// (unrelated histories — `git merge-base` exits 1 with no output).
+    /// Any other failure (bad revision, not a repository, ...) is an error.
+    pub fn merge_base(&self, a: &str, b: &str) -> Result<Option<String>> {
+        let output = Command::new("git")
+            .args(["merge-base", a, b])
+            .output()
+            .context("Failed to execute git merge-base command")?;
+
+        if !output.status.success() {
+            if output.status.code() == Some(1) {
+                return Ok(None);
+            }
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("Git merge-base failed: {}", stderr);
+        }
+
+        let stdout =
+            String::from_utf8(output.stdout).context("Failed to parse git merge-base output")?;
+        Ok(Some(stdout.trim().to_string()))
+    }
+
+    /// Create an unreferenced commit wrapping `tree` with a single `parent`,
+    /// returning the new commit hash.
+    ///
+    /// Used by squash-merge detection to synthesize a one-commit equivalent
+    /// of a branch's cumulative diff. Identity is injected via environment
+    /// variables so the probe works even where user.name/user.email are not
+    /// configured. The object is deliberately left dangling — nothing ever
+    /// references it, and `git gc` sweeps it with other unreachable objects.
+    pub fn commit_tree(&self, tree: &str, parent: &str, message: &str) -> Result<String> {
+        let output = Command::new("git")
+            .args(["commit-tree", tree, "-p", parent, "-m", message])
+            .env("GIT_AUTHOR_NAME", "daft")
+            .env("GIT_AUTHOR_EMAIL", "daft@localhost")
+            .env("GIT_COMMITTER_NAME", "daft")
+            .env("GIT_COMMITTER_EMAIL", "daft@localhost")
+            .output()
+            .context("Failed to execute git commit-tree command")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("Git commit-tree failed: {}", stderr);
+        }
+
+        String::from_utf8(output.stdout)
+            .context("Failed to parse git commit-tree output")
+            .map(|s| s.trim().to_string())
+    }
+
     /// Run `git cherry <upstream> <branch>` and return output.
     /// Lines prefixed with `-` indicate patches already upstream.
     /// Lines prefixed with `+` indicate patches NOT upstream.

--- a/src/git/refs.rs
+++ b/src/git/refs.rs
@@ -245,17 +245,22 @@ impl GitCommand {
     /// returning the new commit hash.
     ///
     /// Used by squash-merge detection to synthesize a one-commit equivalent
-    /// of a branch's cumulative diff. Identity is injected via environment
-    /// variables so the probe works even where user.name/user.email are not
-    /// configured. The object is deliberately left dangling — nothing ever
-    /// references it, and `git gc` sweeps it with other unreachable objects.
+    /// of a branch's cumulative diff. Identity and dates are injected via
+    /// environment variables — identity so the probe works even where
+    /// user.name/user.email are not configured, fixed epoch dates so
+    /// repeated probes of the same tree+parent produce the same SHA instead
+    /// of accumulating a new dangling object per run. The object is
+    /// deliberately left unreferenced, and `git gc` sweeps it with other
+    /// unreachable objects.
     pub fn commit_tree(&self, tree: &str, parent: &str, message: &str) -> Result<String> {
         let output = Command::new("git")
             .args(["commit-tree", tree, "-p", parent, "-m", message])
             .env("GIT_AUTHOR_NAME", "daft")
             .env("GIT_AUTHOR_EMAIL", "daft@localhost")
+            .env("GIT_AUTHOR_DATE", "1970-01-01T00:00:00+0000")
             .env("GIT_COMMITTER_NAME", "daft")
             .env("GIT_COMMITTER_EMAIL", "daft@localhost")
+            .env("GIT_COMMITTER_DATE", "1970-01-01T00:00:00+0000")
             .output()
             .context("Failed to execute git commit-tree command")?;
 

--- a/tests/manual/scenarios/branch-delete/deletes-squash-merged-multi-commit.yml
+++ b/tests/manual/scenarios/branch-delete/deletes-squash-merged-multi-commit.yml
@@ -1,0 +1,49 @@
+name: Branch delete removes a squash-merged multi-commit branch
+description: >
+  Branch-delete's merged-into-default validation (Check 4) uses the shared merge
+  verifier. A multi-commit branch squash-merged into the default branch must
+  delete without --force even though git cherry finds no per-commit patch-id
+  match. Regression for the cherry-only squash detection (issue #662).
+
+repos:
+  - name: test-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone and create feature branch with two commits
+    run: |
+      git-worktree-clone --layout contained $REMOTE_TEST_REPO
+      cd $WORK_DIR/test-repo
+      git-worktree-checkout -b feature/squashed
+      cd $WORK_DIR/test-repo/feature/squashed
+      echo "one" > one.txt
+      git add one.txt
+      git commit -m "part one"
+      echo "two" > two.txt
+      git add two.txt
+      git commit -m "part two"
+      git push origin feature/squashed
+    expect:
+      exit_code: 0
+
+  - name: Squash-merge the branch into main
+    run: |
+      cd $WORK_DIR/test-repo/main
+      git merge --squash feature/squashed
+      git commit -m "squashed feature (#2)"
+      git push origin main
+    expect:
+      exit_code: 0
+
+  - name: Delete without --force succeeds
+    run: git-worktree-branch-delete feature/squashed 2>&1
+    cwd: "$WORK_DIR/test-repo"
+    expect:
+      exit_code: 0
+      output_not_contains:
+        - "not merged"
+
+  - name: Worktree directory is gone
+    run: test ! -d $WORK_DIR/test-repo/feature/squashed
+    expect:
+      exit_code: 0

--- a/tests/manual/scenarios/prune/prune-removes-squash-merged-multi-commit.yml
+++ b/tests/manual/scenarios/prune/prune-removes-squash-merged-multi-commit.yml
@@ -1,0 +1,73 @@
+name: Prune removes a squash-merged multi-commit branch without --force
+description: >
+  A multi-commit branch squash-merged into the default branch has no per-commit
+  patch-id match, so git cherry alone misclassifies it as unmerged. The merge
+  verifier must recognize the branch's cumulative diff landing as one squash
+  commit and prune the worktree without --force. Regression for prune/sync
+  skipping every merged multi-commit branch (issue #662).
+
+repos:
+  - name: test-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone the repository
+    run: git-worktree-clone --layout contained $REMOTE_TEST_REPO
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-repo/main"
+
+  - name: Create feature worktree
+    run: git-worktree-checkout -b feat/x
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-repo/feat/x"
+
+  - name: Commit two changes on feat/x and push
+    run: |
+      cd $WORK_DIR/test-repo/feat/x
+      printf 'one\n' > part-one.txt
+      git add part-one.txt
+      git commit -m "feat: part one"
+      printf 'two\n' > part-two.txt
+      git add part-two.txt
+      git commit -m "feat: part two"
+      git push origin feat/x
+    expect:
+      exit_code: 0
+
+  - name: Squash-merge feat/x into main (GitHub squash-merge style)
+    run: |
+      cd $WORK_DIR/test-repo/main
+      git merge --squash feat/x
+      git commit -m "feat: squashed feature (#1)"
+      git push origin main
+    expect:
+      exit_code: 0
+
+  - name: Delete the remote branch (merged upstream)
+    run: git -C $WORK_DIR/test-repo/main push origin --delete feat/x
+    expect:
+      exit_code: 0
+
+  - name: Prune removes the squash-merged worktree without --force
+    run: git-worktree-prune 2>&1
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+      output_not_contains:
+        - "not merged"
+        - "--force"
+
+  - name: Worktree directory is gone
+    run: test ! -d $WORK_DIR/test-repo/feat/x
+    expect:
+      exit_code: 0
+
+  - name: Local branch ref is gone
+    run: git -C $WORK_DIR/test-repo/main show-ref --verify refs/heads/feat/x
+    expect:
+      exit_code: 128


### PR DESCRIPTION
## Problem

PR #629 added a data-loss guard: `prune`/`sync` verify a gone branch is actually merged before deleting its worktree, and `daft remove` applies the same check (Check 4). The shared verifier ran two checks — `merge-base --is-ancestor` (regular/FF merges) and `git cherry` (squash merges via per-commit patch-id equivalence).

`git cherry` matches **per-commit** patch-ids, so a branch of N>1 commits squashed into a single target commit never matches: every merged multi-commit branch was misclassified as unmerged. Since PRs here are always squash-merged, routine post-merge cleanup demanded `--force` — which trains users to always force, re-exposing the very #628 scenario the guard exists to prevent.

## Fix

Add a third detection step to `is_branch_merged_into`, reached only when the two cheaper checks say "not merged" — a cumulative-diff squash probe (the `git-delete-squashed` technique):

1. `git merge-base <target> <branch>` → fork point (no merge base ⇒ unrelated histories ⇒ not merged)
2. `git commit-tree <branch>^{tree} -p <base>` → synthetic unreferenced commit whose diff ≡ the branch's total diff since forking
3. `git cherry <target> <synthetic>` → a `-` line means a patch-equivalent commit exists on the target ⇒ squash-merged

The probe stays conservative: "merged" is only ever reported when an actual patch-equivalent commit exists on the target, so the guard loses nothing. All three consumers (prune, sync, branch-delete) benefit through the shared verifier. The probe's dangling commit object is swept by `git gc`; identity for `commit-tree` is env-injected so it works without configured `user.name`/`user.email`.

Known remaining gap (documented in code docs): a squash commit whose diff was altered during merge (conflict resolution, maintainer edits) still reads as unmerged — deliberately conservative; a `git merge-tree` subsumption check is a possible follow-up.

## Tests

- 5 unit tests in `src/core/worktree/merged.rs` — the regression case (multi-commit squash → must detect merged; fails without the fix), single-commit squash, regular merge, genuinely-unmerged stays unmerged, unrelated histories.
- 2 YAML scenarios: `prune/prune-removes-squash-merged-multi-commit.yml` and `branch-delete/deletes-squash-merged-multi-commit.yml` — end-to-end cleanup without `--force`.
- Existing guard scenarios (`prune-skips-gone-but-unmerged`, `refuses-unmerged`, `force-unmerged`) stay green.

Fixes #662

🤖 Generated with [Claude Code](https://claude.com/claude-code)