### PR TITLE
fix(output): defer hook-path warnings while a live region owns stderr

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -492,8 +492,13 @@ defaults (PRAGMAs, perms, env scrub) come for free.
 
 1. **Schema first.** Add a `.sql` file in `src/store/migrations/` with the next
    sequence number, e.g. `002_trust_registry.sql`. Never edit a shipped
-   migration in place; only append. Add a unit test in `store::migrate::tests`
-   that asserts the new tables exist after `to_latest`.
+   migration in place; only append. Never _renumber_ one either — a number any
+   build has run against real state is burned. If a parallel PR claims your
+   number first, rebase onto the next free number AND manually repair every
+   store your pre-rebase builds stamped (#720: such a store fails every open
+   with "table already exists", forever, and the wedge outlives the rebase). Add
+   a unit test in `store::migrate::tests` that asserts the new tables exist
+   after `to_latest`.
 2. **Typed row model.** Add a struct in `src/store/models/<thing>.rs` — one Rust
    field per SQL column, no JSON blobs.
 3. **Repo with parameterized queries.** Add a struct in

--- a/src/coordinator/adapters/sqlite_store.rs
+++ b/src/coordinator/adapters/sqlite_store.rs
@@ -372,6 +372,43 @@ mod tests {
         (tmp, SqliteJobsStore::new(pool))
     }
 
