### PR TITLE
fix(deps): bump crossbeam-epoch to 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/.dep-age-allowlist
+++ b/.dep-age-allowlist
@@ -28,3 +28,11 @@ cargo:anyhow@1.0.103
 # Safe to remove after 2026-07-11.
 cargo:quick-xml@0.41.0
 cargo:plist@1.10.0
+
+# why: RUSTSEC-2026-0204 (invalid pointer dereference in crossbeam-epoch's
+# fmt::Pointer/Display impl for Atomic/Shared — NULL-pointer-deref DoS class)
+# turns the cargo-deny advisories gate red; crossbeam-epoch 0.9.20 (2026-07-06)
+# is the designated fix (patched >=0.9.20) and is 4 days old at time of bump —
+# the same security exception Dependabot PRs get automatically.
+# Safe to remove after 2026-07-13.
+cargo:crossbeam-epoch@0.9.20

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,9 +629,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## What

Bumps `crossbeam-epoch` `0.9.18 → 0.9.20` (Cargo.lock only) to clear **RUSTSEC-2026-0204**, plus a `.dep-age-allowlist` entry for the 4-day-old fix version.

## Why

`crossbeam-epoch <0.9.20` has an invalid pointer dereference in its `fmt::Pointer`/`Display` impl for `Atomic`/`Shared` (NULL-pointer-deref class, RUSTSEC-2026-0204, published 2026-07-06). This turns the `cargo-deny` advisories gate (`dep-license-check`) **red on every cargo PR**. It is ambient on `master` — daft pulls `crossbeam-epoch` transitively through three paths:

- `termimad → crossbeam`
- `ignore` (direct dep)
- `tera → globwalk → ignore`

so it blocks all open Dependabot cargo bumps (#650, #676, #681, #684) regardless of what they change.

Actual exposure is ~nil (daft never `Display`s a crossbeam `Atomic`/`Shared`; it lives under `ignore`'s parallel directory walk), so this is a supply-chain / gate-hygiene fix rather than an exploitable bug — but the gate must be green to unblock the dependency queue.

## Fix

`0.9.20` is the designated patched release (`patched = >= 0.9.20`). It is a semver-compatible patch bump of a leaf transitive crate, so `Cargo.lock` changes only its version + checksum (no other resolution churn). Because `0.9.20` (2026-07-06) is 4 days old, a `.dep-age-allowlist` entry is added carrying the same security exception Dependabot security PRs get automatically (safe to remove after 2026-07-13).

## Validation

- `cargo deny check advisories` → `advisories ok` (exit 0)
- `scripts/check-lockfile-age.sh` (`BASE_REF=origin/master`) → passes, explicitly allows `crossbeam-epoch@0.9.20`
- pre-push `build-check` (`cargo build`) → green

The `cargo-deny` advisories gate itself (`dep-license-check`) is the regression guard.

Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0204

🤖 Generated with [Claude Code](https://claude.com/claude-code)
