### PR TITLE
chore: bump MSRV 1.94 → 1.95

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -65,7 +65,7 @@ updates:
         patterns:
           - "*"
     # dtolnay/rust-toolchain tags name the Rust toolchain version they install
-    # (e.g. @1.94.0 installs Rust 1.94.0), not a version of the action itself.
+    # (e.g. @1.95.0 installs Rust 1.95.0), not a version of the action itself.
     # Dependabot can't see this — bumping the tag would request a non-existent
     # toolchain. The MSRV value is owned by Cargo.toml's rust-version field.
     ignore:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -179,10 +179,10 @@ jobs:
       - name: Install mise
         uses: jdx/mise-action@v4.2.0
 
-      # mise installs the toolchain pinned in mise.toml (rust = "1.94") and
+      # mise installs the toolchain pinned in mise.toml (rust = "1.95") and
       # exports RUSTUP_TOOLCHAIN, overriding the dtolnay-installed `stable`.
       # Components from the dtolnay step were installed for `stable`, not for
-      # the mise-managed 1.94.x — re-install them for the active toolchain so
+      # the mise-managed 1.95.x — re-install them for the active toolchain so
       # `cargo fmt`/`cargo clippy` resolve against a complete component set.
       - name: Ensure rustfmt + clippy for mise-managed toolchain
         run: rustup component add rustfmt clippy
@@ -206,7 +206,7 @@ jobs:
   # declared in Cargo.toml's `rust-version`. `cargo check` is enough; the
   # `lint` job above already runs full build+test on stable. Cheap minutes
   # gate that prevents silent MSRV regressions when new code accidentally
-  # uses post-1.94 stdlib features.
+  # uses post-1.95 stdlib features.
   msrv-check:
     needs: changes
     if: >-
@@ -217,13 +217,13 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.0
 
-      - name: Set up Rust 1.94 (MSRV)
-        uses: dtolnay/rust-toolchain@1.94.0
+      - name: Set up Rust 1.95 (MSRV)
+        uses: dtolnay/rust-toolchain@1.95.0
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
-          key: msrv-1.94
+          key: msrv-1.95
 
       # `--locked` refuses to rewrite Cargo.lock, so a manifest/lockfile
       # mismatch (e.g. a Dependabot grouped-update PR that bumps Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ term-styles = { path = "term-styles", version = "0.1.0" }
 name = "daft"
 version = "1.20.0"
 edition = "2024"
-rust-version = "1.94"
+rust-version = "1.95"
 description = "A comprehensive Git extensions toolkit that enhances developer workflows, starting with powerful worktree management"
 authors = ["avihu <avihu@users.noreply.github.com>"]
 license = "MIT OR Apache-2.0"
@@ -151,8 +151,9 @@ r2d2_sqlite = "0.34"
 # Memory probe for the sync push resource governor (#678). `system` is the
 # only feature daft needs (RAM/swap + process RSS); the public API is fully
 # safe, keeping `forbid(unsafe_code)` intact — same precedent as `rusqlite`.
