### PR TITLE
fix(push): skip pre-push hook on ref-only upstream pushes

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -674,10 +674,14 @@ repo's git-level `pre-push` hook (native `.git/hooks` or `core.hooksPath`
 managers like lefthook/husky/pre-commit). The hook run is reported as a
 `pre-push` phase. A failing hook blocks the push and the command exits non-zero
 — any worktree it created or moved is still completed and usable, and the error
-names the manual recovery command. Pass `--no-verify` to the pushing command
-(`daft sync --push`, `daft start`/`go -b`, `daft rename`, `daft remove`,
-`daft multi-remote move`) to skip the hook for one invocation. `--skip-hooks`
-does NOT affect git-level hooks — it only filters daft's own jobs.
+names the manual recovery command. Exception: the automatic upstream push on
+`daft start`/`go -b` runs the hook only when it introduces new commits;
+branching off a fully-pushed base is a ref-only push and skips the hook (config
+`daft.checkout.pushVerify`: `auto` default, `always`, `never`). Pass
+`--no-verify` to the pushing command (`daft sync --push`, `daft start`/`go -b`,
+`daft rename`, `daft remove`, `daft multi-remote move`) to skip the hook for one
+invocation. `--skip-hooks` does NOT affect git-level hooks — it only filters
+daft's own jobs.
 
 ### Move Hooks
 