+    #[test]
+    fn renumbered_migration_wedge_fails_open_with_diagnosable_chain() {
+        // Reproduces #720: a store stamped `user_version = 4` by a build
+        // whose 4th migration was `worktree_sizes` (the pre-rebase #706
+        // branch) collides with the merged lineage, where 004 is
+        // `hook_profiles` and `worktree_sizes` is 005. `to_latest` replays
+        // 005 into a schema that already has the table, so every open of
+        // that store fails. The failure must keep its full context chain:
+        // the best-effort warning sites print `{e:#}`, and without the
+        // SQLite root cause the wedge is undiagnosable in the field.
+        let tmp = TempDir::new().unwrap();
+        let db = tmp.path().join(crate::store::paths::COORDINATOR_DB);
+        let conn = rusqlite::Connection::open(&db).unwrap();
+        conn.execute_batch(&format!(
+            "PRAGMA application_id = {};",
+            crate::store::connection::APPLICATION_ID
+        ))
+        .unwrap();
+        conn.execute_batch(include_str!(
+            "../../store/migrations/005_worktree_sizes.sql"
+        ))
+        .unwrap();
+        conn.execute_batch("PRAGMA user_version = 4;").unwrap();
+        drop(conn);
+
+        let err = SqliteJobsStore::for_repo_base(tmp.path()).unwrap_err();
+        let chain = format!("{err:#}");
+        assert!(
+            chain.contains("open coordinator store"),
+            "outer context missing: {chain}"
+        );
+        assert!(
+            chain.contains("already exists"),
+            "SQLite root cause missing from chain: {chain}"
+        );
+    }
+
     fn sample_inv() -> InvocationRow {
         InvocationRow {
             repo_hash: "r".into(),

--- a/src/executor/log_sink.rs
+++ b/src/executor/log_sink.rs
@@ -13,6 +13,7 @@ use crate::coordinator::log_record::{LogRecord, OutputKind, StatusEvent, record_
 use crate::coordinator::log_store::{JobMeta, JobStatus, LogStore};
 use crate::coordinator::ports::JobsStorePort;
 use crate::executor::NodeStatus;
+use crate::output::deferred_warn;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
@@ -82,7 +83,7 @@ impl BufferingLogSink {
         let job_store = match SqliteJobsStore::for_repo_base(&store.base_dir) {
             Ok(js) => Some(js),
             Err(e) => {
-                crate::output::deferred_warn::warn(format!(
+                deferred_warn::warn(format!(
                     "daft: warning: opening coordinator store at {} failed: {e:#} \
                      (foreground job records will not be persisted to the store)",
                     store.base_dir.display()
@@ -142,7 +143,7 @@ impl BufferingLogSink {
             max_log_size_bytes: meta.max_log_size_bytes,
         };
         if let Err(e) = js.upsert_job(&row) {
-            crate::output::deferred_warn::warn(format!(
+            deferred_warn::warn(format!(
                 "daft: failed to persist job '{}' to the coordinator store: {e:#}",
                 meta.name
             ));
@@ -238,7 +239,7 @@ impl LogSink for BufferingLogSink {
             .store
             .write_job_record_jsonl(&self.invocation_id, &meta, &records)
         {
-            crate::output::deferred_warn::warn(format!(
+            deferred_warn::warn(format!(
                 "daft: failed to write job record for '{}': {e:#}",
                 spec.name
             ));
@@ -273,7 +274,7 @@ impl LogSink for BufferingLogSink {
             .store
             .write_job_record_jsonl(&self.invocation_id, &meta, &records)
         {
-            crate::output::deferred_warn::warn(format!(
+            deferred_warn::warn(format!(
                 "daft: failed to write job record for '{}': {e:#}",
                 spec.name
             ));

--- a/src/executor/log_sink.rs
+++ b/src/executor/log_sink.rs
@@ -82,11 +82,11 @@ impl BufferingLogSink {
         let job_store = match SqliteJobsStore::for_repo_base(&store.base_dir) {
             Ok(js) => Some(js),
             Err(e) => {
-                eprintln!(
-                    "daft: warning: opening coordinator store at {} failed: {e} \
+                crate::output::deferred_warn::warn(format!(
+                    "daft: warning: opening coordinator store at {} failed: {e:#} \
                      (foreground job records will not be persisted to the store)",
                     store.base_dir.display()
-                );
+                ));
                 None
             }
         };
@@ -113,7 +113,8 @@ impl BufferingLogSink {
     }
 
     /// Persist a `JobMeta` into the SQLite store as a `JobRow`. Best
-    /// effort: errors go to stderr and don't abort the surrounding write.
+    /// effort: errors go through the deferred-warning channel and don't
+    /// abort the surrounding write.
     fn persist_job_row(&self, meta: &JobMeta, tags: &[String]) {
         let Some(js) = self.job_store.as_ref() else {
             return;
@@ -141,10 +142,10 @@ impl BufferingLogSink {
             max_log_size_bytes: meta.max_log_size_bytes,
         };
         if let Err(e) = js.upsert_job(&row) {
-            eprintln!(
-                "daft: failed to persist job '{}' to the coordinator store: {e}",
+            crate::output::deferred_warn::warn(format!(
+                "daft: failed to persist job '{}' to the coordinator store: {e:#}",
                 meta.name
-            );
+            ));
         }
     }
 }
@@ -237,7 +238,10 @@ impl LogSink for BufferingLogSink {
             .store
             .write_job_record_jsonl(&self.invocation_id, &meta, &records)
         {
-            eprintln!("daft: failed to write job record for '{}': {e}", spec.name);
+            crate::output::deferred_warn::warn(format!(
+                "daft: failed to write job record for '{}': {e:#}",
+                spec.name
+            ));
         }
         // SQLite source-of-truth write happens after the log file is on
         // disk so a successful `daft hooks jobs logs` lookup can rely on
@@ -269,7 +273,10 @@ impl LogSink for BufferingLogSink {
             .store
             .write_job_record_jsonl(&self.invocation_id, &meta, &records)
         {
-            eprintln!("daft: failed to write job record for '{}': {e}", spec.name);
+            crate::output::deferred_warn::warn(format!(
+                "daft: failed to write job record for '{}': {e:#}",
+                spec.name
+            ));
         }
         self.persist_job_row(&meta, &spec.tags);
     }

--- a/src/hooks/trust.rs
+++ b/src/hooks/trust.rs
@@ -13,6 +13,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use super::trust_dto::{TrustDatabaseV1_0_0, TrustDatabaseV2_0_0};
+use crate::output::deferred_warn;
 
 /// Trust level for a repository.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
@@ -430,14 +431,18 @@ impl TrustDatabase {
                     // so a recoverable-but-corrupt registry is never lost, and
                     // warn. This is the foreground heal path, so the warning is
                     // seen (unlike the background pruner, which no-ops above).
+                    // Deferred rather than `eprintln!`ed: no live region reaches
+                    // a trust mutation today, but that is a property of the
+                    // current call graph, not something this side of the lock
+                    // can check (#720).
                     let backup = back_up_corrupt(&src)?;
-                    eprintln!(
+                    deferred_warn::warn(format!(
                         "warning: daft trust registry at {} was unreadable ({e:#}); \
                          backed it up to {} and started a fresh registry. \
                          Re-run `daft hooks trust` to restore grants.",
                         src.display(),
                         backup.display()
-                    );
+                    ));
                 }
                 db.save_to(&repos)?;
                 // Retire a legacy trust.json now that V3 repos.json is written.

--- a/src/hooks/trust_skip.rs
+++ b/src/hooks/trust_skip.rs
@@ -169,16 +169,17 @@ pub fn flush_pending_notice(git_dir: &Path, output: &mut dyn Output) {
     }
 }
 
-/// Best-effort write of a `status = 'skipped'` invocation row. Failures are
-/// reported on raw stderr (same precedent as the yaml executor's
-/// invocation-meta write) — never via `output.notice`, which in TUI mode
+/// Best-effort write of a `status = 'skipped'` invocation row. Failures go
+/// through the deferred-warning channel (same precedent as the yaml
+/// executor's invocation-meta write): stderr immediately, or after a live
+/// region closes (#720) — never via `output.notice`, which in TUI mode
 /// would vanish into the buffer and hide the degradation.
 pub fn record_skip(ctx: &HookContext, reason: &str) {
     if let Err(e) = try_record_skip(ctx, reason) {
-        eprintln!(
-            "daft: failed to record skipped {} hook: {e}",
+        crate::output::deferred_warn::warn(format!(
+            "daft: failed to record skipped {} hook: {e:#}",
             ctx.hook_type.yaml_name()
-        );
+        ));
     }
 }
 
@@ -209,10 +210,10 @@ fn try_record_skip(ctx: &HookContext, reason: &str) -> anyhow::Result<()> {
 /// `skip:` condition fires.
 pub fn clear_skips(ctx: &HookContext) {
     if let Err(e) = try_clear_skips(ctx) {
-        eprintln!(
-            "daft: failed to clear skipped-{} records: {e}",
+        crate::output::deferred_warn::warn(format!(
+            "daft: failed to clear skipped-{} records: {e:#}",
             ctx.hook_type.yaml_name()
-        );
+        ));
     }
 }
 

--- a/src/hooks/trust_skip.rs
+++ b/src/hooks/trust_skip.rs
@@ -41,6 +41,7 @@ use crate::coordinator::ports::JobsStorePort;
 use crate::hooks::HookContext;
 use crate::hooks::HookType;
 use crate::output::Output;
+use crate::output::deferred_warn;
 use crate::store::models::InvocationRow;
 use crate::store::models::invocation::{INVOCATION_STATUS_SKIPPED, SKIP_REASON_UNTRUSTED};
 use std::collections::{BTreeSet, HashMap};
@@ -176,7 +177,7 @@ pub fn flush_pending_notice(git_dir: &Path, output: &mut dyn Output) {
 /// would vanish into the buffer and hide the degradation.
 pub fn record_skip(ctx: &HookContext, reason: &str) {
     if let Err(e) = try_record_skip(ctx, reason) {
-        crate::output::deferred_warn::warn(format!(
+        deferred_warn::warn(format!(
             "daft: failed to record skipped {} hook: {e:#}",
             ctx.hook_type.yaml_name()
         ));
@@ -210,7 +211,7 @@ fn try_record_skip(ctx: &HookContext, reason: &str) -> anyhow::Result<()> {
 /// `skip:` condition fires.
 pub fn clear_skips(ctx: &HookContext) {
     if let Err(e) = try_clear_skips(ctx) {
-        crate::output::deferred_warn::warn(format!(
+        deferred_warn::warn(format!(
             "daft: failed to clear skipped-{} records: {e:#}",
             ctx.hook_type.yaml_name()
         ));

--- a/src/hooks/yaml_executor/mod.rs
+++ b/src/hooks/yaml_executor/mod.rs
@@ -222,7 +222,9 @@ pub fn execute_yaml_hook_with_rc(
         created_at: chrono::Utc::now(),
     };
     if let Err(e) = store.write_invocation_meta(&invocation_id, &inv_meta) {
-        eprintln!("daft: failed to write invocation meta for '{hook_name}': {e}");
+        crate::output::deferred_warn::warn(format!(
+            "daft: failed to write invocation meta for '{hook_name}': {e:#}"
+        ));
     }
 
     let mut jobs = get_effective_jobs(hook_def);
@@ -408,7 +410,9 @@ pub fn execute_yaml_hook_with_rc(
         match crate::coordinator::adapters::SqliteJobsStore::for_repo_base(&store.base_dir) {
             Ok(js) => Some(js),
             Err(e) => {
-                eprintln!("daft: failed to open coordinator store for '{hook_name}': {e}");
+                crate::output::deferred_warn::warn(format!(
+                    "daft: failed to open coordinator store for '{hook_name}': {e:#}"
+                ));
                 None
             }
         };
@@ -433,10 +437,10 @@ pub fn execute_yaml_hook_with_rc(
             sj.reason.as_str(),
         )];
         if let Err(e) = store.write_job_record_jsonl(&invocation_id, &meta, &records) {
-            eprintln!(
-                "daft: failed to write skipped job record for '{}': {e}",
+            crate::output::deferred_warn::warn(format!(
+                "daft: failed to write skipped job record for '{}': {e:#}",
                 sj.name
-            );
+            ));
         }
         if let Some(ref js) = job_store_for_skipped {
             use crate::coordinator::ports::JobsStorePort;
@@ -462,10 +466,10 @@ pub fn execute_yaml_hook_with_rc(
                 max_log_size_bytes: meta.max_log_size_bytes,
             };
             if let Err(e) = js.upsert_job(&row) {
-                eprintln!(
-                    "daft: failed to persist skipped job row for '{}': {e}",
+                crate::output::deferred_warn::warn(format!(
+                    "daft: failed to persist skipped job row for '{}': {e:#}",
                     sj.name
-                );
+                ));
             }
         }
     }
@@ -481,7 +485,9 @@ pub fn execute_yaml_hook_with_rc(
     if let Some(ref js) = job_store_for_skipped {
         use crate::coordinator::ports::JobsStorePort;
         if let Err(e) = js.write_repo_policy(&repo_hash, &repo_policy) {
-            eprintln!("daft: failed to write repo policy for '{hook_name}': {e}");
+            crate::output::deferred_warn::warn(format!(
+                "daft: failed to write repo policy for '{hook_name}': {e:#}"
+            ));
         }
     }
 

--- a/src/hooks/yaml_executor/mod.rs
+++ b/src/hooks/yaml_executor/mod.rs
@@ -18,6 +18,7 @@ use crate::executor::LogConfig;
 use crate::executor::presenter::JobPresenter;
 use crate::hooks::tracking::{TrackedAttribute, effective_tracks};
 use crate::output::Output;
+use crate::output::deferred_warn;
 use crate::settings::HookOutputConfig;
 use anyhow::Result;
 use std::collections::HashSet;
@@ -222,7 +223,7 @@ pub fn execute_yaml_hook_with_rc(
         created_at: chrono::Utc::now(),
     };
     if let Err(e) = store.write_invocation_meta(&invocation_id, &inv_meta) {
-        crate::output::deferred_warn::warn(format!(
+        deferred_warn::warn(format!(
             "daft: failed to write invocation meta for '{hook_name}': {e:#}"
         ));
     }
@@ -410,7 +411,7 @@ pub fn execute_yaml_hook_with_rc(
         match crate::coordinator::adapters::SqliteJobsStore::for_repo_base(&store.base_dir) {
             Ok(js) => Some(js),
             Err(e) => {
-                crate::output::deferred_warn::warn(format!(
+                deferred_warn::warn(format!(
                     "daft: failed to open coordinator store for '{hook_name}': {e:#}"
                 ));
                 None
@@ -437,7 +438,7 @@ pub fn execute_yaml_hook_with_rc(
             sj.reason.as_str(),
         )];
         if let Err(e) = store.write_job_record_jsonl(&invocation_id, &meta, &records) {
-            crate::output::deferred_warn::warn(format!(
+            deferred_warn::warn(format!(
                 "daft: failed to write skipped job record for '{}': {e:#}",
                 sj.name
             ));
@@ -466,7 +467,7 @@ pub fn execute_yaml_hook_with_rc(
                 max_log_size_bytes: meta.max_log_size_bytes,
             };
             if let Err(e) = js.upsert_job(&row) {
-                crate::output::deferred_warn::warn(format!(
+                deferred_warn::warn(format!(
                     "daft: failed to persist skipped job row for '{}': {e:#}",
                     sj.name
                 ));
@@ -485,7 +486,7 @@ pub fn execute_yaml_hook_with_rc(
     if let Some(ref js) = job_store_for_skipped {
         use crate::coordinator::ports::JobsStorePort;
         if let Err(e) = js.write_repo_policy(&repo_hash, &repo_policy) {
-            crate::output::deferred_warn::warn(format!(
+            deferred_warn::warn(format!(
                 "daft: failed to write repo policy for '{hook_name}': {e:#}"
             ));
         }

--- a/src/output/deferred_warn.rs
+++ b/src/output/deferred_warn.rs
@@ -19,8 +19,8 @@
 //! [`enable_raw_mode_guard`](crate::output::tui::enable_raw_mode_guard)
 //! holds a guard for the whole raw-mode window, so the inline-TUI commands
 //! get deferral without per-site wiring. The indicatif-region renderers
-//! (see [`term_guard`](crate::output::term_guard)) share the foreign-bytes
-//! hazard and can adopt a guard the same way when needed.
+//! (see `output::term_guard`) share the foreign-bytes hazard and can adopt
+//! a guard the same way when needed.
 
 use std::sync::{Mutex, MutexGuard, PoisonError};
 

--- a/src/output/deferred_warn.rs
+++ b/src/output/deferred_warn.rs
@@ -1,0 +1,180 @@
+//! Deferred `daft:` warning channel for live-region windows.
+//!
+//! A raw `eprintln!` while an inline live region owns stderr shreds the
+//! render (#720): with the terminal in raw mode each bare `\n` staircases
+//! instead of returning the carriage, long lines wrap and scroll the screen
+//! underneath the renderer, and later cell-diff repaints land on rows that
+//! have since moved — torn tables, duplicated frames, stray spinner glyphs.
+//!
+//! Best-effort degradation warnings that can fire from hook/executor worker
+//! threads while a live region is on screen (the sync/list live tables
+//! today) must go through [`warn`] instead of `eprintln!`:
+//!
+//! * terminal free → the line prints to stderr immediately, unchanged;
+//! * a [`LiveRegionGuard`] alive → the line queues (exact duplicates
+//!   collapse into a repeat count) and flushes to stderr when the outermost
+//!   guard drops — after the region has closed and, for raw-mode windows,
+//!   after cooked mode is restored.
+//!
+//! [`enable_raw_mode_guard`](crate::output::tui::enable_raw_mode_guard)
+//! holds a guard for the whole raw-mode window, so the inline-TUI commands
+//! get deferral without per-site wiring. The indicatif-region renderers
+//! (see [`term_guard`](crate::output::term_guard)) share the foreign-bytes
+//! hazard and can adopt a guard the same way when needed.
+
+use std::sync::{Mutex, MutexGuard, PoisonError};
+
+/// Global queue + live-region depth. One mutex is fine: warnings are rare
+/// (degradation paths only) and the flush runs at most once per command.
+static STATE: Mutex<WarnQueue> = Mutex::new(WarnQueue::new());
+
+/// Emit a warning line on stderr — immediately when no live region is
+/// active, deferred until the region closes otherwise.
+pub fn warn(msg: impl Into<String>) {
+    if let Some(line) = lock().warn(msg.into()) {
+        eprintln!("{line}");
+    }
+}
+
+/// Marks a live region as owning stderr for its lifetime. Warnings queue
+/// while at least one guard is alive; dropping the guard that closes the
+/// outermost region flushes them.
+#[must_use = "warnings defer only while the guard is alive"]
+pub struct LiveRegionGuard(());
+
+pub fn live_region_guard() -> LiveRegionGuard {
+    lock().enter();
+    LiveRegionGuard(())
+}
+
+impl Drop for LiveRegionGuard {
+    fn drop(&mut self) {
+        for line in lock().exit() {
+            eprintln!("{line}");
+        }
+    }
+}
+
+fn lock() -> MutexGuard<'static, WarnQueue> {
+    STATE.lock().unwrap_or_else(PoisonError::into_inner)
+}
+
+/// Pure queue logic, kept separate from the global so tests don't contend
+/// over process-wide state.
+struct WarnQueue {
+    depth: usize,
+    entries: Vec<(String, usize)>,
+}
+
+impl WarnQueue {
+    const fn new() -> Self {
+        Self {
+            depth: 0,
+            entries: Vec::new(),
+        }
+    }
+
+    /// Returns the line to print immediately, or `None` when it was queued.
+    fn warn(&mut self, msg: String) -> Option<String> {
+        if self.depth == 0 {
+            return Some(msg);
+        }
+        match self.entries.iter_mut().find(|(seen, _)| *seen == msg) {
+            Some((_, count)) => *count += 1,
+            None => self.entries.push((msg, 1)),
+        }
+        None
+    }
+
+    fn enter(&mut self) {
+        self.depth += 1;
+    }
+
+    /// Returns the queued lines to flush — non-empty only when this exit
+    /// closes the outermost region.
+    fn exit(&mut self) -> Vec<String> {
+        self.depth = self.depth.saturating_sub(1);
+        if self.depth > 0 {
+            return Vec::new();
+        }
+        self.entries
+            .drain(..)
+            .map(|(msg, count)| {
+                if count > 1 {
+                    format!("{msg} (\u{00D7}{count})")
+                } else {
+                    msg
+                }
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prints_immediately_outside_live_region() {
+        let mut q = WarnQueue::new();
+        assert_eq!(q.warn("daft: boom".into()), Some("daft: boom".into()));
+        assert!(q.exit().is_empty(), "nothing was queued");
+    }
+
+    #[test]
+    fn defers_and_flushes_in_first_seen_order() {
+        let mut q = WarnQueue::new();
+        q.enter();
+        assert_eq!(q.warn("a".into()), None);
+        assert_eq!(q.warn("b".into()), None);
+        assert_eq!(q.exit(), vec!["a".to_string(), "b".to_string()]);
+    }
+
+    #[test]
+    fn duplicates_collapse_into_a_repeat_count() {
+        // The #720 shape: one wedged store, the same three warnings fired
+        // once per pruned worktree — nine foreign lines mid-render.
+        let mut q = WarnQueue::new();
+        q.enter();
+        for _ in 0..3 {
+            q.warn("daft: failed to open coordinator store".into());
+        }
+        q.warn("daft: something else".into());
+        assert_eq!(
+            q.exit(),
+            vec![
+                "daft: failed to open coordinator store (\u{00D7}3)".to_string(),
+                "daft: something else".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn nested_regions_flush_only_at_the_outermost_exit() {
+        let mut q = WarnQueue::new();
+        q.enter(); // raw-mode window
+        q.enter(); // TuiRenderer::run inside it
+        q.warn("late".into());
+        assert!(q.exit().is_empty(), "inner exit must not flush");
+        assert_eq!(q.exit(), vec!["late".to_string()]);
+    }
+
+    #[test]
+    fn queue_resets_after_flush() {
+        let mut q = WarnQueue::new();
+        q.enter();
+        q.warn("first window".into());
+        assert_eq!(q.exit().len(), 1);
+        // Back to immediate printing, and no stale entries on re-entry.
+        assert_eq!(q.warn("now".into()), Some("now".into()));
+        q.enter();
+        assert_eq!(q.exit(), Vec::<String>::new());
+    }
+
+    #[test]
+    fn unbalanced_exit_saturates() {
+        let mut q = WarnQueue::new();
+        assert!(q.exit().is_empty());
+        assert_eq!(q.warn("still fine".into()), Some("still fine".into()));
+    }
+}

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -19,6 +19,7 @@
 
 mod buffering;
 mod cli;
+pub mod deferred_warn;
 pub mod emit;
 pub mod format;
 pub mod hook_progress;

--- a/src/output/tui/driver.rs
+++ b/src/output/tui/driver.rs
@@ -102,6 +102,13 @@ impl<S: LiveScreen> TuiRenderer<S> {
         let render_start = Instant::now();
         let viewport_height = self.state.viewport_height(self.extra_rows);
 
+        // Foreign `daft:` warnings must not reach stderr while the inline
+        // viewport owns it (#720). Callers usually hold a raw-mode guard
+        // that already defers them for the whole window; this guard makes
+        // the render loop safe even without that discipline. Declared
+        // before `terminal` so it drops after the final teardown.
+        let _defer_warnings = crate::output::deferred_warn::live_region_guard();
+
         let backend = ratatui::backend::CrosstermBackend::new(std::io::stderr());
         let mut terminal = Terminal::with_options(
             backend,
@@ -361,12 +368,24 @@ impl LiveScreen for TuiState {
 /// driver echoing `^C` mid-render. Callers keep a process-global SIGINT
 /// handler installed as the fallback for when raw mode fails to enable —
 /// and for the moment this guard drops, when Ctrl+C is a signal again.
+///
+/// The guard also holds a [`deferred_warn`](crate::output::deferred_warn)
+/// live-region guard: `daft:` warnings from worker threads queue for the
+/// whole raw-mode window instead of staircasing through the render (#720).
 pub fn enable_raw_mode_guard() -> RawModeGuard {
+    let defer_warnings = crate::output::deferred_warn::live_region_guard();
     let _ = crossterm::terminal::enable_raw_mode();
-    RawModeGuard
+    RawModeGuard {
+        _defer_warnings: defer_warnings,
+    }
 }
 
-pub struct RawModeGuard;
+pub struct RawModeGuard {
+    /// Struct fields drop after the `Drop::drop` body runs, so the queued
+    /// warnings flush after `disable_raw_mode` — in cooked mode, below the
+    /// region.
+    _defer_warnings: crate::output::deferred_warn::LiveRegionGuard,
+}
 
 impl Drop for RawModeGuard {
     fn drop(&mut self) {

--- a/src/output/tui/driver.rs
+++ b/src/output/tui/driver.rs
@@ -2,6 +2,7 @@ use super::columns::Column;
 use super::render;
 use super::state::TuiState;
 use crate::core::worktree::sync_dag::DagEvent;
+use crate::output::deferred_warn::{self, LiveRegionGuard};
 use crossterm::event::{self, Event, KeyCode, KeyModifiers};
 use ratatui::{
     Frame, Terminal, TerminalOptions, Viewport,
@@ -107,7 +108,7 @@ impl<S: LiveScreen> TuiRenderer<S> {
         // that already defers them for the whole window; this guard makes
         // the render loop safe even without that discipline. Declared
         // before `terminal` so it drops after the final teardown.
-        let _defer_warnings = crate::output::deferred_warn::live_region_guard();
+        let _defer_warnings = deferred_warn::live_region_guard();
 
         let backend = ratatui::backend::CrosstermBackend::new(std::io::stderr());
         let mut terminal = Terminal::with_options(
@@ -369,11 +370,11 @@ impl LiveScreen for TuiState {
 /// handler installed as the fallback for when raw mode fails to enable —
 /// and for the moment this guard drops, when Ctrl+C is a signal again.
 ///
-/// The guard also holds a [`deferred_warn`](crate::output::deferred_warn)
-/// live-region guard: `daft:` warnings from worker threads queue for the
-/// whole raw-mode window instead of staircasing through the render (#720).
+/// The guard also holds a [`deferred_warn`] live-region guard: `daft:`
+/// warnings from worker threads queue for the whole raw-mode window instead
+/// of staircasing through the render (#720).
 pub fn enable_raw_mode_guard() -> RawModeGuard {
-    let defer_warnings = crate::output::deferred_warn::live_region_guard();
+    let defer_warnings = deferred_warn::live_region_guard();
     let _ = crossterm::terminal::enable_raw_mode();
     RawModeGuard {
         _defer_warnings: defer_warnings,
@@ -384,7 +385,7 @@ pub struct RawModeGuard {
     /// Struct fields drop after the `Drop::drop` body runs, so the queued
     /// warnings flush after `disable_raw_mode` — in cooked mode, below the
     /// region.
-    _defer_warnings: crate::output::deferred_warn::LiveRegionGuard,
+    _defer_warnings: LiveRegionGuard,
 }
 
 impl Drop for RawModeGuard {


### PR DESCRIPTION
Fixes #720

## What broke

`daft sync -v` rendered shredded output — staircased `daft: failed to … coordinator store …` warnings, a duplicated/torn live table, stray spinner glyphs — whenever the per-repo store failed to open. Two independent defects compounded:

1. **Live-region shredding.** The best-effort store warnings in the hook/executor paths (`trust_skip`, `yaml_executor`, `log_sink`) are raw `eprintln!`s from worker threads. During sync/list the inline viewport owns stderr in raw mode: each bare `\n` staircases (ONLCR off), wrapped lines scroll the screen underneath ratatui, and subsequent cell-diff repaints land on rows that have moved. One wedged store fired 9+ foreign writes mid-render.
2. **Swallowed causes.** Every site printed `{e}` — anyhow's plain `Display` shows only the outermost context (`open coordinator store at <path>`), so the actual root cause never surfaced. The trigger (a dev-only migration-renumber wedge: stores stamped `user_version=4` by pre-rebase #706 builds fail every open on `table worktree_sizes already exists`) was undiagnosable from the CLI.

## The fix

- **`output::deferred_warn`** — a deferred warning channel: `warn()` prints to stderr immediately when the terminal is free; while any `LiveRegionGuard` is alive it queues (exact duplicates collapse into a `(×N)` count) and the guard closing the outermost region flushes, in first-seen order. `enable_raw_mode_guard()` holds a guard for the whole raw-mode window — flush happens after `disable_raw_mode`, so queued lines print in cooked mode below the region. `TuiRenderer::run` holds its own as a backstop for raw-guard-less callers.
- All eleven hook/executor warning sites route through `warn()` and format with the full error chain (`{e:#}`).
- CLAUDE.md (Adding a New DB-backed Feature): migration numbers any build has run against real state are burned — never renumber; repair pre-rebase-stamped stores when a rebase forces one.

Not in scope: self-healing wedged stores (manual repair documented in #720; a `daft doctor` check is a possible follow-up).

## Testing

- `renumbered_migration_wedge_fails_open_with_diagnosable_chain` reproduces the #720 store shape (v4 + `worktree_sizes`, no `hook_profiles`) and asserts the open fails with the SQLite root cause intact in the `{:#}` chain.
- Six unit tests on the warn-queue logic: immediate print outside regions, deferral, first-seen ordering, duplicate collapsing, nested-region flush-at-outermost, reset after flush, saturating unbalanced exit.
- `mise run fmt` / `clippy` / `test:unit` green (2529 tests). A PTY-level render assertion for the mangle itself isn't practical in the YAML harness; the queue tests + guard wiring cover the mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