-# Pinned to the 0.38 line: 0.39+ raises sysinfo's MSRV to 1.95, above
-# daft's 1.94 (see the MSRV Policy section in CLAUDE.md).
+# Held on the 0.38 line, but the MSRV rationale for that pin lapsed with the
+# 1.94 → 1.95 bump: 0.39 requires exactly 1.95, so moving the line forward
+# is no longer blocked — see #710.
 sysinfo = { version = "0.38.4", default-features = false, features = ["system"] }
 
 # libc is Unix-only (uses fork/pipes)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![CI](https://github.com/avihut/daft/actions/workflows/test.yml/badge.svg)](https://github.com/avihut/daft/actions/workflows/test.yml)
 [![Release](https://img.shields.io/github/v/release/avihut/daft?label=release)](https://github.com/avihut/daft/releases/latest)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](#license)
-[![Rust](https://img.shields.io/badge/rust-1.94%2B-orange.svg)](https://www.rust-lang.org/)
+[![Rust](https://img.shields.io/badge/rust-1.95%2B-orange.svg)](https://www.rust-lang.org/)
 [![Homebrew](https://img.shields.io/badge/homebrew-avihut%2Ftap-blueviolet)](https://github.com/avihut/homebrew-tap)
 [![macOS](https://img.shields.io/badge/macOS-supported-success)](https://github.com/avihut/daft/releases)
 [![Linux](https://img.shields.io/badge/Linux-supported-success)](https://github.com/avihut/daft/releases)
@@ -211,7 +211,7 @@ for manual installation options.
 ## Requirements
 
 - **Git** 2.5+ (for worktree support)
-- **Rust** 1.94+ (only for building from source)
+- **Rust** 1.95+ (only for building from source)
 
 ## Contributing
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -195,4 +195,4 @@ See [Shell Integration](./shell-integration.md) for full details.
 ## Requirements
 
 - **Git** 2.5+ (for worktree support)
-- **Rust** 1.94+ (only needed when building from source)
+- **Rust** 1.95+ (only needed when building from source)

--- a/mise.lock
+++ b/mise.lock
@@ -297,5 +297,5 @@ url = "https://github.com/neovim/neovim/releases/download/stable/nvim-win64.zip"
 url = "https://github.com/neovim/neovim/releases/download/stable/nvim-win64.zip"
 
 [[tools.rust]]
-version = "1.94.1"
+version = "1.95.0"
 backend = "core:rust"

--- a/mise.toml
+++ b/mise.toml
@@ -21,7 +21,7 @@ minimum_release_age = "7d"
 # Pin the aqua backend explicitly so binstall itself never falls back to a
 # cargo-from-source build (chicken-and-egg).
 "aqua:cargo-bins/cargo-binstall" = "1.18.1"
-rust = "1.94"
+rust = "1.95"
 lefthook = "2.1.6"
 cocogitto = "7.0.0"
 bun = "1.3.13"

--- a/term-styles/Cargo.toml
+++ b/term-styles/Cargo.toml
@@ -2,7 +2,7 @@
 name = "term-styles"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.94"
+rust-version = "1.95"
 description = "Terminal ANSI styling utilities (colors, bold, dim) shared across the daft workspace."
 license = "MIT OR Apache-2.0"
 publish = false


### PR DESCRIPTION
Rust 1.97.0 shipped on 2026-07-07, putting the declared MSRV of `1.94` three minor versions behind stable — outside the `latest_stable - 2` policy in CLAUDE.md. This moves the floor to `1.97 - 2` = **1.95**.

`.github/workflows/msrv-staleness-check.yml` had not yet surfaced this: it runs monthly on the 1st, and 1.97 landed on the 7th. Dispatching it manually opened #712, which confirmed the gap independently (`gap of 3`).

## Changes

All six sync-points named in the MSRV Policy section of CLAUDE.md:

| File | Change |
| --- | --- |
| `Cargo.toml` | `rust-version = "1.95"` |
| `term-styles/Cargo.toml` | `rust-version = "1.95"` |
| `mise.toml` | `rust = "1.95"` |
| `.github/workflows/test.yml` | `dtolnay/rust-toolchain@1.95.0`, cache key `msrv-1.95`, step name + comments |
| `README.md` | badge + Requirements |
| `docs/getting-started/installation.md` | Requirements |

Plus two that `rg` catches but the policy list does not: `mise.lock` (regenerated by `mise install`, `1.94.1` → `1.95.0`) and the `dtolnay/rust-toolchain` example comment in `.github/dependabot.yml`.

`Cargo.lock` is deliberately untouched — the workspace pins `resolver = "2"`, so `rust-version` does not participate in dependency resolution.

## Verification

CLAUDE.md notes that MSRV bumps surface clippy-lint escalations and transitive-dep MSRV conflicts needing human triage. Neither appeared:

- `rustup run 1.95.0 cargo check --all-targets --locked` — clean
- `mise run clippy` on the 1.95 toolchain — zero warnings
- `mise run fmt` — no changes
- `mise run test:unit` — 2491 passed, 0 failed

## Follow-up: this unblocks #710

#710 (Dependabot bumping `sysinfo` 0.38.4 → 0.39.5) is currently failing, and its root cause is unrelated to MSRV: it updated **only** `Cargo.lock` and left `Cargo.toml`'s `^0.38.4` constraint alone, so every `cargo --locked` invocation errors with `cannot update the lock file`. That is the known Dependabot cargo interaction already documented in `dependabot.yml` and guarded by the `--locked` checks in `test.yml`.

But its *second* blocker was real: sysinfo 0.39.x declares `rust-version = 1.95`. This PR clears that, so the 0.38 pin can now be lifted. The pin comment in `Cargo.toml` is updated here to say so rather than continue asserting a rationale that no longer holds. #710 itself still needs a proper `Cargo.toml` + `Cargo.lock` update — closing and re-cutting it is likely cleaner than fixing it in place.

Fixes #712

🤖 Generated with [Claude Code](https://claude.com/claude-code)