### PR TITLE
fix(prune): detect squash merges the patch-id probes miss

### DIFF
--- a/docs/cli/git-worktree-prune.md
+++ b/docs/cli/git-worktree-prune.md
@@ -25,7 +25,12 @@ and finally deletes the local branches.
 A deleted remote branch does not by itself prove the work was merged, so each
 gone branch is verified against the default branch (regular or squash merge)
 before anything is deleted; gone-but-unmerged branches are kept with a
-warning. Worktrees whose untracked daft files (daft.yml / daft.local.yml)
+warning. Squash merges are matched by content, not by patch text, so a squash
+still counts as merged when an intervening commit shifted the surrounding
+lines. A branch that no local check can place is checked against the forge as
+a last resort: it counts as merged only if a freshly fetched pull request
+reports merged, targets the default branch, and has the local branch's exact
+commit as its head. Worktrees whose untracked daft files (daft.yml / daft.local.yml)
 were refined since daft seeded them are also kept, with a pointer at
 daft-file(1) merge for consolidation. --force overrides both: unmerged
 branches are deleted and refined daft files are discarded to

--- a/docs/cli/git-worktree-prune.md
+++ b/docs/cli/git-worktree-prune.md
@@ -29,8 +29,10 @@ warning. Squash merges are matched by content, not by patch text, so a squash
 still counts as merged when an intervening commit shifted the surrounding
 lines. A branch that no local check can place is checked against the forge as
 a last resort: it counts as merged only if a freshly fetched pull request
-reports merged, targets the default branch, and has the local branch's exact
-commit as its head. Worktrees whose untracked daft files (daft.yml / daft.local.yml)
+reports merged, targets the default branch, and merged a commit that contains
+the local branch tip. Only recent pull requests are visible to that check, so
+a branch abandoned long ago can still be reported unmerged; delete it with
+--force. Worktrees whose untracked daft files (daft.yml / daft.local.yml)
 were refined since daft seeded them are also kept, with a pointer at
 daft-file(1) merge for consolidation. --force overrides both: unmerged
 branches are deleted and refined daft files are discarded to

--- a/man/daft-prune.1
+++ b/man/daft-prune.1
@@ -23,8 +23,10 @@ warning. Squash merges are matched by content, not by patch text, so a squash
 still counts as merged when an intervening commit shifted the surrounding
 lines. A branch that no local check can place is checked against the forge as
 a last resort: it counts as merged only if a freshly fetched pull request
