### PR TITLE
test: real-state tripwire + fix repo-catalog/state test-isolation leaks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,20 @@ a substitute. Production two-stage probes that expect
 `fatal: not a git repository` as a negative signal must suppress the stderr at
 the call site.
 
+**Never let a test write daft's real config/state/data dirs.** A tripwire —
+`xtask real-state-guard`, wired into `test:{unit,integration,manual}` and `ci`
+through `mise-tasks/test/_state_guard_lib.sh` — fingerprints the real
+`~/Library/Application Support/daft` (catalog DB + `repos.json`) and
+`~/.local/state/daft` (`jobs/` entry set) before each suite and fails the run if
+they change, locally and in CI. Tests that exercise hook / visitor-seed code
+paths open the coordinator store via `paths::for_repo`, which resolves
+`daft_state_dir()`; wrap them in `#[serial]` +
+`store::paths::IsolatedStateDir::new()` so they write a tempdir, not the
+developer's real state. Suites that exec a built binary also run a read-only
+`daft __dirs` preflight that fails fast if the binary ignores `DAFT_*_DIR` (a
+release/tagged build, or a system `daft` on `PATH`). See #697; prior art
+#478/#669.
+
 ## XDG Conventions
 
 This project follows the XDG Base Directory Specification. Use the `dirs` crate

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5687,6 +5687,7 @@ dependencies = [
  "crossterm",
  "ctrlc",
  "daft",
+ "dirs 6.0.0",
  "indicatif",
  "nix",
  "rayon",

--- a/mise-tasks/test/_state_guard_lib.sh
+++ b/mise-tasks/test/_state_guard_lib.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Sourceable helper: the real-state test-isolation tripwire (#697).
+#
+# Guards against the leak class where a test run writes daft's *real*
+# config/state/data dirs instead of its sandbox — the failure that put 822
+# throwaway /tmp repos into the developer's real catalog.db. Two layers:
+#
+#   * assert_binary_honors_overrides <daft-bin> — a READ-ONLY preflight. Runs
+#     `<daft-bin> __dirs` under a throwaway DAFT_*_DIR sandbox and fails if the
+#     binary resolves the real dirs instead. Catches a non-dev-build binary (a
+#     release/tagged build with the DAFT_*_DIR overrides compiled out) or a
+#     system `daft` shadowing the local one on PATH — *before* the suite can
+#     leak. Only meaningful for suites that exec a built binary (integration,
+#     manual); unit tests honor the overrides by construction under cfg(test).
+#
+#   * with_state_guard <cmd...> — snapshots the real dirs, runs the command,
+#     then re-verifies them via `xtask real-state-guard`. A change is fatal
+#     (exit 1) regardless of the command's own exit code; an unchanged run
+#     passes the command's exit code through so genuine test failures still
+#     surface.
+#
+# Escape hatch: DAFT_SKIP_STATE_GUARD=1 disables both layers.
+#
+# File is intentionally non-executable so mise hides it from `mise tasks ls`.
+
+# Invoke the xtask guard. Centralized so the snapshot and verify calls stay in
+# lockstep (same package, same quieting).
+_state_guard_xtask() {
+  cargo run -q --package xtask -- real-state-guard "$@"
+}
+
+# Read-only preflight: assert the daft binary at $1 honors DAFT_*_DIR.
+assert_binary_honors_overrides() {
+  [ "${DAFT_SKIP_STATE_GUARD:-}" = "1" ] && return 0
+  local bin="$1"
+  if [[ ! -x "$bin" ]]; then
+    echo "state-guard preflight: daft binary not found or not executable: $bin" >&2
+    return 1
+  fi
+
+  local probe out key got ok=1
+  probe="$(mktemp -d)"
+  # `__dirs` is a read-only internal command: it only prints the config/data/
+  # state dirs this binary resolves. If the binary honors the overrides, every
+  # path lands under $probe.
+  if ! out="$(DAFT_CONFIG_DIR="$probe/cfg" DAFT_DATA_DIR="$probe/data" \
+              DAFT_STATE_DIR="$probe/state" "$bin" __dirs 2>/dev/null)"; then
+    echo "state-guard preflight: '$bin __dirs' failed (binary too old to have __dirs, or broken)" >&2
+    rm -rf "$probe"
+    return 1
+  fi
+
+  local kupper
+  for key in config data state; do
+    got="$(printf '%s\n' "$out" | awk -F '\t' -v k="$key" '$1 == k { print $2 }')"
+    case "$got" in
+      "$probe"/*) ;;
+      *)
+        # Uppercase via tr (not ${key^^}) so the helper stays portable across
+        # bash and zsh rather than depending on bash-4 parameter expansion.
+        kupper="$(printf '%s' "$key" | tr '[:lower:]' '[:upper:]')"
+        echo "state-guard preflight: binary ignores DAFT_${kupper}_DIR (resolved: ${got:-<none>})" >&2
+        ok=0
+        ;;
+    esac
+  done
+  rm -rf "$probe"
+
+  if [[ "$ok" != "1" ]]; then
+    {
+      echo ""
+      echo "The binary under test does not honor DAFT_*_DIR:"
+      echo "  $bin"
+      echo "It is not a daft_dev_build (a release/tagged build, or a system daft on"
+      echo "PATH). Running the suite would leak test data into your real"
+      echo "config/state/data dirs. Rebuild the dev binary. See #697."
+    } >&2
+    return 1
+  fi
+}
+
+# Snapshot the real dirs, run "$@", then verify they are unchanged. A change is
+# fatal; otherwise the command's own exit code is returned.
+with_state_guard() {
+  if [ "${DAFT_SKIP_STATE_GUARD:-}" = "1" ]; then
+    "$@"
+    return $?
+  fi
+
+  local fp rc=0
+  fp="$(mktemp)"
+  if ! _state_guard_xtask snapshot "$fp"; then
+    echo "state-guard: failed to snapshot real dirs before the run" >&2
+    rm -f "$fp"
+    return 1
+  fi
+
+  "$@" || rc=$?
+
+  if ! _state_guard_xtask verify "$fp"; then
+    rm -f "$fp"
+    # The tripwire fired: the run wrote the real dirs. This is fatal even if
+    # the suite itself passed — the point is that it must never happen.
+    exit 1
+  fi
+  rm -f "$fp"
+  return "$rc"
+}

--- a/mise-tasks/test/integration/_default
+++ b/mise-tasks/test/integration/_default
@@ -6,4 +6,9 @@ set -euo pipefail
 source "$(dirname "$0")/_release_bin_lib.sh"
 ensure_release_binaries
 
-cargo run --package xtask -- test-matrix
+# Real-state tripwire (#697): the bash matrix was the source of 802 of the 822
+# leaked catalog rows. Fail fast if the release binary ignores DAFT_*_DIR, then
+# verify the matrix left the real config/state/data dirs untouched.
+source "$(dirname "$0")/../_state_guard_lib.sh"
+assert_binary_honors_overrides "target/release/daft"
+with_state_guard cargo run --package xtask -- test-matrix

--- a/mise-tasks/test/manual/_default
+++ b/mise-tasks/test/manual/_default
@@ -16,4 +16,9 @@ source "$(dirname "$0")/_shared_bin_lib.sh"
 shared_bin=$(shared_bin_ensure)
 export DAFT_BINARY_DIR="$shared_bin"
 
-exec cargo run --package xtask -- manual-test "$@"
+# Real-state tripwire (#697): fail fast if the shared binary ignores DAFT_*_DIR,
+# then verify the run left the real config/state/data dirs untouched. (Drops the
+# earlier `exec` so the verify step can run after the suite completes.)
+source "$(dirname "$0")/../_state_guard_lib.sh"
+assert_binary_honors_overrides "$shared_bin/daft"
+with_state_guard cargo run --package xtask -- manual-test "$@"

--- a/mise-tasks/test/unit
+++ b/mise-tasks/test/unit
@@ -2,6 +2,8 @@
 #MISE description="Run Rust unit tests"
 set -euo pipefail
 
+source "$(dirname "$0")/_state_guard_lib.sh"
+
 echo "Running Rust unit tests..."
 # Cap test parallelism. At the harness's default (= num_cpus), the suite's
 # fd pressure from gitoxide + sqlite + spawn-heavy tests can push individual
@@ -9,4 +11,9 @@ echo "Running Rust unit tests..."
 # git::oxide, store::{migrate,pool}, and hooks::yaml_executor cases — and
 # flaking the pre-push hook. --test-threads=4 keeps wall-clock close to the
 # uncapped run (~+2s on ~1800 tests) and eliminates the flake.
-cargo test --lib --tests --locked -- --test-threads=4
+#
+# Wrapped in the real-state tripwire (#697): even unit tests must never write
+# the developer's real config/state/data dirs (see #478 for the state-dir leak
+# this class covers). No binary preflight here — unit tests honor DAFT_*_DIR by
+# construction under cfg(test).
+with_state_guard cargo test --lib --tests --locked -- --test-threads=4

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -213,7 +213,9 @@ fn guide_existing_config(root: &Path, existing: &Path, output: &mut dyn Output) 
 mod tests {
     use super::*;
     use crate::output::TestOutput;
+    use crate::store::paths::IsolatedStateDir;
     use crate::utils::git_command_at;
+    use serial_test::serial;
     use std::fs;
     use tempfile::tempdir;
 
@@ -381,7 +383,13 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_install_in_position_container_root_installs_across_worktrees() {
+        // Isolate the state dir: a container-root install propagates visitor
+        // seeds, which open the coordinator store via `paths::for_repo` and
+        // would otherwise write the developer's real `~/.local/state/daft`
+        // (#697 — the same isolation-leak class as #478/#669).
+        let _state = IsolatedStateDir::new();
         let base = tempdir().unwrap();
         let proj = build_contained(base.path(), false, &["main", "feature"]);
 

--- a/src/core/worktree/branch_delete.rs
+++ b/src/core/worktree/branch_delete.rs
@@ -1823,6 +1823,7 @@ mod tests {
 
     // ── keep_local_branch integration tests ────────────────────────────────
 
+    use crate::store::paths::IsolatedStateDir;
     use serial_test::serial;
     use std::process::Command as ShellCommand;
     use std::process::Stdio;
@@ -1910,6 +1911,7 @@ mod tests {
         use crate::output::TestOutput;
 
         let _cwd = CwdGuard::new();
+        let _state = IsolatedStateDir::new();
         let tmp = tempfile::tempdir().unwrap();
         init_repo(tmp.path());
         let feat_wt = tmp.path().join("feat");
@@ -1963,6 +1965,7 @@ mod tests {
         use crate::output::TestOutput;
 
         let _cwd = CwdGuard::new();
+        let _state = IsolatedStateDir::new();
         let tmp = tempfile::tempdir().unwrap();
         init_repo(tmp.path());
         let feat_wt = tmp.path().join("feat");
@@ -2019,6 +2022,7 @@ mod tests {
         use crate::core::stage::{Row, StageEvent, StageId};
 
         let _cwd = CwdGuard::new();
+        let _state = IsolatedStateDir::new();
         let tmp = tempfile::tempdir().unwrap();
         init_repo(tmp.path());
         let feat_wt = tmp.path().join("feat");
@@ -2207,6 +2211,7 @@ mod tests {
         }
 
         let _cwd = CwdGuard::new();
+        let _state = IsolatedStateDir::new();
         let tmp = tempfile::tempdir().unwrap();
         init_repo(tmp.path());
         let feat_wt = tmp.path().join("feat");
@@ -2271,6 +2276,7 @@ mod tests {
         use crate::output::TestOutput;
 
         let _cwd = CwdGuard::new();
+        let _state = IsolatedStateDir::new();
         let tmp = tempfile::tempdir().unwrap();
         init_repo(tmp.path());
         let feat_wt = tmp.path().join("feat");
@@ -2408,6 +2414,7 @@ mod tests {
     #[serial]
     fn divergence_guard_refuses_delete_when_local_yml_differs() {
         let _cwd = CwdGuard::new();
+        let _state = IsolatedStateDir::new();
         let tmp = tempfile::tempdir().unwrap();
         init_repo(tmp.path());
         let feat_wt = tmp.path().join("feat");
@@ -2503,6 +2510,7 @@ mod tests {
     #[serial]
     fn divergence_guard_bypassed_with_force() {
         let _cwd = CwdGuard::new();
+        let _state = IsolatedStateDir::new();
         let tmp = tempfile::tempdir().unwrap();
         init_repo(tmp.path());
         let feat_wt = tmp.path().join("feat");
@@ -2606,6 +2614,7 @@ mod tests {
     #[serial]
     fn consolidation_choice_writes_target_then_removes() {
         let _cwd = CwdGuard::new();
+        let _state = IsolatedStateDir::new();
         let tmp = tempfile::tempdir().unwrap();
         init_repo(tmp.path());
         let feat_wt = tmp.path().join("feat");

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,6 +135,30 @@ fn main() -> Result<()> {
                         }
                         return Ok(());
                     }
+                    "__dirs" => {
+                        // Internal, read-only: print the config/data/state dirs
+                        // as THIS binary resolves them — honoring DAFT_*_DIR
+                        // only in dev builds, exactly like every real command.
+                        // The test harnesses' real-state tripwire preflight
+                        // parses this to fail fast when the binary under test
+                        // ignores the overrides (a non-dev-build, or a system
+                        // `daft` shadowing the local one on PATH), before it can
+                        // leak into the real config/state/data dirs. See #697.
+                        for (key, dir) in [
+                            ("config", daft::daft_config_dir()),
+                            ("data", daft::daft_data_dir()),
+                            ("state", daft::daft_state_dir()),
+                        ] {
+                            match dir {
+                                Ok(p) => println!("{key}\t{}", p.display()),
+                                Err(e) => {
+                                    eprintln!("daft __dirs: {key}: {e:#}");
+                                    std::process::exit(1);
+                                }
+                            }
+                        }
+                        return Ok(());
+                    }
                     #[cfg(unix)]
                     "__capture-aliases" => {
                         // Internal: session-detach trampoline for the

--- a/src/store/paths.rs
+++ b/src/store/paths.rs
@@ -180,6 +180,46 @@ pub fn tighten_perms(_path: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Test-only RAII guard that redirects the daft *state* dir to a fresh temp
+/// dir for the duration of a test, restoring the previous `DAFT_STATE_DIR` on
+/// drop. Tests that exercise hook / visitor-seed code paths open the
+/// coordinator store via [`for_repo`], which resolves `daft_state_dir()`;
+/// without this guard they write the developer's real `~/.local/state/daft/`
+/// (#697 — the same isolation-leak class as #478/#669).
+///
+/// Callers MUST be `#[serial]`: the `DAFT_STATE_DIR` mutation is process-global,
+/// so it is only safe when no other test runs concurrently.
+#[cfg(test)]
+pub(crate) struct IsolatedStateDir {
+    _tmp: tempfile::TempDir,
+    prev: Option<std::ffi::OsString>,
+}
+
+#[cfg(test)]
+impl IsolatedStateDir {
+    pub(crate) fn new() -> Self {
+        let tmp = tempfile::tempdir().expect("create temp state dir");
+        let prev = std::env::var_os(crate::STATE_DIR_ENV);
+        // SAFETY: `set_var` is `unsafe fn` in edition 2024 (process-global, not
+        // thread-safe). Callers are `#[serial]`, serializing the mutation.
+        unsafe { std::env::set_var(crate::STATE_DIR_ENV, tmp.path()) };
+        Self { _tmp: tmp, prev }
+    }
+}
+
+#[cfg(test)]
+impl Drop for IsolatedStateDir {
+    fn drop(&mut self) {
+        // SAFETY: as in `new` — serialized by `#[serial]`.
+        unsafe {
+            match &self.prev {
+                Some(v) => std::env::set_var(crate::STATE_DIR_ENV, v),
+                None => std::env::remove_var(crate::STATE_DIR_ENV),
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -236,6 +276,50 @@ mod tests {
 
         let err = catalog_db_under(base.path()).unwrap_err();
         assert!(matches!(err, StoreError::PathOutsideStateDir(_)));
+    }
+
+    /// #697 regression: both the read-write catalog path and the read-only
+    /// completion probe must resolve under the sandboxed `DAFT_DATA_DIR`, never
+    /// the real data dir. This locks the `catalog_db()` / `catalog_db_probe()`
+    /// → `daft_data_dir()` composition to the override so a future refactor
+    /// can't silently retarget the developer's real `catalog.db` (the leak this
+    /// ticket cleaned up). `#[serial]` serializes it against the other
+    /// `DAFT_*_DIR` override tests, which mutate the same process-global env.
+    #[test]
+    #[serial_test::serial]
+    fn catalog_paths_resolve_under_data_dir_override() {
+        let sandbox = tempfile::tempdir().unwrap();
+        // SAFETY: `set_var`/`remove_var` are `unsafe fn` in edition 2024
+        // (process-global, not thread-safe). `#[serial]` serializes this test
+        // against every other env-mutating test; CLAUDE.md permits unsafe in
+        // tests. Restore the env *before* asserting so a panic can't leak it.
+        unsafe {
+            std::env::set_var(crate::DATA_DIR_ENV, sandbox.path());
+        }
+        let db = catalog_db();
+        let probe = catalog_db_probe();
+        unsafe {
+            std::env::remove_var(crate::DATA_DIR_ENV);
+        }
+
+        // Read-write path: canonicalized, so compare against the canonical
+        // sandbox (macOS resolves `/var` → `/private/var`).
+        let db = db.expect("catalog_db() under DAFT_DATA_DIR override");
+        let canonical_sandbox = sandbox.path().canonicalize().unwrap();
+        assert!(
+            db.starts_with(&canonical_sandbox),
+            "catalog_db() {db:?} escaped the DAFT_DATA_DIR sandbox {canonical_sandbox:?}"
+        );
+        assert!(db.ends_with(format!("{CATALOG_SUBDIR}/{CATALOG_DB}")));
+
+        // Read-only probe: non-creating and non-canonicalizing, so it starts
+        // with the raw override path.
+        let probe = probe.expect("catalog_db_probe() under DAFT_DATA_DIR override");
+        assert!(
+            probe.starts_with(sandbox.path()),
+            "catalog_db_probe() {probe:?} escaped the DAFT_DATA_DIR sandbox {:?}",
+            sandbox.path()
+        );
     }
 
     #[test]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -15,6 +15,9 @@ clap_mangen = "0.3"
 crossterm = "0.29"
 ctrlc = "3.5.2"
 daft = { path = "..", version = "1.19.0" }
+# Real-dir resolution for the `real-state-guard` tripwire. Pinned to the same
+# version daft itself uses so it reuses the already-locked entry (no cooldown).
+dirs = "6.0"
 indicatif = "0.18.4"
 rayon = "1.10"
 # Reflink + recursive walk for the sandbox's template snapshot / reset.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -5,6 +5,7 @@
 
 mod bench;
 mod manual_test;
+mod real_state_guard;
 
 use anyhow::{bail, Context, Result};
 use clap::{Parser, Subcommand};
@@ -429,6 +430,19 @@ enum Commands {
         #[arg(long, short = 'j', value_name = "N")]
         jobs: Option<usize>,
     },
+
+    /// Snapshot / verify the real daft state dirs — the test-isolation
+    /// tripwire (#697). Fails if a suite run wrote the real config/state/data
+    /// dirs (i.e. DAFT_*_DIR isolation was silently off, e.g. a non-dev-build
+    /// binary under test).
+    RealStateGuard {
+        /// `snapshot` to record the fingerprint, `verify` to check it.
+        #[arg(value_enum)]
+        mode: real_state_guard::Mode,
+
+        /// Fingerprint file to write (snapshot) or read (verify).
+        file: PathBuf,
+    },
 }
 
 fn main() -> Result<()> {
@@ -477,6 +491,7 @@ fn main() -> Result<()> {
                 jobs_explicit,
             )
         }
+        Commands::RealStateGuard { mode, file } => real_state_guard::run(mode, &file),
     }
 }
 

--- a/xtask/src/real_state_guard.rs
+++ b/xtask/src/real_state_guard.rs
@@ -1,0 +1,366 @@
+//! `xtask real-state-guard` — the test-isolation tripwire (#697).
+//!
+//! Snapshots the *real* daft state a test run must never touch, then verifies
+//! it is unchanged after the suite. It exists because the daft test harnesses
+//! sandbox state via `DAFT_{CONFIG,DATA,STATE}_DIR`, but that isolation
+//! silently evaporates if the binary under test is not a `daft_dev_build` (a
+//! release/tagged build, or a system `daft` on `PATH`): the overrides compile
+//! out and every catalog / registry / job write lands in the developer's real
+//! dirs. #696's catalog leak (822 `/tmp` repos in the real `catalog.db`) is the
+//! incident this guards against; #666 (`repos.json`) and #478/#669 (state
+//! `jobs/`) are the same class on the other two surfaces.
+//!
+//! The guard resolves the real dirs itself via `dirs` — it never reads
+//! `DAFT_*_DIR`, so it always targets the real surface regardless of the
+//! ambient env — and never *creates* anything it inspects. A drift test pins
+//! its resolution to daft's own `daft_{config,data,state}_dir()` (overrides
+//! unset) so the two cannot diverge.
+//!
+//! Coverage is *targeted*, not a whole-XDG-dir walk: on macOS the config and
+//! data dirs are the same `~/Library/Application Support/daft` that also hosts
+//! centralized-layout worktrees, so a wholesale walk would be slow and trip on
+//! unrelated edits. Instead:
+//!   * `<data>/daft/catalog/`     — content-hash every file (the DB triplet).
+//!   * `<config>/daft/repos.json` — content-hash the repo/trust registry.
+//!   * `<state>/daft/` + `jobs/`  — a compact entry-set digest (count + a hash
+//!     of the sorted child names). These dirs are litter-prone — the real
+//!     `jobs/` can hold tens of thousands of orphaned dirs (#669) — so we store
+//!     a digest, not every name, and never hash child *contents* (job
+//!     DBs/sockets churn at runtime; a leaked repo always lands under a
+//!     brand-new UUID name, which the digest catches).
+
+use anyhow::{bail, Context, Result};
+use clap::ValueEnum;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum Mode {
+    /// Record the current real-state fingerprint into <FILE>.
+    Snapshot,
+    /// Recompute the fingerprint and fail if it differs from <FILE>.
+    Verify,
+}
+
+/// Run the guard in `mode`, reading/writing the fingerprint at `file`.
+pub fn run(mode: Mode, file: &Path) -> Result<()> {
+    let now = capture().context("capturing real daft-state fingerprint")?;
+    match mode {
+        Mode::Snapshot => {
+            let yaml = serde_yaml::to_string(&now).context("serializing fingerprint")?;
+            std::fs::write(file, yaml)
+                .with_context(|| format!("writing fingerprint to {}", file.display()))?;
+            Ok(())
+        }
+        Mode::Verify => {
+            let prev_yaml = std::fs::read_to_string(file)
+                .with_context(|| format!("reading fingerprint from {}", file.display()))?;
+            let prev: Snapshot = serde_yaml::from_str(&prev_yaml)
+                .with_context(|| format!("parsing fingerprint from {}", file.display()))?;
+            let diffs = prev.diff(&now);
+            if diffs.is_empty() {
+                return Ok(());
+            }
+            bail!("{}", tripwire_message(&diffs));
+        }
+    }
+}
+
+/// Fingerprint of the daft-owned artifacts on the three real XDG surfaces.
+/// Absent files/dirs are represented as empty/`None`/`!exists` so a run that
+/// *creates* one (the leak we guard against) shows up as a diff.
+#[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+struct Snapshot {
+    /// `filename -> content hash` for every file directly in
+    /// `<data>/daft/catalog/`. Empty when the catalog dir does not exist.
+    catalog: BTreeMap<String, String>,
+    /// Content hash of `<config>/daft/repos.json`, or `None` when absent.
+    repos_json: Option<String>,
+    /// Entry-set digest of `<state>/daft/`.
+    state_top: DirDigest,
+    /// Entry-set digest of `<state>/daft/jobs/`.
+    state_jobs: DirDigest,
+}
+
+/// Compact digest of a directory's immediate entry set: whether it exists, how
+/// many children it has, and a hash of their sorted names. Storing a digest
+/// rather than every name keeps the fingerprint tiny even when `jobs/` holds
+/// tens of thousands of entries.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct DirDigest {
+    /// `false` when the directory does not exist — a valid state that becomes
+    /// a diff the moment a run creates it.
+    exists: bool,
+    count: usize,
+    /// FNV of the sorted, newline-joined child names (`""` when absent).
+    names_hash: String,
+}
+
+impl Snapshot {
+    /// Human-readable list of the surfaces that changed between `self`
+    /// (recorded) and `now` (recomputed). Empty ⇒ nothing leaked.
+    fn diff(&self, now: &Snapshot) -> Vec<String> {
+        let mut out = Vec::new();
+        if self.catalog != now.catalog {
+            out.push("data:   the repo catalog under <data>/daft/catalog/ changed".to_string());
+        }
+        if self.repos_json != now.repos_json {
+            out.push("config: <config>/daft/repos.json changed".to_string());
+        }
+        if self.state_top != now.state_top {
+            out.push(format!(
+                "state:  entries under <state>/daft/ changed ({} → {})",
+                self.state_top.count, now.state_top.count
+            ));
+        }
+        if self.state_jobs != now.state_jobs {
+            out.push(format!(
+                "state:  entries under <state>/daft/jobs/ changed ({} → {})",
+                self.state_jobs.count, now.state_jobs.count
+            ));
+        }
+        out
+    }
+}
+
+/// Capture the current fingerprint of the real surfaces.
+fn capture() -> Result<Snapshot> {
+    Ok(Snapshot {
+        catalog: hash_dir_files(&real_data_dir()?.join("catalog"))?,
+        repos_json: hash_file_opt(&real_config_dir()?.join("repos.json"))?,
+        state_top: dir_digest(&real_state_dir())?,
+        state_jobs: dir_digest(&real_state_dir().join("jobs"))?,
+    })
+}
+
+/// Build the failure message, appending the concrete real paths so the reader
+/// knows exactly which files to inspect.
+fn tripwire_message(diffs: &[String]) -> String {
+    let mut msg = String::from(
+        "TRIPWIRE: the real daft state changed during this run — the test suite leaked \
+         into your real config/state/data dirs.\n\n",
+    );
+    for d in diffs {
+        msg.push_str("  • ");
+        msg.push_str(d);
+        msg.push('\n');
+    }
+    msg.push_str(
+        "\nThis almost always means the binary under test is not a daft_dev_build — a \
+         release/tagged build, or a system `daft` on PATH — so DAFT_*_DIR was ignored and \
+         writes hit the real dirs. Rebuild the dev binary and re-run. See #697.\n\n\
+         Real dirs on this machine:\n",
+    );
+    let show = |label: &str, p: Result<PathBuf>| match p {
+        Ok(p) => format!("  {label}: {}\n", p.display()),
+        Err(_) => format!("  {label}: <unresolved>\n"),
+    };
+    msg.push_str(&show("config", real_config_dir()));
+    msg.push_str(&show("data  ", real_data_dir()));
+    msg.push_str(&show("state ", Ok(real_state_dir())));
+    msg
+}
+
+// --- real-dir resolution (override-independent; pinned to daft by a test) ---
+
+/// `<config>/daft` — the real config dir, ignoring `DAFT_CONFIG_DIR`. Mirrors
+/// the fallback branch of `daft::daft_config_dir`.
+fn real_config_dir() -> Result<PathBuf> {
+    Ok(dirs::config_dir()
+        .context("resolving OS config dir")?
+        .join("daft"))
+}
+
+/// `<data>/daft` — the real data dir, ignoring `DAFT_DATA_DIR`.
+fn real_data_dir() -> Result<PathBuf> {
+    Ok(dirs::data_dir()
+        .context("resolving OS data dir")?
+        .join("daft"))
+}
+
+/// `<state>/daft` — the real state dir, ignoring `DAFT_STATE_DIR`. Mirrors
+/// `daft::daft_state_dir`'s macOS fallback (`dirs::state_dir()` is `None` on
+/// macOS → `~/.local/state`).
+fn real_state_dir() -> PathBuf {
+    dirs::state_dir()
+        .unwrap_or_else(|| {
+            dirs::home_dir()
+                .expect("Could not determine home directory")
+                .join(".local")
+                .join("state")
+        })
+        .join("daft")
+}
+
+// --- fingerprint primitives ---
+
+/// `filename -> content hash` for every regular file directly under `dir`.
+/// A missing `dir` is a valid state (empty map) — the catalog dir does not
+/// exist until daft first writes it.
+fn hash_dir_files(dir: &Path) -> Result<BTreeMap<String, String>> {
+    let mut map = BTreeMap::new();
+    let rd = match std::fs::read_dir(dir) {
+        Ok(rd) => rd,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(map),
+        Err(e) => return Err(e).with_context(|| format!("reading {}", dir.display())),
+    };
+    for entry in rd {
+        let entry = entry?;
+        if entry.path().is_file() {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            map.insert(name, hash_file(&entry.path())?);
+        }
+    }
+    Ok(map)
+}
+
+/// Content hash of `path`, or `None` when it does not exist.
+fn hash_file_opt(path: &Path) -> Result<Option<String>> {
+    match std::fs::read(path) {
+        Ok(bytes) => Ok(Some(hex(fnv1a64(&bytes)))),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e).with_context(|| format!("hashing {}", path.display())),
+    }
+}
+
+/// Content hash of an existing file.
+fn hash_file(path: &Path) -> Result<String> {
+    let bytes = std::fs::read(path).with_context(|| format!("hashing {}", path.display()))?;
+    Ok(hex(fnv1a64(&bytes)))
+}
+
+/// Compact entry-set digest of `dir` (see [`DirDigest`]). A missing dir yields
+/// `DirDigest::default()` (`exists: false`).
+fn dir_digest(dir: &Path) -> Result<DirDigest> {
+    let rd = match std::fs::read_dir(dir) {
+        Ok(rd) => rd,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(DirDigest::default()),
+        Err(e) => return Err(e).with_context(|| format!("reading {}", dir.display())),
+    };
+    let mut names = Vec::new();
+    for entry in rd {
+        names.push(entry?.file_name().to_string_lossy().into_owned());
+    }
+    names.sort();
+    Ok(DirDigest {
+        exists: true,
+        count: names.len(),
+        names_hash: hex(fnv1a64(names.join("\n").as_bytes())),
+    })
+}
+
+/// FNV-1a-64 over `bytes`. A dependency-free, deterministic content digest —
+/// snapshot and verify run the same xtask binary, so cross-version stability
+/// is irrelevant; all we need is "did these bytes change?".
+fn fnv1a64(bytes: &[u8]) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for &b in bytes {
+        h ^= u64::from(b);
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    h
+}
+
+fn hex(h: u64) -> String {
+    format!("{h:016x}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The guard's own real-dir resolution must track daft's resolvers exactly
+    /// — otherwise the tripwire watches different files than daft writes and is
+    /// worthless. daft's resolvers honor `DAFT_*_DIR` in dev builds, so a
+    /// surface can only be compared when *its* override is unset. We assert
+    /// per-surface (rather than skipping wholesale) so `data` and `state` — the
+    /// surfaces #697 cares about — are still checked even in a dev environment
+    /// that sets `DAFT_CONFIG_DIR` (the `.git/.daft-sandbox`); CI's clean env
+    /// exercises all three. No env mutation, so it stays race-free under
+    /// `cargo test`'s parallelism.
+    #[test]
+    fn guard_dirs_match_daft_resolvers() {
+        if std::env::var_os("DAFT_CONFIG_DIR").is_none() {
+            assert_eq!(real_config_dir().unwrap(), daft::daft_config_dir().unwrap());
+        }
+        if std::env::var_os("DAFT_DATA_DIR").is_none() {
+            assert_eq!(real_data_dir().unwrap(), daft::daft_data_dir().unwrap());
+        }
+        if std::env::var_os("DAFT_STATE_DIR").is_none() {
+            assert_eq!(real_state_dir(), daft::daft_state_dir().unwrap());
+        }
+    }
+
+    #[test]
+    fn absent_surfaces_read_as_empty_not_error() {
+        // Surfaces that don't exist on a fresh machine must round-trip as
+        // "nothing there" rather than erroring — otherwise a clean machine
+        // reads as a leak.
+        let missing = PathBuf::from("/definitely/not/a/real/daft/dir/zzz");
+        assert!(hash_dir_files(&missing.join("catalog")).unwrap().is_empty());
+        assert!(hash_file_opt(&missing.join("repos.json"))
+            .unwrap()
+            .is_none());
+        assert!(!dir_digest(&missing).unwrap().exists);
+    }
+
+    #[test]
+    fn dir_digest_changes_when_a_child_appears() {
+        // The core state-leak signal: a new entry (e.g. a leaked jobs/<uuid>/)
+        // must move the digest.
+        let dir = tempfile::tempdir().unwrap();
+        let before = dir_digest(dir.path()).unwrap();
+        assert!(before.exists && before.count == 0);
+        std::fs::create_dir(dir.path().join("019d-some-repo-uuid")).unwrap();
+        let after = dir_digest(dir.path()).unwrap();
+        assert_ne!(before, after);
+        assert_eq!(after.count, 1);
+    }
+
+    #[test]
+    fn diff_flags_each_surface_independently() {
+        let base = Snapshot::default();
+
+        let mut catalog_changed = Snapshot::default();
+        catalog_changed
+            .catalog
+            .insert("catalog.db".to_string(), "deadbeef".to_string());
+        assert_eq!(base.diff(&catalog_changed).len(), 1);
+        assert!(base.diff(&catalog_changed)[0].contains("catalog"));
+
+        let repos_changed = Snapshot {
+            repos_json: Some("abc".to_string()),
+            ..Snapshot::default()
+        };
+        assert!(base.diff(&repos_changed)[0].contains("repos.json"));
+
+        let jobs_changed = Snapshot {
+            state_jobs: DirDigest {
+                exists: true,
+                count: 1,
+                names_hash: "x".to_string(),
+            },
+            ..Snapshot::default()
+        };
+        assert!(base.diff(&jobs_changed)[0].contains("jobs"));
+
+        // Identical snapshots ⇒ clean.
+        assert!(base.diff(&Snapshot::default()).is_empty());
+    }
+
+    #[test]
+    fn snapshot_round_trips_through_yaml() {
+        let mut snap = Snapshot::default();
+        snap.catalog
+            .insert("catalog.db".to_string(), "1234".to_string());
+        snap.state_top = DirDigest {
+            exists: true,
+            count: 3,
+            names_hash: "abc".to_string(),
+        };
+        let yaml = serde_yaml::to_string(&snap).unwrap();
+        let back: Snapshot = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(snap, back);
+    }
+}


### PR DESCRIPTION
## What

The repo-catalog integration suites leaked throwaway test repos into the
developer's **real** `catalog.db`. Two deliverables, per the ticket:

**1. Cleanup (manual, done on the dev machine).** The real catalog had
accumulated 823 rows — 822 test-origin
(`/private/tmp/git-worktree-integration-tests/...`, `/var/folders` sandboxes)
and exactly 1 real (`daft` itself). Backed the file up, deleted the 822
test rows, kept the real one; `application_id`/`user_version` header pragmas and
WAL left intact.

**2. Enforcement (this PR).** Make "no writes to the real catalog / state /
config" an enforced, un-regressable invariant.

## The tripwire

`xtask real-state-guard {snapshot,verify}` fingerprints the real
config/state/data dirs before each suite and fails the run if they change —
locally and in CI — wired into `test:{unit,integration,manual}` and `ci` through
`mise-tasks/test/_state_guard_lib.sh` (`DAFT_SKIP_STATE_GUARD=1` escape hatch).

- **Targeted coverage**, not a whole-XDG-dir walk — on macOS the data dir also
  hosts centralized-layout worktrees: content-hash the `<data>/daft/catalog/`
  DB triplet and `<config>/daft/repos.json`; compact entry-set digest for the
  litter-prone `<state>/daft/` + `jobs/`.
- Resolves the real dirs via `dirs` (never reads `DAFT_*_DIR`, so it always
  targets the real surface), never creates them; a drift test pins its
  resolution to daft's own `daft_{config,data,state}_dir()`.
- A read-only **`daft __dirs` preflight** fails fast if the binary under test
  ignores `DAFT_*_DIR` — a non-dev-build, or a system `daft` on `PATH` —
  closing the #669 release-window hole for the data surface *before* it can
  leak.

## Leaks the tripwire surfaced (and this PR fixes)

- A store-level regression test locking `catalog_db()` / `catalog_db_probe()` to
  the sandboxed `DAFT_DATA_DIR`.
- Turning the tripwire on revealed a **pre-existing** state-dir leak (#478/#669
  class): 9 unit tests in `branch_delete` + `install` open the coordinator
  store via `paths::for_repo` while running `worktree-post-remove` /
  visitor-seed code, writing the real `~/.local/state/daft/jobs/<uuid>/`. Fixed
  with a shared `#[serial] store::paths::IsolatedStateDir` guard. Backtrace
  tracing confirmed those were the only leak sites; the guarded `test:unit` is
  now green.

## Testing

- `mise run fmt` / `clippy` / `test:unit` green (`test:unit` now runs under the
  tripwire; pre-push hook passed).
- Guard pass/fail paths validated end-to-end: the preflight accepts a dev binary
  and rejects an ignore-overrides binary; the tripwire passes a clean run and
  fires on a simulated real-catalog write.

Fixes #697.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
