### PR TITLE
feat(output): live v toggle for verbose output on the plan-execute rail

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,8 @@ sysinfo = { version = "0.39.6", default-features = false, features = ["system"] 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 # `fs` adds mkfifo/open for the governor's POSIX jobserver FIFO (#678).
-nix = { version = "0.31", features = ["signal", "term", "fs"] }
+# `poll` adds the rail key listener's cancellable /dev/tty read (#729).
+nix = { version = "0.31", features = ["signal", "term", "fs", "poll"] }
 
 [dev-dependencies]
 tempfile = "3.8"

--- a/docs/cli/git-worktree-exec.md
+++ b/docs/cli/git-worktree-exec.md
@@ -62,7 +62,7 @@ git worktree-exec [OPTIONS] [TARGETS] [CMD]
 | `--sequential` | Run worktrees one at a time and stop on first failure |  |
 | `--keep-going` | Run worktrees one at a time and continue through failures |  |
 | `--refresh-aliases` | Re-capture user shell aliases instead of using the cached snapshot |  |
-| `-v, --verbose` | Thread each worktree's full output into the rail and dump captured output for successful worktrees too (no-op for single-target pass-through runs) |  |
+| `-v, --verbose` | Thread each worktree's full output into the rail and dump captured output for successful worktrees too (no-op for single-target pass-through runs). On a terminal, press `v` during a run to toggle threading either way |  |
 
 ## Global Options
 

--- a/docs/reference/progress-timeline.md
+++ b/docs/reference/progress-timeline.md
@@ -207,7 +207,8 @@ with one row per command):
   success, a rolling window while it runs — using the same
   `daft.hooks.output.tailLines` window the hook rail uses. A worker's full
   output reaches scrollback only once the rows ahead of it in the plan drain;
