### PR TITLE
test(integration): fail-closed __dirs preflight so bash suites can't leak into the real catalog

### DIFF
--- a/mise-tasks/test/integration/matrix
+++ b/mise-tasks/test/integration/matrix
@@ -7,4 +7,9 @@ source "$(dirname "$0")/_release_bin_lib.sh"
 ensure_release_binaries
 
 entry="${1:?Usage: mise run test:integration:matrix <entry-name>}"
-cargo run --package xtask -- test-matrix --entry "$entry"
+
+# Real-state tripwire (#697/#738): mirror the guarded default so a single-entry
+# matrix run is protected too (it previously ran outside with_state_guard).
+source "$(dirname "$0")/../_state_guard_lib.sh"
+assert_binary_honors_overrides "target/release/daft"
+with_state_guard cargo run --package xtask -- test-matrix --entry "$entry"

--- a/mise-tasks/test/integration/verbose
+++ b/mise-tasks/test/integration/verbose
@@ -5,4 +5,11 @@
 set -euo pipefail
 
 echo "Running integration tests with verbose output..."
-cd tests/integration && ./test_all.sh
+
+# Real-state tripwire (#697/#738): the framework self-guards in setup(), but
+# mirror the guarded default (_default) here too so the verbose path gets the
+# same snapshot/verify fingerprint — a leak that slips past the __dirs preflight
+# (e.g. a hard-coded real path) still fails the run.
+source "$(dirname "$0")/../_state_guard_lib.sh"
+assert_binary_honors_overrides "target/release/daft"
+with_state_guard bash tests/integration/test_all.sh

--- a/tests/integration/test_all.sh
+++ b/tests/integration/test_all.sh
@@ -62,7 +62,43 @@ test_integration_remote_repo_creation() {
     assert_directory_exists "test-clone" || return 1
     assert_git_repository "test-clone" || return 1
     assert_file_exists "test-clone/README.md" || return 1
-    
+
+    return 0
+}
+
+# Regression (#738): the framework's own leak guard must have teeth. The bash
+# suites isolate the repo catalog purely via the DAFT_*_DIR overrides, which
+# compile out of non-dev builds — a binary that ignores them writes the real
+# catalog (the `test-repo-push-*` orphans that motivated this). setup() now
+# runs assert_binary_honors_overrides; this proves it both rejects a
+# non-honoring binary and accepts the honoring dev binary.
+test_integration_state_guard_preflight() {
+    # Positive: the real binary honors the overrides setup() exported.
+    if ! assert_binary_honors_overrides "$RUST_BINARY_DIR/daft" "$TEMP_BASE_DIR" 2>/dev/null; then
+        log_error "preflight rejected the honoring dev binary (false positive)"
+        return 1
+    fi
+
+    # Negative: a stub daft that ignores DAFT_*_DIR (stands in for a
+    # release/tagged build or a system daft) must be rejected.
+    local stub_dir="$PWD/stub-bin"
+    mkdir -p "$stub_dir"
+    cat > "$stub_dir/daft" <<'STUB'
+#!/bin/sh
+if [ "$1" = "__dirs" ]; then
+  printf 'config\t/nonsandbox/config/daft\n'
+  printf 'data\t/nonsandbox/share/daft\n'
+  printf 'state\t/nonsandbox/state/daft\n'
+fi
+STUB
+    chmod +x "$stub_dir/daft"
+
+    if assert_binary_honors_overrides "$stub_dir/daft" "$TEMP_BASE_DIR" 2>/dev/null; then
+        log_error "preflight accepted a binary that ignores DAFT_*_DIR (guard has no teeth)"
+        return 1
+    fi
+
+    log_success "state-guard preflight rejects non-honoring binaries and accepts the dev binary"
     return 0
 }
 
