### PR TITLE
fix(list): collect only the fields the live view renders or sorts by

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -575,19 +575,19 @@ Available in `run` commands:
 ### Skip and Only Conditions
 
 ```yaml
-skip: CI                         # Skip when env var is truthy
-skip: true                       # Always skip
+skip: CI # Skip when env var is truthy
+skip: true # Always skip
 skip:
-  - merge                        # Skip during merge
-  - rebase                       # Skip during rebase
-  - ref: "release/*"             # Skip if branch matches glob
-  - env: SKIP_HOOKS              # Skip if env var is truthy
-  - run: "test -f .skip-hooks"   # Skip if command exits 0
-    desc: "Skip file exists"     # Human-readable reason for the skip
+  - merge # Skip during merge
+  - rebase # Skip during rebase
+  - ref: "release/*" # Skip if branch matches glob
+  - env: SKIP_HOOKS # Skip if env var is truthy
+  - run: "test -f .skip-hooks" # Skip if command exits 0
+    desc: "Skip file exists" # Human-readable reason for the skip
 
 only:
-  - env: DEPLOY_ENABLED          # Only run when env var is set
-  - ref: "main"                  # Only run on main branch
+  - env: DEPLOY_ENABLED # Only run when env var is set
+  - ref: "main" # Only run on main branch
 ```
 
 ### Trust Management

--- a/src/commands/list_live.rs
+++ b/src/commands/list_live.rs
@@ -248,12 +248,11 @@ pub fn run_live(args: Args) -> Result<()> {
 }
 
 /// Fields the streaming collector must populate for this view: what the