-reports merged, targets the default branch, and has the local branch\*(Aqs exact
-commit as its head. Worktrees whose untracked daft files (daft.yml / daft.local.yml)
+reports merged, targets the default branch, and merged a commit that contains
+the local branch tip. Only recent pull requests are visible to that check, so
+a branch abandoned long ago can still be reported unmerged; delete it with
+\-\-force. Worktrees whose untracked daft files (daft.yml / daft.local.yml)
 were refined since daft seeded them are also kept, with a pointer at
 daft\-file(1) merge for consolidation. \-\-force overrides both: unmerged
 branches are deleted and refined daft files are discarded to

--- a/man/daft-prune.1
+++ b/man/daft-prune.1
@@ -19,7 +19,12 @@ and finally deletes the local branches.
 A deleted remote branch does not by itself prove the work was merged, so each
 gone branch is verified against the default branch (regular or squash merge)
 before anything is deleted; gone\-but\-unmerged branches are kept with a
-warning. Worktrees whose untracked daft files (daft.yml / daft.local.yml)
+warning. Squash merges are matched by content, not by patch text, so a squash
+still counts as merged when an intervening commit shifted the surrounding
+lines. A branch that no local check can place is checked against the forge as
+a last resort: it counts as merged only if a freshly fetched pull request
+reports merged, targets the default branch, and has the local branch\*(Aqs exact
+commit as its head. Worktrees whose untracked daft files (daft.yml / daft.local.yml)
 were refined since daft seeded them are also kept, with a pointer at
 daft\-file(1) merge for consolidation. \-\-force overrides both: unmerged
 branches are deleted and refined daft files are discarded to

--- a/man/git-worktree-prune.1
+++ b/man/git-worktree-prune.1
@@ -23,8 +23,10 @@ warning. Squash merges are matched by content, not by patch text, so a squash
 still counts as merged when an intervening commit shifted the surrounding
 lines. A branch that no local check can place is checked against the forge as
 a last resort: it counts as merged only if a freshly fetched pull request
-reports merged, targets the default branch, and has the local branch\*(Aqs exact
-commit as its head. Worktrees whose untracked daft files (daft.yml / daft.local.yml)
+reports merged, targets the default branch, and merged a commit that contains
+the local branch tip. Only recent pull requests are visible to that check, so
+a branch abandoned long ago can still be reported unmerged; delete it with
+\-\-force. Worktrees whose untracked daft files (daft.yml / daft.local.yml)
 were refined since daft seeded them are also kept, with a pointer at
 daft\-file(1) merge for consolidation. \-\-force overrides both: unmerged
 branches are deleted and refined daft files are discarded to

--- a/man/git-worktree-prune.1
+++ b/man/git-worktree-prune.1
@@ -19,7 +19,12 @@ and finally deletes the local branches.
 A deleted remote branch does not by itself prove the work was merged, so each
 gone branch is verified against the default branch (regular or squash merge)
 before anything is deleted; gone\-but\-unmerged branches are kept with a
-warning. Worktrees whose untracked daft files (daft.yml / daft.local.yml)
+warning. Squash merges are matched by content, not by patch text, so a squash
+still counts as merged when an intervening commit shifted the surrounding
+lines. A branch that no local check can place is checked against the forge as
+a last resort: it counts as merged only if a freshly fetched pull request
+reports merged, targets the default branch, and has the local branch\*(Aqs exact
+commit as its head. Worktrees whose untracked daft files (daft.yml / daft.local.yml)
 were refined since daft seeded them are also kept, with a pointer at
 daft\-file(1) merge for consolidation. \-\-force overrides both: unmerged
 branches are deleted and refined daft files are discarded to

--- a/src/commands/branch_delete.rs
+++ b/src/commands/branch_delete.rs
@@ -1,6 +1,7 @@
 use crate::{
     CD_FILE_ENV,
     core::{CommandBridge, worktree::branch_delete},
+    git::GitCommand,
     hooks::HookExecutor,
     is_git_repository,
     logging::init_logging,
@@ -125,7 +126,10 @@ fn run_branch_delete(args: &Args, output: &mut dyn Output, settings: &DaftSettin
     output.start_spinner("Deleting branches...");
     let exec_result = {
         let mut bridge = CommandBridge::new(output, executor);
-        branch_delete::execute(&params, None, &mut bridge)
+        let witness = crate::commands::forge_cache::merged_witness(
+            &GitCommand::new(true).with_gitoxide(settings.use_gitoxide),
+        );
+        branch_delete::execute(&params, None, witness.as_ref(), &mut bridge)
     };
     output.finish_spinner();
     let result = exec_result?;

--- a/src/commands/forge_cache.rs
+++ b/src/commands/forge_cache.rs
@@ -22,7 +22,8 @@
 //! `pr` column until a later refresh — or a successful `pr:` checkout —
 //! proves the forge reachable again.
 
-use crate::core::worktree::forge_ref::ForgeRefKind;
+use crate::core::worktree::forge_ref::{ForgeBranchRef, ForgeRefKind};
+use crate::core::worktree::ports::{ForgeMergedWitness, NoopForgeWitness};
 use crate::forge::{PrListEntry, RemoteRefInfo};
 use crate::git::GitCommand;
 use crate::store::Pool;
@@ -474,27 +475,168 @@ pub fn run_refresh_forge() -> anyhow::Result<()> {
     nix::unistd::setsid().ok();
     let project_root = crate::core::repo::get_project_root()?;
     let repo_hash = crate::core::repo_identity::compute_repo_id()?;
+    refresh_snapshot(&project_root, &repo_hash).map(|_| ())
+}
+
+/// One listing, persisted as the new snapshot, with the outcome stamped as
+/// forge health. Shared by the detached refresh child and the foreground
+/// merge witness so health semantics can't drift between them.
+fn refresh_snapshot(
+    project_root: &std::path::Path,
+    repo_hash: &str,
+) -> anyhow::Result<Vec<PrListEntry>> {
     // Stamped before the fetch: the start stamp is the in-flight guard's
     // key, so a slow gh can't let a second `daft list` pile on a second
     // concurrent refresh (it attaches to this one instead).
-    record_refresh_started(&repo_hash);
+    record_refresh_started(repo_hash);
     let git = GitCommand::new(true);
     let config = crate::forge::ForgeConfig::load(&git);
-    match crate::forge::fetch_snapshot(&git, &project_root, &config) {
+    match crate::forge::fetch_snapshot(&git, project_root, &config) {
         Ok((kind, entries)) => {
             // Snapshot first, then the success stamp — the live table's poll
             // concludes on the stamp, so the data is always there when it
             // reloads the lookup.
-            persist_snapshot(&repo_hash, kind, &entries);
-            record_refresh_success(&repo_hash);
-            Ok(())
+            persist_snapshot(repo_hash, kind, &entries);
+            record_refresh_success(repo_hash);
+            Ok(entries)
         }
         Err(err) => {
             let deep = crate::forge::classify_unavailable(&err).map(|k| k.kind_str());
-            record_refresh_failure(&repo_hash, deep);
+            record_refresh_failure(repo_hash, deep);
             Err(err)
         }
     }
+}
+
+/// The [`ForgeMergedWitness`] for this run: a live one where a fresh listing
+/// is both possible and appropriate, otherwise the no-op.
+///
+/// Declines for repos that name no forge, and — like every other forge fetch —
+/// for agent and test invocations, which must never fan out network work.
+/// Declining costs nothing but a fallback to the git probes.
+pub fn merged_witness(git: &GitCommand) -> std::sync::Arc<dyn ForgeMergedWitness> {
+    if crate::should_skip_background_tasks(crate::cli::argv())
+        || !crate::forge::repo_forge_capable(git)
+    {
+        return std::sync::Arc::new(NoopForgeWitness);
+    }
+    let (Ok(project_root), Ok(repo_hash)) = (
+        crate::core::repo::get_project_root(),
+        crate::core::repo_identity::compute_repo_id(),
+    ) else {
+        return std::sync::Arc::new(NoopForgeWitness);
+    };
+    std::sync::Arc::new(LiveForgeWitness {
+        project_root,
+        repo_hash,
+        index: std::sync::OnceLock::new(),
+    })
+}
+
+/// Answers "did the forge merge this branch?" from a listing fetched during
+/// this run — never from the cache, which is a stale hint and cannot
+/// authorize deleting anything (#737).
+///
+/// The listing is fetched lazily and at most once. Most runs never fetch at
+/// all: the witness is consulted only for a branch whose upstream is gone and
+/// which every git probe already failed to place, which is rare.
+pub struct LiveForgeWitness {
+    project_root: std::path::PathBuf,
+    repo_hash: String,
+    index: std::sync::OnceLock<MergedPrIndex>,
+}
+
+impl ForgeMergedWitness for LiveForgeWitness {
+    fn merged_pr(
+        &self,
+        branch: &str,
+        tip_oid: &str,
+        target_branch: &str,
+    ) -> Option<ForgeBranchRef> {
+        // Concurrent DAG workers converge here: the first blocks on the
+        // listing, the rest wait on it rather than each firing their own.
+        self.index
+            .get_or_init(|| {
+                // A failed listing indexes as empty — the run falls back to
+                // the git probes, exactly as if the repo had no forge.
+                refresh_snapshot(&self.project_root, &self.repo_hash)
+                    .map_or_else(|_| MergedPrIndex::default(), |e| index_entries(&e))
+            })
+            .witness(branch, tip_oid, target_branch)
+    }
+}
+
+/// A merged PR/MR that could witness for its head branch.
+struct MergedPr {
+    forge_ref: ForgeBranchRef,
+    head_oid: String,
+    base_branch: String,
+}
+
+/// The run's listing, reduced to what the witness decides on.
+#[derive(Default)]
+struct MergedPrIndex {
+    /// Branches carrying an open PR. An open PR means the work continues, so
+    /// nothing that merged earlier can speak for the branch as it stands now.
+    shadowed: std::collections::HashSet<String>,
+    /// Merged PRs by head branch. More than one is ordinary — a branch reused
+    /// across several PRs — which is exactly why the head commit decides.
+    merged: std::collections::HashMap<String, Vec<MergedPr>>,
+}
+
+impl MergedPrIndex {
+    fn witness(&self, branch: &str, tip_oid: &str, target_branch: &str) -> Option<ForgeBranchRef> {
+        if self.shadowed.contains(branch) {
+            return None;
+        }
+        self.merged
+            .get(branch)?
+            .iter()
+            .find(|pr| pr.head_oid == tip_oid && pr.base_branch == target_branch)
+            .map(|pr| pr.forge_ref)
+    }
+}
+
+/// Reduce a listing to the witness index. Pure, so the rules that decide
+/// whether a branch may be deleted are testable without a forge.
+///
+/// Cross-repo rows are excluded for the same reason
+/// [`ForgePrsRepo::by_head_branch`] excludes them: a fork's branch must never
+/// speak for a local branch that happens to share its name. Closed-unmerged
+/// rows never witness at all.
+fn index_entries(entries: &[PrListEntry]) -> MergedPrIndex {
+    let mut index = MergedPrIndex::default();
+    for entry in entries {
+        if entry.is_cross_repo {
+            continue;
+        }
+        match entry.state.as_str() {
+            "open" => {
+                index.shadowed.insert(entry.head_branch.clone());
+            }
+            "merged" => {
+                // Without both pins the row proves nothing about *this*
+                // branch at *this* commit, so it is dropped rather than
+                // half-trusted.
+                let (Some(head_oid), Some(base_branch)) =
+                    (entry.head_oid.clone(), entry.base_branch.clone())
+                else {
+                    continue;
+                };
+                index
+                    .merged
+                    .entry(entry.head_branch.clone())
+                    .or_default()
+                    .push(MergedPr {
+                        forge_ref: ForgeBranchRef::new(entry.kind, entry.number),
+                        head_oid,
+                        base_branch,
+                    });
+            }
+            _ => {}
+        }
+    }
+    index
 }
 
 #[cfg(test)]
@@ -516,7 +658,137 @@ mod tests {
             author: "octocat".into(),
             head_repo_owner: String::new(),
             updated_at: None,
+            head_oid: None,
+            base_branch: None,
         }
+    }
+
+    /// A merged PR carrying both witness pins.
+    fn merged_entry(number: u32, head: &str, head_oid: &str, base: &str) -> PrListEntry {
+        PrListEntry {
+            state: "merged".into(),
+            head_oid: Some(head_oid.into()),
+            base_branch: Some(base.into()),
+            ..entry(number, head, None)
+        }
+    }
+
+    #[test]
+    fn witnesses_a_merged_pr_at_the_branch_tip() {
+        let index = index_entries(&[merged_entry(731, "feat/x", "abc123", "master")]);
+
+        let found = index.witness("feat/x", "abc123", "master");
+        assert_eq!(found.map(|r| r.number), Some(731));
+    }
+
+    /// Branch names get reused. A merged PR for an *earlier* branch of the
+    /// same name must not vouch for whatever work carries the name now —
+    /// which is the whole reason the witness pins the commit.
+    #[test]
+    fn refuses_when_the_tip_is_not_the_merged_pr_head() {
+        let index = index_entries(&[merged_entry(731, "feat/x", "abc123", "master")]);
+
+        assert!(index.witness("feat/x", "different-tip", "master").is_none());
+    }
+
+    /// A stacked PR merged into another feature branch, or a backport merged
+    /// into a release line, is genuinely merged — just not into the branch
+    /// the caller asked about.
+    #[test]
+    fn refuses_when_the_pr_merged_into_a_different_base() {
+        let index = index_entries(&[
+            merged_entry(731, "feat/stacked", "abc123", "feat/parent"),
+            merged_entry(732, "feat/backport", "def456", "release-2"),
+        ]);
+
+        assert!(index.witness("feat/stacked", "abc123", "master").is_none());
+        assert!(index.witness("feat/backport", "def456", "master").is_none());
+        // Against its own base it does witness.
+        assert!(
+            index
+                .witness("feat/stacked", "abc123", "feat/parent")
+                .is_some()
+        );
+    }
+
+    /// An open PR on the branch means the work continues, whatever merged
+    /// before it.
+    #[test]
+    fn an_open_pr_shadows_an_earlier_merged_one() {
+        let index = index_entries(&[
+            merged_entry(700, "feat/x", "abc123", "master"),
+            entry(731, "feat/x", None),
+        ]);
+
+        assert!(index.witness("feat/x", "abc123", "master").is_none());
+    }
+
+    /// A fork's branch must never speak for a local branch sharing its name
+    /// (the rule `ForgePrsRepo::by_head_branch` applies to the cache).
+    #[test]
+    fn ignores_cross_repo_rows() {
+        let mut fork = merged_entry(731, "patch-1", "abc123", "master");
+        fork.is_cross_repo = true;
+
+        assert!(
+            index_entries(&[fork])
+                .witness("patch-1", "abc123", "master")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn ignores_closed_and_pinless_rows() {
+        let mut closed = merged_entry(4, "feat/abandoned", "abc123", "master");
+        closed.state = "closed".into();
+        // A platform that supplied no head commit (or no base) can't witness.
+        let mut pinless = merged_entry(5, "feat/pinless", "abc123", "master");
+        pinless.head_oid = None;
+        let mut baseless = merged_entry(6, "feat/baseless", "abc123", "master");
+        baseless.base_branch = None;
+
+        let index = index_entries(&[closed, pinless, baseless]);
+        assert!(
+            index
+                .witness("feat/abandoned", "abc123", "master")
+                .is_none()
+        );
+        assert!(index.witness("feat/pinless", "abc123", "master").is_none());
+        assert!(index.witness("feat/baseless", "abc123", "master").is_none());
+    }
+
+    /// A branch reused across several PRs indexes them all; the head commit
+    /// picks the one that actually carried this work.
+    #[test]
+    fn picks_the_merged_pr_matching_the_tip() {
+        let index = index_entries(&[
+            merged_entry(700, "feat/x", "old-tip", "master"),
+            merged_entry(731, "feat/x", "new-tip", "master"),
+        ]);
+
+        assert_eq!(
+            index
+                .witness("feat/x", "new-tip", "master")
+                .map(|r| r.number),
+            Some(731)
+        );
+        assert_eq!(
+            index
+                .witness("feat/x", "old-tip", "master")
+                .map(|r| r.number),
+            Some(700)
+        );
+    }
+
+    /// A failed listing indexes as empty, so the run falls back to the git
+    /// probes rather than concluding anything.
+    #[test]
+    fn an_empty_index_witnesses_nothing() {
+        assert!(
+            MergedPrIndex::default()
+                .witness("feat/x", "abc123", "master")
+                .is_none()
+        );
     }
 
     #[test]

--- a/src/commands/forge_cache.rs
+++ b/src/commands/forge_cache.rs
@@ -21,9 +21,15 @@
 //! (missing tool, dead auth, lost repo access) silently hides the default
 //! `pr` column until a later refresh — or a successful `pr:` checkout —
 //! proves the forge reachable again.
+//!
+//! [`LiveForgeWitness`] is the one forge fetch here that is **not** a refresh
+//! trigger. It answers "did a PR merge this branch?" for prune/branch-delete
+//! and writes nothing at all — no snapshot, no health stamp. A merge check
+//! that marked the repo unhealthy would make the next `daft list` quietly
+//! drop its `pr` column, which is not a thing a read may do.
 
 use crate::core::worktree::forge_ref::{ForgeBranchRef, ForgeRefKind};
-use crate::core::worktree::ports::{ForgeMergedWitness, NoopForgeWitness};
+use crate::core::worktree::ports::{ForgeMergedWitness, ForgeWitness, NoopForgeWitness};
 use crate::forge::{PrListEntry, RemoteRefInfo};
 use crate::git::GitCommand;
 use crate::store::Pool;
@@ -478,9 +484,25 @@ pub fn run_refresh_forge() -> anyhow::Result<()> {
     refresh_snapshot(&project_root, &repo_hash).map(|_| ())
 }
 
+/// One listing, with nothing recorded anywhere. The shared fetch underneath
+/// [`refresh_snapshot`] and the merge witness, which must not write.
+fn fetch_listing(
+    project_root: &std::path::Path,
+) -> anyhow::Result<(ForgeRefKind, Vec<PrListEntry>)> {
+    let git = GitCommand::new(true);
+    let config = crate::forge::ForgeConfig::load(&git);
+    crate::forge::fetch_snapshot(&git, project_root, &config)
+}
+
 /// One listing, persisted as the new snapshot, with the outcome stamped as
-/// forge health. Shared by the detached refresh child and the foreground
-/// merge witness so health semantics can't drift between them.
+/// forge health. The detached refresh child's path — the command whose whole
+/// job is to refresh the cache.
+///
+/// The merge witness deliberately does NOT come through here: it is a read,
+/// and a read must not rewrite the cache or the health stamps. Stamping a
+/// failure from `prune` would make the *next* `daft list` silently drop its
+/// `pr` column, which is a spooky enough action at a distance when a refresh
+/// does it and indefensible when a merge check does.
 fn refresh_snapshot(
     project_root: &std::path::Path,
     repo_hash: &str,
@@ -489,9 +511,7 @@ fn refresh_snapshot(
     // key, so a slow gh can't let a second `daft list` pile on a second
     // concurrent refresh (it attaches to this one instead).
     record_refresh_started(repo_hash);
-    let git = GitCommand::new(true);
-    let config = crate::forge::ForgeConfig::load(&git);
-    match crate::forge::fetch_snapshot(&git, project_root, &config) {
+    match fetch_listing(project_root) {
         Ok((kind, entries)) => {
             // Snapshot first, then the success stamp — the live table's poll
             // concludes on the stamp, so the data is always there when it
@@ -520,17 +540,43 @@ pub fn merged_witness(git: &GitCommand) -> std::sync::Arc<dyn ForgeMergedWitness
     {
         return std::sync::Arc::new(NoopForgeWitness);
     }
-    let (Ok(project_root), Ok(repo_hash)) = (
-        crate::core::repo::get_project_root(),
-        crate::core::repo_identity::compute_repo_id(),
-    ) else {
+    let Ok(project_root) = crate::core::repo::get_project_root() else {
         return std::sync::Arc::new(NoopForgeWitness);
     };
     std::sync::Arc::new(LiveForgeWitness {
         project_root,
-        repo_hash,
-        index: std::sync::OnceLock::new(),
+        state: std::sync::Mutex::new(WitnessState::Unfetched),
     })
+}
+
+/// How long a merge check will wait on the forge before giving up and letting
+/// the git verdicts stand.
+///
+/// The witness runs inside sync/prune's worker DAG, where every worker that
+/// needs it converges on the same fetch — so an unreachable forge (VPN down,
+/// rate limited) would otherwise stall the live table indefinitely with no
+/// progress and nothing to cancel. A bounded wait turns "hung" into "slow
+/// once, then falls back".
+const WITNESS_FETCH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+
+/// How many times a *transient* failure may be retried within one run.
+///
+/// A forge that is missing, unauthenticated, or inaccessible fails the same
+/// way forever, so it is recorded once and never retried. A network blip or
+/// rate limit might not, and a run that gave up run-wide on the first branch
+/// would keep every later merged branch — so those get one more chance, but
+/// only one: a flaky forge must not cost one round trip per branch.
+const WITNESS_MAX_ATTEMPTS: usize = 2;
+
+/// The witness's memo across a run.
+enum WitnessState {
+    /// No listing attempted yet.
+    Unfetched,
+    /// A listing (possibly empty, when the forge is permanently unavailable)
+    /// to answer every remaining branch from.
+    Ready(MergedPrIndex),
+    /// Transient failures so far. Retries until [`WITNESS_MAX_ATTEMPTS`].
+    Failed { attempts: usize },
 }
 
 /// Answers "did the forge merge this branch?" from a listing fetched during
@@ -542,27 +588,91 @@ pub fn merged_witness(git: &GitCommand) -> std::sync::Arc<dyn ForgeMergedWitness
 /// which every git probe already failed to place, which is rare.
 pub struct LiveForgeWitness {
     project_root: std::path::PathBuf,
-    repo_hash: String,
-    index: std::sync::OnceLock<MergedPrIndex>,
+    state: std::sync::Mutex<WitnessState>,
+}
+
+impl LiveForgeWitness {
+    /// The run's listing, fetched at most [`WITNESS_MAX_ATTEMPTS`] times.
+    ///
+    /// Concurrent DAG workers converge on the mutex: the first fetches, the
+    /// rest wait on it rather than each firing their own.
+    fn with_index<T>(&self, f: impl FnOnce(&MergedPrIndex) -> T) -> Option<T> {
+        let mut state = self.state.lock().ok()?;
+
+        if let WitnessState::Failed { attempts } = &*state
+            && *attempts >= WITNESS_MAX_ATTEMPTS
+        {
+            return None;
+        }
+
+        if matches!(
+            &*state,
+            WitnessState::Unfetched | WitnessState::Failed { .. }
+        ) {
+            *state = match bounded_listing(&self.project_root) {
+                Ok(entries) => WitnessState::Ready(index_entries(&entries)),
+                // Nothing here will get better within the run: no tool, no
+                // auth, no access — or a forge slow enough to outrun the
+                // wait, where retrying would only spend the timeout again.
+                // Settle on an empty index and stop paying for the answer.
+                Err(ListingError::TimedOut) => WitnessState::Ready(MergedPrIndex::default()),
+                Err(ListingError::Failed(err))
+                    if crate::forge::classify_unavailable(&err).is_some() =>
+                {
+                    WitnessState::Ready(MergedPrIndex::default())
+                }
+                // Transient and fast to discover — a rate limit, a network
+                // blip. Count it and let a later branch try again.
+                Err(ListingError::Failed(_)) => {
+                    let attempts = match &*state {
+                        WitnessState::Failed { attempts } => attempts + 1,
+                        _ => 1,
+                    };
+                    WitnessState::Failed { attempts }
+                }
+            };
+        }
+
+        match &*state {
+            WitnessState::Ready(index) => Some(f(index)),
+            _ => None,
+        }
+    }
+}
+
+/// Why a witness listing produced nothing. Kept apart from the error itself
+/// because the two deserve different answers: a fast failure may be worth
+/// another try, a timeout never is.
+enum ListingError {
+    /// The wait ran out before the forge answered.
+    TimedOut,
+    /// The forge answered, unhappily.
+    Failed(anyhow::Error),
+}
+
+/// One listing, abandoned if it outruns [`WITNESS_FETCH_TIMEOUT`].
+///
+/// The fetch runs on its own thread so the wait is bounded and the caller
+/// stays interruptible; a timed-out `gh` is left to finish and exit on its
+/// own rather than stranding the command behind it.
+fn bounded_listing(project_root: &std::path::Path) -> Result<Vec<PrListEntry>, ListingError> {
+    let (tx, rx) = std::sync::mpsc::channel();
+    let root = project_root.to_path_buf();
+    std::thread::spawn(move || {
+        let _ = tx.send(fetch_listing(&root).map(|(_, entries)| entries));
+    });
+
+    match rx.recv_timeout(WITNESS_FETCH_TIMEOUT) {
+        Ok(Ok(entries)) => Ok(entries),
+        Ok(Err(err)) => Err(ListingError::Failed(err)),
+        Err(_) => Err(ListingError::TimedOut),
+    }
 }
 
 impl ForgeMergedWitness for LiveForgeWitness {
-    fn merged_pr(
-        &self,
-        branch: &str,
-        tip_oid: &str,
-        target_branch: &str,
-    ) -> Option<ForgeBranchRef> {
-        // Concurrent DAG workers converge here: the first blocks on the
-        // listing, the rest wait on it rather than each firing their own.
-        self.index
-            .get_or_init(|| {
-                // A failed listing indexes as empty — the run falls back to
-                // the git probes, exactly as if the repo had no forge.
-                refresh_snapshot(&self.project_root, &self.repo_hash)
-                    .map_or_else(|_| MergedPrIndex::default(), |e| index_entries(&e))
-            })
-            .witness(branch, tip_oid, target_branch)
+    fn witness(&self, branch: &str, tip_oid: &str, target_branch: &str) -> ForgeWitness {
+        self.with_index(|index| index.witness(branch, tip_oid, target_branch))
+            .unwrap_or(ForgeWitness::Unproven)
     }
 }
 
@@ -585,15 +695,36 @@ struct MergedPrIndex {
 }
 
 impl MergedPrIndex {
-    fn witness(&self, branch: &str, tip_oid: &str, target_branch: &str) -> Option<ForgeBranchRef> {
+    fn witness(&self, branch: &str, tip_oid: &str, target_branch: &str) -> ForgeWitness {
         if self.shadowed.contains(branch) {
-            return None;
+            return ForgeWitness::Unproven;
         }
-        self.merged
-            .get(branch)?
+        let Some(candidates) = self.merged.get(branch) else {
+            return ForgeWitness::Unproven;
+        };
+
+        // Only PRs against the branch we were asked about can speak for it —
+        // a stacked or release-line PR is merged somewhere else entirely.
+        let mut on_target = candidates
             .iter()
-            .find(|pr| pr.head_oid == tip_oid && pr.base_branch == target_branch)
-            .map(|pr| pr.forge_ref)
+            .filter(|pr| pr.base_branch == target_branch);
+
+        // An exact head match is the strongest answer, so prefer it over any
+        // PR that merely targeted the same base.
+        if let Some(exact) = on_target.clone().find(|pr| pr.head_oid == tip_oid) {
+            return ForgeWitness::MergedAtTip(exact.forge_ref);
+        }
+
+        // Otherwise a PR on this branch merged a head we do not hold (listing
+        // order decides which, when a reused name has several). Hand it back
+        // and let the caller ask git whether our tip is contained in it —
+        // being wrong here costs a fallback to unmerged, never a deletion.
+        on_target.next().map_or(ForgeWitness::Unproven, |pr| {
+            ForgeWitness::MergedAtOtherHead {
+                pr: pr.forge_ref,
+                head_oid: pr.head_oid.clone(),
+            }
+        })
     }
 }
 
@@ -673,27 +804,50 @@ mod tests {
         }
     }
 
+    /// The PR number behind an exact-tip witness, or `None` for any weaker
+    /// outcome.
+    fn at_tip(outcome: ForgeWitness) -> Option<u32> {
+        match outcome {
+            ForgeWitness::MergedAtTip(pr) => Some(pr.number),
+            _ => None,
+        }
+    }
+
+    fn is_unproven(outcome: ForgeWitness) -> bool {
+        outcome == ForgeWitness::Unproven
+    }
+
     #[test]
     fn witnesses_a_merged_pr_at_the_branch_tip() {
         let index = index_entries(&[merged_entry(731, "feat/x", "abc123", "master")]);
 
-        let found = index.witness("feat/x", "abc123", "master");
-        assert_eq!(found.map(|r| r.number), Some(731));
+        assert_eq!(
+            at_tip(index.witness("feat/x", "abc123", "master")),
+            Some(731)
+        );
     }
 
-    /// Branch names get reused. A merged PR for an *earlier* branch of the
-    /// same name must not vouch for whatever work carries the name now —
-    /// which is the whole reason the witness pins the commit.
+    /// A head the caller does not hold is reported, not swallowed: the PR
+    /// advanced remotely (a suggestion accepted in the web UI) and only git
+    /// can say whether the local tip is contained in it. Deciding here would
+    /// either strand the branch forever or vouch for a reused name.
     #[test]
-    fn refuses_when_the_tip_is_not_the_merged_pr_head() {
+    fn reports_a_merged_pr_whose_head_is_not_the_tip() {
         let index = index_entries(&[merged_entry(731, "feat/x", "abc123", "master")]);
 
-        assert!(index.witness("feat/x", "different-tip", "master").is_none());
+        assert_eq!(
+            index.witness("feat/x", "different-tip", "master"),
+            ForgeWitness::MergedAtOtherHead {
+                pr: index.merged["feat/x"][0].forge_ref,
+                head_oid: "abc123".into(),
+            }
+        );
     }
 
     /// A stacked PR merged into another feature branch, or a backport merged
     /// into a release line, is genuinely merged — just not into the branch
-    /// the caller asked about.
+    /// the caller asked about. Nothing about it is reportable here, not even
+    /// as a head mismatch.
     #[test]
     fn refuses_when_the_pr_merged_into_a_different_base() {
         let index = index_entries(&[
@@ -701,13 +855,20 @@ mod tests {
             merged_entry(732, "feat/backport", "def456", "release-2"),
         ]);
 
-        assert!(index.witness("feat/stacked", "abc123", "master").is_none());
-        assert!(index.witness("feat/backport", "def456", "master").is_none());
+        assert!(is_unproven(index.witness(
+            "feat/stacked",
+            "abc123",
+            "master"
+        )));
+        assert!(is_unproven(index.witness(
+            "feat/backport",
+            "def456",
+            "master"
+        )));
         // Against its own base it does witness.
-        assert!(
-            index
-                .witness("feat/stacked", "abc123", "feat/parent")
-                .is_some()
+        assert_eq!(
+            at_tip(index.witness("feat/stacked", "abc123", "feat/parent")),
+            Some(731)
         );
     }
 
@@ -720,7 +881,7 @@ mod tests {
             entry(731, "feat/x", None),
         ]);
 
-        assert!(index.witness("feat/x", "abc123", "master").is_none());
+        assert!(is_unproven(index.witness("feat/x", "abc123", "master")));
     }
 
     /// A fork's branch must never speak for a local branch sharing its name
@@ -730,11 +891,9 @@ mod tests {
         let mut fork = merged_entry(731, "patch-1", "abc123", "master");
         fork.is_cross_repo = true;
 
-        assert!(
-            index_entries(&[fork])
-                .witness("patch-1", "abc123", "master")
-                .is_none()
-        );
+        assert!(is_unproven(
+            index_entries(&[fork]).witness("patch-1", "abc123", "master")
+        ));
     }
 
     #[test]
@@ -748,13 +907,21 @@ mod tests {
         baseless.base_branch = None;
 
         let index = index_entries(&[closed, pinless, baseless]);
-        assert!(
-            index
-                .witness("feat/abandoned", "abc123", "master")
-                .is_none()
-        );
-        assert!(index.witness("feat/pinless", "abc123", "master").is_none());
-        assert!(index.witness("feat/baseless", "abc123", "master").is_none());
+        assert!(is_unproven(index.witness(
+            "feat/abandoned",
+            "abc123",
+            "master"
+        )));
+        assert!(is_unproven(index.witness(
+            "feat/pinless",
+            "abc123",
+            "master"
+        )));
+        assert!(is_unproven(index.witness(
+            "feat/baseless",
+            "abc123",
+            "master"
+        )));
     }
 
     /// A branch reused across several PRs indexes them all; the head commit
@@ -767,15 +934,11 @@ mod tests {
         ]);
 
         assert_eq!(
-            index
-                .witness("feat/x", "new-tip", "master")
-                .map(|r| r.number),
+            at_tip(index.witness("feat/x", "new-tip", "master")),
             Some(731)
         );
         assert_eq!(
-            index
-                .witness("feat/x", "old-tip", "master")
-                .map(|r| r.number),
+            at_tip(index.witness("feat/x", "old-tip", "master")),
             Some(700)
         );
     }
@@ -784,11 +947,9 @@ mod tests {
     /// probes rather than concluding anything.
     #[test]
     fn an_empty_index_witnesses_nothing() {
-        assert!(
-            MergedPrIndex::default()
-                .witness("feat/x", "abc123", "master")
-                .is_none()
-        );
+        assert!(is_unproven(
+            MergedPrIndex::default().witness("feat/x", "abc123", "master")
+        ));
     }
 
     #[test]
@@ -885,14 +1046,6 @@ mod tests {
         }
     }
 
-    /// Restore the original cwd when the test ends (pass or panic).
-    struct CwdRestore(std::path::PathBuf);
-    impl Drop for CwdRestore {
-        fn drop(&mut self) {
-            let _ = std::env::set_current_dir(&self.0);
-        }
-    }
-
     /// Regression (caught by checkout/pr-cache.yml): the one-open gate+lookup
     /// read must not condition the lookup on forge capability. Capability only
     /// gates the *default* column — an explicit `+pr` in a repo whose remotes
@@ -917,8 +1070,7 @@ mod tests {
             .output()
             .unwrap();
         assert!(init.status.success());
-        let _cwd = CwdRestore(std::env::current_dir().unwrap());
-        std::env::set_current_dir(tmp.path()).unwrap();
+        let _cwd = crate::test_support::CwdGuard::enter(tmp.path());
 
         // Pin the capability probes to THIS repo. The shell-out arms of
         // remote_list/remote_get_url re-sample the process cwd on every call,

--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -1192,9 +1192,12 @@ pub fn run() -> Result<()> {
                     let bd_result = {
                         let executor = HookExecutor::new(hooks_config.clone())?;
                         let mut bridge = CommandBridge::new(&mut output, executor);
+                        // The merge cleanup sets `skip_merge_validation`, so
+                        // Check 4 never runs and no witness is consulted.
                         crate::core::worktree::branch_delete::execute(
                             &bd_params,
                             None,
+                            &crate::core::worktree::ports::NoopForgeWitness,
                             &mut bridge,
                         )?
                     };

--- a/src/commands/prune.rs
+++ b/src/commands/prune.rs
@@ -54,8 +54,10 @@ warning. Squash merges are matched by content, not by patch text, so a squash
 still counts as merged when an intervening commit shifted the surrounding
 lines. A branch that no local check can place is checked against the forge as
 a last resort: it counts as merged only if a freshly fetched pull request
-reports merged, targets the default branch, and has the local branch's exact
-commit as its head. Worktrees whose untracked daft files (daft.yml / daft.local.yml)
+reports merged, targets the default branch, and merged a commit that contains
+the local branch tip. Only recent pull requests are visible to that check, so
+a branch abandoned long ago can still be reported unmerged; delete it with
+--force. Worktrees whose untracked daft files (daft.yml / daft.local.yml)
 were refined since daft seeded them are also kept, with a pointer at
 daft-file(1) merge for consolidation. --force overrides both: unmerged
 branches are deleted and refined daft files are discarded to

--- a/src/commands/prune.rs
+++ b/src/commands/prune.rs
@@ -50,7 +50,12 @@ and finally deletes the local branches.
 A deleted remote branch does not by itself prove the work was merged, so each
 gone branch is verified against the default branch (regular or squash merge)
 before anything is deleted; gone-but-unmerged branches are kept with a
-warning. Worktrees whose untracked daft files (daft.yml / daft.local.yml)
+warning. Squash merges are matched by content, not by patch text, so a squash
+still counts as merged when an intervening commit shifted the surrounding
+lines. A branch that no local check can place is checked against the forge as
+a last resort: it counts as merged only if a freshly fetched pull request
+reports merged, targets the default branch, and has the local branch's exact
+commit as its head. Worktrees whose untracked daft files (daft.yml / daft.local.yml)
 were refined since daft seeded them are also kept, with a pointer at
 daft-file(1) merge for consolidation. --force overrides both: unmerged
 branches are deleted and refined daft files are discarded to

--- a/src/commands/prune.rs
+++ b/src/commands/prune.rs
@@ -194,6 +194,7 @@ fn run_prune(args: Args, settings: DaftSettings) -> Result<()> {
 }
 
 fn run_prune_inner(output: &mut dyn Output, settings: &DaftSettings, force: bool) -> Result<()> {
+    let git = GitCommand::new(true).with_gitoxide(settings.use_gitoxide);
     let params = prune::PruneParams {
         force,
         use_gitoxide: settings.use_gitoxide,
@@ -201,6 +202,7 @@ fn run_prune_inner(output: &mut dyn Output, settings: &DaftSettings, force: bool
         remote_name: settings.remote.clone(),
         prune_cd_target: settings.prune_cd_target,
         cancel: None,
+        merged_witness: crate::commands::forge_cache::merged_witness(&git),
     };
 
     let hooks_config = crate::core::settings::load_hooks_config()?;
@@ -438,6 +440,12 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
 
     let orch_settings = Arc::clone(&shared_settings);
     let shared_hooks_config = Arc::new(hooks_config.clone());
+    // One witness for the whole run: the workers share its single fetch, and
+    // the post-TUI deferred pass must judge on the same data the table showed.
+    let shared_merged_witness = crate::commands::forge_cache::merged_witness(
+        &GitCommand::new(true).with_gitoxide(settings.use_gitoxide),
+    );
+    let orch_merged_witness = Arc::clone(&shared_merged_witness);
 
     // Captures for the post-fetch refresh inside the orchestrator thread.
     let orch_base_branch = Arc::new(base_branch.clone());
@@ -523,6 +531,7 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
                             shared_force,
                             &shared_hooks_config,
                             &tx_for_tasks,
+                            &orch_merged_witness,
                         );
                         if matches!(message, TaskMessage::Deferred) {
                             *deferred_branch_writer.lock().unwrap() = Some(branch_name.clone());
@@ -653,6 +662,7 @@ fn run_tui(args: Args, settings: DaftSettings) -> Result<()> {
         &worktree_map,
         args.force,
         &hooks_config,
+        &shared_merged_witness,
     );
 
     // ── Print hook summaries (warnings/failures) ──────────────────────────

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -690,6 +690,12 @@ fn run_tui(
     }
     let hooks_config = crate::core::settings::load_hooks_config()?;
     let shared_hooks_config = Arc::new(hooks_config.clone());
+    // One witness for the whole run: the workers share its single fetch, and
+    // the post-TUI deferred pass must judge on the same data the table showed.
+    let shared_merged_witness = crate::commands::forge_cache::merged_witness(
+        &GitCommand::new(true).with_gitoxide(settings.use_gitoxide),
+    );
+    let orch_merged_witness = Arc::clone(&shared_merged_witness);
 
     use crate::output::tui::Column;
 
@@ -1095,6 +1101,7 @@ fn run_tui(
                             shared_force,
                             &shared_hooks_config,
                             &tx_for_tasks,
+                            &orch_merged_witness,
                         );
                         if matches!(message, TaskMessage::Deferred) {
                             *deferred_branch_writer.lock().unwrap() = Some(branch_name.clone());
@@ -1400,6 +1407,7 @@ fn run_tui(
         &worktree_map,
         force,
         &hooks_config,
+        &shared_merged_witness,
     );
 
     // ── Post-TUI: print hook summary ────────────────────────────────────
@@ -2199,6 +2207,7 @@ fn run_prune_phase(
     force: bool,
     cancel: &Arc<CancelFlag>,
 ) -> Result<prune::PruneResult> {
+    let git = GitCommand::new(true).with_gitoxide(settings.use_gitoxide);
     let params = prune::PruneParams {
         force,
         use_gitoxide: settings.use_gitoxide,
@@ -2208,6 +2217,7 @@ fn run_prune_phase(
         // Sequential path: make the prune's `git fetch --prune` cancellable
         // like the update/rebase/push phases (#663).
         cancel: Some(Arc::clone(cancel)),
+        merged_witness: crate::commands::forge_cache::merged_witness(&git),
     };
 
     let hooks_config = crate::core::settings::load_hooks_config()?;

--- a/src/commands/sync_shared.rs
+++ b/src/commands/sync_shared.rs
@@ -42,6 +42,7 @@ pub fn execute_prune_task(
     force: bool,
     hooks_config: &HooksConfig,
     tx: &std::sync::mpsc::Sender<DagEvent>,
+    merged_witness: &Arc<dyn crate::core::worktree::ports::ForgeMergedWitness>,
 ) -> (TaskStatus, TaskMessage) {
     let git = GitCommand::new(false).with_gitoxide(settings.use_gitoxide);
     let ctx = prune::PruneContext {
@@ -65,6 +66,7 @@ pub fn execute_prune_task(
         remote_name: remote_name.to_string(),
         prune_cd_target: settings.prune_cd_target,
         cancel: None,
+        merged_witness: Arc::clone(merged_witness),
     };
 
     let executor = match HookExecutor::new(hooks_config.clone()) {
@@ -156,6 +158,7 @@ pub fn handle_post_tui_deferred(
     worktree_map: &HashMap<String, (PathBuf, bool)>,
     force: bool,
     hooks_config: &HooksConfig,
+    merged_witness: &Arc<dyn crate::core::worktree::ports::ForgeMergedWitness>,
 ) {
     let deferred = deferred_branch.lock().unwrap().clone();
     if let Some(ref branch_name) = deferred {
@@ -181,6 +184,10 @@ pub fn handle_post_tui_deferred(
             remote_name: settings.remote.clone(),
             prune_cd_target: settings.prune_cd_target,
             cancel: None,
+            // The same witness the DAG workers used: a fresh one would refetch
+            // the listing, and a no-op one could reverse a verdict the table
+            // already showed the user.
+            merged_witness: Arc::clone(merged_witness),
         };
         // After TUI exits, we can use the full CLI output again
         let config = OutputConfig::with_autocd(false, false, settings.autocd);

--- a/src/commands/worktree_branch.rs
+++ b/src/commands/worktree_branch.rs
@@ -555,7 +555,15 @@ fn run_branch_delete(
     let exec_result = {
         let mut bridge =
             TimelineBridge::new(output, &mut timeline, executor, hook_output_config.clone());
-        branch_delete::execute(&params, push_presenter.as_ref(), &mut bridge)
+        let witness = crate::commands::forge_cache::merged_witness(
+            &GitCommand::new(true).with_gitoxide(settings.use_gitoxide),
+        );
+        branch_delete::execute(
+            &params,
+            push_presenter.as_ref(),
+            witness.as_ref(),
+            &mut bridge,
+        )
     };
     // A run that never committed a plan (validation errors, nothing to
     // delete) collapses the face here, before its legacy error/info lines

--- a/src/core/worktree/branch_delete.rs
+++ b/src/core/worktree/branch_delete.rs
@@ -3,7 +3,7 @@
 //! Deletes branches and their associated worktrees.
 
 use crate::core::stage::{PlanCommit, Row, StageEvent, StageId, StepKey, StepSpec};
-use crate::core::worktree::ports::NoopStageRunner;
+use crate::core::worktree::ports::{ForgeMergedWitness, NoopStageRunner};
 use crate::core::worktree::push::{PushAction, push_with_hooks};
 use crate::core::{
     ConflictSide, ConsolidationChoice, ConsolidationPrompter, ConsolidationRequest, HookRunner,
@@ -148,6 +148,10 @@ struct ValidatedBranch {
     /// surfaced as a timeline annotation. `None` when the check was skipped
     /// (--force, keep_local_branch, merge's own validation).
     merged_into: Option<String>,
+    /// The PR/MR that proved the merge, when the forge is what proved it
+    /// (#737). `None` when git found the work itself — the ordinary case,
+    /// where naming a PR would add noise rather than explain anything.
+    merged_via: Option<crate::core::worktree::forge_ref::ForgeBranchRef>,
     /// What to do with the worktree's untracked daft files before removal.
     daft_files: DaftFilePlan,
 }
@@ -183,9 +187,12 @@ enum ResolveResult {
 ///
 /// `presenter` reports the pre-push hook run on remote-branch deletes
 /// (#599); pass `None` to skip that reporting (the hook is still honored).
+/// `witness` lets Check 4 accept a branch the forge merged but git cannot
+/// place (#737); pass [`NoopForgeWitness`] to decide on git alone.
 pub fn execute(
     params: &BranchDeleteParams,
     presenter: Option<&Arc<dyn JobPresenter>>,
+    witness: &dyn ForgeMergedWitness,
     sink: &mut (impl ProgressSink + HookRunner + ConsolidationPrompter),
 ) -> Result<BranchDeleteResult> {
     let git = GitCommand::new(params.is_quiet).with_gitoxide(params.use_gitoxide);
@@ -230,6 +237,7 @@ pub fn execute(
         &worktree_map,
         current_wt_path.as_ref(),
         current_branch.as_deref(),
+        witness,
         sink,
     );
 
@@ -376,7 +384,13 @@ fn build_plan(
         if !params.remote_only && !params.keep_local_branch && !branch.worktree_only {
             let mut spec = StepSpec::new(key(StageId::DeleteLocalBranch));
             if let Some(ref target) = branch.merged_into {
-                spec = spec.with_annotation(format!("was merged into {target}"));
+                // Name the PR when the forge is what proved the merge: the
+                // branch's own history shows nothing, so the annotation is
+                // the only account of why deleting it is safe.
+                spec = spec.with_annotation(match branch.merged_via {
+                    Some(via) => format!("was merged into {target} via {}", via.short()),
+                    None => format!("was merged into {target}"),
+                });
             }
             rows.push(Row::Step(spec));
         }
@@ -554,6 +568,7 @@ fn validate_branches(
     worktree_map: &HashMap<String, PathBuf>,
     current_wt_path: Option<&PathBuf>,
     current_branch: Option<&str>,
+    witness: &dyn ForgeMergedWitness,
     sink: &mut (impl ProgressSink + ConsolidationPrompter),
 ) -> (Vec<ValidatedBranch>, Vec<ValidationError>) {
     let force = params.force;
@@ -598,7 +613,9 @@ fn validate_branches(
                 remote_branch_name,
                 is_current_worktree: false,
                 worktree_only: false,
+                // Remote-only deletion skips the local merge checks entirely.
                 merged_into: None,
+                merged_via: None,
                 daft_files: DaftFilePlan::Nothing,
             });
             continue;
@@ -674,6 +691,7 @@ fn validate_branches(
                     // elsewhere.
                     worktree_only: true,
                     merged_into: None,
+                    merged_via: None,
                     daft_files: DaftFilePlan::Nothing,
                 });
                 continue;
@@ -707,13 +725,19 @@ fn validate_branches(
         // Check 4: Merged into default branch (skip with --force,
         // keep_local_branch, or the merge cleanup's own validation)
         let mut merged_into = None;
+        let mut merged_via = None;
         if !force && !keep_local_branch && !skip_merge_validation {
-            match is_branch_merged(ctx, branch) {
-                Ok(true) => {
-                    sink.on_step(&format!("Branch '{branch}' is merged into default branch"));
+            match is_branch_merged(ctx, branch, witness) {
+                Ok(verdict) if verdict.is_merged() => {
+                    merged_via = verdict.via();
+                    let how =
+                        merged_via.map_or_else(String::new, |r| format!(" (via {})", r.short()));
+                    sink.on_step(&format!(
+                        "Branch '{branch}' is merged into default branch{how}"
+                    ));
                     merged_into = Some(ctx.default_branch.clone());
                 }
-                Ok(false) => {
+                Ok(_) => {
                     errors.push(ValidationError {
                         branch: branch.clone(),
                         message: format!(
@@ -854,6 +878,7 @@ fn validate_branches(
             is_current_worktree: is_current,
             worktree_only: false,
             merged_into,
+            merged_via,
             daft_files,
         });
     }
@@ -970,8 +995,18 @@ fn plan_refined_files(
 /// Check whether a branch has been merged into the default branch.
 /// Delegates to the shared [`super::merged`] helpers (also used by prune's
 /// gone-but-unmerged guard).
-fn is_branch_merged(ctx: &BranchDeleteContext, branch: &str) -> Result<bool> {
-    super::merged::is_branch_merged(ctx.git, branch, &ctx.default_branch, &ctx.remote_name)
+fn is_branch_merged(
+    ctx: &BranchDeleteContext,
+    branch: &str,
+    witness: &dyn ForgeMergedWitness,
+) -> Result<super::merged::MergedVerdict> {
+    super::merged::is_branch_merged(
+        ctx.git,
+        branch,
+        &ctx.default_branch,
+        &ctx.remote_name,
+        witness,
+    )
 }
 
 /// Compare local and remote SHAs to determine if the branch is in sync.
@@ -1560,6 +1595,7 @@ fn cleanup_empty_parent_dirs(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::worktree::ports::NoopForgeWitness;
 
     /// Plan fixture where every hook phase has discoverable work — the
     /// pre-gating shape, for tests exercising other row conditionals.
@@ -1580,6 +1616,7 @@ mod tests {
             is_current_worktree: false,
             worktree_only: false,
             merged_into: None,
+            merged_via: None,
             daft_files: DaftFilePlan::Nothing,
         };
         let params = BranchDeleteParams {
@@ -1618,6 +1655,7 @@ mod tests {
             is_current_worktree: false,
             worktree_only,
             merged_into: None,
+            merged_via: None,
             daft_files: DaftFilePlan::Nothing,
         };
         let params = |delete_remote: bool| BranchDeleteParams {
@@ -1683,6 +1721,7 @@ mod tests {
             is_current_worktree: false,
             worktree_only: false,
             merged_into: None,
+            merged_via: None,
             daft_files: DaftFilePlan::Nothing,
         };
         assert_eq!(vb.name, "feature/test");
@@ -1701,6 +1740,7 @@ mod tests {
             is_current_worktree: false,
             worktree_only: false,
             merged_into: None,
+            merged_via: None,
             daft_files: DaftFilePlan::Nothing,
         };
         assert!(vb.worktree_path.is_none());
@@ -1718,6 +1758,7 @@ mod tests {
             is_current_worktree: false,
             worktree_only: true,
             merged_into: None,
+            merged_via: None,
             daft_files: DaftFilePlan::Nothing,
         };
         assert!(vb.worktree_only);
@@ -1942,7 +1983,8 @@ mod tests {
         let mut output = TestOutput::new();
         let executor = HookExecutor::new(HooksConfig::default()).unwrap();
         let mut bridge = CommandBridge::new(&mut output, executor);
-        let result = execute(&params, None, &mut bridge).expect("keep_local_branch should succeed");
+        let result = execute(&params, None, &NoopForgeWitness, &mut bridge)
+            .expect("keep_local_branch should succeed");
 
         assert_eq!(result.deletions.len(), 1);
         assert!(
@@ -2010,7 +2052,7 @@ mod tests {
         let mut output = TestOutput::new();
         let executor = HookExecutor::new(HooksConfig::default()).unwrap();
         let mut bridge = CommandBridge::new(&mut output, executor);
-        let result = execute(&params, None, &mut bridge).unwrap();
+        let result = execute(&params, None, &NoopForgeWitness, &mut bridge).unwrap();
 
         assert!(
             result.validation_errors.is_empty(),
@@ -2052,7 +2094,7 @@ mod tests {
             force_flag_label: "-f/--force".to_string(),
         };
         let mut sink = RecordingStageSink::default();
-        let result = execute(&params, None, &mut sink).unwrap();
+        let result = execute(&params, None, &NoopForgeWitness, &mut sink).unwrap();
         assert!(result.validation_errors.is_empty());
 
         // Exactly one plan, committed before any deletion executed.
@@ -2116,6 +2158,7 @@ mod tests {
             is_current_worktree: false,
             worktree_only: false,
             merged_into: None,
+            merged_via: None,
             daft_files: DaftFilePlan::Nothing,
         };
         let params = BranchDeleteParams {
@@ -2243,7 +2286,7 @@ mod tests {
             inner: RecordingStageSink::default(),
             probes: RefCell::new(Vec::new()),
         };
-        let result = execute(&params, None, &mut sink).unwrap();
+        let result = execute(&params, None, &NoopForgeWitness, &mut sink).unwrap();
         assert!(result.validation_errors.is_empty());
 
         // No discoverable hooks: the plan omits both hook rows...
@@ -2336,7 +2379,7 @@ mod tests {
         trust_db.set_trust_level(&canonical_git_dir, crate::hooks::TrustLevel::Allow);
         let executor = HookExecutor::with_trust_db(HooksConfig::default(), trust_db);
         let mut bridge = CommandBridge::new(&mut output, executor);
-        let bd_result = execute(&params, None, &mut bridge).unwrap();
+        let bd_result = execute(&params, None, &NoopForgeWitness, &mut bridge).unwrap();
         assert!(
             bd_result.validation_errors.is_empty(),
             "unexpected validation errors: {:?}",
@@ -2483,7 +2526,7 @@ mod tests {
             force_flag_label: "-D/--force".to_string(),
         };
         let mut bridge = ScriptedBridge::aborting();
-        let result = execute(&params, None, &mut bridge).unwrap();
+        let result = execute(&params, None, &NoopForgeWitness, &mut bridge).unwrap();
 
         assert!(
             !result.validation_errors.is_empty(),
@@ -2573,7 +2616,7 @@ mod tests {
             force_flag_label: "-D/--force".to_string(),
         };
         let mut bridge = ScriptedBridge::aborting();
-        let result = execute(&params, None, &mut bridge).unwrap();
+        let result = execute(&params, None, &NoopForgeWitness, &mut bridge).unwrap();
 
         assert!(
             result.validation_errors.is_empty(),
@@ -2678,7 +2721,7 @@ mod tests {
             choice: crate::core::ConsolidationChoice::Consolidate,
             side: crate::core::ConflictSide::Abort,
         };
-        let result = execute(&params, None, &mut bridge).unwrap();
+        let result = execute(&params, None, &NoopForgeWitness, &mut bridge).unwrap();
 
         assert!(
             result.validation_errors.is_empty(),

--- a/src/core/worktree/merged.rs
+++ b/src/core/worktree/merged.rs
@@ -12,6 +12,7 @@
 
 use crate::git::GitCommand;
 use anyhow::{Context, Result};
+use std::collections::BTreeSet;
 
 /// Check whether a branch has been merged into the default branch.
 ///
@@ -39,7 +40,7 @@ pub fn is_branch_merged(
 
 /// Check whether `branch` has been merged into `target`.
 ///
-/// Three checks, cheapest first:
+/// Four checks, cheapest first:
 ///
 /// 1. `merge-base --is-ancestor` — regular and fast-forward merges.
 /// 2. `git cherry` — per-commit patch-id equivalence (all lines `-`).
@@ -49,11 +50,24 @@ pub fn is_branch_merged(
 /// 3. Cumulative-diff squash probe — a synthetic commit of the branch's
 ///    whole tree parented at the merge base represents the branch's total
 ///    diff as one commit; `git cherry` on that finds the squash commit.
+/// 4. Merge-tree squash probe — compares by *tree result* instead of
+///    patch-id, which is what catches a squash whose diff drifted textually
+///    from the branch's own (#737).
 ///
-/// Known remaining gap: a squash commit whose diff was altered during the
-/// merge (conflict resolution, maintainer edits) matches no probe and is
-/// still reported unmerged — deliberate, since every check here must be
-/// conservative: reporting "merged" is what authorizes deleting the branch.
+/// Checks 2 and 3 both reduce to patch-id equivalence, and patch-id hashes
+/// context lines. That makes them fail on a perfectly ordinary squash: if
+/// anything merged between the branch's fork point and its squash touched
+/// within three lines of one of the branch's hunks, the context differs and
+/// no patch-id matches. Check 4 exists because that is common rather than
+/// exotic — in a repo where feature branches edit shared registration blocks,
+/// two branches merging the same day near-guarantees it.
+///
+/// Known remaining gap: a squash commit whose *content* was altered during
+/// the merge (conflict resolution, maintainer edits) matches no probe here
+/// and is still reported unmerged. Deliberate — every check must be
+/// conservative, since reporting "merged" is what authorizes deleting the
+/// branch — and it is the forge witness in [`is_branch_merged`], not diff
+/// archaeology, that settles those.
 pub fn is_branch_merged_into(git: &GitCommand, branch: &str, target: &str) -> Result<bool> {
     // Step 1: Check if branch is an ancestor of the target (regular merge)
     let is_ancestor = git
@@ -82,7 +96,12 @@ pub fn is_branch_merged_into(git: &GitCommand, branch: &str, target: &str) -> Re
     }
 
     // Step 3: Multi-commit squash probe.
-    squash_probe(git, branch, target)
+    if squash_probe(git, branch, target)? {
+        return Ok(true);
+    }
+
+    // Step 4: Context-insensitive squash probe.
+    merge_tree_probe(git, branch, target, crate::git::supports_merge_tree())
 }
 
 /// Detect a squash merge of a multi-commit branch.
@@ -121,6 +140,74 @@ fn squash_probe(git: &GitCommand, branch: &str, target: &str) -> Result<bool> {
         .lines()
         .next()
         .is_some_and(|line| line.starts_with('-')))
+}
+
+/// Detect a squash merge whose diff no longer matches the branch's own.
+///
+/// Where [`squash_probe`] asks "does some commit carry the same patch?", this
+/// asks "does some commit carry the same *result*?" — immune to context drift,
+/// because a tree hash has no notion of surrounding lines.
+///
+/// For each first-parent commit `C` on `target` since the merge base:
+///
+/// 1. Cheap filter — `C`'s changed-file set must equal the branch's
+///    cumulative changed-file set. Usually this alone leaves one candidate.
+/// 2. Proof — three-way merge the branch into `C^` in memory. If the
+///    resulting tree equals `C`'s tree, then `C` *is* the branch's work
+///    applied at that point, i.e. the squash commit.
+///
+/// Only reached after the cheaper checks failed, and only when git can run
+/// `merge-tree --write-tree` (2.38+); `capable` is a parameter rather than a
+/// direct probe call so both arms stay unit-testable on any dev machine.
+///
+/// Conservative in the same way as its siblings. A branch with no net change
+/// abstains — otherwise any empty commit on the target would match it — and a
+/// squash whose content was edited during the merge matches no tree and stays
+/// unmerged.
+fn merge_tree_probe(git: &GitCommand, branch: &str, target: &str, capable: bool) -> Result<bool> {
+    if !capable {
+        return Ok(false);
+    }
+
+    let Some(base) = git
+        .merge_base(target, branch)
+        .context("merge-tree probe merge-base failed")?
+    else {
+        // Unrelated histories cannot have been squash-merged.
+        return Ok(false);
+    };
+
+    let branch_files: BTreeSet<String> = git
+        .diff_name_only(&base, branch)
+        .context("merge-tree probe branch diff failed")?
+        .into_iter()
+        .collect();
+    if branch_files.is_empty() {
+        return Ok(false);
+    }
+
+    let candidates = git
+        .first_parent_commits(&base, target)
+        .context("merge-tree probe candidate walk failed")?;
+
+    for candidate in candidates {
+        // A root commit has no `C^` to merge onto.
+        let Some(first_parent) = candidate.parents.first() else {
+            continue;
+        };
+        if candidate.files.into_iter().collect::<BTreeSet<_>>() != branch_files {
+            continue;
+        }
+
+        let merged_tree = git
+            .merge_tree_write_tree(first_parent, branch)
+            .context("merge-tree probe merge failed")?;
+        if merged_tree.is_some_and(|tree| tree == candidate.tree) {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
 }
 
 #[cfg(test)]
@@ -186,6 +273,44 @@ mod tests {
         std::fs::write(path.join(file), content).unwrap();
         git_ok(path, &["add", file]);
         git_ok(path, &["commit", "-q", "-m", &format!("add {file}")]);
+    }
+
+    /// Ten numbered lines — room for two edits far enough apart to be separate
+    /// hunks, but close enough to share a ±3-line context window.
+    fn numbered_lines() -> String {
+        (1..=10).map(|n| format!("line {n}\n")).collect::<String>()
+    }
+
+    /// Rewrite one line of `file` on the currently checked-out branch.
+    fn edit_line(path: &Path, file: &str, line: &str, replacement: &str) {
+        let contents = std::fs::read_to_string(path.join(file)).unwrap();
+        let updated = contents.replace(&format!("{line}\n"), &format!("{replacement}\n"));
+        assert_ne!(contents, updated, "expected to rewrite {line}");
+        std::fs::write(path.join(file), updated).unwrap();
+        git_ok(path, &["commit", "-q", "-a", "-m", &format!("edit {line}")]);
+    }
+
+    /// The #737 shape: a branch forks, an unrelated change lands on the target
+    /// *inside the context window* of one of the branch's hunks, then the
+    /// branch is squash-merged cleanly.
+    fn repo_with_context_drifted_squash() -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().unwrap();
+        init_repo(tmp.path());
+        std::fs::write(tmp.path().join("f.txt"), numbered_lines()).unwrap();
+        git_ok(tmp.path(), &["add", "f.txt"]);
+        git_ok(tmp.path(), &["commit", "-q", "-m", "seed"]);
+
+        git_ok(tmp.path(), &["checkout", "-q", "-b", "feat"]);
+        edit_line(tmp.path(), "f.txt", "line 5", "line 5 CHANGED");
+        add_commit(tmp.path(), "feat", "g.txt", "g");
+
+        // Three lines away: a different hunk, but the same context window.
+        git_ok(tmp.path(), &["checkout", "-q", "main"]);
+        edit_line(tmp.path(), "f.txt", "line 8", "line 8 DRIFT");
+
+        git_ok(tmp.path(), &["merge", "--squash", "feat"]);
+        git_ok(tmp.path(), &["commit", "-q", "-m", "feat squashed (#737)"]);
+        tmp
     }
 
     /// Run `is_branch_merged_into` with the process cwd inside `path`
@@ -261,6 +386,124 @@ mod tests {
         assert!(
             !merged_into(tmp.path(), "feat", "main"),
             "unmerged work must never be reported as merged"
+        );
+    }
+
+    /// Regression test for #737. The branch's work landed as an ordinary
+    /// squash commit, but an intermediate merge shifted the context lines
+    /// around one of its hunks, so every patch-id check (`git cherry` and the
+    /// #662 cumulative-diff probe) reports it unmerged. Only the merge-tree
+    /// probe, which compares trees rather than patches, sees through it.
+    ///
+    /// This is the shape that stranded `daft-725` after PR #731 was merged.
+    #[test]
+    #[serial]
+    fn context_drifted_squash_detected_as_merged() {
+        let tmp = repo_with_context_drifted_squash();
+
+        assert!(
+            merged_into(tmp.path(), "feat", "main"),
+            "a squash whose context drifted must still be detected as merged"
+        );
+    }
+
+    /// The drift really does defeat the patch-id checks — otherwise the test
+    /// above would pass without the new probe and prove nothing.
+    #[test]
+    #[serial]
+    fn context_drift_defeats_the_patch_id_probes() {
+        let tmp = repo_with_context_drifted_squash();
+        let _guard = CwdGuard::new();
+        std::env::set_current_dir(tmp.path()).unwrap();
+        let git = GitCommand::new(true);
+
+        assert!(
+            !squash_probe(&git, "feat", "main").unwrap(),
+            "the cumulative-diff probe is expected to miss a drifted squash"
+        );
+        assert!(
+            !merge_tree_probe(&git, "feat", "main", /* capable */ false).unwrap(),
+            "without merge-tree support the branch stays unmerged"
+        );
+        assert!(
+            merge_tree_probe(&git, "feat", "main", /* capable */ true).unwrap(),
+            "with merge-tree support the squash is found"
+        );
+    }
+
+    /// A squash that was *edited* after the fact (the maintainer amended the
+    /// content, or resolved a conflict differently) matches no tree. Staying
+    /// unmerged here is the deliberate conservative floor — proving those
+    /// merges is the forge witness's job, not the probe's.
+    #[test]
+    #[serial]
+    fn altered_squash_content_stays_unmerged() {
+        let tmp = repo_with_context_drifted_squash();
+        // Amend the squash so its tree no longer matches the branch's work.
+        std::fs::write(tmp.path().join("g.txt"), "g, but rewritten on main").unwrap();
+        git_ok(tmp.path(), &["commit", "-q", "-a", "--amend", "--no-edit"]);
+
+        assert!(
+            !merged_into(tmp.path(), "feat", "main"),
+            "an altered-content squash must not be reported merged"
+        );
+    }
+
+    /// The cheap filter is a filter, not a verdict: a commit touching exactly
+    /// the branch's files with different content must not match.
+    #[test]
+    #[serial]
+    fn same_file_set_with_different_content_stays_unmerged() {
+        let tmp = tempfile::tempdir().unwrap();
+        init_repo(tmp.path());
+        git_ok(tmp.path(), &["checkout", "-q", "-b", "feat"]);
+        add_commit(tmp.path(), "feat", "a.txt", "branch content");
+        add_commit(tmp.path(), "feat", "b.txt", "branch content");
+
+        // Same two files, unrelated content, committed straight to main.
+        git_ok(tmp.path(), &["checkout", "-q", "main"]);
+        std::fs::write(tmp.path().join("a.txt"), "main content").unwrap();
+        std::fs::write(tmp.path().join("b.txt"), "main content").unwrap();
+        git_ok(tmp.path(), &["add", "a.txt", "b.txt"]);
+        git_ok(
+            tmp.path(),
+            &["commit", "-q", "-m", "same files, other work"],
+        );
+
+        assert!(!merged_into(tmp.path(), "feat", "main"));
+    }
+
+    /// A branch with no net change has an empty cumulative file set, which
+    /// would otherwise equal the file set of *any* empty commit on the target
+    /// — and merging a net-zero branch onto that commit's parent reproduces
+    /// its tree exactly, so the probe would match on nothing at all. The
+    /// abstain guard is what stops it.
+    ///
+    /// Asserted against the probe directly: the end-to-end verdict for this
+    /// shape is already decided by the older cumulative-diff check, whose
+    /// synthetic empty patch collides with the empty commit's patch-id.
+    #[test]
+    #[serial]
+    fn probe_abstains_when_the_branch_has_no_net_change() {
+        let tmp = tempfile::tempdir().unwrap();
+        init_repo(tmp.path());
+        git_ok(tmp.path(), &["checkout", "-q", "-b", "feat"]);
+        add_commit(tmp.path(), "feat", "tmp.txt", "scratch");
+        std::fs::remove_file(tmp.path().join("tmp.txt")).unwrap();
+        git_ok(tmp.path(), &["commit", "-q", "-a", "-m", "revert scratch"]);
+
+        git_ok(tmp.path(), &["checkout", "-q", "main"]);
+        git_ok(
+            tmp.path(),
+            &["commit", "-q", "--allow-empty", "-m", "empty"],
+        );
+
+        let _guard = CwdGuard::new();
+        std::env::set_current_dir(tmp.path()).unwrap();
+        let git = GitCommand::new(true);
+        assert!(
+            !merge_tree_probe(&git, "feat", "main", /* capable */ true).unwrap(),
+            "a net-zero branch must not match an empty commit's tree"
         );
     }
 

--- a/src/core/worktree/merged.rs
+++ b/src/core/worktree/merged.rs
@@ -11,7 +11,7 @@
 //! NOT detect squash merges and must not be unified with this one.
 
 use crate::core::worktree::forge_ref::ForgeBranchRef;
-use crate::core::worktree::ports::ForgeMergedWitness;
+use crate::core::worktree::ports::{ForgeMergedWitness, ForgeWitness};
 use crate::git::GitCommand;
 use anyhow::{Context, Result};
 use std::collections::BTreeSet;
@@ -61,9 +61,15 @@ pub fn is_branch_merged(
         return Ok(MergedVerdict::Merged { via: None });
     }
 
-    // Also check against the remote tracking branch, which may be ahead of local
+    // Also check against the remote tracking branch, which may be ahead of
+    // local — but only when it exists and actually differs. Every probe above
+    // re-runs against the new target, including step 4's history walk, so
+    // repeating them for a ref that names the same commit (the usual state
+    // right after a fetch) asks git the identical question twice.
     let remote_ref = format!("{remote_name}/{default_branch}");
-    if is_branch_merged_into(git, branch, &remote_ref)? {
+    if remote_target_differs(git, default_branch, &remote_ref)
+        && is_branch_merged_into(git, branch, &remote_ref)?
+    {
         return Ok(MergedVerdict::Merged { via: None });
     }
 
@@ -72,12 +78,42 @@ pub fn is_branch_merged(
     let Ok(tip) = git.rev_parse(&format!("refs/heads/{branch}")) else {
         return Ok(MergedVerdict::NotMerged);
     };
-    match witness.merged_pr(branch, &tip, default_branch) {
-        Some(forge_ref) => Ok(MergedVerdict::Merged {
-            via: Some(forge_ref),
-        }),
-        None => Ok(MergedVerdict::NotMerged),
-    }
+
+    Ok(match witness.witness(branch, &tip, default_branch) {
+        ForgeWitness::MergedAtTip(pr) => MergedVerdict::Merged { via: Some(pr) },
+        ForgeWitness::MergedAtOtherHead { pr, head_oid } => {
+            // The PR's head moved past the tip we hold. That merge carried
+            // this branch's work only if our tip is an ancestor of what
+            // merged; if it is not, we hold commits the PR never had and
+            // "unmerged" is the right answer.
+            //
+            // Needs `head_oid` as a local object, so a PR head that was never
+            // fetched fails closed — the residual gap this cannot close.
+            if git.merge_base_is_ancestor(&tip, &head_oid).unwrap_or(false) {
+                MergedVerdict::Merged { via: Some(pr) }
+            } else {
+                MergedVerdict::NotMerged
+            }
+        }
+        ForgeWitness::Unproven => MergedVerdict::NotMerged,
+    })
+}
+
+/// Whether probing the remote tracking branch could tell us anything the
+/// local target did not.
+///
+/// `false` when the ref does not resolve — a repo that never fetched the
+/// remote's default simply has no such ref, which is not an error and must
+/// not abort the caller before it reaches the forge witness — and `false`
+/// when it names the same commit the local target does.
+fn remote_target_differs(git: &GitCommand, local: &str, remote_ref: &str) -> bool {
+    let Ok(remote_oid) = git.rev_parse(remote_ref) else {
+        return false;
+    };
+    // An unresolvable local target means we cannot rule the remote out, so
+    // probe it — skipping is only safe when we know the two agree.
+    git.rev_parse(local)
+        .map_or(true, |local_oid| local_oid != remote_oid)
 }
 
 /// Check whether `branch` has been merged into `target`.
@@ -137,37 +173,44 @@ pub fn is_branch_merged_into(git: &GitCommand, branch: &str, target: &str) -> Re
         return Ok(true);
     }
 
+    // Both squash probes fork from the same point, so resolve it once.
+    // Unrelated histories cannot have been squash-merged.
+    let Some(base) = git
+        .merge_base(target, branch)
+        .context("squash probe merge-base failed")?
+    else {
+        return Ok(false);
+    };
+
     // Step 3: Multi-commit squash probe.
-    if squash_probe(git, branch, target)? {
+    if squash_probe(git, branch, &base, target)? {
         return Ok(true);
     }
 
     // Step 4: Context-insensitive squash probe.
-    merge_tree_probe(git, branch, target, crate::git::supports_merge_tree())
+    merge_tree_probe(
+        git,
+        branch,
+        &base,
+        target,
+        crate::git::supports_merge_tree(),
+    )
 }
 
 /// Detect a squash merge of a multi-commit branch.
 ///
 /// Synthesizes an unreferenced commit wrapping `branch`'s tree, parented at
-/// the merge base with `target` — its diff is exactly the branch's
+/// `base` (the merge base with `target`) — its diff is exactly the branch's
 /// cumulative diff since forking. If `git cherry` finds a patch-equivalent
 /// commit on `target`, the branch's combined work landed as one squash
 /// commit. The probe object stays dangling and is swept by `git gc`; it is
 /// only created after the cheaper ancestor and per-commit checks failed.
-fn squash_probe(git: &GitCommand, branch: &str, target: &str) -> Result<bool> {
-    let Some(base) = git
-        .merge_base(target, branch)
-        .context("squash probe merge-base failed")?
-    else {
-        // Unrelated histories cannot have been squash-merged.
-        return Ok(false);
-    };
-
+fn squash_probe(git: &GitCommand, branch: &str, base: &str, target: &str) -> Result<bool> {
     let tree = git
         .rev_parse(&format!("{branch}^{{tree}}"))
         .context("squash probe tree lookup failed")?;
     let synthetic = git
-        .commit_tree(&tree, &base, "daft squash-merge probe")
+        .commit_tree(&tree, base, "daft squash-merge probe")
         .context("squash probe commit failed")?;
 
     let cherry_output = git
@@ -206,21 +249,19 @@ fn squash_probe(git: &GitCommand, branch: &str, target: &str) -> Result<bool> {
 /// abstains — otherwise any empty commit on the target would match it — and a
 /// squash whose content was edited during the merge matches no tree and stays
 /// unmerged.
-fn merge_tree_probe(git: &GitCommand, branch: &str, target: &str, capable: bool) -> Result<bool> {
+fn merge_tree_probe(
+    git: &GitCommand,
+    branch: &str,
+    base: &str,
+    target: &str,
+    capable: bool,
+) -> Result<bool> {
     if !capable {
         return Ok(false);
     }
 
-    let Some(base) = git
-        .merge_base(target, branch)
-        .context("merge-tree probe merge-base failed")?
-    else {
-        // Unrelated histories cannot have been squash-merged.
-        return Ok(false);
-    };
-
     let branch_files: BTreeSet<String> = git
-        .diff_name_only(&base, branch)
+        .diff_name_only(base, branch)
         .context("merge-tree probe branch diff failed")?
         .into_iter()
         .collect();
@@ -229,7 +270,7 @@ fn merge_tree_probe(git: &GitCommand, branch: &str, target: &str, capable: bool)
     }
 
     let candidates = git
-        .first_parent_commits(&base, target)
+        .first_parent_commits(base, target)
         .context("merge-tree probe candidate walk failed")?;
 
     for candidate in candidates {
@@ -257,8 +298,9 @@ mod tests {
     use super::*;
     use crate::core::worktree::forge_ref::ForgeRefKind;
     use crate::core::worktree::ports::NoopForgeWitness;
+    use crate::test_support::CwdGuard;
     use serial_test::serial;
-    use std::path::{Path, PathBuf};
+    use std::path::Path;
     use std::process::Stdio;
 
     /// Test-only helper: run `git` quietly in `path` and panic if it fails.
@@ -278,30 +320,6 @@ mod tests {
         );
     }
 
-    /// RAII helper: saves the current working directory on construction and
-    /// restores it on drop. Tests that call `std::env::set_current_dir` use
-    /// this to avoid leaving cwd pointing at a deleted tempdir for the next
-    /// test (which would panic in `std::env::current_dir`).
-    struct CwdGuard {
-        original: PathBuf,
-    }
-
-    impl CwdGuard {
-        fn new() -> Self {
-            Self {
-                original: std::env::current_dir().expect("cwd readable at test start"),
-            }
-        }
-    }
-
-    impl Drop for CwdGuard {
-        fn drop(&mut self) {
-            if std::env::set_current_dir(&self.original).is_err() {
-                let _ = std::env::set_current_dir(std::env::temp_dir());
-            }
-        }
-    }
-
     fn init_repo(path: &Path) {
         git_ok(path, &["init", "-q", "-b", "main"]);
         // Local config so git subprocesses have an identity without touching
@@ -309,6 +327,16 @@ mod tests {
         git_ok(path, &["config", "--local", "user.name", "Test"]);
         git_ok(path, &["config", "--local", "user.email", "test@test.com"]);
         git_ok(path, &["commit", "--allow-empty", "-q", "-m", "init"]);
+    }
+
+    /// Resolve a revision to its full hash.
+    fn rev(path: &Path, revision: &str) -> String {
+        let out = crate::utils::git_command_at(path)
+            .args(["rev-parse", revision])
+            .output()
+            .expect("git rev-parse runs");
+        assert!(out.status.success(), "rev-parse {revision} failed");
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
     }
 
     /// Checkout `branch`, write `content` to `file`, stage and commit it.
@@ -443,6 +471,9 @@ mod tests {
     #[test]
     #[serial]
     fn context_drifted_squash_detected_as_merged() {
+        if merge_tree_unsupported() {
+            return;
+        }
         let tmp = repo_with_context_drifted_squash();
 
         assert!(
@@ -457,22 +488,45 @@ mod tests {
     #[serial]
     fn context_drift_defeats_the_patch_id_probes() {
         let tmp = repo_with_context_drifted_squash();
-        let _guard = CwdGuard::new();
-        std::env::set_current_dir(tmp.path()).unwrap();
+        let _guard = CwdGuard::enter(tmp.path());
         let git = GitCommand::new(true);
+        let base = fork_point(&git, "feat", "main");
 
         assert!(
-            !squash_probe(&git, "feat", "main").unwrap(),
+            !squash_probe(&git, "feat", &base, "main").unwrap(),
             "the cumulative-diff probe is expected to miss a drifted squash"
         );
         assert!(
-            !merge_tree_probe(&git, "feat", "main", /* capable */ false).unwrap(),
+            !merge_tree_probe(&git, "feat", &base, "main", /* capable */ false).unwrap(),
             "without merge-tree support the branch stays unmerged"
         );
         assert!(
-            merge_tree_probe(&git, "feat", "main", /* capable */ true).unwrap(),
+            merge_tree_probe(&git, "feat", &base, "main", /* capable */ true).unwrap(),
             "with merge-tree support the squash is found"
         );
+    }
+
+    /// The merge base the probes fork from, resolved once by the caller in
+    /// production and here by hand.
+    fn fork_point(git: &GitCommand, branch: &str, target: &str) -> String {
+        git.merge_base(target, branch)
+            .expect("merge-base runs")
+            .expect("the fixtures share history")
+    }
+
+    /// Whether the running git predates `merge-tree --write-tree` (2.38).
+    ///
+    /// Tests that assert a *drifted* squash is found are asserting the step-4
+    /// probe, which the capability gate turns off below that version — where
+    /// falling back to the pre-#737 answer is correct behaviour, not a
+    /// regression. Without this they fail red on older distro and
+    /// corporate-pinned gits for an environment reason.
+    fn merge_tree_unsupported() -> bool {
+        let unsupported = !crate::git::supports_merge_tree();
+        if unsupported {
+            eprintln!("skipped: git is older than 2.38, so the merge-tree probe is off");
+        }
+        unsupported
     }
 
     /// A squash that was *edited* after the fact (the maintainer amended the
@@ -542,37 +596,62 @@ mod tests {
             &["commit", "-q", "--allow-empty", "-m", "empty"],
         );
 
-        let _guard = CwdGuard::new();
-        std::env::set_current_dir(tmp.path()).unwrap();
+        let _guard = CwdGuard::enter(tmp.path());
         let git = GitCommand::new(true);
+        let base = fork_point(&git, "feat", "main");
         assert!(
-            !merge_tree_probe(&git, "feat", "main", /* capable */ true).unwrap(),
+            !merge_tree_probe(&git, "feat", &base, "main", /* capable */ true).unwrap(),
             "a net-zero branch must not match an empty commit's tree"
         );
     }
 
-    /// A witness that vouches for one branch at one commit, and refuses
-    /// everything else — the shape a real forge answer takes.
+    /// A witness that vouches for one branch, and refuses everything else —
+    /// the shape a real forge answer takes. `head_oid` chooses which outcome:
+    /// `None` means the PR head is whatever tip it is asked about, `Some`
+    /// pins a different head so the caller has to reason about containment.
     struct FakeWitness {
         branch: &'static str,
         forge_ref: ForgeBranchRef,
+        head_oid: Option<String>,
+    }
+
+    impl FakeWitness {
+        fn at_tip(branch: &'static str, number: u32) -> Self {
+            Self {
+                branch,
+                forge_ref: ForgeBranchRef::new(ForgeRefKind::GithubPr, number),
+                head_oid: None,
+            }
+        }
+
+        fn at_head(branch: &'static str, number: u32, head_oid: &str) -> Self {
+            Self {
+                head_oid: Some(head_oid.to_string()),
+                ..Self::at_tip(branch, number)
+            }
+        }
     }
 
     impl crate::core::worktree::ports::ForgeMergedWitness for FakeWitness {
-        fn merged_pr(
-            &self,
-            branch: &str,
-            _tip_oid: &str,
-            _target_branch: &str,
-        ) -> Option<ForgeBranchRef> {
-            (branch == self.branch).then_some(self.forge_ref)
+        fn witness(&self, branch: &str, _tip_oid: &str, _target_branch: &str) -> ForgeWitness {
+            if branch != self.branch {
+                return ForgeWitness::Unproven;
+            }
+            match &self.head_oid {
+                None => ForgeWitness::MergedAtTip(self.forge_ref),
+                Some(head_oid) => ForgeWitness::MergedAtOtherHead {
+                    pr: self.forge_ref,
+                    head_oid: head_oid.clone(),
+                },
+            }
         }
     }
 
     /// Run the full check, which probes the remote tracking branch as well as
-    /// the local one. Stamps `origin/main` at `main` first — these fixtures
-    /// have no remote, and without the ref the remote probe errors instead of
-    /// answering.
+    /// the local one. Stamps `origin/main` at `main` first so these
+    /// remote-less fixtures exercise the same shape a real repo has — and,
+    /// since the two then name one commit, the skip that keeps the second
+    /// pass from repeating the first's history walk.
     fn witnessed(path: &Path, branch: &str, witness: &dyn ForgeMergedWitness) -> MergedVerdict {
         git_ok(path, &["update-ref", "refs/remotes/origin/main", "main"]);
         let _guard = CwdGuard::new();
@@ -589,10 +668,7 @@ mod tests {
         let tmp = repo_with_context_drifted_squash();
         std::fs::write(tmp.path().join("g.txt"), "g, but rewritten on main").unwrap();
         git_ok(tmp.path(), &["commit", "-q", "-a", "--amend", "--no-edit"]);
-        let witness = FakeWitness {
-            branch: "feat",
-            forge_ref: ForgeBranchRef::new(ForgeRefKind::GithubPr, 731),
-        };
+        let witness = FakeWitness::at_tip("feat", 731);
 
         let verdict = witnessed(tmp.path(), "feat", &witness);
 
@@ -602,6 +678,81 @@ mod tests {
             Some(731),
             "the verdict must name the PR that proved it, so the deletion can be explained"
         );
+    }
+
+    /// The PR advanced past the tip we hold — a suggestion accepted in the
+    /// web UI, a push from another machine — and then merged. Our tip is
+    /// contained in what merged, so the work did land.
+    ///
+    /// This is the population the witness exists for: a squash altered on the
+    /// way in. Pinning on equality alone would strand it forever, since the
+    /// remote branch is gone and the local tip can never catch up.
+    #[test]
+    #[serial]
+    fn a_pr_head_that_advanced_past_our_tip_still_witnesses() {
+        let tmp = tempfile::tempdir().unwrap();
+        init_repo(tmp.path());
+        git_ok(tmp.path(), &["checkout", "-q", "-b", "feat"]);
+        add_commit(tmp.path(), "feat", "a.txt", "a");
+        let tip = rev(tmp.path(), "feat");
+        // The reviewer's suggestion, committed on the PR branch by the forge.
+        add_commit(tmp.path(), "feat", "b.txt", "suggested");
+        let pr_head = rev(tmp.path(), "feat");
+        // Our worktree never saw it: rewind the local branch to where we were.
+        git_ok(tmp.path(), &["checkout", "-q", "main"]);
+        git_ok(tmp.path(), &["branch", "-q", "-f", "feat", &tip]);
+        add_commit(tmp.path(), "main", "other.txt", "other");
+
+        let witness = FakeWitness::at_head("feat", 731, &pr_head);
+        let verdict = witnessed(tmp.path(), "feat", &witness);
+
+        assert_eq!(
+            verdict.via().map(|r| r.number),
+            Some(731),
+            "our tip is an ancestor of the merged head, so the work landed"
+        );
+    }
+
+    /// The same mismatch, but our tip is *not* contained in what merged: we
+    /// hold commits the PR never had. Branch-name reuse looks exactly like
+    /// this, and the answer must stay unmerged — this is the direction that
+    /// authorizes deleting work.
+    #[test]
+    #[serial]
+    fn a_pr_head_that_does_not_contain_our_tip_stays_unmerged() {
+        let tmp = tempfile::tempdir().unwrap();
+        init_repo(tmp.path());
+        git_ok(tmp.path(), &["checkout", "-q", "-b", "old-feat"]);
+        add_commit(tmp.path(), "old-feat", "old.txt", "old work");
+        let unrelated_head = rev(tmp.path(), "old-feat");
+        // A different branch that happens to carry the same name upstream.
+        git_ok(tmp.path(), &["checkout", "-q", "main"]);
+        git_ok(tmp.path(), &["checkout", "-q", "-b", "feat"]);
+        add_commit(tmp.path(), "feat", "new.txt", "unrelated new work");
+        add_commit(tmp.path(), "main", "other.txt", "other");
+
+        let witness = FakeWitness::at_head("feat", 700, &unrelated_head);
+        let verdict = witnessed(tmp.path(), "feat", &witness);
+
+        assert_eq!(verdict, MergedVerdict::NotMerged);
+    }
+
+    /// A head the local repo has never fetched cannot be reasoned about, so
+    /// the check fails closed rather than trusting the forge's word alone.
+    #[test]
+    #[serial]
+    fn an_unfetched_pr_head_fails_closed() {
+        let tmp = tempfile::tempdir().unwrap();
+        init_repo(tmp.path());
+        git_ok(tmp.path(), &["checkout", "-q", "-b", "feat"]);
+        add_commit(tmp.path(), "feat", "a.txt", "a");
+        add_commit(tmp.path(), "main", "other.txt", "other");
+
+        // A well-formed OID that names no object here.
+        let witness = FakeWitness::at_head("feat", 731, "0123456789abcdef0123456789abcdef01234567");
+        let verdict = witnessed(tmp.path(), "feat", &witness);
+
+        assert_eq!(verdict, MergedVerdict::NotMerged);
     }
 
     /// A witness that declines leaves the branch exactly where the git probes
@@ -625,12 +776,12 @@ mod tests {
     #[test]
     #[serial]
     fn git_proof_names_no_pr_and_skips_the_witness() {
+        if merge_tree_unsupported() {
+            return;
+        }
         let tmp = repo_with_context_drifted_squash();
         // A witness that would vouch for this branch, if it were asked.
-        let witness = FakeWitness {
-            branch: "feat",
-            forge_ref: ForgeBranchRef::new(ForgeRefKind::GithubPr, 731),
-        };
+        let witness = FakeWitness::at_tip("feat", 731);
 
         let verdict = witnessed(tmp.path(), "feat", &witness);
 

--- a/src/core/worktree/merged.rs
+++ b/src/core/worktree/merged.rs
@@ -10,32 +10,74 @@
 //! `is_branch_merged_into` for mid-merge bookkeeping; it intentionally does
 //! NOT detect squash merges and must not be unified with this one.
 
+use crate::core::worktree::forge_ref::ForgeBranchRef;
+use crate::core::worktree::ports::ForgeMergedWitness;
 use crate::git::GitCommand;
 use anyhow::{Context, Result};
 use std::collections::BTreeSet;
 
+/// Whether a branch's work reached the target — and, when the forge is what
+/// proved it, which PR/MR did.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MergedVerdict {
+    NotMerged,
+    /// `via` names the PR/MR when the forge witnessed the merge; `None` when
+    /// git itself found the work on the target.
+    Merged {
+        via: Option<ForgeBranchRef>,
+    },
+}
+
+impl MergedVerdict {
+    pub fn is_merged(self) -> bool {
+        matches!(self, Self::Merged { .. })
+    }
+
+    /// The PR/MR that proved the merge, when one did.
+    pub fn via(self) -> Option<ForgeBranchRef> {
+        match self {
+            Self::Merged { via } => via,
+            Self::NotMerged => None,
+        }
+    }
+}
+
 /// Check whether a branch has been merged into the default branch.
 ///
-/// Checks against both the local default branch and its remote tracking
-/// branch (which may be ahead of local).
+/// Asks git first — locally, against both the default branch and its remote
+/// tracking branch, which may be ahead. Only if every probe comes up empty
+/// does it ask the forge, which is the authority on merges git cannot see
+/// (a squash whose content was altered on the way in) but costs a network
+/// round trip, so it goes last rather than first.
 pub fn is_branch_merged(
     git: &GitCommand,
     branch: &str,
     default_branch: &str,
     remote_name: &str,
-) -> Result<bool> {
+    witness: &dyn ForgeMergedWitness,
+) -> Result<MergedVerdict> {
     // Check against local default branch first
     if is_branch_merged_into(git, branch, default_branch)? {
-        return Ok(true);
+        return Ok(MergedVerdict::Merged { via: None });
     }
 
     // Also check against the remote tracking branch, which may be ahead of local
     let remote_ref = format!("{remote_name}/{default_branch}");
     if is_branch_merged_into(git, branch, &remote_ref)? {
-        return Ok(true);
+        return Ok(MergedVerdict::Merged { via: None });
     }
 
-    Ok(false)
+    // Failing to resolve the tip is not an error here: it only means there is
+    // nothing to pin a forge PR to, so the verdict stays unmerged.
+    let Ok(tip) = git.rev_parse(&format!("refs/heads/{branch}")) else {
+        return Ok(MergedVerdict::NotMerged);
+    };
+    match witness.merged_pr(branch, &tip, default_branch) {
+        Some(forge_ref) => Ok(MergedVerdict::Merged {
+            via: Some(forge_ref),
+        }),
+        None => Ok(MergedVerdict::NotMerged),
+    }
 }
 
 /// Check whether `branch` has been merged into `target`.
@@ -213,6 +255,8 @@ fn merge_tree_probe(git: &GitCommand, branch: &str, target: &str, capable: bool)
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::worktree::forge_ref::ForgeRefKind;
+    use crate::core::worktree::ports::NoopForgeWitness;
     use serial_test::serial;
     use std::path::{Path, PathBuf};
     use std::process::Stdio;
@@ -504,6 +548,96 @@ mod tests {
         assert!(
             !merge_tree_probe(&git, "feat", "main", /* capable */ true).unwrap(),
             "a net-zero branch must not match an empty commit's tree"
+        );
+    }
+
+    /// A witness that vouches for one branch at one commit, and refuses
+    /// everything else — the shape a real forge answer takes.
+    struct FakeWitness {
+        branch: &'static str,
+        forge_ref: ForgeBranchRef,
+    }
+
+    impl crate::core::worktree::ports::ForgeMergedWitness for FakeWitness {
+        fn merged_pr(
+            &self,
+            branch: &str,
+            _tip_oid: &str,
+            _target_branch: &str,
+        ) -> Option<ForgeBranchRef> {
+            (branch == self.branch).then_some(self.forge_ref)
+        }
+    }
+
+    /// Run the full check, which probes the remote tracking branch as well as
+    /// the local one. Stamps `origin/main` at `main` first — these fixtures
+    /// have no remote, and without the ref the remote probe errors instead of
+    /// answering.
+    fn witnessed(path: &Path, branch: &str, witness: &dyn ForgeMergedWitness) -> MergedVerdict {
+        git_ok(path, &["update-ref", "refs/remotes/origin/main", "main"]);
+        let _guard = CwdGuard::new();
+        std::env::set_current_dir(path).unwrap();
+        let git = GitCommand::new(true);
+        is_branch_merged(&git, branch, "main", "origin", witness).unwrap()
+    }
+
+    /// The case no git probe can reach: the squash was edited on the way in,
+    /// so no patch and no tree match — but the forge watched it merge.
+    #[test]
+    #[serial]
+    fn forge_witness_settles_a_branch_git_cannot_place() {
+        let tmp = repo_with_context_drifted_squash();
+        std::fs::write(tmp.path().join("g.txt"), "g, but rewritten on main").unwrap();
+        git_ok(tmp.path(), &["commit", "-q", "-a", "--amend", "--no-edit"]);
+        let witness = FakeWitness {
+            branch: "feat",
+            forge_ref: ForgeBranchRef::new(ForgeRefKind::GithubPr, 731),
+        };
+
+        let verdict = witnessed(tmp.path(), "feat", &witness);
+
+        assert!(verdict.is_merged());
+        assert_eq!(
+            verdict.via().map(|r| r.number),
+            Some(731),
+            "the verdict must name the PR that proved it, so the deletion can be explained"
+        );
+    }
+
+    /// A witness that declines leaves the branch exactly where the git probes
+    /// left it: unmerged.
+    #[test]
+    #[serial]
+    fn a_declining_witness_leaves_the_branch_unmerged() {
+        let tmp = tempfile::tempdir().unwrap();
+        init_repo(tmp.path());
+        git_ok(tmp.path(), &["checkout", "-q", "-b", "feat"]);
+        add_commit(tmp.path(), "feat", "a.txt", "a");
+        add_commit(tmp.path(), "main", "other.txt", "other");
+
+        let verdict = witnessed(tmp.path(), "feat", &NoopForgeWitness);
+
+        assert_eq!(verdict, MergedVerdict::NotMerged);
+    }
+
+    /// When git itself finds the work, the forge is never consulted and no PR
+    /// is named — naming one would imply the merge needed proving.
+    #[test]
+    #[serial]
+    fn git_proof_names_no_pr_and_skips_the_witness() {
+        let tmp = repo_with_context_drifted_squash();
+        // A witness that would vouch for this branch, if it were asked.
+        let witness = FakeWitness {
+            branch: "feat",
+            forge_ref: ForgeBranchRef::new(ForgeRefKind::GithubPr, 731),
+        };
+
+        let verdict = witnessed(tmp.path(), "feat", &witness);
+
+        assert_eq!(
+            verdict,
+            MergedVerdict::Merged { via: None },
+            "the merge-tree probe proves this one; the forge is not consulted"
         );
     }
 

--- a/src/core/worktree/ports.rs
+++ b/src/core/worktree/ports.rs
@@ -6,6 +6,7 @@
 //! live with their implementing subsystem. This is the first port outside
 //! `src/coordinator/` and follows the same shape.
 
+use crate::core::worktree::forge_ref::ForgeBranchRef;
 use crate::executor::presenter::JobPresenter;
 use anyhow::Result;
 use std::path::Path;
@@ -69,6 +70,54 @@ pub trait StageRunner {
         refs: &[PushRef],
         presenter: Arc<dyn JobPresenter>,
     ) -> Result<StageOutcome>;
+}
+
+/// Port for asking the forge whether a branch's pull/merge request was
+/// merged (issue #737).
+///
+/// Exists because the git-side probes cannot see every merge. A squash whose
+/// content was altered on the way in — a conflict resolved by the merger,
+/// a maintainer's edit before the button — matches no patch and no tree, yet
+/// the forge watched it happen and is authoritative about it.
+///
+/// The signal is **positive-only**: it can conclude "merged", never "not
+/// merged". Anything short of proof — the forge unreachable, the PR still
+/// open, a field the platform did not supply — must answer `None` and leave
+/// the verdict to the git probes, which default to unmerged. Reporting
+/// "merged" is what authorizes deleting a branch, so an adapter that cannot
+/// prove the claim must not make it.
+pub trait ForgeMergedWitness: Send + Sync {
+    /// The PR/MR that merged `branch`, if the forge proves one did.
+    ///
+    /// Implementations must satisfy all of:
+    ///
+    /// - **Freshly fetched.** A cached state is a stale hint, not a witness.
+    /// - **`tip_oid` is the PR's head.** Branch names get reused; pinning the
+    ///   commit is what stops an old merged PR from vouching for whatever
+    ///   work later took its name.
+    /// - **`target_branch` is the PR's base.** A stacked PR merged into
+    ///   another feature branch, or one merged into a release line, is
+    ///   genuinely "merged" and still absent from the branch this caller
+    ///   asked about.
+    /// - **Nothing open shadows it.** An open PR on the same branch means
+    ///   the work continues regardless of what merged before.
+    fn merged_pr(&self, branch: &str, tip_oid: &str, target_branch: &str)
+    -> Option<ForgeBranchRef>;
+}
+
+/// The witness for repos with no forge, and for every test that has no
+/// business talking to one. Mirrors the `NoopStageRunner` pattern below.
+pub struct NoopForgeWitness;
+
+impl ForgeMergedWitness for NoopForgeWitness {
+    fn merged_pr(
+        &self,
+        _branch: &str,
+        _tip_oid: &str,
+        _target_branch: &str,
+    ) -> Option<ForgeBranchRef> {
+        None
+    }
 }
 
 /// The adapter used until #468 ships: daft manages no stages, so every push

--- a/src/core/worktree/ports.rs
+++ b/src/core/worktree/ports.rs
@@ -82,27 +82,56 @@ pub trait StageRunner {
 ///
 /// The signal is **positive-only**: it can conclude "merged", never "not
 /// merged". Anything short of proof — the forge unreachable, the PR still
-/// open, a field the platform did not supply — must answer `None` and leave
-/// the verdict to the git probes, which default to unmerged. Reporting
-/// "merged" is what authorizes deleting a branch, so an adapter that cannot
-/// prove the claim must not make it.
+/// open, a field the platform did not supply — must answer
+/// [`ForgeWitness::Unproven`] and leave the verdict to the git probes, which
+/// default to unmerged. Reporting "merged" is what authorizes deleting a
+/// branch, so an adapter that cannot prove the claim must not make it.
+///
+/// Adapters answer from whatever listing they can fetch, and those listings
+/// are windowed — the live adapter sees only the most recently merged PRs.
+/// A branch whose PR merged long enough ago to have fallen out of that window
+/// is therefore `Unproven` rather than merged: correct (nothing was proved),
+/// but it means the witness is weakest for the longest-abandoned branches.
+/// Widening the window is a fetch-cost tradeoff, not a correctness fix.
 pub trait ForgeMergedWitness: Send + Sync {
-    /// The PR/MR that merged `branch`, if the forge proves one did.
+    /// What the forge can prove about `branch`'s merge into `target_branch`.
     ///
     /// Implementations must satisfy all of:
     ///
     /// - **Freshly fetched.** A cached state is a stale hint, not a witness.
-    /// - **`tip_oid` is the PR's head.** Branch names get reused; pinning the
-    ///   commit is what stops an old merged PR from vouching for whatever
-    ///   work later took its name.
     /// - **`target_branch` is the PR's base.** A stacked PR merged into
     ///   another feature branch, or one merged into a release line, is
     ///   genuinely "merged" and still absent from the branch this caller
     ///   asked about.
     /// - **Nothing open shadows it.** An open PR on the same branch means
     ///   the work continues regardless of what merged before.
-    fn merged_pr(&self, branch: &str, tip_oid: &str, target_branch: &str)
-    -> Option<ForgeBranchRef>;
+    ///
+    /// `tip_oid` is the local branch tip. An implementation reports whether
+    /// the merged PR's head matched it but must not decide what a mismatch
+    /// means — that needs git, which the caller has and the forge does not.
+    fn witness(&self, branch: &str, tip_oid: &str, target_branch: &str) -> ForgeWitness;
+}
+
+/// What a [`ForgeMergedWitness`] found. Positive-only: no variant asserts
+/// "not merged", only degrees of proof that it was.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ForgeWitness {
+    /// Nothing usable — no merged PR, an open one shadows the name, the forge
+    /// was unreachable, or the platform withheld a field the pins need.
+    Unproven,
+    /// A merged PR against the right base whose head is exactly the local tip.
+    MergedAtTip(ForgeBranchRef),
+    /// A merged PR against the right base whose head is a *different* commit:
+    /// the PR advanced remotely — a suggestion accepted in the web UI, a push
+    /// from another machine — past the tip this caller holds.
+    ///
+    /// Merged, as far as the forge is concerned. Whether that merge carried
+    /// *this* branch's work depends on whether the local tip is an ancestor of
+    /// `head_oid`, which only the caller can answer.
+    MergedAtOtherHead {
+        pr: ForgeBranchRef,
+        head_oid: String,
+    },
 }
 
 /// The witness for repos with no forge, and for every test that has no
@@ -110,13 +139,8 @@ pub trait ForgeMergedWitness: Send + Sync {
 pub struct NoopForgeWitness;
 
 impl ForgeMergedWitness for NoopForgeWitness {
-    fn merged_pr(
-        &self,
-        _branch: &str,
-        _tip_oid: &str,
-        _target_branch: &str,
-    ) -> Option<ForgeBranchRef> {
-        None
+    fn witness(&self, _branch: &str, _tip_oid: &str, _target_branch: &str) -> ForgeWitness {
+        ForgeWitness::Unproven
     }
 }
 

--- a/src/core/worktree/prune.rs
+++ b/src/core/worktree/prune.rs
@@ -28,6 +28,15 @@ pub struct PruneParams {
     /// the phase's `git fetch --prune` is torn down on Ctrl+C instead of
     /// blocking to completion; `daft prune` and the DAG paths pass `None`.
     pub cancel: Option<std::sync::Arc<crate::git::cancel::CancelFlag>>,
+    /// Settles branches the git probes cannot place, by asking the forge
+    /// whether their PR merged (#737).
+    ///
+    /// Shared across the whole run — every DAG worker and the post-TUI
+    /// deferred pass hold the same one — so its listing is fetched at most
+    /// once and every branch is judged against identical data. A second
+    /// witness here would mean a second fetch, and a no-op one in the
+    /// deferred pass could reverse a verdict the table already showed.
+    pub merged_witness: std::sync::Arc<dyn crate::core::worktree::ports::ForgeMergedWitness>,
 }
 
 /// Detail of a single pruned branch.
@@ -320,9 +329,21 @@ pub fn prune_single_branch(
                 branch_name,
                 default_branch,
                 &ctx.remote_name,
+                params.merged_witness.as_ref(),
             ) {
-                Ok(true) => None,
-                Ok(false) => Some(format!(
+                Ok(verdict) if verdict.is_merged() => {
+                    // Name the PR when the forge is what proved it: nothing in
+                    // the branch's own history shows the merge, so an
+                    // unexplained deletion would look wrong.
+                    if let Some(via) = verdict.via() {
+                        sink.on_step(&format!(
+                            "Branch '{branch_name}' was merged via {}",
+                            via.short()
+                        ));
+                    }
+                    None
+                }
+                Ok(_) => Some(format!(
                     "Skipping {branch_name}: remote branch is gone but the local branch \
                      is not merged into {default_branch} (use --force to delete anyway)"
                 )),

--- a/src/forge/github.rs
+++ b/src/forge/github.rs
@@ -84,8 +84,7 @@ fn run_pr_list(
         extra_env.push(("GH_HOST", host));
     }
 
-    let base_fields =
-        "number,title,state,headRefName,isCrossRepository,url,author,headRepositoryOwner,updatedAt";
+    let base_fields = "number,title,state,headRefName,isCrossRepository,url,author,headRepositoryOwner,updatedAt,headRefOid,baseRefName";
     let fields = if with_rollup {
         format!("{base_fields},statusCheckRollup")
     } else {
@@ -155,6 +154,8 @@ fn parse_pr_list(json: &[u8]) -> Result<Vec<PrListEntry>> {
             author: item.author.unwrap_or_default().display_name(),
             head_repo_owner: item.head_repository_owner.unwrap_or_default().login,
             updated_at: item.updated_at.as_deref().and_then(parse_forge_timestamp),
+            head_oid: item.head_ref_oid.filter(|oid| !oid.is_empty()),
+            base_branch: item.base_ref_name.filter(|name| !name.is_empty()),
         })
         .collect())
 }
@@ -218,6 +219,13 @@ struct GhPrListItem {
     updated_at: Option<String>,
     #[serde(rename = "statusCheckRollup", default)]
     status_check_rollup: Vec<GhCheckContext>,
+    /// The head branch's commit — pins a merged PR to the work it carried
+    /// (#737).
+    #[serde(rename = "headRefOid", default)]
+    head_ref_oid: Option<String>,
+    /// The branch the PR targets.
+    #[serde(rename = "baseRefName", default)]
+    base_ref_name: Option<String>,
 }
 
 #[derive(Deserialize, Default)]
@@ -535,6 +543,7 @@ mod tests {
              "headRefName": "feat/x", "isCrossRepository": false,
              "url": "https://github.com/acme/widget/pull/7",
              "author": {"login": "octocat", "name": "The Octocat"},
+             "headRefOid": "abc123def456", "baseRefName": "master",
              "statusCheckRollup": [
                 {"__typename": "CheckRun", "status": "COMPLETED", "conclusion": "SUCCESS"},
                 {"__typename": "StatusContext", "state": "SUCCESS"}
@@ -561,6 +570,12 @@ mod tests {
             entries[1].author, "contributor",
             "no display name (bots, spartan profiles) falls back to the login"
         );
+        // The merge witness's two pins (#737).
+        assert_eq!(entries[0].head_oid.as_deref(), Some("abc123def456"));
+        assert_eq!(entries[0].base_branch.as_deref(), Some("master"));
+        // Absent on the second row: the witness abstains rather than guess.
+        assert_eq!(entries[1].head_oid, None);
+        assert_eq!(entries[1].base_branch, None);
     }
 
     #[test]

--- a/src/forge/gitlab.rs
+++ b/src/forge/gitlab.rs
@@ -135,6 +135,8 @@ fn parse_mr_list(json: &[u8]) -> Result<Vec<PrListEntry>> {
             // Empty = synthesized rows render the plain branch name.
             head_repo_owner: String::new(),
             updated_at: item.updated_at.as_deref().and_then(parse_forge_timestamp),
+            head_oid: item.sha.filter(|sha| !sha.is_empty()),
+            base_branch: item.target_branch.filter(|name| !name.is_empty()),
         })
         .collect())
 }
@@ -157,6 +159,13 @@ struct GlabMrListItem {
     updated_at: Option<String>,
     #[serde(default)]
     author: GlabAuthor,
+    /// The source branch's commit — pins a merged MR to the work it carried
+    /// (#737). GitLab names it `sha`.
+    #[serde(default)]
+    sha: Option<String>,
+    /// The branch the MR targets.
+    #[serde(default)]
+    target_branch: Option<String>,
 }
 
 /// Percent-encode the `/` separators in a project path (`group/sub/repo` →
@@ -296,6 +305,7 @@ mod tests {
              "source_project_id": 1, "target_project_id": 1,
              "web_url": "https://gitlab.com/group/widget/-/merge_requests/45",
              "updated_at": "2026-07-18T09:30:00Z",
+             "sha": "deadbeef1234", "target_branch": "main",
              "author": {"username": "dev", "name": "Devon Developer"}},
             {"iid": 46, "title": "Fork work", "state": "opened",
              "source_branch": "fork-branch",
@@ -325,6 +335,17 @@ mod tests {
         assert_eq!(
             entries[0].updated_at.unwrap().to_rfc3339(),
             "2026-07-18T09:30:00+00:00"
+        );
+        // The merge witness's two pins (#737); absent on the second row, where
+        // the witness abstains rather than guess.
+        assert_eq!(entries[0].head_oid.as_deref(), Some("deadbeef1234"));
+        assert_eq!(entries[0].base_branch.as_deref(), Some("main"));
+        assert_eq!(
+            (
+                entries[1].head_oid.as_deref(),
+                entries[1].base_branch.as_deref()
+            ),
+            (None, None)
         );
         assert_eq!(
             (entries[1].head_repo_owner.as_str(), entries[1].updated_at),

--- a/src/forge/info.rs
+++ b/src/forge/info.rs
@@ -72,6 +72,17 @@ pub struct PrListEntry {
     /// The PR's last-activity timestamp — the Age cell on a synthesized row.
     /// `None` when the platform didn't supply one.
     pub updated_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// Commit the PR's head branch pointed at. Pins a merged PR to the exact
+    /// work it carried, so squash-merge detection can tell "this branch was
+    /// merged" from "a branch that once had this name was merged"
+    /// (`ForgeMergedWitness`, #737). `None` when the platform didn't supply
+    /// one — the witness then abstains rather than guess.
+    pub head_oid: Option<String>,
+    /// Branch the PR was opened against. A merged PR only proves the work
+    /// reached *its own* base: a stacked PR merges into another feature
+    /// branch, a backport into a release line. `None` when the platform
+    /// didn't supply one.
+    pub base_branch: Option<String>,
 }
 
 /// Parse a forge timestamp (RFC 3339, e.g. `2026-07-18T12:00:00Z`) into UTC.

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -14,7 +14,56 @@ mod remote;
 mod stash;
 mod worktree;
 
+pub use refs::FirstParentCommit;
 pub use remote::{PushIo, PushOptions, PushOutputTee, PushStream};
+
+/// First git release with `merge-tree --write-tree` (the in-memory three-way
+/// merge the squash probe needs).
+const MERGE_TREE_MIN_VERSION: (u64, u64) = (2, 38);
+
+static MERGE_TREE_CAPABLE: OnceLock<bool> = OnceLock::new();
+
+/// Whether the installed git can run `merge-tree --write-tree`, probed once
+/// per process.
+///
+/// This is daft's only runtime git-version gate. It exists because the
+/// context-insensitive squash probe is an *optional extra* on top of the
+/// patch-id checks: where git is too old the probe is skipped and detection
+/// falls back to its previous behavior, so an unknown or unparseable version
+/// must answer `false` rather than risk a confusing subcommand error.
+pub(crate) fn supports_merge_tree() -> bool {
+    *MERGE_TREE_CAPABLE.get_or_init(|| {
+        std::process::Command::new("git")
+            .arg("--version")
+            .output()
+            .ok()
+            .filter(|output| output.status.success())
+            .and_then(|output| String::from_utf8(output.stdout).ok())
+            .is_some_and(|version| version_supports_merge_tree(&version))
+    })
+}
+
+/// Decide whether `git --version` output names a release at or past
+/// [`MERGE_TREE_MIN_VERSION`]. Distribution suffixes ride along after the
+/// numbers (`2.39.5 (Apple Git-154)`, `2.45.0.windows.1`) and are ignored;
+/// anything that does not parse answers `false`.
+fn version_supports_merge_tree(version_output: &str) -> bool {
+    let Some(rest) = version_output.trim().strip_prefix("git version ") else {
+        return false;
+    };
+    let mut numbers = rest
+        .split_whitespace()
+        .next()
+        .unwrap_or_default()
+        .split('.');
+    let (Some(Ok(major)), Some(Ok(minor))) = (
+        numbers.next().map(str::parse::<u64>),
+        numbers.next().map(str::parse::<u64>),
+    ) else {
+        return false;
+    };
+    (major, minor) >= MERGE_TREE_MIN_VERSION
+}
 
 // Per-thread count of `gix::discover()` calls (test-only probe).
 //
@@ -225,6 +274,42 @@ mod tests {
         let git = GitCommand::new(true).with_gitoxide(false);
         assert!(git.quiet);
         assert!(!git.use_gitoxide);
+    }
+
+    #[test]
+    fn merge_tree_gate_accepts_2_38_and_newer() {
+        for version in [
+            "git version 2.38.0",
+            "git version 2.39.5 (Apple Git-154)",
+            "git version 2.45.0.windows.1",
+            "git version 3.0.0",
+            "git version 2.55.0\n",
+        ] {
+            assert!(
+                version_supports_merge_tree(version),
+                "{version} should be capable"
+            );
+        }
+    }
+
+    #[test]
+    fn merge_tree_gate_rejects_older_and_unparseable() {
+        for version in [
+            "git version 2.37.9",
+            "git version 2.5.0",
+            "git version 1.9.1",
+            // Anything the parser can't read must fail closed: the probe is
+            // an optional extra, never worth a confusing subcommand error.
+            "git version banana",
+            "git version 2",
+            "",
+            "some other tool 9.9.9",
+        ] {
+            assert!(
+                !version_supports_merge_tree(version),
+                "{version} should not be capable"
+            );
+        }
     }
 
     /// Restores the working directory on drop — even on panic — so a failing

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -312,31 +312,7 @@ mod tests {
         }
     }
 
-    /// Restores the working directory on drop — even on panic — so a failing
-    /// assertion in a cwd-changing `#[serial]` test can't strand a sibling test
-    /// in a since-deleted tempdir. Mirrors the guard in the merge/branch-delete
-    /// tests (the codebase has no shared test-util home for it yet).
-    struct CwdGuard {
-        original: std::path::PathBuf,
-    }
-
-    impl CwdGuard {
-        fn new() -> Self {
-            Self {
-                original: std::env::current_dir().expect("cwd readable at test start"),
-            }
-        }
-    }
-
-    impl Drop for CwdGuard {
-        fn drop(&mut self) {
-            // Best-effort: if the original cwd is gone, fall back to temp_dir so
-            // subsequent tests can at least read cwd.
-            if std::env::set_current_dir(&self.original).is_err() {
-                let _ = std::env::set_current_dir(std::env::temp_dir());
-            }
-        }
-    }
+    use crate::test_support::CwdGuard;
 
     /// #584 regression: a command that shares one `GitCommand` across its
     /// settings load, hooks-config load, and body must discover the repo

--- a/src/git/refs.rs
+++ b/src/git/refs.rs
@@ -337,6 +337,14 @@ impl GitCommand {
     /// filename can forge a record boundary. Rename detection is off so the
     /// path lists are plain set differences, directly comparable with
     /// [`Self::diff_name_only`].
+    ///
+    /// `--no-show-signature` is load-bearing, not hygiene: under a user's
+    /// `log.showSignature = true` git prints the gpg verification block
+    /// *before* the record's NUL, so those lines parse as filenames of the
+    /// preceding commit and every file-set comparison fails. Paths decode
+    /// lossily — they are only compared as opaque set members here, and the
+    /// tree hash is what actually proves the merge, so a non-UTF-8 filename
+    /// must not turn the probe into an error.
     pub fn first_parent_commits(&self, base: &str, target: &str) -> Result<Vec<FirstParentCommit>> {
         let output = Command::new("git")
             .args([
@@ -344,6 +352,7 @@ impl GitCommand {
                 "--first-parent",
                 "--diff-merges=first-parent",
                 "--no-renames",
+                "--no-show-signature",
                 "--format=%x00%H %T %P",
                 "--name-only",
                 &format!("{base}..{target}"),
@@ -356,7 +365,7 @@ impl GitCommand {
             anyhow::bail!("Git log failed: {}", stderr);
         }
 
-        let stdout = String::from_utf8(output.stdout).context("Failed to parse git log output")?;
+        let stdout = String::from_utf8_lossy(&output.stdout);
         Ok(parse_first_parent_log(&stdout))
     }
 
@@ -386,6 +395,10 @@ impl GitCommand {
 
     /// Paths that differ between two revisions, with rename detection off so
     /// the result is comparable with [`Self::first_parent_commits`]' lists.
+    ///
+    /// Decodes lossily for the same reason as [`Self::first_parent_commits`]:
+    /// both sides of the comparison go through the same substitution, so a
+    /// non-UTF-8 path still matches itself.
     pub fn diff_name_only(&self, from: &str, to: &str) -> Result<Vec<String>> {
         let output = Command::new("git")
             .args(["diff", "--name-only", "--no-renames", from, to])
@@ -397,7 +410,7 @@ impl GitCommand {
             anyhow::bail!("Git diff failed: {}", stderr);
         }
 
-        let stdout = String::from_utf8(output.stdout).context("Failed to parse git diff output")?;
+        let stdout = String::from_utf8_lossy(&output.stdout);
         Ok(stdout
             .lines()
             .filter(|line| !line.is_empty())
@@ -449,7 +462,9 @@ fn parse_first_parent_log(stdout: &str) -> Vec<FirstParentCommit> {
 mod tests {
     use super::parse_first_parent_log;
     use crate::git::GitCommand;
+    use crate::test_support::CwdGuard;
     use crate::utils::git_command_at;
+    use serial_test::serial;
     use std::path::{Path, PathBuf};
     use std::process::Stdio;
 
@@ -571,5 +586,148 @@ mod tests {
             .count_commits_not_on_remote("refs/heads/main", "second", &work)
             .unwrap();
         assert_eq!(count, 1, "commits on origin are still new to `second`");
+    }
+
+    /// Three signed commits on `main`, with `log.showSignature` on so git
+    /// prints a verification block for each one.
+    ///
+    /// SSH signing (git >= 2.34) keeps this hermetic — no gpg agent, no
+    /// keyring, all config local. Returns `None` when the toolchain cannot
+    /// sign, so the test degrades to a no-op instead of failing for an
+    /// environment reason.
+    fn repo_with_signed_commits() -> Option<(tempfile::TempDir, PathBuf)> {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let work = dir.path().join("work");
+        let key = dir.path().join("id");
+        std::fs::create_dir_all(&work).unwrap();
+
+        let keygen = std::process::Command::new("ssh-keygen")
+            .args(["-q", "-t", "ed25519", "-N", "", "-C", "test@test.com", "-f"])
+            .arg(&key)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+        if !matches!(keygen, Ok(status) if status.success()) {
+            return None;
+        }
+
+        let pub_key = key.with_extension("pub");
+        let allowed = dir.path().join("allowed_signers");
+        std::fs::write(
+            &allowed,
+            format!("test@test.com {}", std::fs::read_to_string(&pub_key).ok()?),
+        )
+        .ok()?;
+
+        git_in(&work, &["init", "-b", "main"]);
+        git_in(&work, &["config", "--local", "gpg.format", "ssh"]);
+        git_in(
+            &work,
+            &["config", "--local", "user.signingkey", pub_key.to_str()?],
+        );
+        git_in(&work, &["config", "--local", "commit.gpgsign", "true"]);
+        git_in(
+            &work,
+            &[
+                "config",
+                "--local",
+                "gpg.ssh.allowedSignersFile",
+                allowed.to_str()?,
+            ],
+        );
+        git_in(&work, &["config", "--local", "log.showSignature", "true"]);
+
+        for name in ["a.txt", "b.txt", "c.txt"] {
+            std::fs::write(work.join(name), name).unwrap();
+            git_in(&work, &["add", "."]);
+            // The first signed commit is the canary: if the toolchain refuses
+            // to sign, `git_in`'s assert would fail the test for an
+            // environment reason, so probe with a plain status first.
+            let signed = git_command_at(&work)
+                .args(["commit", "-m", name])
+                .env("GIT_AUTHOR_NAME", "Test")
+                .env("GIT_AUTHOR_EMAIL", "test@test.com")
+                .env("GIT_COMMITTER_NAME", "Test")
+                .env("GIT_COMMITTER_EMAIL", "test@test.com")
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status()
+                .ok()?;
+            if !signed.success() {
+                return None;
+            }
+        }
+
+        Some((dir, work))
+    }
+
+    /// #737 regression: a path that is not valid UTF-8 must not turn the
+    /// squash probe into an error. Under `core.quotePath = false` git emits
+    /// such a path's raw bytes, which a strict decode rejects — surfacing
+    /// "could not verify merge status" where the branch would previously have
+    /// been reported cleanly unmerged.
+    ///
+    /// Only runs where the filesystem accepts such a name: APFS/HFS+ reject
+    /// non-UTF-8 filenames outright, so on macOS the scenario cannot exist.
+    #[test]
+    #[serial]
+    #[cfg(target_os = "linux")]
+    fn non_utf8_paths_do_not_error_the_walk() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+
+        let (_dir, work) = repo_with_remote();
+        git_in(&work, &["config", "--local", "core.quotePath", "false"]);
+
+        // 0xFF is not valid UTF-8 in any position.
+        let raw = OsStr::from_bytes(b"bad-\xff-name.txt");
+        if std::fs::write(work.join(raw), "x").is_err() {
+            return;
+        }
+        git_in(&work, &["add", "."]);
+        git_in(&work, &["commit", "-m", "add a non-utf8 path"]);
+
+        let _guard = CwdGuard::enter(&work);
+        let git = GitCommand::new(false);
+
+        let commits = git
+            .first_parent_commits("HEAD~1", "HEAD")
+            .expect("the walk decodes lossily instead of erroring");
+        assert_eq!(commits.len(), 1);
+        assert_eq!(commits[0].files.len(), 1);
+
+        // Both sides substitute identically, so the set comparison the probe
+        // performs still matches the path against itself.
+        let diffed = git
+            .diff_name_only("HEAD~1", "HEAD")
+            .expect("the diff decodes lossily too");
+        assert_eq!(diffed, commits[0].files);
+    }
+
+    /// #737 regression: with `log.showSignature = true` git writes the
+    /// signature verification block to *stdout*, ahead of the next record's
+    /// NUL separator — so it lands in the previous commit's path list. The
+    /// squash probe compares those path lists against the branch's own, so a
+    /// contaminated list matches nothing and merge-tree detection silently
+    /// stops finding squashes for every signed-commit user.
+    #[test]
+    #[serial]
+    fn signature_verification_output_stays_out_of_the_path_lists() {
+        let Some((_dir, work)) = repo_with_signed_commits() else {
+            return;
+        };
+        let _guard = CwdGuard::enter(&work);
+
+        let commits = GitCommand::new(false)
+            .first_parent_commits("HEAD~2", "HEAD")
+            .expect("first-parent walk succeeds");
+
+        assert_eq!(commits.len(), 2, "two commits in HEAD~2..HEAD");
+        // Newest first. Anything beyond the single path each commit touched is
+        // signature text that leaked across the record boundary.
+        assert_eq!(commits[0].files, vec!["c.txt"]);
+        assert_eq!(commits[1].files, vec!["b.txt"]);
     }
 }

--- a/src/git/refs.rs
+++ b/src/git/refs.rs
@@ -328,14 +328,161 @@ impl GitCommand {
 
         String::from_utf8(output.stdout).context("Failed to parse git cherry output")
     }
+
+    /// Walk `<base>..<target>` along first parents, yielding each commit with
+    /// its tree, its parents, and the paths it changed against its first
+    /// parent.
+    ///
+    /// Records are NUL-delimited: a path can never contain a NUL byte, so no
+    /// filename can forge a record boundary. Rename detection is off so the
+    /// path lists are plain set differences, directly comparable with
+    /// [`Self::diff_name_only`].
+    pub fn first_parent_commits(&self, base: &str, target: &str) -> Result<Vec<FirstParentCommit>> {
+        let output = Command::new("git")
+            .args([
+                "log",
+                "--first-parent",
+                "--diff-merges=first-parent",
+                "--no-renames",
+                "--format=%x00%H %T %P",
+                "--name-only",
+                &format!("{base}..{target}"),
+            ])
+            .output()
+            .context("Failed to execute git log command")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("Git log failed: {}", stderr);
+        }
+
+        let stdout = String::from_utf8(output.stdout).context("Failed to parse git log output")?;
+        Ok(parse_first_parent_log(&stdout))
+    }
+
+    /// Three-way merge `branch` into `base_commit` in memory (no worktree, no
+    /// index), returning the resulting tree hash.
+    ///
+    /// `Ok(None)` covers every non-success exit. Git reports both a conflicted
+    /// merge (exit 1, conflicted tree on stdout) and a revision it refuses
+    /// (also exit 1, empty stdout) the same way, and for the squash probe both
+    /// mean the same thing: this candidate is not the branch's squash. The
+    /// probe only ever adds merged verdicts, so collapsing them fails toward
+    /// "not merged".
+    pub fn merge_tree_write_tree(&self, base_commit: &str, branch: &str) -> Result<Option<String>> {
+        let output = Command::new("git")
+            .args(["merge-tree", "--write-tree", base_commit, branch])
+            .output()
+            .context("Failed to execute git merge-tree command")?;
+
+        if !output.status.success() {
+            return Ok(None);
+        }
+
+        let stdout =
+            String::from_utf8(output.stdout).context("Failed to parse git merge-tree output")?;
+        Ok(stdout.lines().next().map(|line| line.trim().to_string()))
+    }
+
+    /// Paths that differ between two revisions, with rename detection off so
+    /// the result is comparable with [`Self::first_parent_commits`]' lists.
+    pub fn diff_name_only(&self, from: &str, to: &str) -> Result<Vec<String>> {
+        let output = Command::new("git")
+            .args(["diff", "--name-only", "--no-renames", from, to])
+            .output()
+            .context("Failed to execute git diff command")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("Git diff failed: {}", stderr);
+        }
+
+        let stdout = String::from_utf8(output.stdout).context("Failed to parse git diff output")?;
+        Ok(stdout
+            .lines()
+            .filter(|line| !line.is_empty())
+            .map(str::to_string)
+            .collect())
+    }
+}
+
+/// One commit on a first-parent walk: its hash, its tree, its parent hashes,
+/// and the paths it changed against its first parent.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FirstParentCommit {
+    pub commit: String,
+    pub tree: String,
+    pub parents: Vec<String>,
+    pub files: Vec<String>,
+}
+
+/// Parse the NUL-delimited `first_parent_commits` log. Pure, so the record
+/// shape unit-tests without a repository.
+///
+/// Each record is `<hash> <tree> <parents...>`, a blank line, then one path
+/// per line. Text before the first NUL (there is none in practice) is
+/// skipped, and a record whose header lacks both a hash and a tree is dropped
+/// rather than guessed at.
+fn parse_first_parent_log(stdout: &str) -> Vec<FirstParentCommit> {
+    stdout
+        .split('\0')
+        .skip(1)
+        .filter_map(|record| {
+            let mut lines = record.lines();
+            let mut header = lines.next()?.split_whitespace();
+            let commit = header.next()?.to_string();
+            let tree = header.next()?.to_string();
+            Some(FirstParentCommit {
+                commit,
+                tree,
+                parents: header.map(str::to_string).collect(),
+                files: lines
+                    .filter(|line| !line.is_empty())
+                    .map(str::to_string)
+                    .collect(),
+            })
+        })
+        .collect()
 }
 
 #[cfg(test)]
 mod tests {
+    use super::parse_first_parent_log;
     use crate::git::GitCommand;
     use crate::utils::git_command_at;
     use std::path::{Path, PathBuf};
     use std::process::Stdio;
+
+    #[test]
+    fn parses_records_with_trees_parents_and_files() {
+        let log = "\0aaa111 ttt111 ppp111\n\nsrc/one.rs\nsrc/two.rs\n\0bbb222 ttt222 ppp222 ppp333\n\ndocs/x.md\n";
+        let commits = parse_first_parent_log(log);
+
+        assert_eq!(commits.len(), 2);
+        assert_eq!(commits[0].commit, "aaa111");
+        assert_eq!(commits[0].tree, "ttt111");
+        assert_eq!(commits[0].parents, vec!["ppp111"]);
+        assert_eq!(commits[0].files, vec!["src/one.rs", "src/two.rs"]);
+        // A merge commit carries both parents; the walk still sees one record.
+        assert_eq!(commits[1].parents, vec!["ppp222", "ppp333"]);
+        assert_eq!(commits[1].files, vec!["docs/x.md"]);
+    }
+
+    #[test]
+    fn parses_root_commit_as_parentless() {
+        let commits = parse_first_parent_log("\0aaa111 ttt111\n\nfirst.txt\n");
+        assert_eq!(commits.len(), 1);
+        assert!(commits[0].parents.is_empty());
+    }
+
+    #[test]
+    fn parses_empty_log_and_file_less_commit() {
+        assert!(parse_first_parent_log("").is_empty());
+        // An empty commit has a header but no paths.
+        let commits = parse_first_parent_log("\0aaa111 ttt111 ppp111\n");
+        assert_eq!(commits.len(), 1);
+        assert!(commits[0].files.is_empty());
+    }
 
     fn git_in(dir: &Path, args: &[&str]) {
         let status = git_command_at(dir)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,6 +293,8 @@ pub mod skill;
 pub mod store;
 pub mod styles;
 pub mod suggest;
+#[cfg(test)]
+pub mod test_support;
 pub mod trust_prune;
 pub mod update_check;
 pub mod utils;

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -1,0 +1,51 @@
+//! Helpers shared across unit-test modules.
+//!
+//! Compiled only under `cfg(test)`. Anything here is test scaffolding, never a
+//! production code path — put runtime helpers in the module that owns them.
+
+use std::path::{Path, PathBuf};
+
+/// Restores the process working directory on drop, even on panic.
+///
+/// The working directory is process-global and unit tests share one process,
+/// so a test that moves it must both hold this guard and be `#[serial]`.
+/// Without the guard a failing assertion strands every later test in a
+/// since-deleted tempdir, where `std::env::current_dir` — and so every git
+/// subprocess that resolves a repo from cwd — fails for reasons that have
+/// nothing to do with the test that reports them.
+pub struct CwdGuard {
+    original: PathBuf,
+}
+
+impl Default for CwdGuard {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CwdGuard {
+    /// Remember the current directory, staying where we are.
+    pub fn new() -> Self {
+        Self {
+            original: std::env::current_dir().expect("cwd readable at test start"),
+        }
+    }
+
+    /// Remember the current directory, then move to `target`.
+    pub fn enter(target: &Path) -> Self {
+        let guard = Self::new();
+        std::env::set_current_dir(target).expect("cd into test directory");
+        guard
+    }
+}
+
+impl Drop for CwdGuard {
+    fn drop(&mut self) {
+        // Best-effort: the original directory may itself have been removed
+        // (a tempdir the test tore down). Landing on temp_dir still leaves the
+        // process somewhere readable, which is what later tests need.
+        if std::env::set_current_dir(&self.original).is_err() {
+            let _ = std::env::set_current_dir(std::env::temp_dir());
+        }
+    }
+}

--- a/tests/integration/test_all.sh
+++ b/tests/integration/test_all.sh
@@ -75,7 +75,7 @@ test_integration_remote_repo_creation() {
 # non-honoring binary and accepts the honoring dev binary.
 test_integration_state_guard_preflight() {
     # Positive: the real binary honors the overrides setup() exported.
-    if ! assert_binary_honors_overrides "$RUST_BINARY_DIR/daft" "$TEMP_BASE_DIR" 2>/dev/null; then
+    if ! assert_binary_honors_overrides "$RUST_BINARY_DIR/daft" "$TEMP_BASE_DIR" >/dev/null 2>&1; then
         log_error "preflight rejected the honoring dev binary (false positive)"
         return 1
     fi
@@ -94,7 +94,13 @@ fi
 STUB
     chmod +x "$stub_dir/daft"
 
-    if assert_binary_honors_overrides "$stub_dir/daft" "$TEMP_BASE_DIR" 2>/dev/null; then
+    # Both streams: the framework's log_* helpers all write to stdout, so
+    # suppressing only stderr would print this suite's loudest alarm —
+    # "Refusing to run: integration tests would touch your real ... dirs" —
+    # on a run where the guard is working exactly as designed. Anyone reading
+    # CI output, or grepping it for that string, would read a green run as a
+    # breach.
+    if assert_binary_honors_overrides "$stub_dir/daft" "$TEMP_BASE_DIR" >/dev/null 2>&1; then
         log_error "preflight accepted a binary that ignores DAFT_*_DIR (guard has no teeth)"
         return 1
     fi

--- a/tests/integration/test_framework.sh
+++ b/tests/integration/test_framework.sh
@@ -98,6 +98,11 @@ cleanup() {
 # that honored DAFT_CONFIG_DIR but resolved data/state to the real dirs would
 # satisfy a whole-output match while still leaking the catalog and the jobs dir.
 assert_binary_honors_overrides() {
+    # Same escape hatch the mise-tasks lib documents ("DAFT_SKIP_STATE_GUARD=1
+    # disables both layers"). Without it here, the documented way to smoke-test
+    # a release/tagged build — whose DAFT_*_DIR overrides are compiled out by
+    # build.rs — aborts the suite in setup() before a single test runs.
+    [ "${DAFT_SKIP_STATE_GUARD:-}" = "1" ] && return 0
     local bin="$1" sandbox="$2"
     if [[ ! -x "$bin" ]]; then
         log_error "state-guard preflight: daft binary not found or not executable: $bin"

--- a/tests/manual/scenarios/prune/prune-removes-context-drifted-squash.yml
+++ b/tests/manual/scenarios/prune/prune-removes-context-drifted-squash.yml
@@ -1,0 +1,96 @@
+name: Prune removes a squash-merged branch whose diff drifted
+description: >
+  A branch squash-merged after an unrelated change landed on the default branch
+  inside one of its hunks' context windows. The context lines differ, so every
+  patch-id check (git cherry and the #662 cumulative-diff probe) reports the
+  branch unmerged and prune skips it as gone-but-unmerged. The merge-tree probe
+  compares trees instead of patches and must see through the drift, pruning
+  without --force. Regression for issue #737, which stranded daft-725 after PR
+  #731 merged. Git-only: no forge involved.
+
+repos:
+  - name: test-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone the repository
+    run: git-worktree-clone --layout contained $REMOTE_TEST_REPO
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-repo/main"
+
+  - name: Seed a numbered file both branches will edit
+    run: |
+      cd $WORK_DIR/test-repo/main
+      printf 'line 1\nline 2\nline 3\nline 4\nline 5\nline 6\nline 7\nline 8\nline 9\nline 10\n' > shared.txt
+      git add shared.txt
+      git commit -m "chore: seed shared file"
+      git push origin main
+    expect:
+      exit_code: 0
+
+  - name: Create feature worktree
+    run: git-worktree-checkout -b feat/drifted
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-repo/feat/drifted"
+
+  - name: Commit two changes on feat/drifted and push
+    run: |
+      cd $WORK_DIR/test-repo/feat/drifted
+      sed -i.bak 's/^line 5$/line 5 CHANGED/' shared.txt && rm -f shared.txt.bak
+      git add shared.txt
+      git commit -m "feat: change line 5"
+      printf 'new file\n' > added.txt
+      git add added.txt
+      git commit -m "feat: add a file"
+      git push origin feat/drifted
+    expect:
+      exit_code: 0
+
+  - name: Land an unrelated change on main inside the branch's context window
+    run: |
+      cd $WORK_DIR/test-repo/main
+      sed -i.bak 's/^line 8$/line 8 DRIFT/' shared.txt && rm -f shared.txt.bak
+      git add shared.txt
+      git commit -m "fix: unrelated change three lines away"
+      git push origin main
+    expect:
+      exit_code: 0
+
+  - name: Squash-merge feat/drifted into main (GitHub squash-merge style)
+    run: |
+      cd $WORK_DIR/test-repo/main
+      git merge --squash feat/drifted
+      git commit -m "feat: drifted feature (#737)"
+      git push origin main
+    expect:
+      exit_code: 0
+
+  - name: Delete the remote branch (merged upstream)
+    run: git -C $WORK_DIR/test-repo/main push origin --delete feat/drifted
+    expect:
+      exit_code: 0
+
+  - name: Prune removes the drifted squash-merged worktree without --force
+    run: git-worktree-prune 2>&1
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+      output_not_contains:
+        - "not merged"
+        - "--force"
+
+  - name: Worktree directory is gone
+    run: test ! -d $WORK_DIR/test-repo/feat/drifted
+    expect:
+      exit_code: 0
+
+  - name: Local branch ref is gone
+    run:
+      git -C $WORK_DIR/test-repo/main show-ref --verify refs/heads/feat/drifted
+    expect:
+      exit_code: 128


### PR DESCRIPTION
`daft sync` / `daft prune` skipped squash-merged worktrees as "gone but
unmerged" whenever the squash's diff drifted textually from the branch's own.

Every squash check in `merged.rs` reduced to patch-id equivalence, and
**patch-id hashes context lines** — so any PR that lands between a branch's
fork point and its squash, touching within ±3 lines of one of the branch's
hunks, breaks the match. This is structural in daft rather than incidental:
verb PRs all edit the same registration blocks. Reproduced on #731, where the
drift came from #727 landing in `completions/fish.rs`.

Two independent ways to say *merged* are added. Neither can say "not merged" —
the default stays unmerged and prune still requires the upstream to be gone.

## Fix 1 — merge-tree probe (git-only, no network)

A new step 4 in `is_branch_merged_into`: candidates are first-parent commits
since the merge base whose changed-file set equals the branch's; proof is
`git merge-tree --write-tree C^ branch` producing a tree identical to `C`'s.
Comparing trees instead of patch text is context-insensitive, so intervening
commits no longer matter.

Gated on git ≥ 2.38 via `crate::git::supports_merge_tree()` — daft's first
runtime git-version gate. Older git skips the probe and detection falls back
to its previous behavior. The capability is a *parameter* at the probe
boundary so both arms unit-test on any dev machine.

## Fix 2 — forge witness (`ForgeMergedWitness` port)

Some merges no git probe can see: a squash whose content was altered on the
way in (conflict resolved by the merger, a maintainer's edit before the
button) matches no patch and no tree. The forge watched it happen.

The witness is **fetched fresh during the run, never read from the cache** —
a cached merged-status is a stale hint, not proof. It carries two pins, both
load-bearing:

- **head OID**, because a merged PR for an older branch of the same name
  rides along in a *fresh* listing too;
- **PR base == target branch**, because a stacked PR or a backport is
  genuinely "merged" while its content is absent from the branch the caller
  asked about.

The port returns `Unproven` / `MergedAtTip` / `MergedAtOtherHead{pr, head_oid}`
rather than a bool: a PR whose head advanced remotely (a web-UI suggestion, a
push from another machine) is exactly the population the witness exists for,
and equality-only would strand it forever. The adapter reports forge facts;
`merged.rs` asks git whether the local tip is an ancestor of that head.
Branch-name reuse resolves to a non-ancestor and stays unmerged; a
never-fetched head fails closed.

The fetch is lazy, memoized, and **bounded** (15 s on a worker thread) — it
sits inside the sync/prune worker DAG, so an unreachable forge must degrade to
"slow once, then fall back" rather than stall every worker. It is also
read-only: it deliberately does *not* stamp forge health, because a `prune`
with no `gh` would otherwise mark the repo unhealthy and silently drop
`daft list`'s `pr` column on the next run.

Construction is gated on `should_skip_background_tasks`, so agent and test
invocations never fan out network work.

## Scope note

The ticket's acceptance line says "not-gone → signal unused". That is
deliberately extended: `branch delete`'s Check 4 is not gone-gated and now
consults the witness too, letting a squash-merged branch delete without
`--force`. The OID + base pins keep this sound without a gone requirement.

## Tests

- Regression test for the context-drift recipe (red before the probe, green
  after) plus probe negatives: amended-content squash, unrelated commit with
  an identical file set, empty-cumulative-diff branch.
- Witness matrix over the adapter index: OID mismatch, base mismatch
  (stacked/release PR), absent fields, open PR shadowing a merged one,
  cross-repo rows, fetch failure.
- End-to-end YAML scenario asserting prune removes a context-drifted squash
  without `--force`.
- A signed-commit regression test: `log.showSignature = true` printed gpg
  verification lines into `git log --name-only` output ahead of the record
  separator, which silently no-opped the probe for every signing user.

Two commits here (`59f383f2`, and part of `70806996`) fix issues in already-
merged #739 code that surfaced during review of this branch: `test_framework.sh`
had dropped the documented `DAFT_SKIP_STATE_GUARD=1` hatch, and `test_all.sh`
suppressed only stderr while `log_error` writes to stdout.

Fixes #737