@@ -301,6 +337,7 @@ run_all_integration_tests() {
     run_test "integration_framework_assertions" "test_integration_framework_assertions"
     run_test "integration_remote_repo_creation" "test_integration_remote_repo_creation"
     run_test "integration_binaries_availability" "test_integration_binaries_availability"
+    run_test "integration_state_guard_preflight" "test_integration_state_guard_preflight"
     
     # Command-specific tests
     run_clone_tests

--- a/tests/integration/test_framework.sh
+++ b/tests/integration/test_framework.sh
@@ -82,6 +82,56 @@ cleanup() {
     fi
 }
 
+# Preflight guard (#697/#738): assert the daft binary at $1 resolves its
+# config/data/state dirs under the sandbox root $2 — i.e. it actually honors the
+# DAFT_*_DIR overrides setup() exports. Those overrides are dev-build gated
+# (build.rs `daft_dev_build`); a DAFT_BUILD_RELEASE build, a stale binary, or a
+# system `daft` on PATH silently ignores them, and setup() only *exports* the
+# sandbox dirs — it cannot force a non-honoring binary to use them. Without this
+# check, git-worktree-clone registers its temp repos into the developer's real
+# repo catalog (the #738 leak). Mirrors the built-in preflight in
+# test_completions.sh and assert_binary_honors_overrides in the mise state-guard
+# lib; the framework needs its own copy because test:integration:{verbose,matrix}
+# and direct ./test_all.sh runs invoke it outside `with_state_guard`.
+#
+# Checked per key, not as one substring match over the whole output: a build
+# that honored DAFT_CONFIG_DIR but resolved data/state to the real dirs would
+# satisfy a whole-output match while still leaking the catalog and the jobs dir.
+assert_binary_honors_overrides() {
+    local bin="$1" sandbox="$2"
+    if [[ ! -x "$bin" ]]; then
+        log_error "state-guard preflight: daft binary not found or not executable: $bin"
+        return 1
+    fi
+
+    local dirs
+    dirs="$("$bin" __dirs 2>/dev/null)" || {
+        log_error "state-guard preflight: '$bin __dirs' failed (binary too old to have __dirs, or broken)"
+        return 1
+    }
+
+    local key resolved kupper ok=0
+    for key in config data state; do
+        resolved="$(printf '%s\n' "$dirs" | awk -F '\t' -v k="$key" '$1 == k { print $2 }')"
+        case "$resolved" in
+            "$sandbox"/*) ;;
+            *)
+                # Uppercase via tr (not ${key^^}) to stay portable across bash 3.2.
+                kupper="$(printf '%s' "$key" | tr '[:lower:]' '[:upper:]')"
+                log_error "state-guard preflight: $bin ignores DAFT_${kupper}_DIR (resolved: ${resolved:-<none>})"
+                ok=1
+                ;;
+        esac
+    done
+
+    if [[ "$ok" != "0" ]]; then
+        log_error "Refusing to run: integration tests would touch your real config/state/data dirs."
+        log_error "The binary is not a daft_dev_build (a release/tagged build, or a system daft on PATH). Rebuild the dev binary. See #697/#738."
+        return 1
+    fi
+    return 0
+}
+
 # Setup function
 setup() {
     log "Setting up Rust integration test environment..."
@@ -154,6 +204,13 @@ setup() {
     # developer's real ~/.claude. Dev-build gated, like the DAFT_*_DIR trio.
     export DAFT_SKILLS_DIR="$TEMP_BASE_DIR/dskills"
     mkdir -p "$DAFT_SKILLS_DIR"
+
+    # Fail closed if the binary under test ignores the DAFT_*_DIR overrides just
+    # exported — otherwise clone/init would leak temp repos into the real
+    # catalog (#738). Belt to the `with_state_guard` suspenders: this fires even
+    # on the unguarded launch paths (test:integration:{verbose,matrix}, a direct
+    # ./test_all.sh) that never see the mise-level guard.
+    assert_binary_honors_overrides "$RUST_BINARY_DIR/daft" "$TEMP_BASE_DIR" || exit 1
 
     # Verify all binaries are available
     local binary_names=("git-worktree-clone" "git-worktree-checkout" "git-worktree-init" "git-worktree-prune")


### PR DESCRIPTION
## Problem

Four orphan `test-repo-push-*` rows showed up in a developer's **real**
`daft repo list`, pointing at long-deleted
`/private/tmp/git-worktree-integration-tests/work/test_*` dirs.

The shared bash integration framework (`test_framework.sh::setup()`) isolates
the repo catalog purely via the `DAFT_*_DIR` env overrides and **never verifies
the binary under test honors them**. Those overrides are dev-build gated
(`build.rs` `daft_dev_build`); a `DAFT_BUILD_RELEASE` build, a stale binary, or a
system `daft` on `PATH` silently ignores them, and `setup()` only *exports* the
sandbox dirs — it can't force a non-honoring binary to use them. When that
happens, `git-worktree-clone` registers its temp repos into the real catalog
(`catalog::register_repo`, warn-only).

`test_completions.sh` and `mise-tasks/test/_state_guard_lib.sh` already
fail-close on this via a `daft __dirs` preflight; the shared framework was the
odd one out. And only the `test:integration` **default** is wrapped in
`with_state_guard` — `test:integration:verbose` (`./test_all.sh`),
`test:integration:matrix` (single `--entry`), and any direct `./test_all.sh` run
were unguarded. `test_push.sh` is just the suite that happened to run through one
of those paths with a non-honoring binary; the tests themselves are correct.

## Fix

- **`assert_binary_honors_overrides()` in `test_framework.sh`**, called from
  `setup()` right after the `DAFT_*_DIR` exports. It runs `daft __dirs` and
  aborts (with the same #697 refusal) unless config/data/state all resolve under
  the sandbox — fail-closing **every** bash suite regardless of which mise task
  or ad-hoc command launched it. Checked per key, so a build that honors only
  `DAFT_CONFIG_DIR` while leaking data/state is still caught. Inlined, mirroring
  the `test_completions.sh` precedent (the real-state guard catches drift
  between the copies).
- **Guard the remaining launch paths (defense-in-depth):** the `verbose` and
  `matrix` mise tasks now mirror the guarded default (`assert` +
  `with_state_guard`), adding the snapshot/verify fingerprint that catches a
  leak slipping past the `__dirs` preflight (e.g. a hard-coded real path).
- **Regression self-test** `test_integration_state_guard_preflight`: a stub
  `daft` whose `__dirs` prints non-sandbox paths must be rejected; the honoring
  dev binary must be accepted.

## Verification

- `bash -n` clean on all four files.
- Guard **accepts** a honoring binary, **rejects** one that ignores `DAFT_*_DIR`
  (with the #697/#738 refusal) and a missing binary.
- The worktree's real dev binary passes the preflight end-to-end.

## Notes / out of scope

- The four existing orphans were cleared out-of-band with
  `daft repo remove --repo <name> --keep-files` (drops a stale entry whose dir is
  already gone; touches nothing on disk, reversible).
- `.github/labeler.yml` has no glob for `tests/**` or `mise-tasks/**`, so this
  change auto-labels with no `area:*`. Left as a possible small follow-up rather
  than widening scope here.

Fixes #738

🤖 Generated with [Claude Code](https://claude.com/claude-code)