--- a/docs/cli/daft-start.md
+++ b/docs/cli/daft-start.md
@@ -30,7 +30,7 @@ operations for a single invocation regardless of config.
 When the push is enabled, the repo's `pre-push` hook runs only when the push
 introduces new commits; a ref-only push of already-pushed commits skips it
 (configurable via `daft.checkout.pushVerify`: `auto`, `always`, or `never` —
-see [Git Hooks](../reference/configuration.md#git-hooks)).
+see [Git Hooks](/reference/configuration#git-hooks)).
 
 ## Arguments
 

--- a/docs/cli/daft-start.md
+++ b/docs/cli/daft-start.md
@@ -27,6 +27,11 @@ and upstream tracking, set `daft.checkout.push true` or use
 `daft config remote-sync --on`. You can also pass `--local` to skip remote
 operations for a single invocation regardless of config.
 
+When the push is enabled, the repo's `pre-push` hook runs only when the push
+introduces new commits; a ref-only push of already-pushed commits skips it
+(configurable via `daft.checkout.pushVerify`: `auto`, `always`, or `never` —
+see [Git Hooks](../reference/configuration.md#git-hooks)).
+
 ## Arguments
 
 | Argument | Description | Required |

--- a/docs/cli/git-worktree-checkout.md
+++ b/docs/cli/git-worktree-checkout.md
@@ -26,7 +26,9 @@ branch is checked out and upstream tracking is configured.
 With -b, creates a new branch and a corresponding worktree in a single
 operation. The new branch is based on the current branch, or on `<base-branch>`
 if specified. After creating the branch locally, it is pushed to the remote
-and upstream tracking is configured.
+and upstream tracking is configured. The repo's pre-push hook runs only when
+that push introduces new commits; a ref-only push of already-pushed commits
+skips it (configurable via daft.checkout.pushVerify: auto, always, or never).
 
 With --start (or -s), if the specified branch does not exist locally or on the
 remote, a new branch and worktree are created automatically, as if 'daft start'

--- a/docs/hooks/index.md
+++ b/docs/hooks/index.md
@@ -51,9 +51,13 @@ daft's hooks do not replace git's own. Every daft-initiated `git push` honors
 the repository's `pre-push` hook — whether it lives in `.git/hooks` or is
 managed by lefthook, husky, or pre-commit via `core.hooksPath`. A failing
 pre-push gate blocks the push and fails the command; its run is reported as a
-`pre-push` phase on the same surface lifecycle hooks use. Pass `--no-verify` to
-any pushing command to skip it for one invocation. See
-[Git Hooks](/reference/configuration#git-hooks) for the details.
+`pre-push` phase on the same surface lifecycle hooks use. The one conditional
+site is the automatic upstream push on branch creation: it consults the hook
+only when it would publish commits the remote does not already have, so
+branching off a fully-pushed base skips it (tunable via
+`daft.checkout.pushVerify`). Pass `--no-verify` to any pushing command to skip
+it for one invocation. See [Git Hooks](/reference/configuration#git-hooks) for
+the details.
 
 ## Where to next
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -77,11 +77,12 @@ By default, daft does not contact the remote during worktree management. All
 remote operations are opt-in. Use `daft config remote-sync` to toggle these
 settings interactively, or set them directly with `git config`.
 
-| Key                        | Default | Description                                                         |
-| -------------------------- | ------- | ------------------------------------------------------------------- |
-| `daft.checkout.fetch`      | `false` | Fetch from remote before creating a worktree for an existing branch |
-| `daft.checkout.push`       | `false` | Push new branches to remote after creation                          |
-| `daft.branchDelete.remote` | `false` | Delete the remote branch when removing a local branch               |
+| Key                        | Default | Description                                                                                            |
+| -------------------------- | ------- | ------------------------------------------------------------------------------------------------------ |
+| `daft.checkout.fetch`      | `false` | Fetch from remote before creating a worktree for an existing branch                                    |
+| `daft.checkout.push`       | `false` | Push new branches to remote after creation                                                             |
+| `daft.checkout.pushVerify` | `auto`  | When that push runs the repo's pre-push hook (`auto`, `always`, `never`) — see [Git Hooks](#git-hooks) |
+| `daft.branchDelete.remote` | `false` | Delete the remote branch when removing a local branch                                                  |
 
 ### Enabling Remote Sync
 
@@ -331,6 +332,23 @@ on `git push` fires on daft's pushes too. The hook run is reported as a
 `pre-push` phase with the hook's output, using the same surface as daft's
 lifecycle hooks.
 
+The automatic upstream push on `daft start` / `git worktree-checkout -b` is the
+one conditional site: it runs the hook only when the push introduces commits the
+target remote does not already have. Branching off a fully-pushed base is a
+ref-only push -- a new branch name pointing at commits the remote already has --
+so there is nothing for a content gate to validate, and the hook is skipped.
+Control this with `daft.checkout.pushVerify`:
+
+| Value    | Behavior                                                       |
+| -------- | -------------------------------------------------------------- |
+| `auto`   | (default) Run the hook only when the push carries new commits  |
+| `always` | Run the hook on every upstream push, including ref-only pushes |
+| `never`  | Never run the hook on the automatic upstream push              |
+
+`always` is for repositories whose pre-push hooks act on the ref rather than the
+content (branch-naming policies, protected-branch guards): daft cannot classify
+an opaque hook, so the automatic skip is based purely on pushed content.
+
 Pass `--no-verify` to skip the hook for one invocation. Every command that can
 push accepts it: `daft sync --push`, `daft start` / `daft go -b` /
 `git worktree-checkout -b`, `daft rename`, `daft remove` /
@@ -340,7 +358,8 @@ Remote operations are disabled by default. When enabled (via
 `daft config remote-sync --on` or by setting the individual keys), this affects:
 
 - **`daft start` / `git worktree-checkout -b`** -- pushes the new branch to set
-  upstream tracking (controlled by `daft.checkout.push`)
+  upstream tracking (controlled by `daft.checkout.push`; pre-push hook gating
+  per `daft.checkout.pushVerify` above)
 - **`daft remove` / `git worktree-branch -d`** -- pushes `--delete` to remove
   the remote branch (controlled by `daft.branchDelete.remote`)
 - **`daft multi-remote move --push`** -- pushes an existing branch to a new

--- a/man/daft-go.1
+++ b/man/daft-go.1
@@ -22,8 +22,11 @@ Use \*(Aq\-\*(Aq as the branch name to switch to the previous worktree, similar 
 \*(Aqcd \-\*(Aq. Repeated \*(Aqdaft go \-\*(Aq toggles between the two most recent worktrees.
 .PP
 With \-b, creates a new branch and worktree in a single operation. The new
-branch is based on the current branch, or on `<base\-branch>` if specified.
-Prefer \*(Aqdaft start\*(Aq for creating new branches.
+branch is based on the current branch, or on `<base\-branch>` if specified. It
+is pushed to the remote and upstream tracking is configured; the pre\-push hook
+runs only when that push introduces new commits, skipping ref\-only pushes
+(configurable via daft.checkout.pushVerify: auto, always, or never). Prefer
+\*(Aqdaft start\*(Aq for creating new branches.
 .PP
 With \-s (\-\-start), if the specified branch does not exist locally or on the
 remote, a new branch and worktree are created automatically. This can also

--- a/man/daft-start.1
+++ b/man/daft-start.1
@@ -13,7 +13,10 @@ using the branch name as the directory name.
 .PP
 The new branch is based on the current branch, or on `<base\-branch>` if
 specified. After creating the branch locally, it is pushed to the remote and
-upstream tracking is configured (unless disabled via daft.checkoutBranch.push).
+upstream tracking is configured (unless disabled via daft.checkout.push). The
+repo\*(Aqs pre\-push hook runs only when that push introduces new commits; a
+ref\-only push of already\-pushed commits skips it (configurable via
+daft.checkout.pushVerify: auto, always, or never).
 .PP
 This command can be run from anywhere within the repository.
 .PP

--- a/man/git-worktree-checkout.1
+++ b/man/git-worktree-checkout.1
@@ -18,7 +18,9 @@ branch is checked out and upstream tracking is configured.
 With \-b, creates a new branch and a corresponding worktree in a single
 operation. The new branch is based on the current branch, or on `<base\-branch>`
 if specified. After creating the branch locally, it is pushed to the remote
-and upstream tracking is configured.
+and upstream tracking is configured. The repo\*(Aqs pre\-push hook runs only when
+that push introduces new commits; a ref\-only push of already\-pushed commits
+skips it (configurable via daft.checkout.pushVerify: auto, always, or never).
 .PP
 With \-\-start (or \-s), if the specified branch does not exist locally or on the
 remote, a new branch and worktree are created automatically, as if \*(Aqdaft start\*(Aq

--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -16,7 +16,7 @@ use crate::{
     is_git_repository,
     logging::init_logging,
     output::{CliOutput, Output, OutputConfig},
-    settings::DaftSettings,
+    settings::{DaftSettings, PushVerify},
     utils::*,
 };
 use anyhow::Result;
@@ -273,7 +273,10 @@ using the branch name as the directory name.
 
 The new branch is based on the current branch, or on `<base-branch>` if
 specified. After creating the branch locally, it is pushed to the remote and
-upstream tracking is configured (unless disabled via daft.checkoutBranch.push).
+upstream tracking is configured (unless disabled via daft.checkout.push). The
+repo's pre-push hook runs only when that push introduces new commits; a
+ref-only push of already-pushed commits skips it (configurable via
+daft.checkout.pushVerify: auto, always, or never).
 
 This command can be run from anywhere within the repository.
 
@@ -849,6 +852,7 @@ fn run_create_branch(
             settings.checkout_push
         },
         no_verify: args.no_verify,
+        push_verify: settings.checkout_push_verify,
         checkout_fetch: if args.local {
             false
         } else {
@@ -869,12 +873,17 @@ fn run_create_branch(
     }
 
     // The pre-push hook run on the auto-upstream push renders phase/job
-    // output through this presenter — keep the spinner off when it will
-    // fire so the two don't fight over the terminal (#599).
-    let push_hook_will_render =
-        params.checkout_push && !params.no_verify && git.pre_push_hook_exists(&project_root);
+    // output through this presenter — keep the spinner off when it MAY
+    // fire so the two don't fight over the terminal (#599). This is a
+    // conservative upper bound: whether the hook actually runs is decided
+    // in core (push_if_enabled), where the post-fetch ref-only probe lives
+    // (#679) — a skipped hook simply never fires the presenter.
+    let push_hook_may_render = params.checkout_push
+        && !params.no_verify
+        && params.push_verify != PushVerify::Never
+        && git.pre_push_hook_exists(&project_root);
     let push_presenter: Option<Arc<dyn crate::executor::presenter::JobPresenter>> =
-        if push_hook_will_render {
+        if push_hook_may_render {
             let p: Arc<dyn crate::executor::presenter::JobPresenter> =
                 crate::executor::cli_presenter::CliPresenter::auto(&hook_output_config);
             Some(p)
@@ -882,7 +891,7 @@ fn run_create_branch(
             None
         };
 
-    if !push_hook_will_render {
+    if !push_hook_may_render {
         output.start_spinner("Creating worktree...");
     }
     let checkout_result = {
@@ -895,7 +904,7 @@ fn run_create_branch(
             &mut bridge,
         )
     };
-    if !push_hook_will_render {
+    if !push_hook_may_render {
         output.finish_spinner();
     }
     let result = checkout_result?;

--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -41,7 +41,9 @@ branch is checked out and upstream tracking is configured.
 With -b, creates a new branch and a corresponding worktree in a single
 operation. The new branch is based on the current branch, or on `<base-branch>`
 if specified. After creating the branch locally, it is pushed to the remote
-and upstream tracking is configured.
+and upstream tracking is configured. The repo's pre-push hook runs only when
+that push introduces new commits; a ref-only push of already-pushed commits
+skips it (configurable via daft.checkout.pushVerify: auto, always, or never).
 
 With --start (or -s), if the specified branch does not exist locally or on the
 remote, a new branch and worktree are created automatically, as if 'daft start'
@@ -165,8 +167,11 @@ Use '-' as the branch name to switch to the previous worktree, similar to
 'cd -'. Repeated 'daft go -' toggles between the two most recent worktrees.
 
 With -b, creates a new branch and worktree in a single operation. The new
-branch is based on the current branch, or on `<base-branch>` if specified.
-Prefer 'daft start' for creating new branches.
+branch is based on the current branch, or on `<base-branch>` if specified. It
+is pushed to the remote and upstream tracking is configured; the pre-push hook
+runs only when that push introduces new commits, skipping ref-only pushes
+(configurable via daft.checkout.pushVerify: auto, always, or never). Prefer
+'daft start' for creating new branches.
 
 With -s (--start), if the specified branch does not exist locally or on the
 remote, a new branch and worktree are created automatically. This can also
@@ -872,12 +877,11 @@ fn run_create_branch(
         output.warning("[experimental] Using gitoxide backend for git operations");
     }
 
-    // The pre-push hook run on the auto-upstream push renders phase/job
-    // output through this presenter — keep the spinner off when it MAY
-    // fire so the two don't fight over the terminal (#599). This is a
-    // conservative upper bound: whether the hook actually runs is decided
-    // in core (push_if_enabled), where the post-fetch ref-only probe lives
-    // (#679) — a skipped hook simply never fires the presenter.
+    // The auto-upstream push may run the repo's pre-push hook and render its
+    // phase/job output through this presenter (#599). Create it whenever a hook
+    // COULD fire — a conservative upper bound, since whether the hook actually
+    // runs is decided in core (push_if_enabled), after the post-fetch ref-only
+    // probe (#679). A skipped hook simply never fires the presenter.
     let push_hook_may_render = params.checkout_push
         && !params.no_verify
         && params.push_verify != PushVerify::Never
@@ -891,9 +895,11 @@ fn run_create_branch(
             None
         };
 
-    if !push_hook_may_render {
-        output.start_spinner("Creating worktree...");
-    }
+    // Always show the spinner for the worktree checkout. When the pre-push hook
+    // renders, core pauses this spinner across the render and resumes it after
+    // (push_if_enabled), so the two never fight — and the common ref-only case,
+    // where the hook is skipped, keeps a visible spinner instead of going silent.
+    output.start_spinner("Creating worktree...");
     let checkout_result = {
         let mut bridge = CommandBridge::new(output, executor);
         checkout_branch::execute(
@@ -904,9 +910,7 @@ fn run_create_branch(
             &mut bridge,
         )
     };
-    if !push_hook_may_render {
-        output.finish_spinner();
-    }
+    output.finish_spinner();
     let result = checkout_result?;
 
     render_create_result(&result, output);

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -47,6 +47,16 @@ pub trait ProgressSink {
 
     /// Report a debug message (shown in verbose mode).
     fn on_debug(&mut self, msg: &str);
+
+    /// Suspend any running command-level spinner so a nested progress UI
+    /// (e.g. the pre-push hook's `MultiProgress`) can own the terminal without
+    /// the two clobbering each other. No-op by default; CLI adapters forward
+    /// to `Output`. Must be paired with [`resume_spinner`](Self::resume_spinner).
+    fn pause_spinner(&mut self) {}
+
+    /// Restore a spinner previously hidden by [`pause_spinner`](Self::pause_spinner).
+    /// No-op by default.
+    fn resume_spinner(&mut self) {}
 }
 
 /// A no-op sink that discards all progress messages.

--- a/src/core/progress.rs
+++ b/src/core/progress.rs
@@ -37,6 +37,14 @@ impl ProgressSink for OutputSink<'_> {
     fn on_debug(&mut self, msg: &str) {
         self.0.debug(msg);
     }
+
+    fn pause_spinner(&mut self) {
+        self.0.pause_spinner();
+    }
+
+    fn resume_spinner(&mut self) {
+        self.0.resume_spinner();
+    }
 }
 
 /// Combined adapter for commands that need both progress reporting and hook
@@ -96,6 +104,14 @@ impl ProgressSink for CommandBridge<'_> {
 
     fn on_debug(&mut self, msg: &str) {
         self.output.debug(msg);
+    }
+
+    fn pause_spinner(&mut self) {
+        self.output.pause_spinner();
+    }
+
+    fn resume_spinner(&mut self) {
+        self.output.resume_spinner();
     }
 }
 

--- a/src/core/settings.rs
+++ b/src/core/settings.rs
@@ -12,6 +12,7 @@
 //! | `daft.checkout.push` | `false` | Push new branches to remote |
 //! | `daft.checkout.fetch` | `false` | Fetch from remote before creating worktrees |
 //! | `daft.checkout.upstream` | `true` | Set upstream tracking |
+//! | `daft.checkout.pushVerify` | `auto` | When the auto-upstream push runs the repo's pre-push hook (`auto`, `always` or `never`) |
 //! | `daft.remote` | `"origin"` | Default remote name |
 //! | `daft.checkoutBranch.carry` | `true` | Default carry for checkout-branch |
 //! | `daft.checkout.carry` | `false` | Default carry for checkout |
@@ -81,9 +82,33 @@ impl PruneCdTarget {
     }
 }
 
+/// When the automatic upstream push consults the repo's `pre-push` hook.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PushVerify {
+    /// Run the hook only when the push introduces commits the target remote
+    /// does not already have; skip it for ref-only pushes (#679).
+    Auto,
+    /// Always run the hook, even for ref-only pushes.
+    Always,
+    /// Never run the hook on the automatic upstream push.
+    Never,
+}
+
+impl PushVerify {
+    /// Parse a string value into a PushVerify.
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.to_lowercase().as_str() {
+            "auto" => Some(Self::Auto),
+            "always" => Some(Self::Always),
+            "never" => Some(Self::Never),
+            _ => None,
+        }
+    }
+}
+
 /// Default values for settings.
 pub mod defaults {
-    use super::PruneCdTarget;
+    use super::{PruneCdTarget, PushVerify};
     use crate::core::worktree::list::Stat;
 
     /// Default value for autocd setting.
@@ -97,6 +122,9 @@ pub mod defaults {
 
     /// Default value for checkout.upstream setting.
     pub const CHECKOUT_UPSTREAM: bool = true;
+
+    /// Default value for checkout.pushVerify setting.
+    pub const CHECKOUT_PUSH_VERIFY: PushVerify = PushVerify::Auto;
 
     /// Default value for remote setting.
     pub const REMOTE: &str = "origin";
@@ -185,6 +213,9 @@ pub mod keys {
 
     /// Config key for checkout.upstream setting.
     pub const CHECKOUT_UPSTREAM: &str = "daft.checkout.upstream";
+
+    /// Config key for checkout.pushVerify setting.
+    pub const CHECKOUT_PUSH_VERIFY: &str = "daft.checkout.pushVerify";
 
     /// Config key for remote setting.
     pub const REMOTE: &str = "daft.remote";
@@ -359,6 +390,9 @@ pub struct DaftSettings {
     /// Set upstream tracking for branches.
     pub checkout_upstream: bool,
 
+    /// When the automatic upstream push runs the repo's pre-push hook.
+    pub checkout_push_verify: PushVerify,
+
     /// Default remote name for operations.
     pub remote: String,
 
@@ -476,6 +510,7 @@ impl Default for DaftSettings {
             checkout_push: defaults::CHECKOUT_PUSH,
             checkout_fetch: defaults::CHECKOUT_FETCH,
             checkout_upstream: defaults::CHECKOUT_UPSTREAM,
+            checkout_push_verify: defaults::CHECKOUT_PUSH_VERIFY,
             remote: defaults::REMOTE.to_string(),
             checkout_branch_carry: defaults::CHECKOUT_BRANCH_CARRY,
             checkout_carry: defaults::CHECKOUT_CARRY,
@@ -545,6 +580,19 @@ impl DaftSettings {
 
         if let Some(value) = git.config_get(keys::CHECKOUT_UPSTREAM)? {
             settings.checkout_upstream = parse_bool(&value, defaults::CHECKOUT_UPSTREAM);
+        }
+
+        if let Some(value) = git.config_get(keys::CHECKOUT_PUSH_VERIFY)?
+            && !value.is_empty()
+        {
+            match PushVerify::parse(&value) {
+                Some(verify) => settings.checkout_push_verify = verify,
+                None => eprintln!(
+                    "daft: unknown value for {}: {:?} — using default",
+                    keys::CHECKOUT_PUSH_VERIFY,
+                    value
+                ),
+            }
         }
 
         if let Some(value) = git.config_get(keys::REMOTE)?
@@ -697,6 +745,19 @@ impl DaftSettings {
 
         if let Some(value) = git.config_get_global(keys::CHECKOUT_UPSTREAM)? {
             settings.checkout_upstream = parse_bool(&value, defaults::CHECKOUT_UPSTREAM);
+        }
+
+        if let Some(value) = git.config_get_global(keys::CHECKOUT_PUSH_VERIFY)?
+            && !value.is_empty()
+        {
+            match PushVerify::parse(&value) {
+                Some(verify) => settings.checkout_push_verify = verify,
+                None => eprintln!(
+                    "daft: unknown value for {}: {:?} — using default",
+                    keys::CHECKOUT_PUSH_VERIFY,
+                    value
+                ),
+            }
         }
 
         if let Some(value) = git.config_get_global(keys::REMOTE)?

--- a/src/core/settings.rs
+++ b/src/core/settings.rs
@@ -1304,6 +1304,20 @@ mod tests {
     }
 
     #[test]
+    fn test_push_verify_parse() {
+        assert_eq!(PushVerify::parse("auto"), Some(PushVerify::Auto));
+        assert_eq!(PushVerify::parse("always"), Some(PushVerify::Always));
+        assert_eq!(PushVerify::parse("never"), Some(PushVerify::Never));
+        // Case-insensitive, like the sibling config-enum parsers.
+        assert_eq!(PushVerify::parse("Auto"), Some(PushVerify::Auto));
+        assert_eq!(PushVerify::parse("ALWAYS"), Some(PushVerify::Always));
+        assert_eq!(PushVerify::parse("Never"), Some(PushVerify::Never));
+        // Unknown and empty values are rejected (caller keeps the default).
+        assert_eq!(PushVerify::parse("verify"), None);
+        assert_eq!(PushVerify::parse(""), None);
+    }
+
+    #[test]
     fn test_parse_bool_true_variants() {
         assert!(parse_bool("true", false));
         assert!(parse_bool("True", false));

--- a/src/core/worktree/checkout_branch.rs
+++ b/src/core/worktree/checkout_branch.rs
@@ -596,7 +596,9 @@ fn push_if_enabled(
     // fully-qualified branch ref — a same-named tag would shadow the short
     // name in rev-list's resolution.
     let (hook_present, unpushed_count) = match params.push_verify {
-        PushVerify::Auto if !params.no_verify => {
+        // `--no-verify` skips silently regardless of hook presence, so don't probe.
+        _ if params.no_verify => (None, None),
+        PushVerify::Auto => {
             let present = git.pre_push_hook_exists(worktree_path);
             let count = if present {
                 match git.count_commits_not_on_remote(
@@ -615,7 +617,11 @@ fn push_if_enabled(
             };
             (Some(present), count)
         }
-        _ => (None, None),
+        // `never` announces the skip only when a hook actually exists, so probe
+        // its presence (a cheap stat). `always` verifies unconditionally and
+        // lets push_with_hooks resolve presence for its own verdict.
+        PushVerify::Never => (Some(git.pre_push_hook_exists(worktree_path)), None),
+        PushVerify::Always => (None, None),
     };
 
     let verify = match resolve_pre_push(
@@ -633,6 +639,17 @@ fn push_if_enabled(
         }
     };
 
+    // When the hook renders through the presenter its `MultiProgress` owns the
+    // terminal, so pause the outer "Creating worktree..." spinner across the
+    // render (the same contract CommandBridge::run_hook uses for post-create
+    // hooks). A ref-only push under `auto` skips the hook (#679), so the
+    // spinner keeps running and stays the only progress the user sees.
+    let renders_hook = verify
+        && presenter.is_some()
+        && hook_present.unwrap_or_else(|| git.pre_push_hook_exists(worktree_path));
+    if renders_hook {
+        sink.pause_spinner();
+    }
     let result = push_with_hooks(
         git,
         PushAction::SetUpstream {
@@ -645,6 +662,9 @@ fn push_if_enabled(
         presenter,
         hook_present,
     );
+    if renders_hook {
+        sink.resume_spinner();
+    }
 
     let failure = match result {
         Ok(outcome) => match outcome.failure {
@@ -681,6 +701,32 @@ fn push_if_enabled(
                         )),
                     );
                 }
+                // #679: the hook was skipped (ref-only auto-skip or --no-verify)
+                // but the push itself failed for a non-hook reason — a server-side
+                // rejection, transport, or auth error. A gate that never ran
+                // cannot have refused the push, yet the branch genuinely never
+                // reached the remote, so escalate to a hard error (like a real
+                // hook rejection) rather than warn-and-continue. This keeps
+                // `daft start <b> && …` from proceeding on a branch that is not
+                // on the remote. Hook-less repos (verdict NoHook) keep the legacy
+                // warn-and-continue behavior.
+                if outcome.hook == HookVerdict::Bypassed {
+                    return (
+                        false,
+                        false,
+                        Some(format!(
+                            "Could not push '{}' to '{}': {}. \
+                             The worktree was created and is ready at '{}'. \
+                             Push manually with: git push -u {} {}",
+                            params.new_branch_name,
+                            params.remote_name,
+                            msg,
+                            worktree_path.display(),
+                            params.remote_name,
+                            params.new_branch_name,
+                        )),
+                    );
+                }
                 msg
             }
         },
@@ -710,9 +756,16 @@ enum PrePushDecision {
 /// Pure decision core for [`push_if_enabled`]'s hook handling: the
 /// `--no-verify` flag wins unconditionally; otherwise `daft.checkout.pushVerify`
 /// rules, with `auto` skipping only a proven ref-only push (hook present and
-/// zero commits absent from the target remote). A failed probe
-/// (`unpushed_count = None`) falls back to verifying — the worst case must be
-/// an unnecessary hook run, never an unverified content push.
+/// zero commits absent from the target remote). On a failed probe
+/// (`unpushed_count = None`) `auto` falls back to verifying — a probe that could
+/// not answer must never silently drop the hook.
+///
+/// The `auto` skip trusts a count derived from local remote-tracking refs, which
+/// are only as fresh as the last fetch (`daft.checkout.fetch`, off by default).
+/// If the remote was rewound or force-pushed since then, a stale-ahead tracking
+/// ref can report zero unpushed commits for a push that does carry content,
+/// skipping the hook — the same trade-off pre-commit's pre-push driver makes.
+/// Set `pushVerify = always` for a hook that must run on every push regardless.
 fn resolve_pre_push(
     setting: PushVerify,
     no_verify_flag: bool,
@@ -723,9 +776,12 @@ fn resolve_pre_push(
         return PrePushDecision::Skip(None);
     }
     match setting {
-        PushVerify::Never => PrePushDecision::Skip(Some(
+        // Only announce the skip when there is actually a hook to skip; a
+        // hook-less repo stays silent, matching `auto`.
+        PushVerify::Never if hook_present => PrePushDecision::Skip(Some(
             "Skipping pre-push hook (daft.checkout.pushVerify = never)",
         )),
+        PushVerify::Never => PrePushDecision::Skip(None),
         PushVerify::Always => PrePushDecision::Verify,
         PushVerify::Auto => {
             if hook_present && unpushed_count == Some(0) {
@@ -739,8 +795,15 @@ fn resolve_pre_push(
 
 #[cfg(test)]
 mod tests {
-    use super::{PrePushDecision, resolve_pre_push};
+    use super::{CheckoutBranchParams, PrePushDecision, push_if_enabled, resolve_pre_push};
+    use crate::core::ProgressSink;
     use crate::core::settings::PushVerify;
+    use crate::executor::presenter::{JobPresenter, NullPresenter};
+    use crate::git::GitCommand;
+    use crate::utils::git_command_at;
+    use std::path::{Path, PathBuf};
+    use std::process::Stdio;
+    use std::sync::Arc;
 
     #[test]
     fn no_verify_flag_skips_silently_regardless_of_setting() {
@@ -756,6 +819,16 @@ mod tests {
     fn never_skips_with_a_reason_even_when_the_push_carries_commits() {
         let decision = resolve_pre_push(PushVerify::Never, false, true, Some(3));
         assert!(matches!(decision, PrePushDecision::Skip(Some(_))));
+    }
+
+    #[test]
+    fn never_without_a_hook_skips_silently() {
+        // Nothing to announce when there is no hook to skip (#679 review): the
+        // `never` arm must stay quiet hook-lessly, like `auto` does.
+        assert_eq!(
+            resolve_pre_push(PushVerify::Never, false, false, None),
+            PrePushDecision::Skip(None)
+        );
     }
 
     #[test]
@@ -795,6 +868,152 @@ mod tests {
         assert_eq!(
             resolve_pre_push(PushVerify::Auto, false, false, Some(0)),
             PrePushDecision::Verify
+        );
+    }
+
+    // --- integration: spinner coordination around the pre-push render (#679) ---
+
+    /// Records the spinner-control calls `push_if_enabled` makes so a test can
+    /// assert the pre-push render is (or is not) bracketed by pause/resume.
+    #[derive(Default)]
+    struct RecordingSink {
+        events: Vec<&'static str>,
+    }
+
+    impl ProgressSink for RecordingSink {
+        fn on_step(&mut self, _msg: &str) {
+            self.events.push("step");
+        }
+        fn on_warning(&mut self, _msg: &str) {
+            self.events.push("warning");
+        }
+        fn on_debug(&mut self, _msg: &str) {}
+        fn pause_spinner(&mut self) {
+            self.events.push("pause");
+        }
+        fn resume_spinner(&mut self) {
+            self.events.push("resume");
+        }
+    }
+
+    fn git_in(dir: &Path, args: &[&str]) {
+        let status = git_command_at(dir)
+            .args(args)
+            .env("GIT_AUTHOR_NAME", "Test")
+            .env("GIT_AUTHOR_EMAIL", "test@test.com")
+            .env("GIT_COMMITTER_NAME", "Test")
+            .env("GIT_COMMITTER_EMAIL", "test@test.com")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .expect("failed to spawn git");
+        assert!(status.success(), "git {args:?} failed in {}", dir.display());
+    }
+
+    /// Bare remote + a one-commit `main` clone pushed to origin, with `feat`
+    /// created at the already-pushed tip (so its upstream push is ref-only) and
+    /// a passing `pre-push` hook installed (so the probe sees a hook and the
+    /// push still succeeds).
+    fn repo_with_hook_and_remote() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let remote = dir.path().join("remote.git");
+        let work = dir.path().join("work");
+        std::fs::create_dir_all(&remote).unwrap();
+        git_in(&remote, &["init", "--bare"]);
+        std::fs::create_dir_all(&work).unwrap();
+        git_in(&work, &["init", "-b", "main"]);
+        git_in(
+            &work,
+            &["remote", "add", "origin", remote.to_str().unwrap()],
+        );
+        std::fs::write(work.join("a.txt"), "a").unwrap();
+        git_in(&work, &["add", "."]);
+        git_in(&work, &["commit", "-m", "init"]);
+        git_in(&work, &["push", "-u", "origin", "main"]);
+        git_in(&work, &["branch", "feat"]);
+
+        let hook = work.join(".git").join("hooks").join("pre-push");
+        std::fs::write(&hook, "#!/bin/sh\nexit 0\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&hook, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        (dir, work)
+    }
+
+    fn params_for(branch: &str, push_verify: PushVerify) -> CheckoutBranchParams {
+        CheckoutBranchParams {
+            new_branch_name: branch.to_string(),
+            base_branch_name: None,
+            carry: false,
+            no_carry: false,
+            remote: None,
+            remote_name: "origin".to_string(),
+            multi_remote_enabled: false,
+            multi_remote_default: "origin".to_string(),
+            checkout_branch_carry: false,
+            checkout_push: true,
+            no_verify: false,
+            push_verify,
+            checkout_fetch: false,
+            layout: None,
+            at_path: None,
+        }
+    }
+
+    #[test]
+    fn render_is_bracketed_by_spinner_pause_and_resume() {
+        // `always` forces the hook to run on the (ref-only) upstream push, so it
+        // renders through the presenter — the outer spinner must be paused for
+        // the duration and resumed after, mirroring CommandBridge::run_hook.
+        let (_dir, work) = repo_with_hook_and_remote();
+        let git = GitCommand::new(false);
+        let params = params_for("feat", PushVerify::Always);
+        let presenter: Arc<dyn JobPresenter> = NullPresenter::arc();
+        let mut sink = RecordingSink::default();
+
+        let (push_set, _skipped, gate) =
+            push_if_enabled(&params, &git, &work, Some(&presenter), &mut sink);
+
+        assert!(
+            push_set,
+            "ref-only push with a passing hook should succeed: {gate:?}"
+        );
+        let pause = sink.events.iter().position(|e| *e == "pause");
+        let resume = sink.events.iter().position(|e| *e == "resume");
+        assert!(
+            pause.is_some() && resume.is_some(),
+            "the render must be bracketed by pause/resume: {:?}",
+            sink.events
+        );
+        assert!(
+            pause < resume,
+            "pause must precede resume: {:?}",
+            sink.events
+        );
+    }
+
+    #[test]
+    fn auto_ref_only_skip_leaves_the_spinner_running() {
+        // The #679 case: a ref-only push under `auto` skips the hook, so the
+        // spinner is never paused — it stays visible for the whole checkout
+        // instead of the terminal going silent.
+        let (_dir, work) = repo_with_hook_and_remote();
+        let git = GitCommand::new(false);
+        let params = params_for("feat", PushVerify::Auto);
+        let presenter: Arc<dyn JobPresenter> = NullPresenter::arc();
+        let mut sink = RecordingSink::default();
+
+        let (push_set, _skipped, gate) =
+            push_if_enabled(&params, &git, &work, Some(&presenter), &mut sink);
+
+        assert!(push_set, "the ref-only push should still succeed: {gate:?}");
+        assert!(
+            !sink.events.contains(&"pause"),
+            "a skipped hook must not pause the spinner: {:?}",
+            sink.events
         );
     }
 }

--- a/src/core/worktree/checkout_branch.rs
+++ b/src/core/worktree/checkout_branch.rs
@@ -4,6 +4,7 @@
 
 use crate::config::git::{COMMITS_AHEAD_THRESHOLD, DEFAULT_COMMIT_COUNT};
 use crate::core::layout::{Layout, auto_gitignore_if_needed};
+use crate::core::settings::PushVerify;
 use crate::core::worktree::ports::NoopStageRunner;
 use crate::core::worktree::push::{HookVerdict, PushAction, push_with_hooks};
 use crate::core::{HookOutcome, HookRunner, ProgressSink};
@@ -42,6 +43,8 @@ pub struct CheckoutBranchParams {
     pub checkout_push: bool,
     /// Skip the repo's pre-push hook on the upstream push (`--no-verify`).
     pub no_verify: bool,
+    /// When the upstream push runs the repo's pre-push hook (from settings).
+    pub push_verify: PushVerify,
     /// Whether to fetch from remote before creating the worktree.
     pub checkout_fetch: bool,
     /// Optional layout for computing the worktree path.
@@ -561,11 +564,15 @@ fn apply_stash(
 /// Push and set upstream tracking if the setting is enabled.
 ///
 /// Runs the push from the new worktree so the repo's `pre-push` hook fires
-/// in the branch being pushed.
+/// in the branch being pushed. Whether git dispatches the hook at all is
+/// resolved per `daft.checkout.pushVerify` (#679): under `auto`, a ref-only
+/// push — one introducing no commits absent from the target remote — has
+/// nothing for a content gate to validate and suppresses the hook.
 /// Returns `(push_set, push_skipped, gate_error)`. A push failure with the
 /// repo's pre-push hook in effect escalates via `gate_error` (the caller
-/// fails the command after finishing worktree setup, #599); hook-less or
-/// bypassed failures keep the legacy warn-and-continue behavior.
+/// fails the command after finishing worktree setup, #599); hook-less,
+/// bypassed, or hook-skipped failures keep the legacy warn-and-continue
+/// behavior (a gate that never ran cannot have refused the push).
 fn push_if_enabled(
     params: &CheckoutBranchParams,
     git: &GitCommand,
@@ -583,6 +590,49 @@ fn push_if_enabled(
         params.remote_name, params.new_branch_name
     ));
 
+    // Probe lazily: hook existence only when `auto` can act on it, and the
+    // unpushed-commit count only when a hook is actually present (with no
+    // hook, verify and skip are behaviorally identical). The probe uses the
+    // fully-qualified branch ref — a same-named tag would shadow the short
+    // name in rev-list's resolution.
+    let (hook_present, unpushed_count) = match params.push_verify {
+        PushVerify::Auto if !params.no_verify => {
+            let present = git.pre_push_hook_exists(worktree_path);
+            let count = if present {
+                match git.count_commits_not_on_remote(
+                    &format!("refs/heads/{}", params.new_branch_name),
+                    &params.remote_name,
+                    worktree_path,
+                ) {
+                    Ok(count) => Some(count),
+                    Err(e) => {
+                        crate::log_debug!("pre-push ref-only probe failed: {e}");
+                        None
+                    }
+                }
+            } else {
+                None
+            };
+            (Some(present), count)
+        }
+        _ => (None, None),
+    };
+
+    let verify = match resolve_pre_push(
+        params.push_verify,
+        params.no_verify,
+        hook_present.unwrap_or(false),
+        unpushed_count,
+    ) {
+        PrePushDecision::Verify => true,
+        PrePushDecision::Skip(reason) => {
+            if let Some(reason) = reason {
+                sink.on_step(reason);
+            }
+            false
+        }
+    };
+
     let result = push_with_hooks(
         git,
         PushAction::SetUpstream {
@@ -590,10 +640,10 @@ fn push_if_enabled(
             branch: &params.new_branch_name,
         },
         worktree_path,
-        !params.no_verify,
+        verify,
         &NoopStageRunner,
         presenter,
-        None,
+        hook_present,
     );
 
     let failure = match result {
@@ -643,4 +693,108 @@ fn push_if_enabled(
         params.remote_name, params.new_branch_name
     ));
     (false, false, None)
+}
+
+/// Verdict on whether git should dispatch the repo's `pre-push` hook for the
+/// automatic upstream push (#679).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PrePushDecision {
+    /// Let git run the hook.
+    Verify,
+    /// Suppress the hook; `Some(reason)` is reported as a progress step
+    /// (`None` for the explicit `--no-verify` flag, which stays silent as it
+    /// always has).
+    Skip(Option<&'static str>),
+}
+
+/// Pure decision core for [`push_if_enabled`]'s hook handling: the
+/// `--no-verify` flag wins unconditionally; otherwise `daft.checkout.pushVerify`
+/// rules, with `auto` skipping only a proven ref-only push (hook present and
+/// zero commits absent from the target remote). A failed probe
+/// (`unpushed_count = None`) falls back to verifying — the worst case must be
+/// an unnecessary hook run, never an unverified content push.
+fn resolve_pre_push(
+    setting: PushVerify,
+    no_verify_flag: bool,
+    hook_present: bool,
+    unpushed_count: Option<u64>,
+) -> PrePushDecision {
+    if no_verify_flag {
+        return PrePushDecision::Skip(None);
+    }
+    match setting {
+        PushVerify::Never => PrePushDecision::Skip(Some(
+            "Skipping pre-push hook (daft.checkout.pushVerify = never)",
+        )),
+        PushVerify::Always => PrePushDecision::Verify,
+        PushVerify::Auto => {
+            if hook_present && unpushed_count == Some(0) {
+                PrePushDecision::Skip(Some("Skipping pre-push hook (no new commits to push)"))
+            } else {
+                PrePushDecision::Verify
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PrePushDecision, resolve_pre_push};
+    use crate::core::settings::PushVerify;
+
+    #[test]
+    fn no_verify_flag_skips_silently_regardless_of_setting() {
+        for setting in [PushVerify::Auto, PushVerify::Always, PushVerify::Never] {
+            assert_eq!(
+                resolve_pre_push(setting, true, true, Some(5)),
+                PrePushDecision::Skip(None)
+            );
+        }
+    }
+
+    #[test]
+    fn never_skips_with_a_reason_even_when_the_push_carries_commits() {
+        let decision = resolve_pre_push(PushVerify::Never, false, true, Some(3));
+        assert!(matches!(decision, PrePushDecision::Skip(Some(_))));
+    }
+
+    #[test]
+    fn always_verifies_even_for_ref_only_pushes() {
+        assert_eq!(
+            resolve_pre_push(PushVerify::Always, false, true, Some(0)),
+            PrePushDecision::Verify
+        );
+    }
+
+    #[test]
+    fn auto_skips_a_ref_only_push_when_a_hook_is_present() {
+        let decision = resolve_pre_push(PushVerify::Auto, false, true, Some(0));
+        assert!(matches!(decision, PrePushDecision::Skip(Some(_))));
+    }
+
+    #[test]
+    fn auto_verifies_when_the_push_carries_new_commits() {
+        assert_eq!(
+            resolve_pre_push(PushVerify::Auto, false, true, Some(2)),
+            PrePushDecision::Verify
+        );
+    }
+
+    #[test]
+    fn auto_verifies_when_the_probe_fails() {
+        assert_eq!(
+            resolve_pre_push(PushVerify::Auto, false, true, None),
+            PrePushDecision::Verify
+        );
+    }
+
+    #[test]
+    fn auto_without_a_hook_verifies_trivially() {
+        // The wiring never probes the count without a hook, but the pure fn
+        // must not skip on hook-less inputs either.
+        assert_eq!(
+            resolve_pre_push(PushVerify::Auto, false, false, Some(0)),
+            PrePushDecision::Verify
+        );
+    }
 }

--- a/src/git/refs.rs
+++ b/src/git/refs.rs
@@ -1,6 +1,8 @@
 use super::GitCommand;
 use super::oxide;
+use crate::utils::git_command_at;
 use anyhow::{Context, Result};
+use std::path::Path;
 use std::process::Command;
 
 impl GitCommand {
@@ -207,6 +209,42 @@ impl GitCommand {
             .context("Failed to parse commit count as number")
     }
 
+    /// Count commits reachable from `rev` but absent from every tracking ref
+    /// of `remote` (`git rev-list --count <rev> --not --remotes=<remote>`).
+    ///
+    /// Zero means a push of `rev` to `remote` is ref-only: every commit it
+    /// would publish is already reachable from that remote's refs as of the
+    /// last fetch. Runs at an explicit `cwd` via [`git_command_at`] so the
+    /// answer comes from that worktree's repo even when daft itself runs
+    /// inside a git hook. Subprocess-only by design — the gitoxide backend
+    /// has no `--not --remotes` walk (same precedent as `merge_base` and
+    /// `commit_tree` below).
+    pub fn count_commits_not_on_remote(&self, rev: &str, remote: &str, cwd: &Path) -> Result<u64> {
+        let output = git_command_at(cwd)
+            .args([
+                "rev-list",
+                "--count",
+                rev,
+                "--not",
+                &format!("--remotes={remote}"),
+            ])
+            .output()
+            .context("Failed to execute git rev-list command")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("Git rev-list failed: {}", stderr);
+        }
+
+        let stdout =
+            String::from_utf8(output.stdout).context("Failed to parse git rev-list output")?;
+
+        stdout
+            .trim()
+            .parse::<u64>()
+            .context("Failed to parse commit count as number")
+    }
+
     /// Check if `commit` is an ancestor of `target` using merge-base.
     pub fn merge_base_is_ancestor(&self, commit: &str, target: &str) -> Result<bool> {
         let output = Command::new("git")
@@ -289,5 +327,102 @@ impl GitCommand {
         }
 
         String::from_utf8(output.stdout).context("Failed to parse git cherry output")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::git::GitCommand;
+    use crate::utils::git_command_at;
+    use std::path::{Path, PathBuf};
+    use std::process::Stdio;
+
+    fn git_in(dir: &Path, args: &[&str]) {
+        let status = git_command_at(dir)
+            .args(args)
+            .env("GIT_AUTHOR_NAME", "Test")
+            .env("GIT_AUTHOR_EMAIL", "test@test.com")
+            .env("GIT_COMMITTER_NAME", "Test")
+            .env("GIT_COMMITTER_EMAIL", "test@test.com")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .expect("failed to spawn git");
+        assert!(status.success(), "git {args:?} failed in {}", dir.display());
+    }
+
+    /// Local bare remote + a one-commit clone on `main` with `origin` wired
+    /// up (mirrors the fixture private to `core::worktree::push::tests`).
+    fn repo_with_remote() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let remote = dir.path().join("remote.git");
+        let work = dir.path().join("work");
+        std::fs::create_dir_all(&remote).unwrap();
+        git_in(&remote, &["init", "--bare"]);
+        std::fs::create_dir_all(&work).unwrap();
+        git_in(&work, &["init", "-b", "main"]);
+        git_in(
+            &work,
+            &["remote", "add", "origin", remote.to_str().unwrap()],
+        );
+        std::fs::write(work.join("a.txt"), "a").unwrap();
+        git_in(&work, &["add", "."]);
+        git_in(&work, &["commit", "-m", "init"]);
+        (dir, work)
+    }
+
+    #[test]
+    fn counts_zero_for_a_new_branch_at_a_pushed_tip() {
+        let (_dir, work) = repo_with_remote();
+        git_in(&work, &["push", "-u", "origin", "main"]);
+        git_in(&work, &["branch", "feat"]);
+
+        let count = GitCommand::new(false)
+            .count_commits_not_on_remote("refs/heads/feat", "origin", &work)
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn counts_local_commits_missing_from_the_remote() {
+        let (_dir, work) = repo_with_remote();
+        git_in(&work, &["push", "-u", "origin", "main"]);
+        std::fs::write(work.join("b.txt"), "b").unwrap();
+        git_in(&work, &["add", "."]);
+        git_in(&work, &["commit", "-m", "local work"]);
+
+        let count = GitCommand::new(false)
+            .count_commits_not_on_remote("refs/heads/main", "origin", &work)
+            .unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn counts_all_commits_when_the_remote_has_no_tracking_refs() {
+        let (_dir, work) = repo_with_remote();
+
+        let count = GitCommand::new(false)
+            .count_commits_not_on_remote("refs/heads/main", "origin", &work)
+            .unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn scopes_the_count_to_the_target_remote() {
+        let (_dir, work) = repo_with_remote();
+        git_in(&work, &["push", "-u", "origin", "main"]);
+        let second = work.parent().unwrap().join("second.git");
+        std::fs::create_dir_all(&second).unwrap();
+        git_in(&second, &["init", "--bare"]);
+        git_in(
+            &work,
+            &["remote", "add", "second", second.to_str().unwrap()],
+        );
+
+        let count = GitCommand::new(false)
+            .count_commits_not_on_remote("refs/heads/main", "second", &work)
+            .unwrap();
+        assert_eq!(count, 1, "commits on origin are still new to `second`");
     }
 }

--- a/tests/manual/scenarios/push-hooks/checkout-branch-autopush-push-verify-knob.yml
+++ b/tests/manual/scenarios/push-hooks/checkout-branch-autopush-push-verify-knob.yml
@@ -1,0 +1,79 @@
+name: daft.checkout.pushVerify always/never override the ref-only skip
+description:
+  "pushVerify=always restores unconditional gating (a failing hook blocks even a
+  ref-only upstream push), and pushVerify=never suppresses the hook even when
+  the push carries new commits (#679)."
+
+repos:
+  - name: knob-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone the repository
+    run: git-worktree-clone --layout contained $REMOTE_KNOB_REPO
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/knob-repo/main"
+
+  - name: Enable the automatic upstream push
+    run: git config daft.checkout.push true
+    cwd: "$WORK_DIR/knob-repo/main"
+    expect: { exit_code: 0 }
+
+  - name: Install a failing pre-push hook via core.hooksPath
+    run: |
+      mkdir -p $WORK_DIR/test-hooks
+      printf '#!/bin/sh\necho "GATE SAYS NO" >&2\nexit 1\n' > $WORK_DIR/test-hooks/pre-push
+      chmod +x $WORK_DIR/test-hooks/pre-push
+      git config core.hooksPath $WORK_DIR/test-hooks
+    cwd: "$WORK_DIR/knob-repo/main"
+    expect: { exit_code: 0 }
+
+  - name: pushVerify=always gates even a ref-only push
+    run: |
+      git config daft.checkout.pushVerify always
+      git-worktree-checkout -b feat-always 2>&1
+    cwd: "$WORK_DIR/knob-repo/main"
+    expect:
+      exit_code: 1
+      output_contains:
+        - "pre-push hook"
+        - "ready at"
+      dirs_exist:
+        - "$WORK_DIR/knob-repo/feat-always"
+
+  - name: The always-gated branch never reached the remote
+    run: git ls-remote --heads origin feat-always
+    cwd: "$WORK_DIR/knob-repo/main"
+    expect:
+      exit_code: 0
+      output_not_contains: ["feat-always"]
+
+  - name: Commit locally on main so the next push carries new commits
+    run: |
+      git config user.email "me@example.com"
+      git config user.name "Me Testuser"
+      echo "local work" > local.txt
+      git add local.txt
+      git commit -m "Local work not on the remote"
+    cwd: "$WORK_DIR/knob-repo/main"
+    expect: { exit_code: 0 }
+
+  - name: pushVerify=never suppresses the hook even with new commits
+    run: |
+      git config daft.checkout.pushVerify never
+      git-worktree-checkout -b feat-never 2>&1
+    cwd: "$WORK_DIR/knob-repo/main"
+    expect:
+      exit_code: 0
+      output_not_contains: ["GATE SAYS NO"]
+      dirs_exist:
+        - "$WORK_DIR/knob-repo/feat-never"
+
+  - name: The never branch reached the remote
+    run: git ls-remote --heads origin feat-never
+    cwd: "$WORK_DIR/knob-repo/main"
+    expect:
+      exit_code: 0
+      output_contains: ["feat-never"]

--- a/tests/manual/scenarios/push-hooks/checkout-branch-autopush-ref-only-push-fails.yml
+++ b/tests/manual/scenarios/push-hooks/checkout-branch-autopush-ref-only-push-fails.yml
@@ -1,0 +1,66 @@
+name: a ref-only push the remote rejects still fails the command
+description:
+  "The ref-only skip (#679) suppresses the client pre-push hook, but it must not
+  mask a genuine push failure. With a client pre-push hook present (so the
+  skipped-hook verdict is Bypassed, not NoHook) and the remote rejecting every
+  push via a pre-receive hook, a ref-only `-b` push exits non-zero — the
+  worktree is still created, the branch never reaches the remote, and the
+  message does not suggest --no-verify (bypassing a client hook cannot fix a
+  server-side refusal)."
+
+repos:
+  - name: reject-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone the repository
+    run: git-worktree-clone --layout contained $REMOTE_REJECT_REPO
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/reject-repo/main"
+
+  - name: Enable the automatic upstream push
+    run: git config daft.checkout.push true
+    cwd: "$WORK_DIR/reject-repo/main"
+    expect: { exit_code: 0 }
+
+  - name:
+      Install a passing client pre-push hook (present, so auto skips it rather
+      than there being none)
+    run: |
+      mkdir -p $WORK_DIR/test-hooks
+      printf '#!/bin/sh\nexit 0\n' > $WORK_DIR/test-hooks/pre-push
+      chmod +x $WORK_DIR/test-hooks/pre-push
+      git config core.hooksPath $WORK_DIR/test-hooks
+    cwd: "$WORK_DIR/reject-repo/main"
+    expect: { exit_code: 0 }
+
+  - name: Make the remote reject every push via a pre-receive hook
+    run: |
+      printf '#!/bin/sh\necho "REMOTE SAYS NO" >&2\nexit 1\n' > $REMOTE_REJECT_REPO/hooks/pre-receive
+      chmod +x $REMOTE_REJECT_REPO/hooks/pre-receive
+    cwd: "$WORK_DIR/reject-repo/main"
+    expect: { exit_code: 0 }
+
+  - name:
+      The ref-only push is skipped client-side but rejected by the remote, so
+      the command fails
+    run: git-worktree-checkout -b feat-rejected 2>&1
+    cwd: "$WORK_DIR/reject-repo/main"
+    expect:
+      exit_code: 1
+      output_contains:
+        - "Could not push"
+        - "ready at"
+      output_not_contains:
+        - "--no-verify"
+      dirs_exist:
+        - "$WORK_DIR/reject-repo/feat-rejected"
+
+  - name: The branch never reached the remote
+    run: git ls-remote --heads origin feat-rejected
+    cwd: "$WORK_DIR/reject-repo/main"
+    expect:
+      exit_code: 0
+      output_not_contains: ["feat-rejected"]

--- a/tests/manual/scenarios/push-hooks/checkout-branch-autopush-ref-only-skips.yml
+++ b/tests/manual/scenarios/push-hooks/checkout-branch-autopush-ref-only-skips.yml
@@ -1,0 +1,65 @@
+name: checkout -b ref-only auto-upstream push skips the pre-push hook
+description:
+  "Branching off a fully-pushed base makes the automatic upstream push ref-only
+  (zero new commits), so under the default pushVerify=auto the repo's pre-push
+  hook has nothing to gate and is skipped: a hook that would fail loudly does
+  not block the push, the branch reaches the remote with upstream tracking set,
+  and the command exits zero (#679)."
+
+repos:
+  - name: refonly-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone the repository
+    run: git-worktree-clone --layout contained $REMOTE_REFONLY_REPO
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/refonly-repo/main"
+
+  - name: Enable the automatic upstream push
+    run: git config daft.checkout.push true
+    cwd: "$WORK_DIR/refonly-repo/main"
+    expect: { exit_code: 0 }
+
+  - name: Install a failing pre-push hook via core.hooksPath
+    run: |
+      mkdir -p $WORK_DIR/test-hooks
+      printf '#!/bin/sh\necho "GATE SAYS NO" >&2\nexit 1\n' > $WORK_DIR/test-hooks/pre-push
+      chmod +x $WORK_DIR/test-hooks/pre-push
+      git config core.hooksPath $WORK_DIR/test-hooks
+    cwd: "$WORK_DIR/refonly-repo/main"
+    expect: { exit_code: 0 }
+
+  - name: Creating a branch off the pushed base succeeds despite the hook
+    run: git-worktree-checkout -b feat-ref-only 2>&1
+    cwd: "$WORK_DIR/refonly-repo/main"
+    expect:
+      exit_code: 0
+      output_not_contains: ["GATE SAYS NO"]
+      dirs_exist:
+        - "$WORK_DIR/refonly-repo/feat-ref-only"
+
+  - name: The branch reached the remote
+    run: git ls-remote --heads origin feat-ref-only
+    cwd: "$WORK_DIR/refonly-repo/main"
+    expect:
+      exit_code: 0
+      output_contains: ["feat-ref-only"]
+
+  - name: Upstream tracking is configured
+    run: git rev-parse --abbrev-ref 'feat-ref-only@{upstream}'
+    cwd: "$WORK_DIR/refonly-repo/main"
+    expect:
+      exit_code: 0
+      output_contains: ["origin/feat-ref-only"]
+
+  - name: The skip is reported in verbose mode
+    run: git-worktree-checkout -b feat-ref-only-verbose --verbose 2>&1
+    cwd: "$WORK_DIR/refonly-repo/main"
+    expect:
+      exit_code: 0
+      output_contains: ["Skipping pre-push hook (no new commits to push)"]
+      dirs_exist:
+        - "$WORK_DIR/refonly-repo/feat-ref-only-verbose"

--- a/tests/manual/scenarios/push-hooks/checkout-branch-autopush-rejected.yml
+++ b/tests/manual/scenarios/push-hooks/checkout-branch-autopush-rejected.yml
@@ -1,9 +1,11 @@
 name: checkout -b auto-upstream push is gated by the pre-push hook
 description:
-  "With daft.checkout.push enabled, a failing pre-push hook gates the automatic
-  upstream push: the worktree is still created and fully set up, the command
-  exits non-zero with a created-but-rejected message, and the branch never
-  reaches the remote."
+  "With daft.checkout.push enabled and a base that is locally ahead (so the
+  upstream push carries new commits — a ref-only push would skip the hook under
+  the default pushVerify=auto, see checkout-branch-autopush-ref-only-skips), a
+  failing pre-push hook gates the automatic upstream push: the worktree is still
+  created and fully set up, the command exits non-zero with a
+  created-but-rejected message, and the branch never reaches the remote."
 
 repos:
   - name: autopush-repo
@@ -19,6 +21,16 @@ steps:
 
   - name: Enable the automatic upstream push
     run: git config daft.checkout.push true
+    cwd: "$WORK_DIR/autopush-repo/main"
+    expect: { exit_code: 0 }
+
+  - name: Commit locally on main so the upstream push carries new commits
+    run: |
+      git config user.email "me@example.com"
+      git config user.name "Me Testuser"
+      echo "local work" > local.txt
+      git add local.txt
+      git commit -m "Local work not on the remote"
     cwd: "$WORK_DIR/autopush-repo/main"
     expect: { exit_code: 0 }
 


### PR DESCRIPTION
## What & why

`#599` made every daft-initiated push honor the repo's `pre-push` hook. On `daft start`'s automatic `git push --set-upstream` that misfires two ways:

1. **Redundant in the common case.** The new branch usually starts at the remote tip, so the push uploads zero new commits — only a ref — yet git still dispatches `pre-push`, running a full validation pass to publish nothing.
2. **Fires before the worktree is set up.** The push (and its hook) runs before `worktree-post-create` hooks, so env-dependent gates fail on missing deps, not bad content — and the branch never gets its upstream.

## The fix

Run the hook only when the push introduces commits the target remote doesn't already have — `git rev-list --count refs/heads/<branch> --not --remotes=<remote>` == 0 ⇒ ref-only ⇒ skip (the same signal pre-commit's pre-push driver uses). A new setting **`daft.checkout.pushVerify`** governs it:

| Value | Behavior |
|-------|----------|
| `auto` (default) | Skip the hook on ref-only pushes; run it when the push carries new commits |
| `always` | Always run the hook, even for ref-only pushes |
| `never` | Never run the hook on the automatic upstream push |

`--no-verify` still bypasses per-invocation. `push_with_hooks` and #599's gating semantics are untouched everywhere else; the skip arrives as `verify=false`.

## Review fixes included

This branch also carries a max-effort review pass:

- A ref-only push that is skipped client-side but then **genuinely fails** (server-side rejection, transport, auth) now exits non-zero instead of warn-and-continue — a skipped gate can't refuse a push, but the branch still never reached the remote.
- The "Creating worktree..." spinner is always shown and paused only across an actual pre-push render (mirroring the post-create-hook contract), so the ref-only case no longer goes silent.
- `never` announces the skip only when a hook exists; the `resolve_pre_push` docstring is honest about the stale-tracking-ref limitation (with `always` as the escape hatch); `daft go -b` / `git worktree-checkout -b` help text now documents the skip + knob.

## Test plan

- Unit: `resolve_pre_push` decision matrix, `count_commits_not_on_remote`, spinner pause/resume bracketing (real pushes), `PushVerify::parse`.
- YAML scenarios (`tests/manual/scenarios/push-hooks/`): ref-only skip, `always`/`never` overrides, the gated-rejection path, and a remote-rejects-a-ref-only-push case.
- `mise run fmt` / `clippy` (0 warnings) / `test:unit` / `test:manual push-hooks` (9 scenarios, 63 steps) — all green.

Fixes #679

🤖 Generated with [Claude Code](https://claude.com/claude-code)