-/// selected columns render plus what the sort inspects, with the `*_LINES`
-/// variants added in `--stat lines` mode (the renderer and `SortKey::compare`
-/// read those then; the summary bits stay in the set because the loading
-/// shimmer keys off them). The collector request routes through here so it
-/// can't drift back to `FieldSet::ALL`, whose hidden SIZE walk kept the
-/// renderer alive for seconds after the table was fully drawn (#665).
+/// selected columns render plus what the sort inspects
+/// (`SortSpec::required_fields`, itself `--stat`-aware). The collector
+/// request routes through here so it can't drift back to `FieldSet::ALL`,
+/// whose hidden SIZE walk kept the renderer alive for seconds after the
+/// table was fully drawn (#665).
 fn collector_fields(columns: &[ListColumn], sort_spec: Option<&SortSpec>, stat: Stat) -> FieldSet {
     let mut fields = FieldSet::EMPTY;
     for column in columns {
@@ -273,6 +272,10 @@ fn collector_fields(columns: &[ListColumn], sort_spec: Option<&SortSpec>, stat: 
         fields |= spec.required_fields();
     }
     if stat == Stat::Lines {
+        // Rendered diff columns display line counts in lines mode, so their
+        // `*_LINES` variants must be collected even without a matching sort
+        // key (sort keys arrive pre-upgraded from `required_fields`). The
+        // summary bits stay in the set — the loading shimmer keys off them.
         if fields.contains(FieldSet::BASE_AHEAD_BEHIND) {
             fields |= FieldSet::BASE_LINES;
         }

--- a/src/commands/list_live.rs
+++ b/src/commands/list_live.rs
@@ -12,7 +12,7 @@ use crate::{
         sort::SortSpec,
         worktree::{
             info_field::FieldSet,
-            list::{EntryKind, WorktreeInfo, collect_branch_info},
+            list::{EntryKind, Stat, WorktreeInfo, collect_branch_info},
             list_stream,
             sync_dag::{DagEvent, PatchSource},
         },
@@ -63,6 +63,12 @@ pub fn run_live(args: Args) -> Result<()> {
         ),
         None => None,
     };
+
+    // Request only the fields this view renders or sorts by. Requesting more
+    // (the old `FieldSet::ALL`) forced every worker through the SIZE cluster —
+    // a full recursive walk of each worktree — before the completion sentinel
+    // could fire and let the renderer exit (#665).
+    let fields = collector_fields(&selected_columns, sort_spec.as_ref(), stat);
 
     let show_local = args.branches || args.all;
     let show_remote = args.remotes || args.all;
@@ -170,7 +176,7 @@ pub fn run_live(args: Args) -> Result<()> {
     let collector_handle = list_stream::spawn(
         list_stream::CollectorRequest {
             targets,
-            fields: FieldSet::ALL,
+            fields,
             stat,
             source: PatchSource::Collector,
             ctx: collector_ctx,
@@ -191,11 +197,11 @@ pub fn run_live(args: Args) -> Result<()> {
         sort_spec,
         false, // pin_default_branch
         false, // partition_by_owner
-        // The streaming collector requests `FieldSet::ALL` (see CollectorRequest
-        // above), so the seed never authoritatively finalizes any field for
-        // `daft list` — every cell starts in the loading state and transitions
-        // when its patch lands.
-        FieldSet::EMPTY,
+        // Seed-finalize the complement of the collector request: fields the
+        // collector won't stream must not read as in-flight (loading shimmer,
+        // verbose footer). Every requested cell starts in the loading state
+        // and transitions when its patch lands.
+        !fields,
     );
 
     // Single source of truth for cancellation: the renderer's Ctrl-C handler
@@ -241,6 +247,45 @@ pub fn run_live(args: Args) -> Result<()> {
     Ok(())
 }
 
+/// Fields the streaming collector must populate for this view: what the
+/// selected columns render plus what the sort inspects, with the `*_LINES`
+/// variants added in `--stat lines` mode (the renderer and `SortKey::compare`
+/// read those then; the summary bits stay in the set because the loading
+/// shimmer keys off them). The collector request routes through here so it
+/// can't drift back to `FieldSet::ALL`, whose hidden SIZE walk kept the
+/// renderer alive for seconds after the table was fully drawn (#665).
+fn collector_fields(columns: &[ListColumn], sort_spec: Option<&SortSpec>, stat: Stat) -> FieldSet {
+    let mut fields = FieldSet::EMPTY;
+    for column in columns {
+        fields |= match column {
+            // Populated by the porcelain seed, never streamed.
+            ListColumn::Annotation | ListColumn::Branch | ListColumn::Path => FieldSet::EMPTY,
+            ListColumn::Size => FieldSet::SIZE,
+            ListColumn::Base => FieldSet::BASE_AHEAD_BEHIND,
+            ListColumn::Changes => FieldSet::CHANGES,
+            ListColumn::Remote => FieldSet::REMOTE_AHEAD_BEHIND,
+            ListColumn::Age => FieldSet::BRANCH_AGE,
+            ListColumn::Owner => FieldSet::OWNER,
+            ListColumn::Hash | ListColumn::LastCommit => FieldSet::LAST_COMMIT,
+        };
+    }
+    if let Some(spec) = sort_spec {
+        fields |= spec.required_fields();
+    }
+    if stat == Stat::Lines {
+        if fields.contains(FieldSet::BASE_AHEAD_BEHIND) {
+            fields |= FieldSet::BASE_LINES;
+        }
+        if fields.contains(FieldSet::CHANGES) {
+            fields |= FieldSet::CHANGES_LINES;
+        }
+        if fields.contains(FieldSet::REMOTE_AHEAD_BEHIND) {
+            fields |= FieldSet::REMOTE_LINES;
+        }
+    }
+    fields
+}
+
 /// RAII guard that enables crossterm raw mode now and restores cooked mode on
 /// drop. Best-effort: if `enable_raw_mode` fails (e.g. stdin isn't a terminal),
 /// the guard is still returned so its `Drop` is safe to run. Disabling raw
@@ -255,5 +300,102 @@ struct RawModeGuard;
 impl Drop for RawModeGuard {
     fn drop(&mut self) {
         let _ = crossterm::terminal::disable_raw_mode();
+    }
+}
+
+#[cfg(test)]
+mod collector_fields_tests {
+    use super::*;
+
+    fn hidden_fields() -> FieldSet {
+        FieldSet::SIZE
+            | FieldSet::MTIME
+            | FieldSet::BASE_LINES
+            | FieldSet::CHANGES_LINES
+            | FieldSet::REMOTE_LINES
+    }
+
+    fn sort(input: &str, stat: Stat) -> SortSpec {
+        SortSpec::parse(input).unwrap().with_stat(stat)
+    }
+
+    /// #665 regression: the default view must not collect SIZE/MTIME (or any
+    /// line-stat field) — the hidden SIZE walk of every worktree is what kept
+    /// `daft list` alive for seconds after the table was fully rendered.
+    #[test]
+    fn default_view_collects_only_rendered_fields() {
+        let fields = collector_fields(ListColumn::list_defaults(), None, Stat::Summary);
+        for needed in [
+            FieldSet::BASE_AHEAD_BEHIND,
+            FieldSet::CHANGES,
+            FieldSet::REMOTE_AHEAD_BEHIND,
+            FieldSet::BRANCH_AGE,
+            FieldSet::OWNER,
+            FieldSet::LAST_COMMIT,
+        ] {
+            assert!(
+                fields.contains(needed),
+                "default view must collect {needed:?}"
+            );
+        }
+        assert!(
+            !fields.intersects(hidden_fields()),
+            "default view must not collect SIZE/MTIME/line stats"
+        );
+    }
+
+    #[test]
+    fn size_column_selection_requests_size() {
+        // Through the real parser, as `--columns +size` resolves it.
+        let resolved = ColumnSelection::parse("+size", CommandKind::List).unwrap();
+        let fields = collector_fields(&resolved.columns, None, Stat::Summary);
+        assert!(fields.contains(FieldSet::SIZE));
+        assert!(!fields.contains(FieldSet::MTIME));
+    }
+
+    #[test]
+    fn size_sort_requests_size_even_without_size_column() {
+        let spec = sort("-size", Stat::Summary);
+        let fields = collector_fields(ListColumn::list_defaults(), Some(&spec), Stat::Summary);
+        assert!(fields.contains(FieldSet::SIZE));
+    }
+
+    #[test]
+    fn activity_sort_requests_mtime_and_last_commit() {
+        let spec = sort("-activity", Stat::Summary);
+        let fields = collector_fields(ListColumn::list_defaults(), Some(&spec), Stat::Summary);
+        assert!(fields.contains(FieldSet::MTIME | FieldSet::LAST_COMMIT));
+        assert!(!fields.contains(FieldSet::SIZE));
+    }
+
+    #[test]
+    fn lines_stat_upgrades_rendered_groups_to_line_fields() {
+        let fields = collector_fields(ListColumn::list_defaults(), None, Stat::Lines);
+        assert!(
+            fields
+                .contains(FieldSet::BASE_LINES | FieldSet::CHANGES_LINES | FieldSet::REMOTE_LINES)
+        );
+        // Summary bits stay: the loading shimmer keys off them.
+        assert!(fields.contains(FieldSet::BASE_AHEAD_BEHIND | FieldSet::CHANGES));
+        assert!(!fields.contains(FieldSet::SIZE));
+    }
+
+    #[test]
+    fn lines_sort_on_hidden_column_still_gets_line_fields() {
+        // `--columns branch,path --sort -base --stat lines`: compare() reads
+        // base_lines_* even though no base column is rendered.
+        let spec = sort("-base", Stat::Lines);
+        let fields = collector_fields(
+            &[ListColumn::Branch, ListColumn::Path],
+            Some(&spec),
+            Stat::Lines,
+        );
+        assert!(fields.contains(FieldSet::BASE_AHEAD_BEHIND | FieldSet::BASE_LINES));
+    }
+
+    #[test]
+    fn seed_only_view_collects_nothing() {
+        let fields = collector_fields(&[ListColumn::Branch, ListColumn::Path], None, Stat::Summary);
+        assert!(fields.is_empty());
     }
 }

--- a/src/core/sort.rs
+++ b/src/core/sort.rs
@@ -436,9 +436,18 @@ impl SortSpec {
 
     /// Returns the set of `WorktreeInfo` fields needed to evaluate this sort
     /// spec. Used by `LiveTable` to skip re-sorts when a patch lands on a
-    /// cell unrelated to the current sort order.
+    /// cell unrelated to the current sort order, and by the live list view
+    /// to scope its collector request.
+    ///
+    /// In `--stat lines` mode the diff columns also depend on their
+    /// line-level fields: `SortKey::compare` reads those then, and the
+    /// collector patches them separately from the summary clusters, so
+    /// omitting them would skip the re-sort those patches should trigger.
+    /// The summary bits stay in the set — the Changes total still folds in
+    /// the summary-cluster `untracked` count.
     pub fn required_fields(&self) -> crate::core::worktree::info_field::FieldSet {
         use crate::core::worktree::info_field::FieldSet;
+        let lines = self.stat == Stat::Lines;
         let mut acc = FieldSet::EMPTY;
         for key in &self.keys {
             acc |= match key.column {
@@ -450,8 +459,13 @@ impl SortSpec {
                 SortColumn::Hash => FieldSet::LAST_COMMIT,
                 SortColumn::Activity => FieldSet::LAST_COMMIT | FieldSet::MTIME,
                 SortColumn::LastCommit => FieldSet::LAST_COMMIT,
+                SortColumn::Base if lines => FieldSet::BASE_AHEAD_BEHIND | FieldSet::BASE_LINES,
                 SortColumn::Base => FieldSet::BASE_AHEAD_BEHIND,
+                SortColumn::Changes if lines => FieldSet::CHANGES | FieldSet::CHANGES_LINES,
                 SortColumn::Changes => FieldSet::CHANGES,
+                SortColumn::Remote if lines => {
+                    FieldSet::REMOTE_AHEAD_BEHIND | FieldSet::REMOTE_LINES
+                }
                 SortColumn::Remote => FieldSet::REMOTE_AHEAD_BEHIND,
             };
         }
@@ -997,5 +1011,39 @@ mod required_fields_tests {
         let f = fields_for("+owner,-size");
         assert!(f.contains(FieldSet::OWNER));
         assert!(f.contains(FieldSet::SIZE));
+    }
+
+    fn lines_fields_for(input: &str) -> FieldSet {
+        SortSpec::parse(input)
+            .unwrap()
+            .with_stat(Stat::Lines)
+            .required_fields()
+    }
+
+    #[test]
+    fn lines_stat_adds_line_fields_to_diff_columns() {
+        // The line-stat clusters patch separately from the summary
+        // clusters, so LiveTable's resort trigger must see these bits too.
+        assert_eq!(
+            lines_fields_for("base"),
+            FieldSet::BASE_AHEAD_BEHIND | FieldSet::BASE_LINES,
+        );
+        assert_eq!(
+            lines_fields_for("changes"),
+            FieldSet::CHANGES | FieldSet::CHANGES_LINES,
+        );
+        assert_eq!(
+            lines_fields_for("remote"),
+            FieldSet::REMOTE_AHEAD_BEHIND | FieldSet::REMOTE_LINES,
+        );
+    }
+
+    #[test]
+    fn lines_stat_leaves_non_diff_columns_unchanged() {
+        assert_eq!(lines_fields_for("size"), FieldSet::SIZE);
+        assert_eq!(
+            lines_fields_for("activity"),
+            FieldSet::LAST_COMMIT | FieldSet::MTIME,
+        );
     }
 }

--- a/src/core/worktree/info_field.rs
+++ b/src/core/worktree/info_field.rs
@@ -40,7 +40,12 @@ impl FieldSet {
             | Self::REMOTE_LINES.0,
     );
 
-    /// All fields. Used by the initial Collector run.
+    /// Every bit set, including bits with no assigned field. Acts as the
+    /// fully-received sentinel: a row whose seeded + patched bits reach
+    /// `ALL` has nothing in flight (the renderer's inflight counter checks
+    /// exactly this), and views with no streaming collector seed it
+    /// outright (`repo remove`). The live list view requests a narrowed
+    /// set instead (`collector_fields`) and seeds the complement.
     pub const ALL: Self = Self(u32::MAX);
 
     pub const fn contains(self, other: Self) -> bool {
@@ -129,6 +134,17 @@ mod tests {
         assert!(!FieldSet::VOLATILE.contains(FieldSet::SIZE));
         assert!(!FieldSet::VOLATILE.contains(FieldSet::OWNER));
         assert!(!FieldSet::VOLATILE.contains(FieldSet::BRANCH_AGE));
+    }
+
+    #[test]
+    fn complement_of_a_request_unions_back_to_all() {
+        // The live table seeds rows with the complement of the collector
+        // request and treats a row as settled once its bits reach `ALL`.
+        // That contract holds only while `ALL` is the full `u32` and `Not`
+        // is the bitwise complement.
+        let requested = FieldSet::CHANGES | FieldSet::OWNER;
+        assert_eq!(requested | !requested, FieldSet::ALL);
+        assert_eq!(!FieldSet::EMPTY, FieldSet::ALL);
     }
 
     #[test]

--- a/test-plans/list-live-field-gating.md
+++ b/test-plans/list-live-field-gating.md
@@ -1,0 +1,39 @@
+---
+branch: daft-665/list-live-hidden-size-walk
+---
+
+# List Live Field Gating
+
+Fix for #665: the live `daft list` path requested `FieldSet::ALL`, so hidden
+SIZE/MTIME collection (a full recursive walk of every worktree) kept the process
+alive for seconds after the table was fully rendered.
+
+## Exit latency
+
+- [x] `daft list` (TTY, default columns) exits with no post-render tail — wall
+      time ≈ the `DAFT_NO_LIVE=1` baseline (0.23–0.27 s vs 0.36 s in the
+      220k-file fixture)
+- [x] Pre-fix vs fixed binary in a 220k-file fixture: 1.8–2.0 s → 0.23 s
+- [x] Real repo (6 worktrees, ~45 GB of build artifacts): 3.5 s cold / 1.1 s
+      warm → ~0.3 s
+- [ ] Interactive terminal: shell prompt timer no longer reports multi-second
+      `daft list` in a large project
+
+## Opt-in expensive fields still work
+
+- [x] `--columns +size` walks again (1.7 s in the fixture) and renders the Size
+      column plus the TOTAL summary footer
+- [x] `--sort=-size` collects sizes even without the Size column (regression
+      unit test + fixture run)
+- [x] `--sort=-activity` collects mtime and renders "Sorted by Activity"
+- [x] YAML list scenarios: 53 scenarios / 167 steps pass
+- [ ] Interactive glance: `daft list --stat lines` live view fills Base /
+      Changes / Remote with line counts (field request covered by unit test;
+      blocking path covered by YAML scenarios)
+
+## Measurement note
+
+Timings were taken through a PTY harness that answers the terminal's
+cursor-position query (`ESC[6n`). Bare `script(1)` with no terminal behind it
+stalls crossterm's inline-viewport bring-up for its ~2 s DSR timeout, which
+masks the walk entirely — worth remembering for any future live-path timing.


### PR DESCRIPTION
## Summary

`daft list` on a TTY rendered its table almost instantly, then hung for seconds before exiting (4 s in this repo, up to 30 s in `node_modules`-heavy projects). The live path requested `FieldSet::ALL` from the streaming collector, so every per-worktree worker also ran the hidden SIZE cluster (`compute_directory_size` — a full recursive walk of each worktree) plus MTIME, even though no default column or sort uses them — and the renderer can only exit once **all** workers join (`WorktreeInfoCollectionDone`).

The blocking path already gates these fields (`has_size` / `compute_mtime` in `run_blocking`); the live path was the only collector callsite passing `FieldSet::ALL`.

## The fix

- New `collector_fields(columns, sort_spec, stat)` helper in `src/commands/list_live.rs`: the union of what the selected columns render (mirrors the renderer's shimmer mapping) and what the sort inspects (`SortSpec::required_fields()`), upgraded with the `*_LINES` variants in `--stat lines` mode.
- `run_live` requests exactly that set, and passes the complement as `TuiState` seeded fields so never-streamed cells don't read as in-flight (loading shimmer, verbose footer counter).
- Exhaustive column match (no `_` arm) so a future `ListColumn` variant forces a decision here.

## Verification

- 7 new unit tests on `collector_fields` (defaults exclude SIZE/MTIME/`*_LINES`; `+size`, `--sort=-size`, `--sort=-activity`, and lines-mode each request what they need; a pure-seed `branch,path` view requests nothing).
- Pre-commit trio green (fmt, clippy, test:unit), 53/53 YAML list scenarios pass.
- E2E timing through a PTY harness that answers the cursor-position query (`ESC[6n`): 220k-file fixture 1.8–2.0 s → 0.23 s (≈ the `DAFT_NO_LIVE=1` baseline); real repo (6 worktrees, ~45 GB of build artifacts) 3.5 s cold / 1.1 s warm → ~0.3 s.
- Opt-in paths intact: `--columns +size` still walks and renders the Size column + TOTAL footer; `--sort=-size` / `--sort=-activity` collect what they need.
- Manual test plan: `test-plans/list-live-field-gating.md`.

Making the SIZE walk itself faster when requested is tracked separately in #668.

Fixes #665

🤖 Generated with [Claude Code](https://claude.com/claude-code)