### PR TITLE
ci: split unit tests out of the lint job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -145,7 +145,9 @@ jobs:
       - name: Run cargo-deny
         run: mise run deny
 
-  # Fast feedback: formatting, linting, unit tests (debug mode only - no release build needed)
+  # Fast feedback: formatting and linting. Unit tests run in the parallel
+  # `unit-tests` job below, split out (#583) so a test failure doesn't
+  # surface as a red `lint` check.
   lint:
     needs: changes
     if: >-
@@ -199,14 +201,41 @@ jobs:
       - name: Run Rust clippy
         run: mise run clippy
 
+  # Rust unit tests (debug build). Split out of `lint` (#583) so the PR
+  # check that goes red names what actually failed, and the two jobs run
+  # in parallel. Same change gating as `lint`.
+  unit-tests:
+    needs: changes
+    if: >-
+      !contains(github.event.pull_request.labels.*.name, 'release') &&
+      (needs.changes.outputs.self == 'true' || needs.changes.outputs.rust ==
+      'true' || needs.changes.outputs.tests == 'true' ||
+      needs.changes.outputs.xtask == 'true')
+    runs-on: ubuntu-latest
+    env:
+      # cargo-cooldown is a local-dev guard with no CI payoff — see the
+      # identical override on `lint` for the full rationale.
+      MISE_DISABLE_TOOLS: cargo:cargo-cooldown
+    steps:
+      - uses: actions/checkout@v7.0.0
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install mise
+        uses: jdx/mise-action@v4.2.0
+
       - name: Run Rust unit tests
         run: mise run test:unit
 
   # MSRV check — proves the source still compiles under the pinned floor
   # declared in Cargo.toml's `rust-version`. `cargo check` is enough; the
-  # `lint` job above already runs full build+test on stable. Cheap minutes
-  # gate that prevents silent MSRV regressions when new code accidentally
-  # uses post-1.95 stdlib features.
+  # `unit-tests` job above already runs full build+test on stable. Cheap
+  # minutes gate that prevents silent MSRV regressions when new code
+  # accidentally uses post-1.95 stdlib features.
   msrv-check:
     needs: changes
     if: >-


### PR DESCRIPTION
## Problem

The `lint` job bundled four steps: `cargo fmt --check`, prettier over docs,
`mise run clippy`, and `mise run test:unit`. Because the unit suite ran inside a
job named `lint`, a test failure surfaced on the PR checks list as a red
**lint** check — sending reviewers looking for a formatting or clippy problem
when the real failure was a test.

This bit us on #582 (a `serde_json` Dependabot bump): `lint` went red, but the
cause was the flaky `squash_style_produces_single_commit_on_target` merge test,
nothing to do with linting or the dependency.

## Change

- `lint` keeps the static checks only: `cargo fmt --check`, prettier, `clippy`.
- New `unit-tests` job runs `mise run test:unit`.

The new job copies `lint`'s `needs: changes` gate and path-filter `if:`
verbatim, so the unit suite triggers on exactly the same changed paths as
before — including `tests/` and `xtask/`, since `test:unit` compiles the
workspace test targets and xtask. Its setup is leaner than lint's: no
rustfmt/clippy components and no `bun install`, because `test:unit` is a plain
`cargo test` under the state-guard tripwire. The `cargo-cooldown` mise override
carries over, pointing at lint's full rationale rather than repeating it.

`msrv-check`'s comment referenced "the `lint` job above already runs full
build+test" — updated to name `unit-tests`.

## Result

- The red check names what actually failed, so triage is immediate.
- Lint and unit tests run in parallel instead of serially, shaving wall-clock.
- A test flake can no longer masquerade as a lint failure.

## Notes

- The split duplicates the Rust/mise setup boilerplate across two jobs, which
  the issue calls out as acceptable — `Swatinem/rust-cache` is shared between
  them.
- `fmt` and `clippy` stay grouped as `lint`, per the issue's leaning on that
  open question.
- Nothing referenced the `lint` job name externally: master has no classic
  branch protection, and its ruleset carries no required-status-checks rule, so
  no repo settings need updating alongside this.
- The flaky merge test itself is out of scope here, as the issue specifies.

## Verification

Prettier passes on the workflow (the same check CI's `lint` job runs), and a
YAML parse confirms the job list plus that the two jobs' `if:` gates are
byte-identical. Editing `test.yml` sets `self=true` in the `changes` job, so
this PR's own run un-skips every job — including the new one.

Fixes #583

🤖 Generated with [Claude Code](https://claude.com/claude-code)