-  its `✓`/`✗`/`⊘` outcome is never delayed. Nothing prints below the footer.
+  its `✓`/`✗`/`⊘` outcome is never delayed. Nothing prints below the footer. You
+  can also press `v` mid-run to switch either way — see [Live keys](#live-keys).
 - A **single explicit-target** run (`daft exec feat/auth -- claude`, or a bare
   `--repo`) inherits stdio directly and renders no rail, so interactive programs
   work unchanged. A fan-out — `--all`, a glob, `--all-repos`, `--related`, or
@@ -241,8 +242,50 @@ shows a dim `held: memory` (or `held: capped` / `held: frozen` / `held: retry`)
 instead of running immediately, and a post-run summary line reports the total
 ("2 pushes throttled 14s to preserve memory headroom").
 
+## Live keys
+
+While the rail is on screen, the stopwatch footer offers what you can press:
+
+```
+└  4.2s   v verbose · ^C cancel
+```
+
+**`v` toggles verbose output for the run in progress.** Start terse and press
+`v` when a job starts looking interesting, or start with `-v` and press `v` to
+quiet it back down — verbosity is a decision you make while watching, not one
+you commit to before the run starts.
+
+The toggle takes effect immediately for rows still running and for every receipt
+printed from then on. Rows that already finished are a different matter: the
+rail is append-only, so their receipts stay exactly where they printed. Turning
+verbose on re-emits the logs of finished rows that printed compactly as a
+fold-out block below, headed by a repeat of the receipt line:
+
+```
+✓  feat/auth
+○  verbose on — replaying 1 finished row
+✓  feat/auth
+│    cargo test --lib
+│    test result: ok. 214 passed
+│
+```
+
+Each log folds out once, so toggling back and forth never repeats it. Failed
+rows are not replayed — their output already threaded when they failed. Turning
+verbose off collapses the live windows and leaves everything already printed
+alone.
+
+The hint and the toggle are terminal-only: with output redirected, in CI, or
+under `--quiet` there is no live region, no key listener, and no change to what
+daft prints. The toggle also does not change the captured-output dump
+`daft exec` writes to a redirected stdout — that follows the `-v` flag you
+passed, so a script's output does not depend on what you pressed. Only
+`daft exec`'s rows replay; hook-job rows (worktree create/remove, `daft run`)
+follow the new density from the next line they print onward.
+
 Pressing `Ctrl-C` mid-run collapses the live remainder of the rail and exits
 with status 130; everything already completed stays in your scrollback. A
 `daft exec` run interrupts cooperatively instead: the first `Ctrl-C` stops the
 running commands (SIGTERM), a second forces them (SIGKILL), and the rail closes
-as a `Cancelled` receipt.
+as a `Cancelled` receipt. This is unchanged by the key listener: `Ctrl-C`
+reaches daft as a real signal, not as a keystroke.

--- a/docs/reference/progress-timeline.md
+++ b/docs/reference/progress-timeline.md
@@ -270,10 +270,14 @@ fold-out block below, headed by a repeat of the receipt line:
 │
 ```
 
-Each log folds out once, so toggling back and forth never repeats it. Failed
-rows are not replayed — their output already threaded when they failed. Turning
-verbose off collapses the live windows and leaves everything already printed
-alone.
+The `verbose on` note appears only when there are finished rows to fold out. A
+flip with nothing to replay — and every `verbose off` — changes the live rows
+alone and adds no line to scrollback, so repeated toggling never piles up notes;
+the footer hint (`v verbose` / `v quiet`) is what always shows the current
+setting. Each log folds out once, so toggling back and forth never repeats it.
+Failed rows are not replayed — their output already threaded when they failed.
+Turning verbose off collapses the live windows and leaves everything already
+printed alone.
 
 The hint and the toggle are terminal-only: with output redirected, in CI, or
 under `--quiet` there is no live region, no key listener, and no change to what

--- a/man/daft-exec.1
+++ b/man/daft-exec.1
@@ -57,7 +57,7 @@ Run worktrees one at a time and continue through failures
 Re\-capture user shell aliases instead of using the cached snapshot
 .TP
 \fB\-v\fR, \fB\-\-verbose\fR
-Thread each worktree\*(Aqs full output into the rail and dump captured output for successful worktrees too (no\-op for single\-target pass\-through runs)
+Thread each worktree\*(Aqs full output into the rail and dump captured output for successful worktrees too (no\-op for single\-target pass\-through runs). On a terminal, press `v` during a run to toggle threading either way
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help (see a summary with \*(Aq\-h\*(Aq)

--- a/man/git-worktree-exec.1
+++ b/man/git-worktree-exec.1
@@ -57,7 +57,7 @@ Run worktrees one at a time and continue through failures
 Re\-capture user shell aliases instead of using the cached snapshot
 .TP
 \fB\-v\fR, \fB\-\-verbose\fR
-Thread each worktree\*(Aqs full output into the rail and dump captured output for successful worktrees too (no\-op for single\-target pass\-through runs)
+Thread each worktree\*(Aqs full output into the rail and dump captured output for successful worktrees too (no\-op for single\-target pass\-through runs). On a terminal, press `v` during a run to toggle threading either way
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help (see a summary with \*(Aq\-h\*(Aq)

--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -1703,6 +1703,7 @@ fn run_checkout(
         output.is_verbose(),
         format!("Opening {header_target}"),
     );
+    timeline.set_verbose_density(hook_output_config.verbose);
 
     timeline.open_planning("Resolving branch");
     let checkout_result = {
@@ -1846,6 +1847,7 @@ fn run_create_branch_core(
         output.is_verbose(),
         format!("Starting {}", args.branch_name),
     );
+    timeline.set_verbose_density(hook_output_config.verbose);
     let interactive = timeline.is_interactive();
 
     // Presenter for the pre-push hook run on the auto-upstream push. On the

--- a/src/commands/clone.rs
+++ b/src/commands/clone.rs
@@ -1707,6 +1707,10 @@ fn run_post_clone_hook(
     // that ignored the user's hooks.output config here); `-v` opts into the
     // full hook block on the rail (#651).
     let hook_output_config = hooks_config.output.with_cli_verbose(output.is_verbose());
+    // Clone resolves its hook-output config here rather than at command
+    // start (cwd-tolerance, above), so the rail learns its job-log density
+    // now — before the block draws, which is all the live flag requires.
+    timeline.set_verbose_density(hook_output_config.verbose);
     let mut executor = HookExecutor::new(hooks_config)?.with_job_filter(
         crate::hooks::yaml_executor::JobFilter::skipping(&args.skip_hooks),
     );
@@ -1773,6 +1777,7 @@ fn run_post_create_hook(
     // see the comment there.
     let hooks_config = crate::core::settings::load_hooks_config_global()?;
     let hook_output_config = hooks_config.output.with_cli_verbose(output.is_verbose());
+    timeline.set_verbose_density(hook_output_config.verbose);
     let mut executor = HookExecutor::new(hooks_config)?.with_job_filter(
         crate::hooks::yaml_executor::JobFilter::skipping(&args.skip_hooks),
     );

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -120,7 +120,7 @@ pub struct Args {
     #[arg(
         short = 'v',
         long = "verbose",
-        help = "Thread each worktree's full output into the rail and dump captured output for successful worktrees too (no-op for single-target pass-through runs)"
+        help = "Thread each worktree's full output into the rail and dump captured output for successful worktrees too (no-op for single-target pass-through runs). On a terminal, press `v` during a run to toggle threading either way"
     )]
     pub verbose: bool,
 

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -441,7 +441,6 @@ fn run_rail(
     let mut timeline = Timeline::new(TimelineMode::auto(false), hook_output.verbose, header);
     timeline.set_ordered_receipts(true);
     timeline.set_row_output(RowOutputConfig {
-        verbose: hook_output.verbose,
         tail_lines: hook_output.tail_lines as usize,
         buffer_cap: Some(core::OUTPUT_CAP_BYTES),
     });

--- a/src/commands/push.rs
+++ b/src/commands/push.rs
@@ -230,6 +230,7 @@ fn run_push(
         output.is_verbose(),
         format!("Pushing {branch}"),
     );
+    timeline.set_verbose_density(hook_output_config.verbose);
     let interactive = timeline.is_interactive();
     let presenter: Option<Arc<dyn JobPresenter>> = if interactive {
         Some(CliPresenter::embedded_for_stage(

--- a/src/commands/worktree_branch.rs
+++ b/src/commands/worktree_branch.rs
@@ -514,6 +514,7 @@ fn run_branch_delete(
         format!("Removing {} branches", branches.len())
     };
     let mut timeline = Timeline::new(TimelineMode::auto(quiet), output.is_verbose(), header);
+    timeline.set_verbose_density(hook_output_config.verbose);
     let interactive = timeline.is_interactive();
 
     // Presenter for the pre-push hook run on remote-branch deletes. On the

--- a/src/core/worktree/exec/rail_presenter.rs
+++ b/src/core/worktree/exec/rail_presenter.rs
@@ -182,7 +182,6 @@ mod tests {
         tl.set_test_draw_target(ProgressDrawTarget::term_like(Box::new(term.clone())));
         tl.set_ordered_receipts(true);
         tl.set_row_output(RowOutputConfig {
-            verbose: false,
             tail_lines: 6,
             buffer_cap: None,
         });
@@ -260,7 +259,6 @@ mod tests {
         tl.set_test_draw_target(ProgressDrawTarget::term_like(Box::new(term.clone())));
         tl.set_ordered_receipts(true);
         tl.set_row_output(RowOutputConfig {
-            verbose: false,
             tail_lines: 6,
             buffer_cap: None,
         });
@@ -319,7 +317,6 @@ mod tests {
         tl.set_test_draw_target(ProgressDrawTarget::term_like(Box::new(term.clone())));
         tl.set_ordered_receipts(true);
         tl.set_row_output(RowOutputConfig {
-            verbose: false,
             tail_lines: 6,
             buffer_cap: None,
         });

--- a/src/executor/command.rs
+++ b/src/executor/command.rs
@@ -198,6 +198,13 @@ pub fn run_command_interactive(
     working_dir: &Path,
     cancel: Option<&crate::git::cancel::CancelFlag>,
 ) -> Result<CommandResult> {
+    // The child inherits stdin, so it owns the terminal for its lifetime.
+    // If a rail key listener is watching (#729), stand it down and hand the
+    // driver back to cooked, echoing input — otherwise the child would run
+    // with `ECHO`/`ICANON` off, showing nothing as the user types, while the
+    // listener raced it for the same bytes. No-op when nothing is listening.
+    let _keys = crate::output::term_guard::suspend_key_input();
+
     let mut command = Command::new("sh");
     command.args(["-c", cmd]);
     command.current_dir(working_dir);

--- a/src/output/term_guard.rs
+++ b/src/output/term_guard.rs
@@ -7,6 +7,17 @@
 //! cursor-up/erase by one, stranding a stale bar line in scrollback.
 //! Disabling `ECHOCTL` for the region's lifetime suppresses the echo.
 //!
+//! When the rail also reads keys (#729's live `v` toggle) the guard
+//! escalates: `ICANON` and `ECHO` come off too, so a keypress arrives
+//! without Enter and without printing itself into the live region.
+//!
+//! **`ISIG` always stays on.** That is what separates this from crossterm's
+//! all-or-nothing raw mode: Ctrl-C keeps raising a real `SIGINT`, so the
+//! interrupt dispatcher — and `daft exec`'s two-stage SIGTERM/SIGKILL
+//! escalation (#663) — are untouched. The corollary is that `^C` is consumed
+//! by the line discipline and never reaches a reader as a byte; a key
+//! listener neither sees nor needs to handle it.
+//!
 //! Used by the multi-worktree exec renderer and the plan-execute timeline.
 
 /// The termios saved by the currently live guard, for interrupt-exit paths
@@ -76,6 +87,150 @@ impl EchoCtlGuard {
     }
 }
 
+/// The live key listener's pause flag, when one is watching the terminal.
+/// `Some` also means the driver is (or should be) in unbuffered mode. One
+/// slot — regions never nest, and only a region reads keys.
+#[cfg(unix)]
+static KEY_LISTENER: std::sync::Mutex<Option<std::sync::Arc<std::sync::atomic::AtomicBool>>> =
+    std::sync::Mutex::new(None);
+
+/// Re-apply the region's baseline input discipline: the live guard's
+/// original with only `ECHOCTL` cleared. Cooked, line-edited, echoing.
+#[cfg(unix)]
+fn apply_region_baseline() {
+    use nix::sys::termios::{LocalFlags, SetArg, tcgetattr, tcsetattr};
+    use std::os::fd::AsFd;
+
+    let Ok(active) = ACTIVE_ORIGINAL.lock() else {
+        return;
+    };
+    let Some(original) = active.as_ref() else {
+        return;
+    };
+    let stderr = std::io::stderr();
+    let Ok(mut attrs) = tcgetattr(stderr.as_fd()) else {
+        return;
+    };
+    // Take the original's whole input discipline back — canonical flags,
+    // `VMIN`/`VTIME` included — then re-apply the region's own edit.
+    attrs.local_flags = original.local_flags;
+    attrs.control_chars = original.control_chars;
+    attrs.local_flags.remove(LocalFlags::ECHOCTL);
+    let _ = tcsetattr(stderr.as_fd(), SetArg::TCSANOW, &attrs);
+}
+
+/// Escalate to unbuffered, unechoed key input on top of the baseline:
+/// `ICANON` and `ECHO` off, `VMIN=1`/`VTIME=0`. `ISIG` is deliberately left
+/// alone — see the module docs.
+///
+/// `VMIN`/`VTIME` are not optional: with `ICANON` off they alone decide what
+/// a read does, and a terminal left at `VMIN=0` by a previous program turns
+/// every read into an instant zero-byte return — which a naive listener
+/// reads as EOF, or spins on.
+#[cfg(unix)]
+fn apply_key_input() -> bool {
+    use nix::sys::termios::{LocalFlags, SetArg, SpecialCharacterIndices, tcgetattr, tcsetattr};
+    use std::os::fd::AsFd;
+
+    let stderr = std::io::stderr();
+    let Ok(mut attrs) = tcgetattr(stderr.as_fd()) else {
+        return false;
+    };
+    attrs
+        .local_flags
+        .remove(LocalFlags::ICANON | LocalFlags::ECHO);
+    attrs.control_chars[SpecialCharacterIndices::VMIN as usize] = 1;
+    attrs.control_chars[SpecialCharacterIndices::VTIME as usize] = 0;
+    tcsetattr(stderr.as_fd(), SetArg::TCSANOW, &attrs).is_ok()
+}
+
+/// Start reading keys unbuffered: escalate the driver and register
+/// `paused` so prompts can stand the listener down. Returns whether the
+/// escalation took (no live guard, or a non-TTY stderr, means no).
+///
+/// Called when a listener actually starts — never at region construction.
+/// Between the two lies the planning face, where prompts run and no reader
+/// exists; escalating there would swallow keystrokes invisibly and hand
+/// them to a listener minutes later.
+#[cfg(unix)]
+pub(crate) fn begin_key_input(paused: std::sync::Arc<std::sync::atomic::AtomicBool>) -> bool {
+    if ACTIVE_ORIGINAL.lock().is_ok_and(|g| g.is_none()) {
+        return false;
+    }
+    install_panic_restore();
+    if !apply_key_input() {
+        return false;
+    }
+    if let Ok(mut slot) = KEY_LISTENER.lock() {
+        *slot = Some(paused);
+    }
+    true
+}
+
+/// Restore the terminal if the process panics while key input is escalated.
+///
+/// `Drop` is not enough: release builds are `panic = "abort"`, where no
+/// destructor runs — the terminal would be left unable to echo the user's
+/// typing, which is a far worse failure than the panic itself. Panic hooks
+/// *do* run before the abort.
+///
+/// Installed once and never removed: it chains the previous hook, and
+/// [`restore_active_termios`] is a no-op when no guard is live, so leaving
+/// it in place costs nothing.
+#[cfg(unix)]
+fn install_panic_restore() {
+    static INSTALLED: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+    INSTALLED.get_or_init(|| {
+        let previous = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |info| {
+            restore_active_termios();
+            previous(info);
+        }));
+    });
+}
+
+/// Stop reading keys: back to the region's cooked baseline.
+#[cfg(unix)]
+pub(crate) fn end_key_input() {
+    if let Ok(mut slot) = KEY_LISTENER.lock() {
+        *slot = None;
+    }
+    apply_region_baseline();
+}
+
+/// Hand the terminal back to a blocking reader — a prompt, or an
+/// interactive hook job with inherited stdin — for as long as the returned
+/// guard lives.
+///
+/// Without this the child would run with `ECHO`/`ICANON` off (no visible
+/// typing, no line editing) while the rail's listener raced it for the same
+/// device. A no-op when nothing is listening, which is every pre-#729 path.
+#[cfg(unix)]
+pub(crate) fn suspend_key_input() -> KeyInputSuspension {
+    let paused = KEY_LISTENER.lock().ok().and_then(|slot| slot.clone());
+    if let Some(flag) = &paused {
+        flag.store(true, std::sync::atomic::Ordering::SeqCst);
+        apply_region_baseline();
+    }
+    KeyInputSuspension { paused }
+}
+
+/// Restores unbuffered key input when it drops. See [`suspend_key_input`].
+#[cfg(unix)]
+pub(crate) struct KeyInputSuspension {
+    paused: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
+}
+
+#[cfg(unix)]
+impl Drop for KeyInputSuspension {
+    fn drop(&mut self) {
+        if let Some(flag) = &self.paused {
+            apply_key_input();
+            flag.store(false, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
+}
+
 #[cfg(unix)]
 impl Drop for EchoCtlGuard {
     fn drop(&mut self) {
@@ -138,3 +293,56 @@ pub(crate) fn restore_termios(_saved: &Option<()>) {}
 
 #[cfg(not(unix))]
 pub(crate) fn restore_active_termios() {}
+
+#[cfg(not(unix))]
+pub(crate) fn begin_key_input(_paused: std::sync::Arc<std::sync::atomic::AtomicBool>) -> bool {
+    false
+}
+
+#[cfg(not(unix))]
+pub(crate) fn end_key_input() {}
+
+#[cfg(not(unix))]
+pub(crate) fn suspend_key_input() -> KeyInputSuspension {
+    KeyInputSuspension
+}
+
+#[cfg(not(unix))]
+pub(crate) struct KeyInputSuspension;
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    #[test]
+    #[serial]
+    fn a_suspension_stands_the_listener_down_and_brings_it_back() {
+        let flag = Arc::new(AtomicBool::new(false));
+        *KEY_LISTENER.lock().unwrap() = Some(Arc::clone(&flag));
+        {
+            let _prompt = suspend_key_input();
+            assert!(
+                flag.load(Ordering::SeqCst),
+                "a prompt must stop the listener reading the keys meant for it"
+            );
+        }
+        assert!(
+            !flag.load(Ordering::SeqCst),
+            "the listener resumes once the prompt is done"
+        );
+        *KEY_LISTENER.lock().unwrap() = None;
+    }
+
+    #[test]
+    #[serial]
+    fn suspending_with_no_listener_is_inert() {
+        // Every pre-#729 prompt: nothing registered, so nothing is paused
+        // and the terminal is never touched.
+        *KEY_LISTENER.lock().unwrap() = None;
+        let suspension = suspend_key_input();
+        assert!(suspension.paused.is_none());
+    }
+}

--- a/src/output/timeline/bridge.rs
+++ b/src/output/timeline/bridge.rs
@@ -35,6 +35,10 @@ pub fn error_line(msg: &str) -> String {
 pub struct RegionOutput {
     handle: TimelineHandle,
     quiet: bool,
+    /// `-v` free-text chatter, not the rail's job-log density: this is the
+    /// `Output` contract's verbosity, and the live `v` toggle (#729)
+    /// deliberately leaves it alone — pressing `v` asks for job output, not
+    /// for debug lines.
     verbose: bool,
 }
 

--- a/src/output/timeline/key_listener.rs
+++ b/src/output/timeline/key_listener.rs
@@ -1,0 +1,154 @@
+//! The rail's live key reader (#729): `v` toggles verbose mid-run.
+//!
+//! The plan-execute rail is an indicatif *output* region — it had no input
+//! path at all, and the `KeyCode`/raw-mode machinery under `output::tui`
+//! belongs to a different renderer family (full raw mode, alternate screen,
+//! `ISIG` off) that would break both indicatif's drawing and `daft exec`'s
+//! two-stage Ctrl-C. So this is deliberately small: one thread, one key, one
+//! `/dev/tty` handle, and a partial termios change owned by
+//! [`crate::output::term_guard`].
+//!
+//! Keys are read from a **dup of stderr**, not from stdin and not from
+//! `/dev/tty`. Stderr is the device the rail draws on — the whole renderer
+//! is gated on `stderr.is_terminal()` — and the one
+//! [`crate::output::term_guard`] configures, so reading it is the only
+//! choice that cannot end up talking to a different terminal than the user
+//! is watching. Stdin is wrong because it may be a pipe or `/dev/null` while
+//! the rail still renders; `/dev/tty` is wrong because it resolves through
+//! the *controlling* terminal, which a process can lack entirely (a pty with
+//! no `setsid`, a container) or which can differ from stderr's device.
+//!
+//! The one cost is that a write-only stderr cannot be read. Terminals are
+//! opened read-write in every normal shell, and if a read does fail the
+//! listener simply stops — the rail then renders at its flag-given density,
+//! exactly as it did before #729.
+//!
+//! `^C` never arrives here. `ISIG` stays on, so the line discipline turns it
+//! into a `SIGINT` before any reader sees a byte — the interrupt dispatcher
+//! and #663's escalation are untouched.
+
+use super::TimelineHandle;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+/// How long a read waits before re-checking the stop and pause flags. Also
+/// the worst-case delay teardown waits on when it joins.
+const POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// A running key listener. Dropping it stops the thread, restores the
+/// terminal, and joins — in that order.
+pub(super) struct KeyListener {
+    stop: Arc<AtomicBool>,
+    thread: Option<std::thread::JoinHandle<()>>,
+}
+
+impl KeyListener {
+    /// Start watching the rail's terminal for `v`. `None` when it cannot be
+    /// read or the driver refuses unbuffered mode, in which case the rail
+    /// renders at its flag-given density — exactly as it did before #729.
+    #[cfg(unix)]
+    pub(super) fn spawn(handle: TimelineHandle) -> Option<Self> {
+        use std::io::IsTerminal;
+        use std::os::fd::AsFd;
+
+        let stderr = std::io::stderr();
+        if !stderr.is_terminal() {
+            return None;
+        }
+        // A dup, so the listener's fd lifetime is its own and closing it
+        // never disturbs the region's writes to fd 2.
+        let tty = stderr.as_fd().try_clone_to_owned().ok()?;
+        let paused = Arc::new(AtomicBool::new(false));
+        if !crate::output::term_guard::begin_key_input(Arc::clone(&paused)) {
+            return None;
+        }
+        let stop = Arc::new(AtomicBool::new(false));
+        let thread = std::thread::spawn({
+            let stop = Arc::clone(&stop);
+            let paused = Arc::clone(&paused);
+            move || read_keys(&tty, &handle, &stop, &paused)
+        });
+        Some(Self {
+            stop,
+            thread: Some(thread),
+        })
+    }
+
+    #[cfg(not(unix))]
+    pub(super) fn spawn(_handle: TimelineHandle) -> Option<Self> {
+        None
+    }
+
+    /// Stop the thread and hand the terminal back. Idempotent.
+    ///
+    /// The join must happen with the timeline's mutex *released*: the
+    /// listener may be blocked on that very lock inside `toggle_verbose`, so
+    /// joining while holding it would deadlock teardown.
+    pub(super) fn stop(&mut self) {
+        self.stop.store(true, Ordering::SeqCst);
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+        crate::output::term_guard::end_key_input();
+    }
+}
+
+impl Drop for KeyListener {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+/// Poll the terminal for single keypresses until told to stop.
+#[cfg(unix)]
+fn read_keys(
+    tty: &std::os::fd::OwnedFd,
+    handle: &TimelineHandle,
+    stop: &AtomicBool,
+    paused: &AtomicBool,
+) {
+    use nix::poll::{PollFd, PollFlags, PollTimeout};
+    use std::os::fd::AsFd;
+
+    while !stop.load(Ordering::SeqCst) {
+        // Paused: do not even poll. The byte stays queued in the terminal
+        // for whoever owns it now (a prompt, an interactive hook job) —
+        // reading it here would steal their input.
+        if paused.load(Ordering::SeqCst) {
+            std::thread::sleep(POLL_INTERVAL);
+            continue;
+        }
+        let mut fds = [PollFd::new(tty.as_fd(), PollFlags::POLLIN)];
+        let timeout = PollTimeout::try_from(POLL_INTERVAL).unwrap_or(PollTimeout::NONE);
+        match nix::poll::poll(&mut fds, timeout) {
+            Ok(0) => continue,
+            Ok(_) => {}
+            // EINTR is routine here: every `^C` interrupts the poll.
+            Err(nix::errno::Errno::EINTR) => continue,
+            Err(_) => break,
+        }
+        // Re-check after the wait: a prompt may have claimed the terminal
+        // while we were polling. The narrow race left — pausing between
+        // this check and the read — can only consume a byte typed *before*
+        // the prompt appeared, which was never aimed at it.
+        if paused.load(Ordering::SeqCst) || stop.load(Ordering::SeqCst) {
+            continue;
+        }
+        let mut buf = [0u8; 1];
+        match nix::unistd::read(tty.as_fd(), &mut buf) {
+            Ok(1) => {
+                if buf[0] == b'v' || buf[0] == b'V' {
+                    handle.toggle_verbose();
+                }
+                // Every other key is swallowed. With `ECHO` off it would
+                // not have printed anyway, and the rail is deliberately not
+                // growing a second keymap.
+            }
+            // A zero-byte read means the terminal went away.
+            Ok(_) => break,
+            Err(nix::errno::Errno::EINTR) => continue,
+            Err(_) => break,
+        }
+    }
+}

--- a/src/output/timeline/mod.rs
+++ b/src/output/timeline/mod.rs
@@ -37,20 +37,47 @@ pub(crate) const NOT_RUN: &str = "(not run)";
 use crate::core::stage::{PlanCommit, StageEvent, StepKey};
 use region::{FinalFace, RegionSetup, Resolution, TimelineCore, UnresolvedPolicy};
 use std::io::IsTerminal;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
+
+/// One invocation's verbosity, shared by every renderer that draws into the
+/// region and read at render time rather than snapshotted at construction.
+///
+/// Density is a *runtime* decision (#729): a `v` keypress mid-run flips the
+/// rail between terse and verbose, so the timeline core, `daft exec`'s row
+/// threads, the embedded hook renderer (rebuilt per phase, behind its own
+/// presenter lock) and the region's `Output` bridge must all consult one
+/// source instead of holding four independent copies.
+#[derive(Clone)]
+pub struct LiveVerbose(Arc<AtomicBool>);
+
+impl LiveVerbose {
+    pub(crate) fn new(on: bool) -> Self {
+        Self(Arc::new(AtomicBool::new(on)))
+    }
+
+    /// The density to render with *now*. `Relaxed` throughout: this flag
+    /// publishes no other memory — every reader repaints from state it
+    /// already owns — so ordering buys nothing.
+    pub(crate) fn get(&self) -> bool {
+        self.0.load(Ordering::Relaxed)
+    }
+
+    pub(crate) fn set(&self, on: bool) {
+        self.0.store(on, Ordering::Relaxed);
+    }
+}
 
 /// Per-row output threads (`daft exec`): each worker's live output rides its
 /// plan row, and its captured log threads into the receipt. Set via
 /// [`Timeline::set_row_output`] before the region materializes; only meaningful
 /// alongside [`Timeline::set_ordered_receipts`].
+///
+/// Density is not a field here — verbose threading reads the timeline's shared
+/// [`LiveVerbose`], so a mid-run toggle reaches these rows too.
 #[derive(Clone, Copy)]
 pub struct RowOutputConfig {
-    /// Thread every row's full log into the receipt (grey under success) and
-    /// show a rolling live window while it runs. Off: only failed/cancelled
-    /// rows thread their captured output, and the live view is one latest-line
-    /// annotation per row.
-    pub verbose: bool,
     /// Rolling live-window height (`daft.hooks.output.tailLines`).
     pub tail_lines: usize,
     /// Byte budget for a row's buffered log (a chatty worker keeps only the
@@ -96,7 +123,15 @@ impl TimelineMode {
 
 struct Inner {
     header: String,
-    verbose: bool,
+    /// Rail density: whether job logs thread under their rows. Live — a `v`
+    /// keypress flips it mid-run (#729).
+    verbose: LiveVerbose,
+    /// The `-v` free-text detail gate. A separate, fixed concern: `-v` is
+    /// developer chatter, `daft.hooks.output.verbose` is job-log density, and
+    /// they have always been seeded independently. The live toggle owns
+    /// density only — pressing `v` asks for a job's output, not for debug
+    /// lines.
+    detail_verbose: bool,
     use_color: bool,
     /// Ordered receipts (`daft exec`): out-of-order completion still leaves a
     /// plan-ordered scrollback receipt. Set via
@@ -125,7 +160,8 @@ impl Inner {
     /// Snapshot the region knobs for a constructor call.
     fn region_setup(&self) -> RegionSetup {
         RegionSetup {
-            verbose: self.verbose,
+            verbose: self.verbose.clone(),
+            detail_verbose: self.detail_verbose,
             use_color: self.use_color,
             ordered: self.ordered,
             row_output: self.row_output,
@@ -236,6 +272,14 @@ impl TimelineHandle {
     /// Whether a live region currently owns the terminal.
     pub fn region_live(&self) -> bool {
         self.lock().core.is_some()
+    }
+
+    /// This invocation's shared density flag — handed to renderers that draw
+    /// into the region from behind their own locks (the per-phase hook
+    /// renderer, the `Output` bridge) so they read the live value instead of
+    /// snapshotting one.
+    pub fn verbose_flag(&self) -> LiveVerbose {
+        self.lock().verbose.clone()
     }
 
     /// Hold `lines` back until the rail closes; the timeline prints them
@@ -357,7 +401,8 @@ impl Timeline {
             handle: TimelineHandle {
                 inner: Arc::new(Mutex::new(Inner {
                     header: header.into(),
-                    verbose,
+                    verbose: LiveVerbose::new(verbose),
+                    detail_verbose: verbose,
                     use_color,
                     ordered: false,
                     row_output: None,
@@ -413,6 +458,19 @@ impl Timeline {
     /// region materializes. Pairs with [`Self::set_ordered_receipts`].
     pub fn set_row_output(&self, config: RowOutputConfig) {
         self.handle.lock().row_output = Some(config);
+    }
+
+    /// Seed the rail's job-log density from the resolved hook-output config
+    /// (`daft.hooks.output.verbose`, already folded with `-v`).
+    ///
+    /// Lifecycle commands seed the timeline's `-v` detail gate from the CLI
+    /// flag alone but render hook jobs at the *config's* density — two
+    /// independent decisions before #729 gave them one shared flag. This is
+    /// the second one. Unlike the other knobs it needs no
+    /// before-materialization ordering: density is read at render time, so
+    /// setting it any time before the hook phase draws is equivalent.
+    pub fn set_verbose_density(&self, verbose: bool) {
+        self.handle.lock().verbose.set(verbose);
     }
 
     /// Update the planning face's label in place ("Cloning repository" →
@@ -640,6 +698,12 @@ impl Timeline {
 
     pub fn handle(&self) -> TimelineHandle {
         self.handle.clone()
+    }
+
+    /// This invocation's shared density flag. See
+    /// [`TimelineHandle::verbose_flag`].
+    pub fn verbose_flag(&self) -> LiveVerbose {
+        self.handle.verbose_flag()
     }
 
     /// Test-only: route the region's draw calls into `target` (an
@@ -1172,17 +1236,11 @@ mod tests {
         );
     }
 
-    fn exec_verbose() -> RowOutputConfig {
+    /// `daft exec`-shaped row output. Density is the timeline's own (seed it
+    /// with [`Timeline::set_verbose_density`]), exactly as `run_rail` wires
+    /// it in production.
+    fn exec_row_output() -> RowOutputConfig {
         RowOutputConfig {
-            verbose: true,
-            tail_lines: 6,
-            buffer_cap: None,
-        }
-    }
-
-    fn exec_default() -> RowOutputConfig {
-        RowOutputConfig {
-            verbose: false,
             tail_lines: 6,
             buffer_cap: None,
         }
@@ -1192,7 +1250,8 @@ mod tests {
     fn verbose_row_threads_its_log_grey_under_success() {
         let (mut tl, term) = captured("Running mise clean in 1 worktree");
         tl.set_ordered_receipts(true);
-        tl.set_row_output(exec_verbose());
+        tl.set_verbose_density(true);
+        tl.set_row_output(exec_row_output());
         tl.commit_plan(PlanCommit::new(vec![exec_row("master")]));
         let k = exec_key("master");
         tl.on_stage(&k, StageEvent::Started);
@@ -1216,7 +1275,7 @@ mod tests {
     fn default_failure_threads_output_but_success_stays_compact() {
         let (mut tl, term) = captured("Running mise clean in 2 worktrees");
         tl.set_ordered_receipts(true);
-        tl.set_row_output(exec_default());
+        tl.set_row_output(exec_row_output());
         tl.commit_plan(PlanCommit::new(vec![exec_row("ok"), exec_row("bad")]));
         let ok = exec_key("ok");
         tl.on_stage(&ok, StageEvent::Started);
@@ -1252,7 +1311,7 @@ mod tests {
         // a `(no output)` thread line — that placeholder is verbose-only.
         let (mut tl, term) = captured("Running true in 1 worktree");
         tl.set_ordered_receipts(true);
-        tl.set_row_output(exec_default());
+        tl.set_row_output(exec_row_output());
         tl.commit_plan(PlanCommit::new(vec![exec_row("q")]));
         let k = exec_key("q");
         tl.on_stage(&k, StageEvent::Started);
@@ -1277,7 +1336,8 @@ mod tests {
     fn verbose_silent_row_marks_no_output() {
         let (mut tl, term) = captured("Running true in 1 worktree");
         tl.set_ordered_receipts(true);
-        tl.set_row_output(exec_verbose());
+        tl.set_verbose_density(true);
+        tl.set_row_output(exec_row_output());
         tl.commit_plan(PlanCommit::new(vec![exec_row("q")]));
         let k = exec_key("q");
         tl.on_stage(&k, StageEvent::Started);

--- a/src/output/timeline/mod.rs
+++ b/src/output/timeline/mod.rs
@@ -67,6 +67,11 @@ impl LiveVerbose {
     pub(crate) fn set(&self, on: bool) {
         self.0.store(on, Ordering::Relaxed);
     }
+
+    /// Flip, returning the new density.
+    pub(crate) fn toggle(&self) -> bool {
+        !self.0.fetch_xor(true, Ordering::Relaxed)
+    }
 }
 
 /// Per-row output threads (`daft exec`): each worker's live output rides its
@@ -282,6 +287,23 @@ impl TimelineHandle {
         self.lock().verbose.clone()
     }
 
+    /// Flip the rail's job-log density mid-run — the live `v` key (#729).
+    /// Returns the new density, or `None` when no region is live to show it
+    /// (the flag stays put: density must not drift while nothing renders).
+    ///
+    /// Called from the key-listener thread, so it takes the same lock every
+    /// worker thread already funnels through: the flip, the fold-out replay
+    /// and the live repaint are one atomic step against any concurrent row
+    /// event.
+    pub fn toggle_verbose(&self) -> Option<bool> {
+        let mut inner = self.lock();
+        let flag = inner.verbose.clone();
+        let core = inner.core.as_mut()?;
+        let on = flag.toggle();
+        core.on_density_toggled(on);
+        Some(on)
+    }
+
     /// Hold `lines` back until the rail closes; the timeline prints them
     /// after the footer (blank-line separated). No-op semantics match the
     /// rest of the handle: with no region the lines still drain at teardown,
@@ -471,6 +493,21 @@ impl Timeline {
     /// setting it any time before the hook phase draws is equivalent.
     pub fn set_verbose_density(&self, verbose: bool) {
         self.handle.lock().verbose.set(verbose);
+    }
+
+    /// Keep compact receipts' captured logs so a later `v` can fold them out
+    /// (#729). Off by default: retention is only worth its memory when
+    /// something can actually toggle, so the key listener turns it on once it
+    /// is watching. Requires a live region.
+    pub fn set_retain_for_replay(&self, on: bool) {
+        if let Some(core) = self.handle.lock().core.as_mut() {
+            core.set_retain_for_replay(on);
+        }
+    }
+
+    /// Flip the rail's density mid-run. See [`TimelineHandle::toggle_verbose`].
+    pub fn toggle_verbose(&self) -> Option<bool> {
+        self.handle.toggle_verbose()
     }
 
     /// Update the planning face's label in place ("Cloning repository" →
@@ -1352,6 +1389,203 @@ mod tests {
              \u{2502}\n\
              \u{2514}  Done in 0.1s"
         );
+    }
+
+    // ── live density toggle (#729) ───────────────────────────────────────
+    //
+    // A `v` keypress flips density mid-run. Scrollback is append-only, so a
+    // verbose-ward flip cannot rewrite the compact receipts already printed
+    // — it re-emits their captured logs below as a fold-out block instead.
+    // These drive the toggle directly; the key listener that calls it is
+    // TTY-only and out of scope here.
+
+    /// A terse run with retention on, so finished compact rows keep their
+    /// logs (production turns this on only when a key listener exists).
+    fn toggleable(header: &str, rows: &[&str]) -> (Timeline, indicatif::InMemoryTerm) {
+        let (mut tl, term) = captured(header);
+        tl.set_ordered_receipts(true);
+        tl.set_row_output(exec_row_output());
+        tl.commit_plan(PlanCommit::new(
+            rows.iter().map(|label| exec_row(label)).collect(),
+        ));
+        tl.set_retain_for_replay(true);
+        (tl, term)
+    }
+
+    fn run_row(tl: &mut Timeline, label: &str, output: &str) {
+        let key = exec_key(label);
+        tl.on_stage(&key, StageEvent::Started);
+        tl.handle().push_row_output(&key, output);
+        tl.on_stage(&key, StageEvent::Completed { annotation: None });
+    }
+
+    #[test]
+    fn toggling_verbose_folds_out_finished_rows_and_threads_later_ones() {
+        let (mut tl, term) = toggleable("Running cargo test in 2 worktrees", &["a", "b"]);
+        run_row(&mut tl, "a", "a-out");
+        assert_eq!(tl.toggle_verbose(), Some(true));
+        run_row(&mut tl, "b", "b-out");
+        tl.finish("Done in 0.1s");
+        // `a`'s compact receipt stays frozen where it printed; its log folds
+        // out below under a repeat of the same receipt line. `b`, which
+        // resolved after the flip, threads inline like any verbose row.
+        assert_eq!(
+            term.contents(),
+            "\u{250c}  Running cargo test in 2 worktrees\n\
+             \u{2502}\n\
+             \u{2713}  a\n\
+             \u{25cb}  verbose on \u{2014} replaying 1 finished row\n\
+             \u{2713}  a\n\
+             \u{2502}    a-out\n\
+             \u{2502}\n\
+             \u{2713}  b\n\
+             \u{2502}    b-out\n\
+             \u{2502}\n\
+             \u{2514}  Done in 0.1s"
+        );
+    }
+
+    #[test]
+    fn replay_is_consumed_so_flipping_back_and_forth_never_repeats_a_log() {
+        let (mut tl, term) = toggleable("Running cargo test in 1 worktree", &["a"]);
+        run_row(&mut tl, "a", "a-out");
+        assert_eq!(tl.toggle_verbose(), Some(true));
+        assert_eq!(tl.toggle_verbose(), Some(false));
+        assert_eq!(tl.toggle_verbose(), Some(true));
+        tl.finish("Done in 0.1s");
+        // Exactly one fold-out: the second verbose-ward flip has nothing left
+        // to replay, and says so by dropping the count clause.
+        assert_eq!(
+            term.contents(),
+            "\u{250c}  Running cargo test in 1 worktree\n\
+             \u{2502}\n\
+             \u{2713}  a\n\
+             \u{25cb}  verbose on \u{2014} replaying 1 finished row\n\
+             \u{2713}  a\n\
+             \u{2502}    a-out\n\
+             \u{2502}\n\
+             \u{25cb}  verbose off\n\
+             \u{25cb}  verbose on\n\
+             \u{2502}\n\
+             \u{2514}  Done in 0.1s"
+        );
+    }
+
+    #[test]
+    fn without_retention_a_toggle_still_notes_but_has_nothing_to_fold_out() {
+        // The default: no key listener, so compact receipts drop their
+        // buffers exactly as they always did and a toggle can only affect
+        // what comes next.
+        let (mut tl, term) = captured("Running cargo test in 2 worktrees");
+        tl.set_ordered_receipts(true);
+        tl.set_row_output(exec_row_output());
+        tl.commit_plan(PlanCommit::new(vec![exec_row("a"), exec_row("b")]));
+        run_row(&mut tl, "a", "a-out");
+        assert_eq!(tl.toggle_verbose(), Some(true));
+        run_row(&mut tl, "b", "b-out");
+        tl.finish("Done in 0.1s");
+        assert_eq!(
+            term.contents(),
+            "\u{250c}  Running cargo test in 2 worktrees\n\
+             \u{2502}\n\
+             \u{2713}  a\n\
+             \u{25cb}  verbose on\n\
+             \u{2713}  b\n\
+             \u{2502}    b-out\n\
+             \u{2502}\n\
+             \u{2514}  Done in 0.1s"
+        );
+    }
+
+    #[test]
+    fn toggling_back_to_terse_stops_threading_later_receipts() {
+        let (mut tl, term) = captured("Running cargo test in 2 worktrees");
+        tl.set_ordered_receipts(true);
+        tl.set_verbose_density(true);
+        tl.set_row_output(exec_row_output());
+        tl.commit_plan(PlanCommit::new(vec![exec_row("a"), exec_row("b")]));
+        run_row(&mut tl, "a", "a-out");
+        assert_eq!(tl.toggle_verbose(), Some(false));
+        run_row(&mut tl, "b", "b-out");
+        tl.finish("Done in 0.1s");
+        // `a`'s threaded receipt stays printed — nothing is retracted; `b`
+        // simply arrives compact.
+        assert_eq!(
+            term.contents(),
+            "\u{250c}  Running cargo test in 2 worktrees\n\
+             \u{2502}\n\
+             \u{2713}  a\n\
+             \u{2502}    a-out\n\
+             \u{2502}\n\
+             \u{25cb}  verbose off\n\
+             \u{2713}  b\n\
+             \u{2502}\n\
+             \u{2514}  Done in 0.1s"
+        );
+    }
+
+    #[test]
+    fn a_row_waiting_on_the_ordered_drain_adopts_the_density_it_prints_at() {
+        // `b` finishes first but cannot print until `a` does. It resolved
+        // terse; by the time it actually reaches scrollback the user has
+        // asked for verbose, so it threads. Append-only is intact — the line
+        // had not been printed yet.
+        let (mut tl, term) = toggleable("Running cargo test in 2 worktrees", &["a", "b"]);
+        run_row(&mut tl, "b", "b-out");
+        assert_eq!(tl.toggle_verbose(), Some(true));
+        run_row(&mut tl, "a", "a-out");
+        tl.finish("Done in 0.1s");
+        assert_eq!(
+            term.contents(),
+            "\u{250c}  Running cargo test in 2 worktrees\n\
+             \u{2502}\n\
+             \u{25cb}  verbose on\n\
+             \u{2713}  a\n\
+             \u{2502}    a-out\n\
+             \u{2502}\n\
+             \u{2713}  b\n\
+             \u{2502}    b-out\n\
+             \u{2502}\n\
+             \u{2514}  Done in 0.1s"
+        );
+    }
+
+    #[test]
+    fn a_failed_row_never_queues_for_replay_its_evidence_already_showed() {
+        let (mut tl, term) = toggleable("Running cargo test in 1 worktree", &["bad"]);
+        let key = exec_key("bad");
+        tl.on_stage(&key, StageEvent::Started);
+        tl.handle().push_row_output(&key, "boom");
+        tl.on_stage(
+            &key,
+            StageEvent::Failed {
+                detail: "exit 1".into(),
+            },
+        );
+        assert_eq!(tl.toggle_verbose(), Some(true));
+        tl.finish("Finished with failures in 0.1s");
+        assert_eq!(
+            term.contents(),
+            "\u{250c}  Running cargo test in 1 worktree\n\
+             \u{2502}\n\
+             \u{2717}  bad  exit 1\n\
+             \u{2502}    boom\n\
+             \u{2502}\n\
+             \u{25cb}  verbose on\n\
+             \u{2502}\n\
+             \u{2514}  Finished with failures in 0.1s"
+        );
+    }
+
+    #[test]
+    fn toggle_is_inert_without_a_live_region() {
+        // Plain and Hidden have no region to repaint and no scrollback of
+        // their own; the density must not drift where nothing renders.
+        for mode in [TimelineMode::Plain, TimelineMode::Hidden] {
+            let tl = Timeline::new(mode, false, "Opening feat/x");
+            assert_eq!(tl.toggle_verbose(), None);
+            assert!(!tl.verbose_flag().get(), "density stayed put in {mode:?}");
+        }
     }
 
     // ── planning face (the region opens before the plan) ─────────────────

--- a/src/output/timeline/mod.rs
+++ b/src/output/timeline/mod.rs
@@ -17,6 +17,7 @@
 //! `DAFT_TESTING` output contracts (and the whole YAML suite) unchanged.
 
 mod bridge;
+mod key_listener;
 mod plan;
 mod rail_hook;
 mod region;
@@ -268,6 +269,11 @@ impl TimelineHandle {
     /// prompt's own interrupt swap would deadblock the dispatcher. The
     /// prompt exit leaves the (already cleared) region alone.
     pub fn suspend_for_prompt<R>(&self, f: impl FnOnce() -> R) -> R {
+        // The prompt needs the terminal it can see and edit in: hand back
+        // cooked input and stand the rail's key listener down for the
+        // window, or the two would race for the same device and the user
+        // would type into a void. No-op when nothing is listening.
+        let _keys = crate::output::term_guard::suspend_key_input();
         let outer = crate::interrupt::swap_behavior(|| crate::prompt::exit_for_cancelled_prompt());
         let result = self.suspend(f);
         crate::interrupt::restore_behavior(outer);
@@ -412,6 +418,10 @@ pub struct Timeline {
     handle: TimelineHandle,
     mode: TimelineMode,
     started: Instant,
+    /// Watches the terminal for `v` once the plan commits (#729). Owned here
+    /// rather than by the region so teardown can join it *after* releasing
+    /// the timeline mutex the listener contends for.
+    keys: Option<key_listener::KeyListener>,
 }
 
 impl Timeline {
@@ -436,6 +446,7 @@ impl Timeline {
             },
             mode,
             started: Instant::now(),
+            keys: None,
         }
     }
 
@@ -543,12 +554,40 @@ impl Timeline {
                 installing_over_face,
                 "plan committed twice for one invocation"
             );
+            self.start_key_listener();
             return;
         }
         let mp = inner.make_multi_progress();
         let header = inner.header.clone();
         let setup = inner.region_setup();
         inner.core = Some(TimelineCore::new(mp, header, plan, setup, self.started));
+        drop(inner);
+        self.start_key_listener();
+    }
+
+    /// Watch the terminal for the live `v` toggle (#729), now that there are
+    /// plan rows to re-render.
+    ///
+    /// Not during the planning face: prompts run under it (clone's
+    /// consolidation), and putting the driver in unbuffered mode around a
+    /// prompt with nothing reading would swallow the user's typing. Not
+    /// under `cfg(test)` either — a wall-clock reader thread would make the
+    /// transcript assertions depend on timing, and there is no terminal to
+    /// read from anyway.
+    fn start_key_listener(&mut self) {
+        if self.keys.is_some() || !self.is_interactive() || cfg!(test) {
+            return;
+        }
+        self.keys = key_listener::KeyListener::spawn(self.handle.clone());
+        if self.keys.is_some() {
+            // Something can toggle now, so compact receipts start keeping
+            // their logs for a possible fold-out, and the footer offers the
+            // key.
+            self.set_retain_for_replay(true);
+            if let Some(core) = self.handle.lock().core.as_mut() {
+                core.set_keys_hint(true);
+            }
+        }
     }
 
     /// Collapse a still-planning region without a trace (no footer, no
@@ -673,6 +712,12 @@ impl Timeline {
     }
 
     fn teardown(&mut self, footer_text: &str, policy: UnresolvedPolicy) {
+        // Stop reading keys first, and with no lock held: the listener may be
+        // parked on the very mutex this function is about to take, inside
+        // `toggle_verbose`. Joining it from under that lock would deadlock.
+        if let Some(mut keys) = self.keys.take() {
+            keys.stop();
+        }
         let (core, deferred) = {
             let mut inner = self.handle.lock();
             (

--- a/src/output/timeline/mod.rs
+++ b/src/output/timeline/mod.rs
@@ -1498,8 +1498,10 @@ mod tests {
         assert_eq!(tl.toggle_verbose(), Some(false));
         assert_eq!(tl.toggle_verbose(), Some(true));
         tl.finish("Done in 0.1s");
-        // Exactly one fold-out: the second verbose-ward flip has nothing left
-        // to replay, and says so by dropping the count clause.
+        // Exactly one fold-out: the intervening `verbose off` and the second
+        // `verbose on` have nothing to replay, so they add no note — a flip
+        // that changes only the live region stays out of scrollback, and the
+        // footer hint alone carries it.
         assert_eq!(
             term.contents(),
             "\u{250c}  Running cargo test in 1 worktree\n\
@@ -1509,18 +1511,17 @@ mod tests {
              \u{2713}  a\n\
              \u{2502}    a-out\n\
              \u{2502}\n\
-             \u{25cb}  verbose off\n\
-             \u{25cb}  verbose on\n\
-             \u{2502}\n\
              \u{2514}  Done in 0.1s"
         );
     }
 
     #[test]
-    fn without_retention_a_toggle_still_notes_but_has_nothing_to_fold_out() {
+    fn without_retention_a_toggle_is_silent_but_still_flips_later_rows() {
         // The default: no key listener, so compact receipts drop their
         // buffers exactly as they always did and a toggle can only affect
-        // what comes next.
+        // what comes next. With nothing to fold out, the flip leaves no note
+        // in scrollback — only `b`, which runs after it, shows the new
+        // density.
         let (mut tl, term) = captured("Running cargo test in 2 worktrees");
         tl.set_ordered_receipts(true);
         tl.set_row_output(exec_row_output());
@@ -1534,7 +1535,6 @@ mod tests {
             "\u{250c}  Running cargo test in 2 worktrees\n\
              \u{2502}\n\
              \u{2713}  a\n\
-             \u{25cb}  verbose on\n\
              \u{2713}  b\n\
              \u{2502}    b-out\n\
              \u{2502}\n\
@@ -1554,7 +1554,7 @@ mod tests {
         run_row(&mut tl, "b", "b-out");
         tl.finish("Done in 0.1s");
         // `a`'s threaded receipt stays printed — nothing is retracted; `b`
-        // simply arrives compact.
+        // simply arrives compact. The flip itself leaves no note.
         assert_eq!(
             term.contents(),
             "\u{250c}  Running cargo test in 2 worktrees\n\
@@ -1562,7 +1562,6 @@ mod tests {
              \u{2713}  a\n\
              \u{2502}    a-out\n\
              \u{2502}\n\
-             \u{25cb}  verbose off\n\
              \u{2713}  b\n\
              \u{2502}\n\
              \u{2514}  Done in 0.1s"
@@ -1584,7 +1583,6 @@ mod tests {
             term.contents(),
             "\u{250c}  Running cargo test in 2 worktrees\n\
              \u{2502}\n\
-             \u{25cb}  verbose on\n\
              \u{2713}  a\n\
              \u{2502}    a-out\n\
              \u{2502}\n\
@@ -1615,8 +1613,6 @@ mod tests {
              \u{2502}\n\
              \u{2717}  bad  exit 1\n\
              \u{2502}    boom\n\
-             \u{2502}\n\
-             \u{25cb}  verbose on\n\
              \u{2502}\n\
              \u{2514}  Finished with failures in 0.1s"
         );

--- a/src/output/timeline/rail_hook.rs
+++ b/src/output/timeline/rail_hook.rs
@@ -233,7 +233,19 @@ impl RailHookRenderer {
         if self.quiet {
             return;
         }
-        if self.verbose.get() {
+        let verbose = self.verbose.get();
+        // Self-heal a density that changed under a running job (a live `v`,
+        // #729). The toggle runs on the timeline's lock and cannot reach into
+        // this renderer — it lives behind the presenter's — so each job
+        // reconciles its own thread the next time it has a line to draw.
+        if verbose != state.thread.is_open() {
+            if verbose {
+                state.thread.open(&self.mp, &state.bar, &self.thread_styles);
+            } else {
+                state.thread.close(&self.mp);
+            }
+        }
+        if verbose {
             // The thread carries the liveness — the annotation slot keeps the
             // job's description instead of racing the newest tail line. Output
             // un-promotes: the elapsed counter answers "is this silent job

--- a/src/output/timeline/rail_hook.rs
+++ b/src/output/timeline/rail_hook.rs
@@ -21,7 +21,7 @@
 
 use super::render::{self, HookJobFace};
 use super::thread_block::{ThreadStyles, ThreadedJob};
-use super::{HookEmbed, TimelineHandle};
+use super::{HookEmbed, LiveVerbose, TimelineHandle};
 use crate::output::hook_progress::{JobOutcome, JobResultEntry, format_duration};
 use crate::output::palette::{DARK_GREY, GREY};
 use crate::settings::HookOutputConfig;
@@ -63,9 +63,11 @@ pub struct RailHookRenderer {
     handle: TimelineHandle,
     use_color: bool,
     quiet: bool,
-    /// `-v` / `daft.hooks.output.verbose`: thread each job's log under its
-    /// row instead of the succinct latest-line annotation.
-    verbose: bool,
+    /// `-v` / `daft.hooks.output.verbose` / a live `v` keypress: thread each
+    /// job's log under its row instead of the succinct latest-line
+    /// annotation. Shared with the rail, so it is read per line drawn — the
+    /// renderer outlives no phase, but a toggle can land mid-phase.
+    verbose: LiveVerbose,
     /// Live-thread window size (`tailLines`); the receipt is never windowed.
     tail_lines: usize,
     /// `timerDelay` before a silent job's spinner gains an elapsed suffix.
@@ -121,7 +123,7 @@ impl RailHookRenderer {
             handle,
             use_color: embed.use_color,
             quiet: config.quiet,
-            verbose: config.verbose,
+            verbose: embed.verbose,
             tail_lines: config.tail_lines as usize,
             timer_delay: Duration::from_secs(u64::from(config.timer_delay_secs)),
             section_label: embed.section_label,
@@ -148,7 +150,7 @@ impl RailHookRenderer {
             Some(label) => label.clone(),
             None => format!("{hook_name} hooks"),
         };
-        let annotation = self.verbose.then(|| {
+        let annotation = self.verbose.get().then(|| {
             if label == hook_name {
                 format!("daft v{}", crate::VERSION)
             } else {
@@ -189,7 +191,7 @@ impl RailHookRenderer {
         // Verbose: open the job's thread with the `❯ <command>` provenance
         // line and the bottom air. Quiet keeps its "suppress hook output"
         // contract — threads vanish entirely.
-        if self.verbose && !self.quiet {
+        if self.verbose.get() && !self.quiet {
             thread.open(&self.mp, &bar, &self.thread_styles);
         }
 
@@ -203,7 +205,7 @@ impl RailHookRenderer {
         self.refresh_bar(name);
         if let Some(state) = self.jobs.get(name) {
             state.bar.enable_steady_tick(Duration::from_millis(80));
-            if self.verbose {
+            if self.verbose.get() {
                 // Ticking promoter: a job still silent past `timerDelay` shows
                 // a dim elapsed counter in its annotation slot until output or
                 // resolution. The message always travels the `{wide_msg}`
@@ -231,7 +233,7 @@ impl RailHookRenderer {
         if self.quiet {
             return;
         }
-        if self.verbose {
+        if self.verbose.get() {
             // The thread carries the liveness — the annotation slot keeps the
             // job's description instead of racing the newest tail line. Output
             // un-promotes: the elapsed counter answers "is this silent job
@@ -291,7 +293,7 @@ impl RailHookRenderer {
         let output = state
             .map(|s| s.thread.output().to_vec())
             .unwrap_or_default();
-        if !self.verbose && !self.quiet && !output.is_empty() {
+        if !self.verbose.get() && !self.quiet && !output.is_empty() {
             let head = if self.use_color {
                 format!(
                     "{}error:{} hook job '{name}' failed:",
@@ -388,7 +390,7 @@ impl RailHookRenderer {
     /// rail end (always with the total; the 1s threshold is for row
     /// durations, not the relocated "done in").
     pub fn print_summary(&self, total_duration: Duration) {
-        if !self.verbose || self.finished.is_empty() {
+        if !self.verbose.get() || self.finished.is_empty() {
             return;
         }
         let note = render::section_close(
@@ -420,7 +422,7 @@ impl RailHookRenderer {
             .iter()
             .any(|name| msg.starts_with(&format!("Job '{name}' failed")));
         if redundant {
-            if self.verbose {
+            if self.verbose.get() {
                 let suffix = msg.strip_prefix("Job ").unwrap_or(msg);
                 let line = if self.use_color {
                     format!("{}error:{} hook job {suffix}", styles::RED, styles::RESET)
@@ -453,7 +455,7 @@ impl RailHookRenderer {
     /// closed with one empty thread line so consecutive blocks don't fuse.
     /// Quiet suppresses the whole thread.
     fn persist_log(&self, thread: Option<&ThreadedJob>, failed: bool) {
-        if !self.verbose || self.quiet {
+        if !self.verbose.get() || self.quiet {
             return;
         }
         let Some(thread) = thread else {
@@ -557,11 +559,16 @@ mod tests {
         let anchor = mp.add(ProgressBar::new_spinner());
         anchor.set_style(ProgressStyle::with_template("{msg}").unwrap());
         let tl = Timeline::new(TimelineMode::Interactive { color: false }, false, "t");
+        // The rail carries the density; the embed hands it to the renderer —
+        // the same wiring every lifecycle command performs with its resolved
+        // hook-output config.
+        tl.set_verbose_density(config.verbose);
         let handle = tl.handle();
         let embed = HookEmbed {
             mp,
             anchor,
             use_color,
+            verbose: tl.verbose_flag(),
             section_label: section_label.map(String::from),
             in_group: false,
         };

--- a/src/output/timeline/region.rs
+++ b/src/output/timeline/region.rs
@@ -13,9 +13,9 @@
 //! accounting); templates are never empty; rows are single-line (labels and
 //! annotations are pre-composed, annotations truncate via `{wide_msg}`).
 
-use super::RowOutputConfig;
 use super::render::{self, RowFace};
 use super::thread_block::{ThreadStyles, ThreadedJob};
+use super::{LiveVerbose, RowOutputConfig};
 use crate::core::stage::{PlanCommit, Row, StepKey, StepSpec};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use std::collections::HashMap;
@@ -33,9 +33,10 @@ struct RowThread {
 }
 
 /// The per-invocation region knobs, bundled so the constructors stay lean.
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub(super) struct RegionSetup {
-    pub verbose: bool,
+    pub verbose: LiveVerbose,
+    pub detail_verbose: bool,
     pub use_color: bool,
     pub ordered: bool,
     pub row_output: Option<RowOutputConfig>,
@@ -57,6 +58,11 @@ pub struct HookEmbed {
     /// Whether the region renders ANSI (NO_COLOR tracks the rail, not the
     /// renderer's own stderr probe).
     pub use_color: bool,
+    /// The rail's live density, shared so the block renders at whatever
+    /// density is current when each line is drawn — the hook renderer is
+    /// rebuilt per phase behind the presenter's own lock, out of reach of
+    /// the timeline mutex a mid-run toggle holds.
+    pub verbose: LiveVerbose,
     /// The consumed row's plan label ("post-create hooks") when the step is
     /// a hook phase — the succinct renderer's section anchor. `None` for
     /// gate embeds (pre-push under an active Push/DeleteRemote row), whose
@@ -127,7 +133,13 @@ enum StepState {
 pub(super) struct TimelineCore {
     mp: MultiProgress,
     use_color: bool,
-    verbose: bool,
+    /// This invocation's live job-log density (`-v`,
+    /// `daft.hooks.output.verbose`, or a mid-run `v` keypress). Read at
+    /// render time — never snapshotted into a row or a renderer.
+    verbose: LiveVerbose,
+    /// The `-v` free-text detail gate ([`Self::detail`]) — fixed at
+    /// construction, deliberately outside the live toggle's reach.
+    detail_verbose: bool,
     /// Ordered receipts (`daft exec`): rows resolve out of completion order,
     /// but the scrollback receipt must stay in plan order. When set, `resolve`
     /// repaints the row's final face in place and defers persistence to
@@ -284,6 +296,7 @@ impl TimelineCore {
     fn scaffold(mp: MultiProgress, header: String, setup: RegionSetup, started: Instant) -> Self {
         let RegionSetup {
             verbose,
+            detail_verbose,
             use_color,
             ordered,
             row_output,
@@ -345,6 +358,7 @@ impl TimelineCore {
             mp,
             use_color,
             verbose,
+            detail_verbose,
             ordered,
             persisted_upto: 0,
             row_output,
@@ -657,7 +671,7 @@ impl TimelineCore {
                 // row inside a worktree group nests one tier (depth 1).
                 let styles = ThreadStyles::new(use_color, usize::from(in_group));
                 let mut job = ThreadedJob::new(cfg.buffer_cap, None);
-                if cfg.verbose {
+                if self.verbose.get() {
                     job.open(&self.mp, bar, &styles);
                 }
                 self.row_threads.insert(idx, RowThread { job, styles });
@@ -849,7 +863,7 @@ impl TimelineCore {
                 if let Some(thread) = self.row_threads.remove(&idx) {
                     thread.job.mark_resolved();
                     thread.job.remove_thread_bars(&self.mp);
-                    let verbose = self.row_output.is_some_and(|c| c.verbose);
+                    let verbose = self.row_output.is_some() && self.verbose.get();
                     if verbose {
                         lines.extend(thread.job.compose_log(&thread.styles, failed));
                         lines.push(thread.styles.thread_air());
@@ -1037,7 +1051,7 @@ impl TimelineCore {
             return;
         };
         thread.job.record(line);
-        if cfg.verbose {
+        if self.verbose.get() {
             thread
                 .job
                 .roll_window(&self.mp, &thread.styles, cfg.tail_lines, &bar);
@@ -1055,7 +1069,7 @@ impl TimelineCore {
 
     /// `-v` free-text detail under the active step (dim, transient).
     pub(super) fn detail(&mut self, text: &str) {
-        if !self.verbose {
+        if !self.detail_verbose {
             return;
         }
         let Some(active_bar) = self.active_bar() else {
@@ -1149,6 +1163,7 @@ impl TimelineCore {
             mp: self.mp.clone(),
             anchor,
             use_color: self.use_color,
+            verbose: self.verbose.clone(),
             section_label,
             in_group,
         })

--- a/src/output/timeline/region.rs
+++ b/src/output/timeline/region.rs
@@ -218,6 +218,9 @@ pub(super) struct TimelineCore {
     footer: ProgressBar,
     /// Stops the footer's elapsed ticker at teardown.
     footer_done: Arc<AtomicBool>,
+    /// Whether the stopwatch footer advertises the live `v` key — set once a
+    /// listener is actually watching.
+    keys_hint: Arc<AtomicBool>,
     /// Dim free-text sub-line under the active step (`-v` only).
     detail_bar: Option<ProgressBar>,
     /// Suppresses the TTY's `^C` echo for the region's lifetime — the echo
@@ -353,20 +356,32 @@ impl TimelineCore {
             render::footer(&footer_counter(started, use_color), use_color),
         );
         let footer_done = Arc::new(AtomicBool::new(false));
+        // Set once a key listener is watching (#729): the stopwatch line then
+        // also offers the key. It rides the footer rather than taking a line
+        // of its own, so it costs no region height and retires with the
+        // stopwatch — the hint never reaches scrollback.
+        let keys_hint = Arc::new(AtomicBool::new(false));
         #[cfg(not(test))]
         {
             let bar = footer.clone();
             let done = Arc::clone(&footer_done);
+            let hint = Arc::clone(&keys_hint);
+            let density = verbose.clone();
             std::thread::spawn(move || {
                 loop {
                     std::thread::sleep(Duration::from_millis(100));
                     if done.load(Ordering::SeqCst) {
                         break;
                     }
-                    bar.set_message(render::footer(
-                        &footer_counter(started, use_color),
-                        use_color,
-                    ));
+                    let mut line = render::footer(&footer_counter(started, use_color), use_color);
+                    if hint.load(Ordering::Relaxed) {
+                        line.push_str(&render::paint(
+                            crate::output::palette::DARK_GREY,
+                            key_hint(density.get()),
+                            use_color,
+                        ));
+                    }
+                    bar.set_message(line);
                 }
             });
         }
@@ -401,6 +416,7 @@ impl TimelineCore {
             row_threads: HashMap::new(),
             replayable: Vec::new(),
             retain_for_replay: false,
+            keys_hint,
             label_width: 0,
             slots: Vec::new(),
             header,
@@ -640,6 +656,12 @@ impl TimelineCore {
     /// [`Self::retain_for_replay`].
     pub(super) fn set_retain_for_replay(&mut self, on: bool) {
         self.retain_for_replay = on;
+    }
+
+    /// Advertise the live `v` key on the stopwatch footer. The next ticker
+    /// pass (≤100 ms) picks it up.
+    pub(super) fn set_keys_hint(&mut self, on: bool) {
+        self.keys_hint.store(on, Ordering::Relaxed);
     }
 
     /// The density flipped mid-run (a live `v`): note it, fold out whatever
@@ -1898,6 +1920,19 @@ fn line_style() -> ProgressStyle {
 /// The pending footer's stopwatch face: the command's elapsed so far, in the
 /// rail's grey. Zeroed under cfg(test) so the InMemoryTerm sequence
 /// assertions stay deterministic (no ticker repaints it there either).
+/// The live-key hint trailing the stopwatch, phrased as what the key will
+/// do next rather than what mode you are in — the label of a control, not a
+/// readout. Ctrl-C rides along because the two are the rail's whole
+/// interactive surface, and naming it here is also the promise that it still
+/// reaches the process (the listener keeps `ISIG` on).
+fn key_hint(verbose: bool) -> &'static str {
+    if verbose {
+        "   v quiet \u{b7} ^C cancel"
+    } else {
+        "   v verbose \u{b7} ^C cancel"
+    }
+}
+
 fn footer_counter(started: Instant, use_color: bool) -> String {
     #[cfg(test)]
     let elapsed = {
@@ -1979,5 +2014,18 @@ mod tests {
         }
         let plain = StepSpec::new(StepKey::new(StageId::Push));
         assert_eq!(display_label(&plain, StepPhase::Done), "Pushed");
+    }
+
+    #[test]
+    fn the_key_hint_names_what_the_key_does_next() {
+        // A control's label, not a mode readout: while terse it offers
+        // verbose, and while verbose it offers quiet.
+        assert!(key_hint(false).contains("v verbose"));
+        assert!(key_hint(true).contains("v quiet"));
+        // Ctrl-C is advertised in both — the listener keeps `ISIG` on, so
+        // the promise holds.
+        for hint in [key_hint(false), key_hint(true)] {
+            assert!(hint.contains("^C cancel"), "got: {hint}");
+        }
     }
 }

--- a/src/output/timeline/region.rs
+++ b/src/output/timeline/region.rs
@@ -672,18 +672,19 @@ impl TimelineCore {
     /// alt-screen TUI — so a verbose-ward flip re-emits their logs *below*
     /// as a fold-out block instead.
     pub(super) fn on_density_toggled(&mut self, verbose: bool) {
-        let note = if verbose {
-            match self.replayable.len() {
-                0 => "verbose on".to_string(),
+        // A note earns a permanent scrollback line only when the flip adds
+        // content — a verbose-ward flip with finished rows to fold out below.
+        // A bare on/off flip changes the live region alone: windows open or
+        // collapse and the footer hint flips to match, so the current density
+        // is already visible without a note. Emitting one per keypress just
+        // piles up `verbose on`/`verbose off` lines (#729 field feedback).
+        if verbose && !self.replayable.is_empty() {
+            let note = match self.replayable.len() {
                 1 => "verbose on \u{2014} replaying 1 finished row".to_string(),
                 n => format!("verbose on \u{2014} replaying {n} finished rows"),
-            }
-        } else {
-            "verbose off".to_string()
-        };
-        let line = render::note(&note, self.use_color);
-        self.println_above(&line);
-        if verbose {
+            };
+            let line = render::note(&note, self.use_color);
+            self.println_above(&line);
             self.replay_folded_out();
         }
         self.repaint_live_density(verbose);

--- a/src/output/timeline/region.rs
+++ b/src/output/timeline/region.rs
@@ -32,6 +32,16 @@ struct RowThread {
     styles: ThreadStyles,
 }
 
+/// A receipt already in scrollback whose captured log was *not* printed with
+/// it (a compact success), kept so a later `v` can fold it out below.
+struct ReplayEntry {
+    /// The receipt line exactly as it was persisted, reprinted to head the
+    /// fold-out block so the log is unambiguously attributed.
+    row_line: String,
+    job: ThreadedJob,
+    styles: ThreadStyles,
+}
+
 /// The per-invocation region knobs, bundled so the constructors stay lean.
 #[derive(Clone)]
 pub(super) struct RegionSetup {
@@ -119,12 +129,28 @@ enum StepState {
         started: Instant,
     },
     /// Ordered mode only: resolved with a final face, repainted onto the live
-    /// bar in plan position, awaiting the prefix drain into scrollback. `lines`
-    /// is the composed receipt block — the row line, then any output-thread
-    /// lines (failed/cancelled rows always thread; every row threads under
-    /// verbose). Eager mode persists immediately and never uses this.
+    /// bar in plan position, awaiting the prefix drain into scrollback. Eager
+    /// mode persists immediately and never uses this.
+    ///
+    /// The row line is fixed at resolve, but the *block* is composed at
+    /// persist ([`TimelineCore::persist_recorded_at`]): a row can sit here for
+    /// seconds behind a slower predecessor, and a `v` pressed in that window
+    /// should thread its log. Nothing visible is rewritten — the block simply
+    /// has not been printed yet.
     Recorded {
-        lines: Vec<String>,
+        row_line: String,
+        /// Failed/cancelled rows thread their captured output at any density
+        /// (evidence), and never queue for replay.
+        failed: bool,
+        /// The row's output thread, parked with its buffer intact. Boxed so
+        /// one waiting row's buffer does not set the size of every `Slot`.
+        ///
+        /// This holds a resolved row's buffer until the drain reaches it,
+        /// where the terse path used to free it at resolve. The window is
+        /// short (only while earlier rows are still running) and bounded by
+        /// the same per-row `buffer_cap` the verbose path has always carried
+        /// for the same rows — worth one composition path over two.
+        thread: Option<Box<RowThread>>,
     },
     /// Persisted, silently removed, or replaced by an embedded hook block.
     Resolved,
@@ -159,6 +185,15 @@ pub(super) struct TimelineCore {
     /// Live output threads keyed by slot index (exec rows). A side table so
     /// the `Slot::Step` variant and its match sites are unchanged.
     row_threads: HashMap<usize, RowThread>,
+    /// Compact receipts whose captured log is still foldable-out, oldest
+    /// first. Drained by a verbose-ward toggle; entries are consumed, so
+    /// flipping back and forth never prints one row's log twice.
+    replayable: Vec<ReplayEntry>,
+    /// Whether compact receipts park their buffers here at all. Off unless
+    /// something can actually toggle (a key listener) — otherwise a terse
+    /// hundred-worktree `daft exec` would hold a hundred capped buffers for
+    /// a fold-out that can never be asked for.
+    retain_for_replay: bool,
     label_width: usize,
     slots: Vec<Slot>,
     /// Seeded header text, retained until the plan lands (the plan may
@@ -364,6 +399,8 @@ impl TimelineCore {
             row_output,
             suppress_footer_spacer: false,
             row_threads: HashMap::new(),
+            replayable: Vec::new(),
+            retain_for_replay: false,
             label_width: 0,
             slots: Vec::new(),
             header,
@@ -592,6 +629,120 @@ impl TimelineCore {
     pub(super) fn println_above(&mut self, line: &str) {
         self.mp.println(line).ok();
         self.last_persisted_was_spacer = false;
+        // Whatever the last receipt ended with, this line ends the region's
+        // scrollback now — so the footer owes its `│` separator again. Left
+        // set, a warning (or a density note) landing after a threaded exec
+        // receipt would swallow it and butt the footer against the text.
+        self.suppress_footer_spacer = false;
+    }
+
+    /// Keep compact receipts' captured logs foldable-out. See
+    /// [`Self::retain_for_replay`].
+    pub(super) fn set_retain_for_replay(&mut self, on: bool) {
+        self.retain_for_replay = on;
+    }
+
+    /// The density flipped mid-run (a live `v`): note it, fold out whatever
+    /// the terse run left buffered, and repaint the rows still running.
+    ///
+    /// Receipts already in scrollback are never rewritten — the rail is
+    /// append-only, which is the whole difference between it and an
+    /// alt-screen TUI — so a verbose-ward flip re-emits their logs *below*
+    /// as a fold-out block instead.
+    pub(super) fn on_density_toggled(&mut self, verbose: bool) {
+        let note = if verbose {
+            match self.replayable.len() {
+                0 => "verbose on".to_string(),
+                1 => "verbose on \u{2014} replaying 1 finished row".to_string(),
+                n => format!("verbose on \u{2014} replaying {n} finished rows"),
+            }
+        } else {
+            "verbose off".to_string()
+        };
+        let line = render::note(&note, self.use_color);
+        self.println_above(&line);
+        if verbose {
+            self.replay_folded_out();
+        }
+        self.repaint_live_density(verbose);
+    }
+
+    /// Re-emit each parked compact receipt with its full log. Entries are
+    /// consumed: toggling off and on again re-folds nothing.
+    fn replay_folded_out(&mut self) {
+        let entries = std::mem::take(&mut self.replayable);
+        if entries.is_empty() {
+            return;
+        }
+        for entry in entries {
+            self.mp.println(entry.row_line).ok();
+            for line in entry.job.compose_log(&entry.styles, false) {
+                self.mp.println(line).ok();
+            }
+            self.mp.println(entry.styles.thread_air()).ok();
+        }
+        self.last_persisted_was_spacer = false;
+        self.suppress_footer_spacer = true;
+    }
+
+    /// Repaint every still-active row at the new density: verbose opens each
+    /// row's window (pre-filled from the buffer it has been keeping all
+    /// along, so the flip reveals history rather than starting from the next
+    /// line); terse takes the windows down and puts the latest line back on
+    /// the row's own annotation.
+    fn repaint_live_density(&mut self, verbose: bool) {
+        let Some(cfg) = self.row_output else {
+            return;
+        };
+        let use_color = self.use_color;
+        let label_width = self.label_width;
+        let indices: Vec<usize> = self.row_threads.keys().copied().collect();
+        for idx in indices {
+            let Some(Slot::Step {
+                spec, bar, state, ..
+            }) = self.slots.get(idx)
+            else {
+                continue;
+            };
+            if !matches!(state, StepState::Active { .. }) {
+                continue;
+            }
+            let Some(bar) = bar.clone() else {
+                continue;
+            };
+            let label = display_label(spec, StepPhase::Active);
+            let inks = super::plan::subject_inks_for(spec.key.id);
+            let annotation = spec.annotation.clone();
+            let Some(thread) = self.row_threads.get_mut(&idx) else {
+                continue;
+            };
+            let message = if verbose {
+                thread.job.open(&self.mp, &bar, &thread.styles);
+                thread
+                    .job
+                    .roll_window(&self.mp, &thread.styles, cfg.tail_lines, &bar);
+                // Output moved below the row; the annotation slot reverts to
+                // the row's own (usually empty for an exec row).
+                render::active_message(&label, annotation.as_deref(), label_width, inks, use_color)
+            } else {
+                thread.job.close(&self.mp);
+                let latest = thread.job.output().last().map(|line| {
+                    render::paint(
+                        crate::output::palette::DARK_GREY,
+                        line.trim_end(),
+                        use_color,
+                    )
+                });
+                render::active_message(
+                    &label,
+                    latest.as_deref().or(annotation.as_deref()),
+                    label_width,
+                    inks,
+                    use_color,
+                )
+            };
+            bar.set_message(message);
+        }
     }
 
     /// Clear the region, run `f` (e.g. a stdout write that must not land
@@ -854,32 +1005,32 @@ impl TimelineCore {
                     in_group,
                     use_color,
                 );
-                // Compose the receipt block: the row line, then the output
-                // thread. The live window bars leave now; the log rejoins as
-                // scrollback at drain. Verbose threads every row (grey under
-                // success, `(no output)` placeholder included); default only
-                // threads a failure/cancel that actually printed something.
-                let mut lines = vec![row_line.clone()];
-                if let Some(thread) = self.row_threads.remove(&idx) {
+                // The row stops moving now — its live window bars leave and
+                // its promoter is retired — but the receipt block is NOT
+                // composed here. The buffer is parked with the row and read
+                // at persist, so a density toggle landing while this row
+                // waits its turn in the ordered drain still reaches it.
+                let thread = self.row_threads.remove(&idx).map(|mut thread| {
                     thread.job.mark_resolved();
-                    thread.job.remove_thread_bars(&self.mp);
-                    let verbose = self.row_output.is_some() && self.verbose.get();
-                    if verbose {
-                        lines.extend(thread.job.compose_log(&thread.styles, failed));
-                        lines.push(thread.styles.thread_air());
-                    } else if failed && !thread.job.output().is_empty() {
-                        lines.extend(thread.job.compose_log(&thread.styles, true));
-                        lines.push(thread.styles.thread_air());
-                    }
-                }
+                    // `close`, not `remove_thread_bars`: this row will never
+                    // reopen, so drop the bar handles with the bars — a
+                    // parked replay entry should hold its log, not a fistful
+                    // of detached `ProgressBar`s.
+                    thread.job.close(&self.mp);
+                    Box::new(thread)
+                });
                 // Repaint the live bar in place with the final face (drop the
                 // spinner style so the composed line isn't double-glyphed).
                 if let Some(b) = bar.as_ref() {
                     b.disable_steady_tick();
                     b.set_style(line_style());
-                    b.set_message(row_line);
+                    b.set_message(row_line.clone());
                 }
-                *state = StepState::Recorded { lines };
+                *state = StepState::Recorded {
+                    row_line,
+                    failed,
+                    thread,
+                };
             }
         }
         self.drain_ordered_prefix();
@@ -935,25 +1086,53 @@ impl TimelineCore {
         self.persisted_upto = pending_group.unwrap_or(i);
     }
 
-    /// Persist a `Recorded` row's stored block: remove its (final-faced) live
-    /// bar and print the identical row line (and any output-thread lines) into
-    /// scrollback.
+    /// Persist a `Recorded` row: remove its (final-faced) live bar, compose
+    /// the receipt block *at the current density*, and print it.
+    ///
+    /// Verbose threads every row (grey under success, `(no output)`
+    /// placeholder included); terse threads only a failure/cancel that
+    /// actually printed something, and parks the rest for a possible
+    /// fold-out.
     fn persist_recorded_at(&mut self, idx: usize) {
-        let lines = {
+        let (row_line, failed, thread) = {
             let Slot::Step { bar, state, .. } = &mut self.slots[idx] else {
                 return;
             };
-            let StepState::Recorded { lines } = state else {
+            let StepState::Recorded {
+                row_line,
+                failed,
+                thread,
+            } = state
+            else {
                 return;
             };
-            let lines = std::mem::take(lines);
+            let recorded = (std::mem::take(row_line), *failed, thread.take());
             if let Some(taken) = bar.take() {
                 taken.disable_steady_tick();
                 self.mp.remove(&taken);
             }
             *state = StepState::Resolved;
-            lines
+            recorded
         };
+        let mut lines = vec![row_line.clone()];
+        let mut park: Option<ReplayEntry> = None;
+        if let Some(thread) = thread {
+            let thread = *thread;
+            let has_output = !thread.job.output().is_empty();
+            if self.verbose.get() || (failed && has_output) {
+                lines.extend(thread.job.compose_log(&thread.styles, failed));
+                lines.push(thread.styles.thread_air());
+            } else if self.retain_for_replay && has_output {
+                // Compact, and the log never reached the terminal: keep it
+                // foldable-out. (A failure with output threaded above, so it
+                // never lands here — its evidence is already shown.)
+                park = Some(ReplayEntry {
+                    row_line,
+                    job: thread.job,
+                    styles: thread.styles,
+                });
+            }
+        }
         // A threaded block (row line + log + `│` air) ends spacer-like; a bare
         // row line does not. The footer reads this to avoid doubling the
         // separator; group/note spacing keeps the standard bookkeeping.
@@ -961,6 +1140,7 @@ impl TimelineCore {
         for line in lines {
             self.mp.println(line).ok();
         }
+        self.replayable.extend(park);
         self.last_persisted_was_spacer = false;
         self.suppress_footer_spacer = ends_with_air;
     }

--- a/src/output/timeline/thread_block.rs
+++ b/src/output/timeline/thread_block.rs
@@ -163,6 +163,13 @@ impl ThreadedJob {
         row_bar: &ProgressBar,
         styles: &ThreadStyles,
     ) {
+        // Idempotent: a density toggle can ask an already-open thread to
+        // open again, and re-running the body would orphan the live bars it
+        // overwrites (they stay in the `MultiProgress`, drawn forever) and
+        // stack a second trailer.
+        if self.is_open() {
+            return;
+        }
         self.cmd_bar = self.command_preview.as_deref().map(|cmd| {
             let pb = mp.insert_after(row_bar, ProgressBar::new_spinner());
             pb.set_style(styles.thread.clone());
@@ -291,6 +298,27 @@ impl ThreadedJob {
         self.resolved.store(true, Ordering::SeqCst);
     }
 
+    /// Whether the live thread block is currently up.
+    pub(super) fn is_open(&self) -> bool {
+        self.trailer.is_some()
+    }
+
+    /// Take the live thread down *and forget its bars* — the inverse of
+    /// [`Self::open`], for a row that keeps running at a lower density (the
+    /// `v` toggle flipping back to terse).
+    ///
+    /// Distinct from [`Self::remove_thread_bars`], which detaches the bars on
+    /// the way to a receipt and never reopens. Here the handles must go too:
+    /// a detached bar still counts toward `tail_bars.len()`, so the next
+    /// [`Self::roll_window`] would think its window was already grown and
+    /// write every line into bars that draw nothing.
+    pub(super) fn close(&mut self, mp: &MultiProgress) {
+        self.remove_thread_bars(mp);
+        self.cmd_bar = None;
+        self.tail_bars.clear();
+        self.trailer = None;
+    }
+
     /// Remove the live thread bars (never the row bar — the caller owns that).
     /// `mp.remove`, never `finish_and_clear` (the zombie-line lesson):
     /// receipts replace them via `mp.println`.
@@ -406,6 +434,58 @@ mod tests {
         let mut job = ThreadedJob::new(Some(4), None);
         job.record("a-very-long-single-line");
         assert_eq!(job.output(), &["a-very-long-single-line".to_string()]);
+    }
+
+    #[test]
+    fn closing_forgets_its_bars_so_the_window_can_reopen() {
+        // The density toggle's off→on cycle. `remove_thread_bars` alone
+        // detaches the bars but keeps the handles, so a reopened window would
+        // believe it had already grown to `tail_lines` and write every line
+        // into bars that draw nothing.
+        let mp = MultiProgress::with_draw_target(indicatif::ProgressDrawTarget::hidden());
+        let row = mp.add(ProgressBar::new_spinner());
+        let styles = ThreadStyles::new(false, 0);
+        let mut job = ThreadedJob::new(None, None);
+        job.record("one");
+        job.record("two");
+
+        job.open(&mp, &row, &styles);
+        job.roll_window(&mp, &styles, 4, &row);
+        assert!(job.is_open());
+        assert_eq!(job.tail_len(), 1);
+
+        job.close(&mp);
+        assert!(!job.is_open(), "close must forget the trailer");
+        assert_eq!(job.tail_len(), 0, "close must forget the tail bars");
+
+        // Reopening rebuilds the window from live bars, and it repaints the
+        // *buffered* tail — the toggle reveals what the row already printed,
+        // not just what it prints next.
+        job.open(&mp, &row, &styles);
+        job.roll_window(&mp, &styles, 4, &row);
+        job.roll_window(&mp, &styles, 4, &row);
+        assert_eq!(job.tail_len(), 2);
+        assert_eq!(
+            job.tail_messages(),
+            vec!["one".to_string(), "two".to_string()]
+        );
+    }
+
+    #[test]
+    fn opening_an_already_open_thread_is_a_no_op() {
+        let mp = MultiProgress::with_draw_target(indicatif::ProgressDrawTarget::hidden());
+        let row = mp.add(ProgressBar::new_spinner());
+        let styles = ThreadStyles::new(false, 0);
+        let mut job = ThreadedJob::new(None, Some("cargo test".to_string()));
+        job.open(&mp, &row, &styles);
+        let first = job.cmd_bar_message();
+        job.open(&mp, &row, &styles);
+        assert!(job.has_cmd_bar());
+        assert_eq!(
+            job.cmd_bar_message(),
+            first,
+            "a second open must not orphan the first provenance bar"
+        );
     }
 
     #[test]

--- a/test-plans/rail-verbose-toggle.md
+++ b/test-plans/rail-verbose-toggle.md
@@ -1,0 +1,62 @@
+---
+branch: daft-729/feat/rail-verbose-toggle
+---
+
+# Live verbose toggle on the plan-execute rail
+
+The automated coverage drives a PTY, which proves the mechanics but not the
+feel. These need a real terminal.
+
+## The toggle itself
+
+- [ ] `daft exec --all -- <slow chatty command>` — press `v` mid-run; live rows
+      grow a rolling output window and the footer hint flips to `v quiet`
+- [ ] Press `v` again — windows collapse, latest line returns to the row's own
+      annotation, hint flips back to `v verbose`
+- [ ] Rows that already finished compactly fold out once, under a repeat of
+      their receipt line, headed by `verbose on — replaying N finished rows`
+- [ ] Toggling on/off/on does not replay the same log twice
+- [ ] Start with `-v` and press `v` — later receipts arrive compact; what
+      already printed stays
+- [ ] Failed rows are not replayed (their output threaded when they failed)
+
+## Reading the result
+
+- [ ] The fold-out block is attributable at a glance — you can tell which row
+      each replayed log belongs to
+- [ ] The hint is legible but recedes; it never competes with the rows
+- [ ] Nothing jumps or double-prints as the density changes under load (try a
+      20+ worktree fan-out)
+
+## Terminal handling
+
+- [ ] Typing `v` prints nothing into the region
+- [ ] Other keys typed during a run are swallowed silently, not echoed
+- [ ] After the run: typing echoes normally and line editing works (`stty -a`
+      shows `icanon` and `echo`)
+- [ ] Same after `Ctrl-C`, and after a run that ends in failure
+
+## Ctrl-C (#663 must be untouched)
+
+- [ ] First `Ctrl-C` cancels the workers; the rail closes as `Cancelled after t`
+      rather than being torn down
+- [ ] A command that ignores SIGTERM needs a second `Ctrl-C` to die
+- [ ] No literal `^C` is echoed into the region
+- [ ] Exit status is still 130
+
+## Prompts and interactive jobs under a live region
+
+- [ ] `daft clone --install` (or any prompt after the plan commits): the prompt
+      echoes what you type and accepts Enter normally
+- [ ] `v` typed while the prompt is up goes to the prompt, not the rail
+- [ ] After the prompt, `v` toggles again
+- [ ] `daft run` with a multi-job task containing an interactive job: the job
+      owns the terminal, typing is visible, and the rail resumes after
+
+## Other rails
+
+- [ ] `daft start` / `daft go` with hooks: pressing `v` mid-phase switches
+      hook-job rendering from the next line onward
+- [ ] `daft run` with several jobs: same
+- [ ] Non-TTY (`daft exec --all ... | cat`, CI): no hint, no key handling,
+      output unchanged

--- a/test-plans/rail-verbose-toggle.md
+++ b/test-plans/rail-verbose-toggle.md
@@ -16,6 +16,9 @@ feel. These need a real terminal.
 - [ ] Rows that already finished compactly fold out once, under a repeat of
       their receipt line, headed by `verbose on — replaying N finished rows`
 - [ ] Toggling on/off/on does not replay the same log twice
+- [ ] Toggling repeatedly while rows are still running leaves no `verbose on` /
+      `verbose off` lines piling up in scrollback — only the footer hint and the
+      live rows change (a note appears only to head a fold-out replay)
 - [ ] Start with `-v` and press `v` — later receipts arrive compact; what
       already printed stays
 - [ ] Failed rows are not replayed (their output threaded when they failed)

--- a/tests/integration/pty_run.py
+++ b/tests/integration/pty_run.py
@@ -8,7 +8,13 @@ This wrapper plays the terminal's role: it sets a sane window size, drains
 the master into a log file, answers every DSR query with a synthetic
 "row 1, col 1" report, and exits with the command's status.
 
-Usage: pty_run.py <log-file> <command> [args...]
+It can also type: --send-after PATTERN:BYTES writes BYTES to the pty the
+first time PATTERN appears in the output. Repeat the flag to script a
+sequence (two Ctrl-Cs for a two-stage cancel, say); each trigger fires at
+most once, in the order its pattern appears. BYTES accepts Python escapes,
+so \\x03 is Ctrl-C.
+
+Usage: pty_run.py [--send-after PATTERN:BYTES]... <log-file> <command> [args...]
 """
 
 import fcntl
@@ -21,16 +27,54 @@ import sys
 import termios
 
 
+def parse_args(argv):
+    """Split leading flags from the log path and command."""
+    triggers = []
+    ctty = False
+    while argv and argv[0] in ("--send-after", "--ctty"):
+        if argv[0] == "--ctty":
+            ctty = True
+            argv = argv[1:]
+            continue
+        spec = argv[1]
+        pattern, _, payload = spec.partition(":")
+        triggers.append(
+            [
+                pattern.encode(),
+                payload.encode().decode("unicode_escape").encode("latin-1"),
+            ]
+        )
+        argv = argv[2:]
+    return triggers, ctty, argv[0], argv[1:]
+
+
 def main():
-    log_path, *cmd = sys.argv[1:]
+    triggers, ctty, log_path, cmd = parse_args(sys.argv[1:])
     master, slave = pty.openpty()
     # ratatui needs a non-zero viewport; 24x80 matches a classic terminal.
     fcntl.ioctl(slave, termios.TIOCSWINSZ, struct.pack("HHHH", 24, 80, 0, 0))
 
-    proc = subprocess.Popen(cmd, stdin=slave, stdout=slave, stderr=slave, close_fds=True)
+    # --ctty: make the child a session leader owning this pty, so writing
+    # \x03 to the master actually raises SIGINT in it. Without it the pty has
+    # no foreground process group and the interrupt goes nowhere. Opt-in,
+    # because a new session also detaches the child from the caller's job
+    # control — only interrupt tests want that.
+    def become_session_leader():
+        os.setsid()
+        fcntl.ioctl(slave, termios.TIOCSCTTY, 0)
+
+    proc = subprocess.Popen(
+        cmd,
+        stdin=slave,
+        stdout=slave,
+        stderr=slave,
+        close_fds=True,
+        preexec_fn=become_session_leader if ctty else None,
+    )
     os.close(slave)
 
     tail = b""
+    seen = b""
     with open(log_path, "wb") as log:
         while True:
             try:
@@ -55,6 +99,18 @@ def main():
                     except OSError:
                         pass
                     tail = b""
+                # Fire any scripted input whose cue has now appeared. The
+                # first pending trigger only, so a sequence stays ordered
+                # even when one chunk satisfies several cues.
+                if triggers:
+                    seen += chunk
+                    if triggers[0][0] in seen:
+                        try:
+                            os.write(master, triggers[0][1])
+                        except OSError:
+                            pass
+                        triggers.pop(0)
+                        seen = b""
             elif proc.poll() is not None:
                 # Command exited and the pty went quiet: drain and stop.
                 while True:

--- a/tests/integration/test_all.sh
+++ b/tests/integration/test_all.sh
@@ -24,6 +24,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/test_sync_governor.sh"
 source "$(dirname "${BASH_SOURCE[0]}")/test_push.sh"
 source "$(dirname "${BASH_SOURCE[0]}")/test_unknown_command.sh"
 source "$(dirname "${BASH_SOURCE[0]}")/test_exec.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/test_exec_verbose_toggle.sh"
 source "$(dirname "${BASH_SOURCE[0]}")/test_run.sh"
 source "$(dirname "${BASH_SOURCE[0]}")/test_list.sh"
 source "$(dirname "${BASH_SOURCE[0]}")/test_worktree_exec.sh"
@@ -359,6 +360,7 @@ run_all_integration_tests() {
     run_push_tests
     run_unknown_command_tests
     run_exec_tests
+    run_exec_verbose_toggle_tests
     run_run_tests
     run_list_tests
     run_worktree_exec_tests

--- a/tests/integration/test_exec_verbose_toggle.sh
+++ b/tests/integration/test_exec_verbose_toggle.sh
@@ -21,7 +21,17 @@ TOGGLE_PTY_RUN="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/pty_run.py"
 # standing in for are suppressed individually instead: no orphaned
 # update-check / trust-prune / log-clean daemons.
 _toggle_daft() {
+    # TERM is load-bearing here, and CI is where its absence bites. daft's own
+    # color gate (colors_enabled_stderr) is TERM-agnostic under a PTY, so it
+    # still picks the Interactive rail and spawns the key listener — but
+    # indicatif hides its entire draw target when TERM is unset or `dumb`, as
+    # it is on a bare GitHub runner. The region then paints nothing, the `v`
+    # toggle has no visible effect, and the mid-run/interrupt assertions fail
+    # even though the listener ran. Pin a color-capable TERM so the rail
+    # actually renders under the PTY regardless of the runner's ambient value.
+    # (Locally TERM is already xterm-*, which is why this only failed in CI.)
     env -u DAFT_TESTING \
+        TERM=xterm-256color \
         DAFT_NO_UPDATE_CHECK=1 \
         DAFT_NO_TRUST_PRUNE=1 \
         DAFT_NO_LOG_CLEAN=1 \

--- a/tests/integration/test_exec_verbose_toggle.sh
+++ b/tests/integration/test_exec_verbose_toggle.sh
@@ -69,14 +69,17 @@ test_exec_v_toggles_verbose_midrun() {
     local out
     out=$(_toggle_clean "$log")
 
-    if ! grep -q "verbose on" <<<"$out"; then
-        log_error "no density note after pressing v"
-        return 1
-    fi
     # A *threaded* line wears the thread gutter; the same text as a row
     # annotation would prove nothing, since terse mode shows it there too.
     if ! grep -qE '^│ +first-line' <<<"$out"; then
         log_error "verbose did not thread a job's log into its receipt"
+        return 1
+    fi
+    # Every row was still running when v landed, so nothing had finished to
+    # fold out — the flip must leave no note in scrollback. A note per keypress
+    # used to pile up here (#729 field report); it now heads a replay only.
+    if grep -q "verbose on\|verbose off" <<<"$out"; then
+        log_error "a density note appeared for a flip with nothing to replay"
         return 1
     fi
     log_success "v flips the rail to verbose mid-run"
@@ -127,7 +130,10 @@ test_exec_ctrl_c_still_cancels_with_listener_active() {
     local out
     out=$(_toggle_clean "$log")
 
-    if ! grep -q "verbose on" <<<"$out"; then
+    # The toggle is confirmed by the footer hint flipping to `v quiet` (now
+    # offering the way back), not by a scrollback note — a mid-run flip with
+    # nothing finished writes none.
+    if ! grep -q "v quiet" <<<"$out"; then
         log_error "the toggle did not register before the interrupt"
         return 1
     fi

--- a/tests/integration/test_exec_verbose_toggle.sh
+++ b/tests/integration/test_exec_verbose_toggle.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+
+# Integration tests for the live `v` verbose toggle on the plan-execute
+# rail (#729).
+#
+# The toggle only exists on a TTY, so these drive daft under a DSR-answering
+# PTY (pty_run.py) and script the keypresses with --send-after. Everything
+# here is invisible to the YAML suite, which runs with DAFT_TESTING set and
+# therefore never materializes a region at all.
+
+source "$(dirname "${BASH_SOURCE[0]}")/test_framework.sh"
+
+TOGGLE_PTY_RUN="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/pty_run.py"
+
+# Run daft with the live rail actually enabled.
+#
+# The framework exports DAFT_TESTING to keep the suite's ~2000 invocations
+# quiet, and one of the things it suppresses is the interactive region
+# itself (`TimelineMode::auto` → Hidden) — which is the entire subject of
+# these tests. So it comes off here, and the three background spawns it was
+# standing in for are suppressed individually instead: no orphaned
+# update-check / trust-prune / log-clean daemons.
+_toggle_daft() {
+    env -u DAFT_TESTING \
+        DAFT_NO_UPDATE_CHECK=1 \
+        DAFT_NO_TRUST_PRUNE=1 \
+        DAFT_NO_LOG_CLEAN=1 \
+        DAFT_NO_HINTS=1 \
+        "$@"
+}
+
+# Strip ANSI and split the pty's carriage-returned repaints into lines.
+_toggle_clean() {
+    sed -e 's/\x1b\[[0-9;]*[a-zA-Z]//g' -e 's/\r/\n/g' "$1"
+}
+
+# A repo with three worktrees, so `daft exec` fans out onto the rail rather
+# than collapsing to single-target passthrough.
+_toggle_fixture() {
+    local name="$1"
+    local remote_repo
+    remote_repo=$(create_test_remote "$name" "master") || return 1
+    git -C "$remote_repo" branch feat-a master || return 1
+    git -C "$remote_repo" branch feat-b master || return 1
+    git-worktree-clone --layout contained "$remote_repo" || return 1
+    local root="$PWD/$name"
+    # Each checkout runs in a subshell from a known-good directory inside the
+    # repo: relying on inherited cwd made this order-dependent.
+    (cd "$root/master" && git-worktree-checkout feat-a) || return 1
+    (cd "$root/master" && git-worktree-checkout feat-b) || return 1
+    # `daft exec --all` runs from the container root, where it sees all three.
+    cd "$root" || return 1
+    return 0
+}
+
+# Pressing `v` mid-run flips the live rows to verbose and threads every
+# row's captured log into its receipt.
+test_exec_v_toggles_verbose_midrun() {
+    _toggle_fixture "toggle-midrun" || return 1
+    local log="$TEMP_BASE_DIR/toggle-midrun.log"
+
+    # The keypress lands one poll (~100ms) after `first-line` appears, so the
+    # rows must still be running then. Three seconds keeps that margin wide
+    # on a loaded CI box; a shorter sleep makes this a timing flake.
+    _toggle_daft python3 "$TOGGLE_PTY_RUN" --send-after 'first-line:v' "$log" \
+        daft exec --all -- sh -c 'echo first-line; sleep 3; echo second-line' \
+        >/dev/null 2>&1
+
+    local out
+    out=$(_toggle_clean "$log")
+
+    if ! grep -q "verbose on" <<<"$out"; then
+        log_error "no density note after pressing v"
+        return 1
+    fi
+    # A *threaded* line wears the thread gutter; the same text as a row
+    # annotation would prove nothing, since terse mode shows it there too.
+    if ! grep -qE '^│ +first-line' <<<"$out"; then
+        log_error "verbose did not thread a job's log into its receipt"
+        return 1
+    fi
+    log_success "v flips the rail to verbose mid-run"
+    return 0
+}
+
+# Without the keypress the run is byte-for-byte the terse rail it always
+# was: no note, no threads, no hint left in scrollback.
+test_exec_without_v_stays_terse() {
+    _toggle_fixture "toggle-baseline" || return 1
+    local log="$TEMP_BASE_DIR/toggle-baseline.log"
+
+    _toggle_daft python3 "$TOGGLE_PTY_RUN" "$log" \
+        daft exec --all -- sh -c 'echo first-line; sleep 1; echo second-line' \
+        >/dev/null 2>&1
+
+    local out
+    out=$(_toggle_clean "$log")
+
+    if grep -q "verbose on\|verbose off" <<<"$out"; then
+        log_error "a density note appeared without any keypress"
+        return 1
+    fi
+    if grep -qE '^│ +first-line' <<<"$out"; then
+        log_error "receipts threaded their logs without -v or a toggle"
+        return 1
+    fi
+    log_success "an untoggled run stays terse"
+    return 0
+}
+
+# #663's two-stage Ctrl-C must survive the listener: `ISIG` stays on, so the
+# first ^C is still a real SIGINT that cancels the workers and closes the
+# rail — not a keystroke the reader swallows, and not a torn-down region.
+test_exec_ctrl_c_still_cancels_with_listener_active() {
+    _toggle_fixture "toggle-interrupt" || return 1
+    local log="$TEMP_BASE_DIR/toggle-interrupt.log"
+
+    # --ctty: the child needs its own session owning the pty, or the
+    # interrupt has no foreground process group to reach.
+    _toggle_daft python3 "$TOGGLE_PTY_RUN" --ctty \
+        --send-after 'started:v' \
+        --send-after 'v quiet:\x03' \
+        "$log" \
+        daft exec --all -- sh -c 'echo started; sleep 20' \
+        >/dev/null 2>&1
+
+    local out
+    out=$(_toggle_clean "$log")
+
+    if ! grep -q "verbose on" <<<"$out"; then
+        log_error "the toggle did not register before the interrupt"
+        return 1
+    fi
+    if ! grep -qi "cancelled" <<<"$out"; then
+        log_error "^C did not reach daft's cancellation with a listener active"
+        return 1
+    fi
+    # `ECHOCTL` stays off for the region's life: a literal ^C in the region
+    # would desync indicatif's line accounting.
+    if grep -qE '^\^C' <<<"$out"; then
+        log_error "a raw ^C echoed into the live region"
+        return 1
+    fi
+    log_success "two-stage Ctrl-C survives the key listener"
+    return 0
+}
+
+# The terminal must be handed back the way it was found. A half-configured
+# driver (no echo, no line editing) is a far worse failure than anything the
+# rail could print.
+test_exec_restores_terminal_modes() {
+    _toggle_fixture "toggle-termios" || return 1
+    local log="$TEMP_BASE_DIR/toggle-termios.log"
+
+    # `stty -a` runs inside the same pty right after daft exits; the wrapper
+    # preserves daft's exit code so the harness still reports it.
+    _toggle_daft python3 "$TOGGLE_PTY_RUN" --send-after 'first-line:v' "$log" \
+        sh -c 'daft exec --all -- sh -c "echo first-line; sleep 3" >/dev/null 2>&1; rc=$?; stty -a; exit $rc' \
+        >/dev/null 2>&1
+
+    local modes
+    modes=$(_toggle_clean "$log" | tr ' ' '\n' | grep -E '^-?(icanon|echo)$' | sort -u)
+
+    if grep -q '^-icanon$' <<<"$modes"; then
+        log_error "terminal left in non-canonical mode after the run"
+        return 1
+    fi
+    if grep -q '^-echo$' <<<"$modes"; then
+        log_error "terminal left with echo disabled after the run"
+        return 1
+    fi
+    if ! grep -q '^icanon$' <<<"$modes" || ! grep -q '^echo$' <<<"$modes"; then
+        log_error "could not read the terminal modes back: $modes"
+        return 1
+    fi
+    log_success "terminal modes restored after the run"
+    return 0
+}
+
+# --- Test runner ---
+run_exec_verbose_toggle_tests() {
+    run_test "exec_v_toggles_verbose_midrun" test_exec_v_toggles_verbose_midrun
+    run_test "exec_without_v_stays_terse" test_exec_without_v_stays_terse
+    run_test "exec_ctrl_c_still_cancels_with_listener_active" test_exec_ctrl_c_still_cancels_with_listener_active
+    run_test "exec_restores_terminal_modes" test_exec_restores_terminal_modes
+}
+
+# Main execution (when run directly)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    setup
+    run_exec_verbose_toggle_tests
+    print_summary
+    exit $?
+fi


### PR DESCRIPTION
Fixes #729

Pressing `v` mid-run now flips the plan-execute rail between terse and verbose
live, instead of `-v` being an at-invocation commitment. It's built at the
Timeline layer (`src/output/timeline/`), so every rail consumer gets it:
`exec`, `run`, `go`/`start`/`clone`/`push`/`remove`.

## What it does

- **Live density flip** — `v` toggles active exec rows between the dim
  latest-line annotation and a rolling output window (pre-filled from the row's
  retained buffer). The footer stopwatch carries an always-on hint that flips
  `v verbose` ⇄ `v quiet`.
- **Fold-out replay** — flipping verbose-ward re-emits the full logs of exec
  rows that already finished as compact successes, headed by
  `verbose on — replaying N finished rows`. Replayed buffers are consumed, so
  toggling back and forth never double-prints. Failures are never replayed
  (their output already showed when they failed).
- **Persist-time density** — a row that resolves while a `v` is in flight
  decides its receipt density at persist time, so a late toggle still threads
  its log. Append-only: nothing already printed is rewritten.
- **Ctrl-C untouched** — the key listener keeps `ISIG` on, so the first `^C` is
  still a real SIGINT into #663's two-stage cancellation, never a swallowed
  keystroke.

## Notes

- `-v` (the free-text `detail()` gate) and `daft.hooks.output.verbose` (job-log
  density) stay distinct knobs; the live toggle drives density. Commit 1
  unifies the lifecycle-command seed onto the folded config value — a
  deliberate, called-out behavior change.
- TTY-only: `Plain`/`Hidden` regions are byte-identical to before (no listener,
  no termios change), so CI and piped output are unaffected.
- Replay scope is exec's per-row output threads only; `run`/lifecycle hook rows
  flip density for subsequent rendering but don't replay (documented).

## Commits

1. `feat(output): make rail verbosity one live-readable flag` — `Copy`-bool →
   shared `LiveVerbose(Arc<AtomicBool>)` read at render time.
2. `feat(output): flip rail density live, with a fold-out for finished rows` —
   toggle semantics, persist-time receipts, gated replay retention.
3. `feat(output): read v from the rail's terminal to toggle verbosity live` —
   the key listener, escalating termios guard, footer hint.
4. `test(output): PTY coverage for the live verbose toggle, plus docs` —
   `pty_run.py` key injection, four integration cases, docs + manual test plan.
5. `fix(output): only note a density flip when it heads a fold-out` —
   field-feedback fix: a bare flip no longer writes a scrollback note (they
   were piling up on repeated toggles); notes now only head a fold-out replay,
   and the footer hint is the always-on density indicator.

## Testing

- 2807 unit tests, clippy, fmt, `man:verify` + `docs:cli:verify` all green.
- New PTY-driven integration suite (`test_exec_verbose_toggle.sh`, four cases):
  mid-run flip threads logs, an untoggled run stays byte-for-byte terse,
  two-stage Ctrl-C survives the listener, terminal modes restored.
- E2E-verified under a real PTY; xhigh code review clean (no findings survived
  verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
