### PR TITLE
feat(list): keep branch identity through rebase and detached HEAD

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -903,13 +903,29 @@ Valid formats: `json`, `ndjson`, `tsv`, `csv`, `yaml`, `toon`, `markdown`.
 `{% if %}`).
 
 **`daft list` output contract**: table columns show branch (`✦` marks the
-default branch), path (relative to cwd), base ahead/behind, file status (`+N`
-staged, `-N` unstaged, `?N` untracked), remote status (`⇡N` unpushed, `⇣N`
-unpulled), branch age, owner, and commit info. When `user.email` is configured,
-output splits into two sections (your branches / other branches) per the
-resolved owner. `--format json` fields include `is_default_branch`, `staged`,
-`unstaged`, `untracked`, `remote_ahead`, `remote_behind`, `branch_age`,
-`owner_name`, `owner_email`; the `owner` field is `{name, email}` or `null`.
+default branch), path (relative to cwd), base ahead/behind, file status (`!N`
+conflicted, `+N` staged, `-N` unstaged, `?N` untracked), remote status (`⇡N`
+unpushed, `⇣N` unpulled), branch age, owner, and commit info. When `user.email`
+is configured, output splits into two sections (your branches / other branches)
+per the resolved owner. `--format json` fields include `is_default_branch`,
+`staged`, `unstaged`, `untracked`, `conflicted`, `operation`, `identity_source`,
+`remote_ahead`, `remote_behind`, `branch_age`, `owner_name`, `owner_email`; the
+`owner` field is `{name, email}` or `null`.
+
+**Paused operations and detached HEAD**: a worktree keeps its branch name while
+git has HEAD detached to run an operation — mid-rebase the row still names the
+branch and keeps its branch-keyed fields, rather than reporting `(detached)`.
+`operation` names the paused operation (`rebase`, `merge`, `cherry-pick`,
+`revert`, `bisect`, `am`, or `null`), `conflicted` counts unresolved files
+(never double-counted as staged and unstaged), and `identity_source` says how
+the name was established: `attached` (checked out), `recovered` (read from the
+paused operation), `persisted` (daft's record of what the worktree was created
+for), or `none`. `is_sandbox` is true only for a detached checkout that no
+operation explains — so a rebasing worktree is **not** a sandbox. The `status`
+column (`--columns +status`) renders the same state as words
+(`rebasing · 2 conflicts`, `rebasing · resolved`, `detached @ <sha>`,
+`drifted`). `daft list --merging` filters to worktrees mid-_merge_ only, not any
+operation.
 
 **`daft hooks jobs` output**: a flat table with one row per job carrying
 invocation context (`invocation_id`, `invocation_short`, `worktree`,
@@ -918,34 +934,36 @@ the job's `output.log`.
 
 **Column selection (`--columns`)** on `list`/`sync`/`prune`: default columns
 `annotation`, `branch`, `path`, `base`, `changes`, `remote`, `age`, `owner`,
-`last-commit`; optional `size` (adds a total footer) and `hash`. On all three,
-`pr` is also a default (`#N`/`!N` for PR/MR checkouts and for local branches
-with an open or merged PR) — but only in repos with a GitHub/GitLab remote, and
-daft silently drops it while the forge integration is broken in a way needing
-user action (gh/glab missing or unauthenticated; it returns after a successful
-refresh — do not treat the column's absence as an error). `--columns +pr` forces
-it regardless. While the `pr` column shows, `daft list` also adds a row for
-every open PR the table doesn't already represent (`sync`/`prune` show the
-column on their worktree rows without adding rows): PR-bearing local branches
-appear without `-b` (`"kind": "branch"` in json), and PRs with no local presence
-— colleagues' branches, fork PRs — appear as rows built from forge data
-(`"kind": "pr"`; fork rows named `owner:branch`; the PR title in the
-commit-subject field). Merged/closed PRs decorate rows but never add one. Branch
-and PR rows report the PR author as their owner; worktree rows keep the locally
-deduced owner (name and email). Expect these extra rows when parsing default
-list output — filter by `kind`, or pass `--columns -pr`, which removes the rows
-and the column as one unit, for a worktrees-only listing. In piped/`NO_COLOR`
-output — what agents read — the PR's cached fate trails as a glyph: `✓`/`✗`/`●`
-CI pass/fail/running, `◆` merged, `○` closed; in a color terminal the number's
-color carries the same states instead (green/red/yellow, purple merged, dim
-closed). The cache refreshes in the background via `daft update`/`daft sync` and
-on listing with the column; prefer `--format json` (`pr_state`, `ci_status`,
-`pr_url` fields — present in the default schema even when the table hides the
-column) over parsing glyphs. Two modes — replace (`--columns branch,path,age`:
-exactly those, in order) and modifier (`--columns +size,-age`: adjust defaults;
-auto-detected when every entry starts with `+`/`-`). The `status` column is
-always pinned on `sync`/`prune`. Persistent defaults:
-`git config daft.<cmd>.columns`.
+`last-commit`; optional `size` (adds a total footer) and `hash`. `daft list`
+also offers `status` (paused operation and conflict state in words), which sorts
+before `branch`; it is list-only, since sync and prune pin their own
+task-progress column of that name. On all three, `pr` is also a default
+(`#N`/`!N` for PR/MR checkouts and for local branches with an open or merged PR)
+— but only in repos with a GitHub/GitLab remote, and daft silently drops it
+while the forge integration is broken in a way needing user action (gh/glab
+missing or unauthenticated; it returns after a successful refresh — do not treat
+the column's absence as an error). `--columns +pr` forces it regardless. While
+the `pr` column shows, `daft list` also adds a row for every open PR the table
+doesn't already represent (`sync`/`prune` show the column on their worktree rows
+without adding rows): PR-bearing local branches appear without `-b`
+(`"kind": "branch"` in json), and PRs with no local presence — colleagues'
+branches, fork PRs — appear as rows built from forge data (`"kind": "pr"`; fork
+rows named `owner:branch`; the PR title in the commit-subject field).
+Merged/closed PRs decorate rows but never add one. Branch and PR rows report the
+PR author as their owner; worktree rows keep the locally deduced owner (name and
+email). Expect these extra rows when parsing default list output — filter by
+`kind`, or pass `--columns -pr`, which removes the rows and the column as one
+unit, for a worktrees-only listing. In piped/`NO_COLOR` output — what agents
+read — the PR's cached fate trails as a glyph: `✓`/`✗`/`●` CI pass/fail/running,
+`◆` merged, `○` closed; in a color terminal the number's color carries the same
+states instead (green/red/yellow, purple merged, dim closed). The cache
+refreshes in the background via `daft update`/`daft sync` and on listing with
+the column; prefer `--format json` (`pr_state`, `ci_status`, `pr_url` fields —
+present in the default schema even when the table hides the column) over parsing
+glyphs. Two modes — replace (`--columns branch,path,age`: exactly those, in
+order) and modifier (`--columns +size,-age`: adjust defaults; auto-detected when
+every entry starts with `+`/`-`). The `status` column is always pinned on
+`sync`/`prune`. Persistent defaults: `git config daft.<cmd>.columns`.
 
 **Sorting (`--sort`)** on `list`/`sync`/`prune`: columns `branch`, `path`,
 `size`, `age`, `owner`, `hash`, `activity`, `commit`; prefix `+` ascending

--- a/docs/cli/daft-list.md
+++ b/docs/cli/daft-list.md
@@ -25,7 +25,7 @@ Each worktree is shown with:
 - Branch name, with `✦` for the default branch
 - Relative path from the current directory
 - Ahead/behind counts vs. the base branch (e.g. +3 -1)
-- File status: +N staged, -N unstaged, ?N untracked
+- File status: !N conflicted, +N staged, -N unstaged, ?N untracked
 - Remote tracking status: ⇡N unpushed, ⇣N unpulled
 - Branch age since creation (e.g. 3d, 2w, 5mo)
 - Last commit: shorthand age + subject (e.g. 1h fix login bug)
@@ -47,10 +47,46 @@ changes). This is slower as it requires computing diffs for each worktree.
 Use `--format` for machine-readable output suitable for scripting. Supported
 formats: `json`, `ndjson`, `tsv`, `csv`, `yaml`, `toon`, `markdown`. JSON
 output includes fields like `is_default_branch`, `staged`, `unstaged`,
-`untracked`, `remote_ahead`, `remote_behind`, `branch_age`, `owner_name`, and
-`owner_email`. Use `--template '<tera>'` for custom output.
+`untracked`, `conflicted`, `operation`, `identity_source`, `remote_ahead`,
+`remote_behind`, `branch_age`, `owner_name`, and `owner_email`. Use
+`--template '<tera>'` for custom output.
 
 Use `--columns` to select which columns are shown and in what order.
+
+### Paused operations and detached HEAD
+
+Git detaches a worktree's HEAD to run a rebase, and keeps it detached until the
+rebase finishes. A worktree in that state keeps its branch name here: the row
+still reads `feat/x`, sorts in its usual place, and keeps its Base, Age, Owner
+and PR cells. The annotation column gains a glyph for the paused operation —
+`⟲` rebase, `⇄` merge, `⤷` cherry-pick, `⎌` revert, `◐` bisect, `✉` `git am` —
+and unresolved conflicts appear as a red `!N` under Changes.
+
+Add the `status` column to see the state in words:
+
+```bash
+daft list --columns +status
+```
+
+It reads `rebasing · 2 conflicts` while conflicts remain, and
+`rebasing · resolved` once they are resolved and staged but the operation is
+still waiting to be continued — a state nothing else in the table can show,
+since the conflict count is then zero.
+
+Only a detached checkout that no operation explains is treated as a scratch
+sandbox (`○`, dimmed). Even then, if daft knows what branch the worktree was
+created for it keeps that name and reports the checked-out commit as
+`detached @ <sha>`.
+
+If the checked-out branch disagrees with what daft recorded the worktree was
+for — someone checked out a different branch into it, or renamed one outside
+`daft rename` — the checkout wins the name and the row is marked `drifted`.
+`daft doctor` lists these, and `daft doctor --fix` updates the records to match
+what is checked out.
+
+Structured output carries the same information as `operation` (null when none),
+`conflicted`, and `identity_source` (`attached`, `recovered`, `persisted`, or
+`none`).
 
 ### Two-section layout
 

--- a/docs/cli/git-worktree-list.md
+++ b/docs/cli/git-worktree-list.md
@@ -44,7 +44,7 @@ an operation: mid-rebase the row still reads `feat/x`, sorts in place, and
 keeps its Base/Age/Owner cells. The annotation column gains a glyph for the
 paused operation, and unresolved conflicts show as a red `!N` under Changes.
 Add the `status` column (--columns +status) to spell the state out, e.g.
-"rebasing - 2 conflicts" or "rebasing - resolved" when everything is resolved
+"rebasing · 2 conflicts" or "rebasing · resolved" when everything is resolved
 and the operation is only waiting to be continued.
 
 Only a detached checkout that no operation explains is treated as a scratch

--- a/docs/cli/git-worktree-list.md
+++ b/docs/cli/git-worktree-list.md
@@ -113,7 +113,7 @@ git worktree-list [OPTIONS] [REPO]
 | `-a, --all` | Show all branches (equivalent to -b -r) |  |
 | `--merging` | Only show worktrees with an in-progress merge |  |
 | `--stat <STAT>` | Statistics mode: summary or lines (default: from git config daft.list.stat, or summary) |  |
-| `--columns <COLUMNS>` | Columns to display (comma-separated). Replace: branch,path,age. Modify defaults: +col,-col. Available: branch, path, size, base, changes, remote, pr, age, annotation, owner, hash, last-commit |  |
+| `--columns <COLUMNS>` | Columns to display (comma-separated). Replace: branch,path,age. Modify defaults: +col,-col. Available: branch, path, size, base, changes, remote, pr, age, annotation, status, owner, hash, last-commit |  |
 | `--sort <SORT>` | Sort order (comma-separated). +col ascending, -col descending. Columns: branch, path, size, base, changes, remote, age, owner, hash, activity, commit |  |
 | `--repo <REPO>` | List another cataloged repository's worktrees |  |
 | `--all-repos` | List every cataloged repository's worktrees |  |

--- a/docs/cli/git-worktree-list.md
+++ b/docs/cli/git-worktree-list.md
@@ -39,6 +39,20 @@ Use -a / --all to show both (equivalent to -b -r).
 
 Non-worktree branches are shown with dimmed styling and blank Path/Changes columns.
 
+A worktree keeps its branch name even while git has detached its HEAD to run
+an operation: mid-rebase the row still reads `feat/x`, sorts in place, and
+keeps its Base/Age/Owner cells. The annotation column gains a glyph for the
+paused operation, and unresolved conflicts show as a red `!N` under Changes.
+Add the `status` column (--columns +status) to spell the state out, e.g.
+"rebasing - 2 conflicts" or "rebasing - resolved" when everything is resolved
+and the operation is only waiting to be continued.
+
+Only a detached checkout that no operation explains is treated as a scratch
+sandbox. Where daft knows what branch a worktree was made for, even that keeps
+its name, shown alongside the checked-out commit. A worktree whose checkout
+disagrees with that record is flagged as drifted; `daft doctor --fix`
+reconciles the record.
+
 Use --stat lines to show line-level change counts (insertions and deletions)
 instead of the default summary (commit counts for base/remote, file counts for
 changes). This is slower as it requires computing diffs for each worktree.

--- a/man/daft-list.1
+++ b/man/daft-list.1
@@ -38,7 +38,7 @@ an operation: mid\-rebase the row still reads `feat/x`, sorts in place, and
 keeps its Base/Age/Owner cells. The annotation column gains a glyph for the
 paused operation, and unresolved conflicts show as a red `!N` under Changes.
 Add the `status` column (\-\-columns +status) to spell the state out, e.g.
-"rebasing \- 2 conflicts" or "rebasing \- resolved" when everything is resolved
+"rebasing · 2 conflicts" or "rebasing · resolved" when everything is resolved
 and the operation is only waiting to be continued.
 .PP
 Only a detached checkout that no operation explains is treated as a scratch

--- a/man/daft-list.1
+++ b/man/daft-list.1
@@ -33,6 +33,20 @@ Use \-a / \-\-all to show both (equivalent to \-b \-r).
 .PP
 Non\-worktree branches are shown with dimmed styling and blank Path/Changes columns.
 .PP
+A worktree keeps its branch name even while git has detached its HEAD to run
+an operation: mid\-rebase the row still reads `feat/x`, sorts in place, and
+keeps its Base/Age/Owner cells. The annotation column gains a glyph for the
+paused operation, and unresolved conflicts show as a red `!N` under Changes.
+Add the `status` column (\-\-columns +status) to spell the state out, e.g.
+"rebasing \- 2 conflicts" or "rebasing \- resolved" when everything is resolved
+and the operation is only waiting to be continued.
+.PP
+Only a detached checkout that no operation explains is treated as a scratch
+sandbox. Where daft knows what branch a worktree was made for, even that keeps
+its name, shown alongside the checked\-out commit. A worktree whose checkout
+disagrees with that record is flagged as drifted; `daft doctor \-\-fix`
+reconciles the record.
+.PP
 Use \-\-stat lines to show line\-level change counts (insertions and deletions)
 instead of the default summary (commit counts for base/remote, file counts for
 changes). This is slower as it requires computing diffs for each worktree.

--- a/man/daft-list.1
+++ b/man/daft-list.1
@@ -141,7 +141,7 @@ lines: Line\-level counts: insertions/deletions for all columns
 .RE
 .TP
 \fB\-\-columns\fR \fI<COLUMNS>\fR
-Columns to display (comma\-separated). Replace: branch,path,age. Modify defaults: +col,\-col. Available: branch, path, size, base, changes, remote, pr, age, annotation, owner, hash, last\-commit
+Columns to display (comma\-separated). Replace: branch,path,age. Modify defaults: +col,\-col. Available: branch, path, size, base, changes, remote, pr, age, annotation, status, owner, hash, last\-commit
 .TP
 \fB\-\-sort\fR \fI<SORT>\fR
 Sort order (comma\-separated). +col ascending, \-col descending. Columns: branch, path, size, base, changes, remote, age, owner, hash, activity, commit

--- a/man/git-worktree-list.1
+++ b/man/git-worktree-list.1
@@ -38,7 +38,7 @@ an operation: mid\-rebase the row still reads `feat/x`, sorts in place, and
 keeps its Base/Age/Owner cells. The annotation column gains a glyph for the
 paused operation, and unresolved conflicts show as a red `!N` under Changes.
 Add the `status` column (\-\-columns +status) to spell the state out, e.g.
-"rebasing \- 2 conflicts" or "rebasing \- resolved" when everything is resolved
+"rebasing · 2 conflicts" or "rebasing · resolved" when everything is resolved
 and the operation is only waiting to be continued.
 .PP
 Only a detached checkout that no operation explains is treated as a scratch

--- a/man/git-worktree-list.1
+++ b/man/git-worktree-list.1
@@ -33,6 +33,20 @@ Use \-a / \-\-all to show both (equivalent to \-b \-r).
 .PP
 Non\-worktree branches are shown with dimmed styling and blank Path/Changes columns.
 .PP
+A worktree keeps its branch name even while git has detached its HEAD to run
+an operation: mid\-rebase the row still reads `feat/x`, sorts in place, and
+keeps its Base/Age/Owner cells. The annotation column gains a glyph for the
+paused operation, and unresolved conflicts show as a red `!N` under Changes.
+Add the `status` column (\-\-columns +status) to spell the state out, e.g.
+"rebasing \- 2 conflicts" or "rebasing \- resolved" when everything is resolved
+and the operation is only waiting to be continued.
+.PP
+Only a detached checkout that no operation explains is treated as a scratch
+sandbox. Where daft knows what branch a worktree was made for, even that keeps
+its name, shown alongside the checked\-out commit. A worktree whose checkout
+disagrees with that record is flagged as drifted; `daft doctor \-\-fix`
+reconciles the record.
+.PP
 Use \-\-stat lines to show line\-level change counts (insertions and deletions)
 instead of the default summary (commit counts for base/remote, file counts for
 changes). This is slower as it requires computing diffs for each worktree.

--- a/man/git-worktree-list.1
+++ b/man/git-worktree-list.1
@@ -141,7 +141,7 @@ lines: Line\-level counts: insertions/deletions for all columns
 .RE
 .TP
 \fB\-\-columns\fR \fI<COLUMNS>\fR
-Columns to display (comma\-separated). Replace: branch,path,age. Modify defaults: +col,\-col. Available: branch, path, size, base, changes, remote, pr, age, annotation, owner, hash, last\-commit
+Columns to display (comma\-separated). Replace: branch,path,age. Modify defaults: +col,\-col. Available: branch, path, size, base, changes, remote, pr, age, annotation, status, owner, hash, last\-commit
 .TP
 \fB\-\-sort\fR \fI<SORT>\fR
 Sort order (comma\-separated). +col ascending, \-col descending. Columns: branch, path, size, base, changes, remote, age, owner, hash, activity, commit

--- a/src/commands/completions/bash.rs
+++ b/src/commands/completions/bash.rs
@@ -93,7 +93,14 @@ pub(super) fn generate_bash_completion_string(command_name: &str) -> Result<Stri
     if has_columns {
         output.push_str("    # Column name completion for --columns\n");
         output.push_str("    if [[ \"$prev\" == \"--columns\" ]]; then\n");
-        output.push_str("        local columns=\"annotation branch path size base changes remote pr age owner hash last-commit\"\n");
+        // `status` is list-only: sync/prune pin their own operation-progress
+        // Status column and reject the token.
+        let columns = if command_name == "git-worktree-list" {
+            "annotation status branch path size base changes remote pr age owner hash last-commit"
+        } else {
+            "annotation branch path size base changes remote pr age owner hash last-commit"
+        };
+        output.push_str(&format!("        local columns=\"{columns}\"\n"));
         output.push_str("        local prefixed=\"\"\n");
         output.push_str("        for c in $columns; do prefixed=\"$prefixed $c +$c -$c\"; done\n");
         output.push_str("        COMPREPLY=( $(compgen -W \"$prefixed\" -- \"$cur\") )\n");

--- a/src/commands/completions/fig.rs
+++ b/src/commands/completions/fig.rs
@@ -246,6 +246,8 @@ pub(super) fn generate_fig_completion_string(command_name: &str) -> Result<Strin
             let args = if has_columns && long == "--columns" {
                 let column_defs = [
                     ("annotation", "Annotation markers"),
+                    // list-only; filtered out below for sync/prune.
+                    ("status", "Paused operation and conflicts"),
                     ("branch", "Branch name"),
                     ("path", "Worktree path"),
                     ("size", "Disk size of worktree"),
@@ -259,7 +261,10 @@ pub(super) fn generate_fig_completion_string(command_name: &str) -> Result<Strin
                     ("last-commit", "Last commit"),
                 ];
                 let mut suggestions: Vec<FigSuggestion> = Vec::new();
-                for (name, description) in &column_defs {
+                for (name, description) in column_defs
+                    .iter()
+                    .filter(|(name, _)| *name != "status" || command_name == "git-worktree-list")
+                {
                     suggestions.push(FigSuggestion {
                         name: name.to_string(),
                         description: description.to_string(),

--- a/src/commands/completions/fish.rs
+++ b/src/commands/completions/fish.rs
@@ -140,6 +140,8 @@ pub(super) fn generate_fish_completion_string(command_name: &str) -> Result<Stri
         output.push_str("\n# Column name completions for --columns\n");
         let columns = [
             ("annotation", "Annotation markers"),
+            // list-only; filtered out below for sync/prune.
+            ("status", "Paused operation and conflicts"),
             ("branch", "Branch name"),
             ("path", "Worktree path"),
             ("size", "Disk size of worktree"),
@@ -152,7 +154,10 @@ pub(super) fn generate_fish_completion_string(command_name: &str) -> Result<Stri
             ("hash", "Commit hash"),
             ("last-commit", "Last commit"),
         ];
-        for (name, desc) in &columns {
+        for (name, desc) in columns
+            .iter()
+            .filter(|(name, _)| *name != "status" || command_name == "git-worktree-list")
+        {
             output.push_str(&format!(
                 "complete -c {} -l columns -x -a '{} +{} -{}' -d '{}'\n",
                 command_name, name, name, name, desc

--- a/src/commands/completions/zsh.rs
+++ b/src/commands/completions/zsh.rs
@@ -110,6 +110,9 @@ pub(super) fn generate_zsh_completion_string(command_name: &str) -> Result<Strin
         output.push_str("        local -a column_values\n");
         output.push_str("        column_values=(\n");
         output.push_str("            'annotation:Annotation markers'\n");
+        if command_name == "git-worktree-list" {
+            output.push_str("            'status:Paused operation and conflicts'\n");
+        }
         output.push_str("            'branch:Branch name'\n");
         output.push_str("            'path:Worktree path'\n");
         output.push_str("            'size:Disk size of worktree'\n");
@@ -122,6 +125,9 @@ pub(super) fn generate_zsh_completion_string(command_name: &str) -> Result<Strin
         output.push_str("            'hash:Commit hash'\n");
         output.push_str("            'last-commit:Last commit'\n");
         output.push_str("            '+annotation:Add annotation markers'\n");
+        if command_name == "git-worktree-list" {
+            output.push_str("            '+status:Add operation status'\n");
+        }
         output.push_str("            '+branch:Add branch name'\n");
         output.push_str("            '+path:Add worktree path'\n");
         output.push_str("            '+size:Add disk size of worktree'\n");
@@ -134,6 +140,9 @@ pub(super) fn generate_zsh_completion_string(command_name: &str) -> Result<Strin
         output.push_str("            '+hash:Add commit hash'\n");
         output.push_str("            '+last-commit:Add last commit'\n");
         output.push_str("            '-annotation:Remove annotation markers'\n");
+        if command_name == "git-worktree-list" {
+            output.push_str("            '-status:Remove operation status'\n");
+        }
         output.push_str("            '-branch:Remove branch name'\n");
         output.push_str("            '-path:Remove worktree path'\n");
         output.push_str("            '-size:Remove disk size of worktree'\n");

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -186,6 +186,7 @@ fn run_repository_checks(ctx: &repository::RepoContext) -> CheckCategory {
         repository::check_daft_config(ctx),
         repository::check_worktree_layout(ctx),
         repository::check_worktree_consistency(ctx),
+        repository::check_worktree_identity_drift(ctx),
         repository::check_fetch_refspec(ctx),
         repository::check_remote_head(ctx),
         repository::check_remote_sync_config(ctx),

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -726,6 +726,7 @@ fn run_blocking(args: Args) -> Result<()> {
 struct EmitColumns {
     branch: bool,
     annotation: bool,
+    status: bool,
     path: bool,
     size: bool,
     base: bool,
@@ -748,6 +749,11 @@ impl EmitColumns {
         Self {
             branch: has(ListColumn::Branch),
             annotation: has(ListColumn::Annotation),
+            // Opt-in like size/hash (explicit selection only, never in
+            // defaults): the composed text is presentation, but a selection
+            // that names the column must produce it — every selectable
+            // column maps to at least one field.
+            status: selected.contains(&ListColumn::Status),
             path: has(ListColumn::Path),
             size: selected.contains(&ListColumn::Size),
             base: has(ListColumn::Base),
@@ -777,6 +783,9 @@ impl EmitColumns {
             h.push("is_sandbox".into());
             h.push("operation".into());
             h.push("identity_source".into());
+        }
+        if self.status {
+            h.push("status".into());
         }
         if self.path {
             h.push("path".into());
@@ -876,6 +885,14 @@ fn build_emit_table(
             match info.identity_source {
                 Some(src) => row.push(Cell::str(src.as_str())),
                 None => row.push(Cell::null()),
+            }
+        }
+        if cols.status {
+            let status = crate::output::format::format_worktree_status(info);
+            if status.is_empty() {
+                row.push(Cell::null());
+            } else {
+                row.push(Cell::str(status));
             }
         }
         if cols.path {
@@ -1710,8 +1727,47 @@ mod tests {
         assert!(!table.headers.contains(&"size_bytes".to_string()));
         // Hash column is NOT in defaults; should not appear.
         assert!(!table.headers.contains(&"hash".to_string()));
+        // Status column is NOT in defaults; should not appear.
+        assert!(!table.headers.contains(&"status".to_string()));
         // Empty infos means no rows.
         assert_eq!(table.rows.len(), 0);
+    }
+
+    /// Every selectable column must map to structured output. Regression:
+    /// `status` had no emit arm, so `--columns status --format json`
+    /// produced a zero-header table — one `{}` per worktree, exit 0 — and
+    /// `--columns branch,status` silently dropped the column the user named.
+    #[test]
+    fn build_emit_table_emits_the_status_column_when_selected() {
+        let mut rebasing = crate::core::worktree::list::WorktreeInfo::empty("feat/x");
+        rebasing.op = Some(crate::git::op_state::OpKind::Rebase);
+        rebasing.conflicted = 2;
+        let plain = crate::core::worktree::list::WorktreeInfo::empty("main");
+
+        let table = build_emit_table(
+            &[rebasing, plain],
+            std::path::Path::new("/tmp/proj"),
+            std::path::Path::new("/tmp/proj"),
+            Stat::Summary,
+            &[ListColumn::Branch, ListColumn::Status],
+            0,
+            None,
+        );
+        let status_idx = table
+            .headers
+            .iter()
+            .position(|h| h == "status")
+            .expect("selected status column emits a header");
+        assert_eq!(
+            table.rows[0][status_idx],
+            Cell::str("rebasing · 2 conflicts"),
+            "the cell carries the same text the table renders"
+        );
+        assert_eq!(
+            table.rows[1][status_idx],
+            Cell::null(),
+            "an ordinary row emits null, not an empty string"
+        );
     }
 
     /// The identity/operation fields ride the columns they belong to and are

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -171,7 +171,7 @@ pub struct Args {
 
     #[arg(
         long,
-        help = "Columns to display (comma-separated). Replace: branch,path,age. Modify defaults: +col,-col. Available: branch, path, size, base, changes, remote, pr, age, annotation, owner, hash, last-commit"
+        help = "Columns to display (comma-separated). Replace: branch,path,age. Modify defaults: +col,-col. Available: branch, path, size, base, changes, remote, pr, age, annotation, status, owner, hash, last-commit"
     )]
     pub(crate) columns: Option<String>,
 
@@ -200,6 +200,8 @@ pub struct Args {
 struct TableRow {
     /// Annotation column: current marker (">") and/or default branch indicator ("✦").
     annotation: String,
+    /// Paused operation and conflict state in words (e.g. "rebasing · 2 conflicts").
+    status: String,
     /// Branch name.
     name: String,
     /// Relative path from current directory.
@@ -1299,6 +1301,9 @@ fn print_table(
             if use_color && is_non_worktree {
                 TableRow {
                     annotation,
+                    // Non-worktree rows never carry an operation, so this is
+                    // empty; dimmed for consistency if that ever changes.
+                    status: styles::dim(&vals.status),
                     name: styles::dim(&vals.branch),
                     path: styles::dim(&vals.path),
                     size: if vals.size.is_empty() {
@@ -1355,6 +1360,12 @@ fn print_table(
             } else {
                 TableRow {
                     annotation,
+                    status: if vals.status.is_empty() || !use_color {
+                        vals.status.clone()
+                    } else {
+                        // Same attention colour as the annotation glyph.
+                        styles::yellow(&vals.status)
+                    },
                     name: vals.branch.clone(),
                     path: vals.path.clone(),
                     size: vals.size.clone(),
@@ -1379,6 +1390,7 @@ fn print_table(
         .filter(|c| **c != ListColumn::Annotation)
         .map(|c| {
             let label = match c {
+                ListColumn::Status => "Status",
                 ListColumn::Branch => "Branch",
                 ListColumn::Path => "Path",
                 ListColumn::Size => "Size",
@@ -1441,6 +1453,7 @@ fn print_table(
         let data_cols: Vec<&str> = col_headers
             .iter()
             .map(|(_, c)| match c {
+                ListColumn::Status => row.status.as_str(),
                 ListColumn::Branch => row.name.as_str(),
                 ListColumn::Path => row.path.as_str(),
                 ListColumn::Size => row.size.as_str(),

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -71,7 +71,7 @@ an operation: mid-rebase the row still reads `feat/x`, sorts in place, and
 keeps its Base/Age/Owner cells. The annotation column gains a glyph for the
 paused operation, and unresolved conflicts show as a red `!N` under Changes.
 Add the `status` column (--columns +status) to spell the state out, e.g.
-"rebasing - 2 conflicts" or "rebasing - resolved" when everything is resolved
+"rebasing · 2 conflicts" or "rebasing · resolved" when everything is resolved
 and the operation is only waiting to be continued.
 
 Only a detached checkout that no operation explains is treated as a scratch

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -578,6 +578,22 @@ fn run_blocking(args: Args) -> Result<()> {
         crate::commands::size_cache::persist_worktree_sizes(&repo_hash, fresh);
     }
 
+    // Refresh the identity records from what was just observed. Only rows
+    // whose branch is attached or recovered are reported — never a detached
+    // reading, which would let a stale record overwrite the good one it
+    // exists to be the fallback for.
+    if let Some(store) = crate::core::worktree::identity_store::IdentityStore::open(&git_common_dir)
+    {
+        store.record_all(infos.iter().filter_map(|i| {
+            // Attached only. A row whose name was *recovered* is right about
+            // its branch but is not what this record is a fallback for, and a
+            // row downgraded by the collision guard carries the placeholder
+            // name — recording either would write fiction over fact.
+            (i.identity_source == Some(crate::core::worktree::identity::IdentitySource::Attached))
+                .then_some((i.path.as_deref()?, i.name.as_str()))
+        }));
+    }
+
     // Kick the detached refresh whenever `pr` was in play at all — including
     // when the gate just hid the column: the probe is what detects a repaired
     // auth and silently restores it on a later run.

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -284,6 +284,10 @@ fn should_use_live(args: &Args) -> bool {
     !args.emit.is_structured()
         && std::env::var_os("DAFT_NO_LIVE").is_none()
         && std::io::stdout().is_terminal()
+        // `--merging` is a display filter the live renderer does not apply, so
+        // on a TTY it used to be silently ignored and every worktree was
+        // listed. Route the filtered view at the renderer that honors it.
+        && !args.merging
 }
 
 /// Resolve the base branch to compare against, honoring `daft.remote` (not a
@@ -636,14 +640,21 @@ fn run_blocking(args: Args) -> Result<()> {
     }
 
     if args.merging {
-        infos.retain(|info| {
-            info.path.as_ref().is_some_and(|p| {
-                matches!(
-                    crate::core::worktree::merge::detect_in_progress(p),
-                    Ok(Some(crate::core::worktree::merge::InProgressOp::Merge))
-                )
-            })
-        });
+        // Reads the operation each row was already enriched with, rather than
+        // re-probing every worktree. Still merge-specific: `--merging` means
+        // merges, not "any operation" — a rebase has its own signals now (the
+        // annotation glyph and the status column).
+        infos.retain(|info| info.op == Some(crate::git::op_state::OpKind::Merge));
+
+        // A filter that matched nothing is not an empty repository. Falling
+        // through to the table's empty branch would print the new-user
+        // onboarding block ("No worktrees yet", `daft go <branch>`) to
+        // someone who has worktrees and just asked which of them are
+        // mid-merge.
+        if infos.is_empty() && !args.emit.is_structured() {
+            println!("No worktrees have a merge in progress.");
+            return Ok(());
+        }
     }
 
     let now = Utc::now().timestamp();
@@ -732,6 +743,8 @@ impl EmitColumns {
             h.push("is_current".into());
             h.push("is_default_branch".into());
             h.push("is_sandbox".into());
+            h.push("operation".into());
+            h.push("identity_source".into());
         }
         if self.path {
             h.push("path".into());
@@ -752,6 +765,7 @@ impl EmitColumns {
             h.push("staged".into());
             h.push("unstaged".into());
             h.push("untracked".into());
+            h.push("conflicted".into());
         }
         if self.changes_lines {
             h.push("staged_lines_inserted".into());
@@ -823,6 +837,14 @@ fn build_emit_table(
             row.push(Cell::bool(info.is_current));
             row.push(Cell::bool(info.is_default_branch));
             row.push(Cell::bool(info.is_sandbox));
+            match info.op {
+                Some(op) => row.push(Cell::str(op.as_str())),
+                None => row.push(Cell::null()),
+            }
+            match info.identity_source {
+                Some(src) => row.push(Cell::str(src.as_str())),
+                None => row.push(Cell::null()),
+            }
         }
         if cols.path {
             let rel_path = info
@@ -874,6 +896,7 @@ fn build_emit_table(
             row.push(Cell::Int(info.staged as i64));
             row.push(Cell::Int(info.unstaged as i64));
             row.push(Cell::Int(info.untracked as i64));
+            row.push(Cell::Int(info.conflicted as i64));
         }
         if cols.changes_lines {
             row.push(
@@ -1655,6 +1678,65 @@ mod tests {
         assert_eq!(table.rows.len(), 0);
     }
 
+    /// The identity/operation fields ride the columns they belong to and are
+    /// present under the default column set.
+    #[test]
+    fn build_emit_table_carries_identity_and_conflict_fields() {
+        let table = build_emit_table(
+            &[],
+            std::path::Path::new("/tmp/proj"),
+            std::path::Path::new("/tmp/proj"),
+            Stat::Summary,
+            ListColumn::list_defaults(),
+            0,
+            None,
+        );
+        for field in ["operation", "identity_source", "conflicted"] {
+            assert!(
+                table.headers.contains(&field.to_string()),
+                "default structured output must carry `{field}`"
+            );
+        }
+    }
+
+    /// Every emitted row must have exactly one cell per header — the two
+    /// halves are written in separate `if` chains, so a field added to one
+    /// and not the other silently shears the whole table.
+    #[test]
+    fn emit_rows_line_up_with_headers_for_a_recovered_worktree() {
+        let mut info = crate::core::worktree::list::WorktreeInfo::empty("feat/x");
+        info.path = Some(std::path::PathBuf::from("/tmp/proj/feat"));
+        info.op = Some(crate::git::op_state::OpKind::Rebase);
+        info.identity_source = Some(crate::core::worktree::identity::IdentitySource::Recovered);
+        info.conflicted = 2;
+
+        for stat in [Stat::Summary, Stat::Lines] {
+            let table = build_emit_table(
+                std::slice::from_ref(&info),
+                std::path::Path::new("/tmp/proj"),
+                std::path::Path::new("/tmp/proj"),
+                stat,
+                ListColumn::list_defaults(),
+                0,
+                None,
+            );
+            assert_eq!(table.rows.len(), 1);
+            assert_eq!(
+                table.rows[0].len(),
+                table.headers.len(),
+                "row/header width mismatch in {stat:?} mode"
+            );
+
+            let at = |name: &str| {
+                let idx = table.headers.iter().position(|h| h == name).unwrap();
+                format!("{:?}", table.rows[0][idx])
+            };
+            assert!(at("operation").contains("rebase"));
+            assert!(at("identity_source").contains("recovered"));
+            assert!(at("conflicted").contains('2'));
+        }
+    }
+
     /// Full parity with the live table: the blocking renderer paints the
     /// current worktree's line with the shared row background; header,
     /// other rows, and the no-color path stay untouched.
@@ -1691,6 +1773,8 @@ mod tests {
             size_bytes: None,
             working_tree_mtime: None,
             is_sandbox: false,
+            op: None,
+            identity_source: None,
             forge_ref: None,
         };
         let infos = [info("main", true), info("feat", false)];
@@ -1751,6 +1835,8 @@ mod tests {
             size_bytes: Some(1024),
             working_tree_mtime: None,
             is_sandbox: false,
+            op: None,
+            identity_source: None,
             forge_ref: None,
         };
         let selected = &[ListColumn::Branch, ListColumn::Path, ListColumn::Size];

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1080,6 +1080,42 @@ impl Peaker for PriorityMaxExcept {
     }
 }
 
+/// Paint one row's annotation cell for the plain table.
+///
+/// Slot layout comes from [`AnnotationSlots`]; this only applies ANSI colour
+/// and pads unfilled slots so glyphs line up vertically down the column.
+fn render_annotation(
+    slots: crate::output::annotation::AnnotationSlots,
+    info: &crate::core::worktree::list::WorktreeInfo,
+    use_color: bool,
+) -> String {
+    use crate::output::annotation::AnnotationGlyph;
+
+    let mut out = String::new();
+    for (i, glyph) in slots.glyphs(info).into_iter().enumerate() {
+        if i > 0 {
+            out.push(' ');
+        }
+        let Some(glyph) = glyph else {
+            out.push(' ');
+            continue;
+        };
+        let symbol = glyph.symbol();
+        if !use_color {
+            out.push_str(symbol);
+            continue;
+        }
+        out.push_str(&match glyph {
+            AnnotationGlyph::Current => styles::cyan(symbol),
+            AnnotationGlyph::DefaultBranch => styles::bright_purple(symbol),
+            AnnotationGlyph::Sandbox => styles::dim(symbol),
+            // Operations share the attention colour with the status column.
+            AnnotationGlyph::Operation(_) => styles::yellow(symbol),
+        });
+    }
+    out
+}
+
 fn print_table(
     infos: &[crate::core::worktree::list::WorktreeInfo],
     project_root: &std::path::Path,
@@ -1131,9 +1167,9 @@ fn print_table(
     let now = Utc::now().timestamp();
 
     // Determine which annotation types exist across all rows
-    let has_any_current = infos.iter().any(|i| i.is_current);
-    let has_any_default = infos.iter().any(|i| i.is_default_branch);
-    let has_any_sandbox = infos.iter().any(|i| i.is_sandbox);
+    // Which annotation sub-positions this run needs (shared with the live
+    // renderer so the two lay the column out identically).
+    let slots = crate::output::annotation::AnnotationSlots::for_rows(infos);
 
     let col_ctx = ColumnContext {
         project_root,
@@ -1161,50 +1197,7 @@ fn print_table(
         .iter()
         .zip(col_vals.iter())
         .map(|(info, vals)| {
-            // Build annotation: ">" first (cyan), then "✦" (bright purple),
-            // then "○" (dim) for sandbox
-            let mut annotation = String::new();
-            if has_any_current {
-                if info.is_current {
-                    if use_color {
-                        annotation.push_str(&styles::cyan(styles::CURRENT_WORKTREE_SYMBOL));
-                    } else {
-                        annotation.push_str(styles::CURRENT_WORKTREE_SYMBOL);
-                    }
-                } else {
-                    annotation.push(' ');
-                }
-                if has_any_default || has_any_sandbox {
-                    annotation.push(' ');
-                }
-            }
-            if has_any_default {
-                if info.is_default_branch {
-                    if use_color {
-                        annotation.push_str(&styles::bright_purple(styles::DEFAULT_BRANCH_SYMBOL));
-                    } else {
-                        annotation.push_str(styles::DEFAULT_BRANCH_SYMBOL);
-                    }
-                } else if info.is_sandbox {
-                    if use_color {
-                        annotation.push_str(&styles::dim(styles::SANDBOX_SYMBOL));
-                    } else {
-                        annotation.push_str(styles::SANDBOX_SYMBOL);
-                    }
-                } else {
-                    annotation.push(' ');
-                }
-            } else if has_any_sandbox {
-                if info.is_sandbox {
-                    if use_color {
-                        annotation.push_str(&styles::dim(styles::SANDBOX_SYMBOL));
-                    } else {
-                        annotation.push_str(styles::SANDBOX_SYMBOL);
-                    }
-                } else {
-                    annotation.push(' ');
-                }
-            }
+            let annotation = render_annotation(slots, info, use_color);
 
             // Stat::Lines mode overrides base/changes/remote with line-level counts
             let (base, head, remote) = if stat == Stat::Lines {
@@ -1403,8 +1396,7 @@ fn print_table(
         })
         .collect();
 
-    let show_annotations = selected_columns.contains(&ListColumn::Annotation)
-        && (has_any_current || has_any_default || has_any_sandbox);
+    let show_annotations = selected_columns.contains(&ListColumn::Annotation) && !slots.is_empty();
 
     // Format a header cell: dim+underline for label, sort arrow with
     // brightness gradient based on sort priority rank.

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1127,8 +1127,9 @@ fn render_annotation(
             AnnotationGlyph::Current => styles::cyan(symbol),
             AnnotationGlyph::DefaultBranch => styles::bright_purple(symbol),
             AnnotationGlyph::Sandbox => styles::dim(symbol),
-            // Operations share the attention colour with the status column.
-            AnnotationGlyph::Operation(_) => styles::yellow(symbol),
+            // Operations and drift share the attention colour with the
+            // status column.
+            AnnotationGlyph::Operation(_) | AnnotationGlyph::Drift => styles::yellow(symbol),
         });
     }
     out
@@ -1796,6 +1797,7 @@ mod tests {
             is_sandbox: false,
             op: None,
             identity_source: None,
+            drifted: false,
             forge_ref: None,
         };
         let infos = [info("main", true), info("feat", false)];
@@ -1858,6 +1860,7 @@ mod tests {
             is_sandbox: false,
             op: None,
             identity_source: None,
+            drifted: false,
             forge_ref: None,
         };
         let selected = &[ListColumn::Branch, ListColumn::Path, ListColumn::Size];

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -66,6 +66,20 @@ Use -a / --all to show both (equivalent to -b -r).
 
 Non-worktree branches are shown with dimmed styling and blank Path/Changes columns.
 
+A worktree keeps its branch name even while git has detached its HEAD to run
+an operation: mid-rebase the row still reads `feat/x`, sorts in place, and
+keeps its Base/Age/Owner cells. The annotation column gains a glyph for the
+paused operation, and unresolved conflicts show as a red `!N` under Changes.
+Add the `status` column (--columns +status) to spell the state out, e.g.
+"rebasing - 2 conflicts" or "rebasing - resolved" when everything is resolved
+and the operation is only waiting to be continued.
+
+Only a detached checkout that no operation explains is treated as a scratch
+sandbox. Where daft knows what branch a worktree was made for, even that keeps
+its name, shown alongside the checked-out commit. A worktree whose checkout
+disagrees with that record is flagged as drifted; `daft doctor --fix`
+reconciles the record.
+
 Use --stat lines to show line-level change counts (insertions and deletions)
 instead of the default summary (commit counts for base/remote, file counts for
 changes). This is slower as it requires computing diffs for each worktree.
@@ -584,7 +598,7 @@ fn run_blocking(args: Args) -> Result<()> {
     // exists to be the fallback for.
     if let Some(store) = crate::core::worktree::identity_store::IdentityStore::open(&git_common_dir)
     {
-        store.record_all(infos.iter().filter_map(|i| {
+        store.observe_all(infos.iter().filter_map(|i| {
             // Attached only. A row whose name was *recovered* is right about
             // its branch but is not what this record is a fallback for, and a
             // row downgraded by the collision guard carries the placeholder

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1232,7 +1232,13 @@ fn print_table(
             } else {
                 (
                     format_ahead_behind(info.ahead, info.behind, use_color),
-                    format_head_status(info.staged, info.unstaged, info.untracked, use_color),
+                    format_head_status(
+                        info.conflicted,
+                        info.staged,
+                        info.unstaged,
+                        info.untracked,
+                        use_color,
+                    ),
                     format_remote_status(info.remote_ahead, info.remote_behind, use_color),
                 )
             };
@@ -1666,6 +1672,7 @@ mod tests {
             staged: 0,
             unstaged: 0,
             untracked: 0,
+            conflicted: 0,
             remote_ahead: None,
             remote_behind: None,
             last_commit_timestamp: None,
@@ -1725,6 +1732,7 @@ mod tests {
             staged: 0,
             unstaged: 0,
             untracked: 0,
+            conflicted: 0,
             remote_ahead: None,
             remote_behind: None,
             last_commit_timestamp: None,

--- a/src/commands/list_live.rs
+++ b/src/commands/list_live.rs
@@ -498,6 +498,9 @@ fn collector_fields(columns: &[ListColumn], sort_spec: Option<&SortSpec>, stat: 
             ListColumn::Size => FieldSet::SIZE,
             ListColumn::Base => FieldSet::BASE_AHEAD_BEHIND,
             ListColumn::Changes => FieldSet::CHANGES,
+            // The operation is known at seed; the conflict/resolved qualifier
+            // rides the same counts the Changes cell uses.
+            ListColumn::Status => FieldSet::CHANGES,
             ListColumn::Remote => FieldSet::REMOTE_AHEAD_BEHIND,
             ListColumn::Age => FieldSet::BRANCH_AGE,
             ListColumn::Owner => FieldSet::OWNER,

--- a/src/commands/list_live.rs
+++ b/src/commands/list_live.rs
@@ -89,7 +89,10 @@ pub fn run_live(args: Args) -> Result<()> {
     let entries = crate::core::worktree::porcelain::parse_worktree_list_porcelain(&porcelain);
     // Same recovery the blocking path does, at seed time so the Branch cell
     // — which is never streamed — is right in the very first frame.
-    let identities = crate::core::worktree::identity::resolve_identities(&entries);
+    let identities = crate::core::worktree::identity::resolve_identities_with(
+        &entries,
+        &crate::core::worktree::identity_store::read_identities(&git_common_dir),
+    );
     let mut worktree_infos: Vec<WorktreeInfo> = Vec::new();
     let mut targets: Vec<list_stream::CollectorTarget> = Vec::new();
     let mut worktree_branches: HashSet<String> = HashSet::new();

--- a/src/commands/list_live.rs
+++ b/src/commands/list_live.rs
@@ -480,7 +480,7 @@ pub fn run_live(args: Args) -> Result<()> {
     // rows only, never a detached reading.
     if let Some(store) = crate::core::worktree::identity_store::IdentityStore::open(&git_common_dir)
     {
-        store.record_all(final_state.live.rows.iter().filter_map(|row| {
+        store.observe_all(final_state.live.rows.iter().filter_map(|row| {
             // Attached only — see the blocking path.
             (row.info.identity_source
                 == Some(crate::core::worktree::identity::IdentitySource::Attached))

--- a/src/commands/list_live.rs
+++ b/src/commands/list_live.rs
@@ -113,9 +113,7 @@ pub fn run_live(args: Args) -> Result<()> {
         info.path = Some(entry.path.clone());
         info.is_current = is_current;
         info.is_default_branch = is_default_branch;
-        info.is_sandbox = identity.is_sandbox;
-        info.op = identity.op;
-        info.identity_source = Some(identity.source);
+        apply_identity(&mut info, &identity);
         info.kind = EntryKind::Worktree;
         worktree_infos.push(info);
 
@@ -498,6 +496,23 @@ pub fn run_live(args: Args) -> Result<()> {
     }
     Ok(())
 }
+/// Copy a resolved identity's derived fields onto a seeded row.
+///
+/// Every identity-derived field must flow through here: these are seed-only —
+/// no patch ever carries them — so one missed copy leaves the field at
+/// `WorktreeInfo::empty`'s default for the whole session while the blocking
+/// renderer shows it, a silent renderer-parity break (`drifted` was lost
+/// exactly this way once).
+fn apply_identity(
+    info: &mut WorktreeInfo,
+    identity: &crate::core::worktree::identity::WorktreeIdentity,
+) {
+    info.is_sandbox = identity.is_sandbox;
+    info.op = identity.op;
+    info.identity_source = Some(identity.source);
+    info.drifted = identity.drifted;
+}
+
 /// Fields the streaming collector must populate for this view: what the
 /// selected columns render plus what the sort inspects
 /// (`SortSpec::required_fields`, itself `--stat`-aware). The collector
@@ -514,8 +529,11 @@ fn collector_fields(columns: &[ListColumn], sort_spec: Option<&SortSpec>, stat: 
             ListColumn::Base => FieldSet::BASE_AHEAD_BEHIND,
             ListColumn::Changes => FieldSet::CHANGES,
             // The operation is known at seed; the conflict/resolved qualifier
-            // rides the same counts the Changes cell uses.
-            ListColumn::Status => FieldSet::CHANGES,
+            // rides the same counts the Changes cell uses. LAST_COMMIT feeds
+            // the op-less Persisted arm (`detached @ <sha>`) — without it a
+            // narrow selection leaves the cell at a bare `detached` forever.
+            // The hash is HEAD-content-cached, so this adds no walk.
+            ListColumn::Status => FieldSet::CHANGES | FieldSet::LAST_COMMIT,
             ListColumn::Remote => FieldSet::REMOTE_AHEAD_BEHIND,
             ListColumn::Age => FieldSet::BRANCH_AGE,
             ListColumn::Owner => FieldSet::OWNER,
@@ -558,6 +576,45 @@ mod collector_fields_tests {
 
     fn sort(input: &str, stat: Stat) -> SortSpec {
         SortSpec::parse(input).unwrap().with_stat(stat)
+    }
+
+    /// The live seed must carry *every* identity-derived field. These are
+    /// seed-only — no patch refreshes them — so a missed copy leaves the
+    /// field at its `empty()` default for the whole session while the
+    /// blocking renderer shows it. Regression: `drifted` was dropped here,
+    /// making the drift glyph and the `status` column's "drifted" dead on
+    /// the default TTY renderer.
+    #[test]
+    fn seed_copies_every_identity_derived_field() {
+        let identity = crate::core::worktree::identity::WorktreeIdentity {
+            name: "feat/x".to_string(),
+            branch: Some("feat/x".to_string()),
+            source: crate::core::worktree::identity::IdentitySource::Attached,
+            op: Some(crate::git::op_state::OpKind::Rebase),
+            is_sandbox: false,
+            drifted: true,
+        };
+        let mut info = crate::core::worktree::list::WorktreeInfo::empty("feat/x");
+        apply_identity(&mut info, &identity);
+        assert!(!info.is_sandbox);
+        assert_eq!(info.op, Some(crate::git::op_state::OpKind::Rebase));
+        assert_eq!(
+            info.identity_source,
+            Some(crate::core::worktree::identity::IdentitySource::Attached)
+        );
+        assert!(info.drifted, "drifted must survive the seed copy");
+    }
+
+    /// The status column's op-less Persisted arm renders `detached @ <sha>`
+    /// from `last_commit_hash`, which streams only under LAST_COMMIT. With a
+    /// narrow selection (`--columns status,branch`) the live cell otherwise
+    /// sticks at a bare `detached` forever while the piped path shows the
+    /// sha.
+    #[test]
+    fn status_column_collects_changes_and_last_commit() {
+        let resolved = ColumnSelection::parse("status,branch", CommandKind::List).unwrap();
+        let fields = collector_fields(&resolved.columns, None, Stat::Summary);
+        assert!(fields.contains(FieldSet::CHANGES | FieldSet::LAST_COMMIT));
     }
 
     /// #665 regression: the default view must not collect SIZE/MTIME (or any

--- a/src/commands/list_live.rs
+++ b/src/commands/list_live.rs
@@ -87,31 +87,32 @@ pub fn run_live(args: Args) -> Result<()> {
         .worktree_list_porcelain()
         .map_err(|e| anyhow::anyhow!("{e}"))?;
     let entries = crate::core::worktree::porcelain::parse_worktree_list_porcelain(&porcelain);
+    // Same recovery the blocking path does, at seed time so the Branch cell
+    // — which is never streamed — is right in the very first frame.
+    let identities = crate::core::worktree::identity::resolve_identities(&entries);
     let mut worktree_infos: Vec<WorktreeInfo> = Vec::new();
     let mut targets: Vec<list_stream::CollectorTarget> = Vec::new();
     let mut worktree_branches: HashSet<String> = HashSet::new();
 
-    for entry in entries {
-        if entry.is_bare {
+    for (entry, identity) in entries.into_iter().zip(identities) {
+        let Some(identity) = identity else {
             continue;
-        }
-        let branch_display = if entry.is_detached {
-            "(detached)".to_string()
-        } else {
-            entry.branch.clone().unwrap_or_default()
         };
+        let branch_display = identity.name.clone();
         let canonical = entry
             .path
             .canonicalize()
             .unwrap_or_else(|_| entry.path.clone());
         let is_current = current_path.as_deref() == Some(canonical.as_path());
-        let is_default_branch = entry.branch.as_deref() == Some(base_branch.as_str());
+        let is_default_branch = identity.branch.as_deref() == Some(base_branch.as_str());
 
         let mut info = WorktreeInfo::empty(&branch_display);
         info.path = Some(entry.path.clone());
         info.is_current = is_current;
         info.is_default_branch = is_default_branch;
-        info.is_sandbox = entry.is_detached;
+        info.is_sandbox = identity.is_sandbox;
+        info.op = identity.op;
+        info.identity_source = Some(identity.source);
         info.kind = EntryKind::Worktree;
         worktree_infos.push(info);
 
@@ -119,11 +120,15 @@ pub fn run_live(args: Args) -> Result<()> {
             branch_name: branch_display.clone(),
             path: Some(entry.path.clone()),
             kind: EntryKind::Worktree,
-            is_detached: entry.is_detached,
+            // "has no branch to query", not "HEAD is detached" — a recovered
+            // worktree has a real ref, so its branch-keyed cells must stream.
+            is_detached: identity.branch.is_none(),
         });
 
-        if !branch_display.is_empty() && !entry.is_detached {
-            worktree_branches.insert(branch_display);
+        // Recovered branches join the dedup set too, or `--branches` would
+        // list the branch a second time as a worktree-less local branch.
+        if let Some(branch) = identity.branch {
+            worktree_branches.insert(branch);
         }
     }
 

--- a/src/commands/list_live.rs
+++ b/src/commands/list_live.rs
@@ -473,6 +473,18 @@ pub fn run_live(args: Args) -> Result<()> {
         crate::commands::size_cache::persist_worktree_sizes(&repo_hash, fresh);
     }
 
+    // Same identity refresh the blocking path does — attached and recovered
+    // rows only, never a detached reading.
+    if let Some(store) = crate::core::worktree::identity_store::IdentityStore::open(&git_common_dir)
+    {
+        store.record_all(final_state.live.rows.iter().filter_map(|row| {
+            // Attached only — see the blocking path.
+            (row.info.identity_source
+                == Some(crate::core::worktree::identity::IdentitySource::Attached))
+            .then_some((row.info.path.as_deref()?, row.info.name.as_str()))
+        }));
+    }
+
     // On normal completion, workers have already finished and `join()` returns
     // immediately. On cancellation, workers may still be mid-`git` invocation
     // (the cancel flag is checked between clusters, not mid-command). Skip the

--- a/src/core/columns.rs
+++ b/src/core/columns.rs
@@ -142,6 +142,9 @@ fn parse_modifier_tokens<C: SelectableColumn>(
 pub enum ListColumn {
     /// Current/default branch annotation markers.
     Annotation,
+    /// Paused git operation and conflict state, spelled out. Opt-in — the
+    /// annotation column carries the same state as glyphs by default.
+    Status,
     /// Branch name.
     Branch,
     /// Worktree path.
@@ -171,6 +174,7 @@ impl ListColumn {
     pub fn all() -> &'static [ListColumn] {
         &[
             ListColumn::Annotation,
+            ListColumn::Status,
             ListColumn::Branch,
             ListColumn::Path,
             ListColumn::Size,
@@ -242,17 +246,20 @@ impl ListColumn {
     pub fn canonical_position(self) -> u8 {
         match self {
             Self::Annotation => 1,
-            Self::Branch => 2,
-            Self::Path => 3,
-            Self::Size => 4,
-            Self::Base => 5,
-            Self::Changes => 6,
-            Self::Remote => 7,
-            Self::Pr => 8,
-            Self::Age => 9,
-            Self::Owner => 10,
-            Self::Hash => 11,
-            Self::LastCommit => 12,
+            // Before Branch: state reads first, identity second — the same
+            // order the annotation glyphs already sit in.
+            Self::Status => 2,
+            Self::Branch => 3,
+            Self::Path => 4,
+            Self::Size => 5,
+            Self::Base => 6,
+            Self::Changes => 7,
+            Self::Remote => 8,
+            Self::Pr => 9,
+            Self::Age => 10,
+            Self::Owner => 11,
+            Self::Hash => 12,
+            Self::LastCommit => 13,
         }
     }
 
@@ -260,6 +267,7 @@ impl ListColumn {
     pub fn cli_name(self) -> &'static str {
         match self {
             Self::Annotation => "annotation",
+            Self::Status => "status",
             Self::Branch => "branch",
             Self::Path => "path",
             Self::Size => "size",
@@ -296,6 +304,7 @@ impl FromStr for ListColumn {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.trim().to_lowercase().as_str() {
             "annotation" => Ok(Self::Annotation),
+            "status" => Ok(Self::Status),
             "branch" => Ok(Self::Branch),
             "path" => Ok(Self::Path),
             "size" => Ok(Self::Size),
@@ -386,7 +395,8 @@ impl ColumnSelection {
         match (token.as_str(), command) {
             ("status", CommandKind::Sync | CommandKind::Prune | CommandKind::Clone) => {
                 Err("'status' column cannot be controlled on this command\n  \
-                     it is always shown as the first column"
+                     it always shows the operation status as the first column\n  \
+                     (the selectable `status` column exists on `daft list`)"
                     .to_string())
             }
             ("pr", CommandKind::Clone) => Err("'pr' column is not available on `daft clone`\n  \
@@ -743,7 +753,6 @@ mod tests {
     #[test]
     fn test_unknown_column_parse_fails() {
         assert!("unknown".parse::<ListColumn>().is_err());
-        assert!("status".parse::<ListColumn>().is_err());
         assert!("".parse::<ListColumn>().is_err());
     }
 
@@ -895,10 +904,49 @@ mod tests {
         assert!(err.contains("cannot be controlled"), "Got: {err}");
     }
 
+    /// `status` is a real, selectable column on `daft list` — and only
+    /// there. Sync/prune/clone pin their own operation-progress Status
+    /// column, so the token stays rejected for them.
     #[test]
-    fn test_status_on_list_unknown() {
-        let err = ColumnSelection::parse("status,branch", CommandKind::List).unwrap_err();
-        assert!(err.contains("unknown column 'status'"), "Got: {err}");
+    fn test_status_selectable_on_list_only() {
+        let resolved = ColumnSelection::parse("status,branch", CommandKind::List).unwrap();
+        assert_eq!(
+            resolved.columns,
+            vec![ListColumn::Status, ListColumn::Branch]
+        );
+
+        for command in [CommandKind::Sync, CommandKind::Prune, CommandKind::Clone] {
+            let err = ColumnSelection::parse("status,branch", command).unwrap_err();
+            assert!(err.contains("cannot be controlled"), "Got: {err}");
+            assert!(
+                err.contains("daft list"),
+                "the error should point at where the column does exist. Got: {err}"
+            );
+        }
+    }
+
+    /// The whole point of the canonical position: `+status` lands before
+    /// Branch no matter where the user wrote it.
+    #[test]
+    fn test_modifier_add_status_lands_before_branch() {
+        let resolved = ColumnSelection::parse("+status", CommandKind::List).unwrap();
+        let status = resolved
+            .columns
+            .iter()
+            .position(|c| *c == ListColumn::Status)
+            .expect("status column added");
+        let branch = resolved
+            .columns
+            .iter()
+            .position(|c| *c == ListColumn::Branch)
+            .expect("branch column present");
+        assert!(
+            status < branch,
+            "status must precede branch, got {:?}",
+            resolved.columns
+        );
+        // And it is opt-in: absent from the defaults.
+        assert!(!ListColumn::list_defaults().contains(&ListColumn::Status));
     }
 
     #[test]

--- a/src/core/repo.rs
+++ b/src/core/repo.rs
@@ -219,10 +219,23 @@ pub(crate) fn find_worktree_for_branch(cwd: &Path, branch: &str) -> Option<PathB
         return None;
     }
     let porcelain = String::from_utf8_lossy(&porcelain.stdout);
-    crate::core::worktree::porcelain::parse_worktree_list_porcelain(&porcelain)
-        .into_iter()
+    let entries = crate::core::worktree::porcelain::parse_worktree_list_porcelain(&porcelain);
+
+    if let Some(w) = entries
+        .iter()
         .find(|w| !w.is_bare && w.branch.as_deref() == Some(branch))
-        .map(|w| w.path)
+    {
+        return Some(w.path.clone());
+    }
+
+    // A worktree mid-rebase reports no branch, so the match above misses it
+    // even though its content is the branch's. Ask the operation probe —
+    // strictly after every attached checkout has had its say.
+    entries
+        .iter()
+        .filter(|w| w.is_detached)
+        .find(|w| crate::git::op_state::recovered_branch(&w.path).as_deref() == Some(branch))
+        .map(|w| w.path.clone())
 }
 
 pub(crate) fn find_representative_worktree(cwd: &Path) -> Option<PathBuf> {
@@ -573,5 +586,89 @@ mod tests {
         // Outside any repository → None.
         let outside = tempfile::tempdir().unwrap();
         assert_eq!(git_common_dir_at(outside.path()), None);
+    }
+
+    /// Stand up `main` plus a linked worktree on `feat/x`, then stop a rebase
+    /// of `feat/x` onto `main` on a conflict — the state in which git detaches
+    /// HEAD and the porcelain stops naming the branch. Returns (repo, worktree).
+    fn repo_with_conflicted_rebase(dir: &Path) -> (std::path::PathBuf, std::path::PathBuf) {
+        git(dir, &["init", "-q", "-b", "main"]);
+        std::fs::write(dir.join("f.txt"), "base\n").unwrap();
+        git(dir, &["add", "f.txt"]);
+        git(dir, &["commit", "-qm", "base"]);
+
+        git(dir, &["branch", "feat/x"]);
+        std::fs::write(dir.join("f.txt"), "main side\n").unwrap();
+        git(dir, &["commit", "-qam", "main change"]);
+
+        let worktree = dir.join("wt-feat");
+        git(
+            dir,
+            &[
+                "worktree",
+                "add",
+                "-q",
+                worktree.to_str().unwrap(),
+                "feat/x",
+            ],
+        );
+        std::fs::write(worktree.join("f.txt"), "feat side\n").unwrap();
+        git(&worktree, &["commit", "-qam", "feat change"]);
+
+        // Expected to exit non-zero: it stops on the conflict, which is the
+        // whole point — so this one cannot use the asserting `git` helper.
+        let out = crate::utils::git_command_at(&worktree)
+            .args(["rebase", "main"])
+            .env("GIT_AUTHOR_NAME", "Test")
+            .env("GIT_AUTHOR_EMAIL", "test@test.com")
+            .env("GIT_COMMITTER_NAME", "Test")
+            .env("GIT_COMMITTER_EMAIL", "test@test.com")
+            .output()
+            .expect("git rebase");
+        assert!(!out.status.success(), "the rebase was supposed to conflict");
+
+        (dir.to_path_buf(), worktree)
+    }
+
+    /// Regression (#736): mid-rebase the porcelain reports no branch, so a
+    /// name-only match reported "no worktree for this branch" while the
+    /// branch's worktree sat right there — and callers went off and created
+    /// or resolved the wrong thing.
+    #[test]
+    fn finds_the_worktree_of_a_branch_being_rebased() {
+        let dir = tempfile::tempdir().unwrap();
+        let (repo, worktree) = repo_with_conflicted_rebase(dir.path());
+
+        // Precondition: git really has detached HEAD, so this is not just
+        // testing the ordinary attached path.
+        let porcelain = crate::utils::git_command_at(&repo)
+            .args(["worktree", "list", "--porcelain"])
+            .output()
+            .unwrap();
+        let porcelain = String::from_utf8_lossy(&porcelain.stdout);
+        assert!(
+            !porcelain.contains("branch refs/heads/feat/x"),
+            "expected git to report the rebasing worktree as detached, got:\n{porcelain}"
+        );
+
+        assert_eq!(
+            find_worktree_for_branch(&repo, "feat/x").map(|p| p.canonicalize().unwrap()),
+            Some(worktree.canonicalize().unwrap()),
+        );
+    }
+
+    #[test]
+    fn attached_worktrees_still_win_over_recovered_ones() {
+        let dir = tempfile::tempdir().unwrap();
+        let (repo, _worktree) = repo_with_conflicted_rebase(dir.path());
+
+        // `main` is attached; it must resolve to the main worktree, never to
+        // the detached one the probe also has an opinion about.
+        assert_eq!(
+            find_worktree_for_branch(&repo, "main").map(|p| p.canonicalize().unwrap()),
+            Some(repo.canonicalize().unwrap()),
+        );
+        // And an unrelated name still resolves to nothing.
+        assert_eq!(find_worktree_for_branch(&repo, "nope"), None);
     }
 }

--- a/src/core/sort.rs
+++ b/src/core/sort.rs
@@ -32,7 +32,8 @@ pub enum SortColumn {
     LastCommit,
     /// Sort by total base divergence (`ahead + behind`).
     Base,
-    /// Sort by total local changes (`staged + unstaged + untracked`).
+    /// Sort by total local changes
+    /// (`conflicted + staged + unstaged + untracked`).
     Changes,
     /// Sort by total remote divergence (`remote_ahead + remote_behind`).
     Remote,
@@ -194,9 +195,12 @@ impl SortKey {
                     let b_total = b_lines + b.untracked;
                     self.apply_direction(a_total.cmp(&b_total))
                 } else {
-                    // Summary: total file count (staged + unstaged + untracked).
-                    let a_total = a.staged + a.unstaged + a.untracked;
-                    let b_total = b.staged + b.unstaged + b.untracked;
+                    // Summary: total file count (conflicted + staged +
+                    // unstaged + untracked). Conflicted files count once,
+                    // here as everywhere: without the term, a worktree whose
+                    // only changes are unresolved conflicts sorts as clean.
+                    let a_total = a.conflicted + a.staged + a.unstaged + a.untracked;
+                    let b_total = b.conflicted + b.staged + b.unstaged + b.untracked;
                     self.apply_direction(a_total.cmp(&b_total))
                 }
             }
@@ -758,6 +762,24 @@ mod tests {
         spec.sort(&mut infos);
         let sizes: Vec<Option<u64>> = infos.iter().map(|i| i.size_bytes).collect();
         assert_eq!(sizes, vec![Some(300), Some(200), Some(100)]);
+    }
+
+    /// A worktree whose only changes are unresolved conflicts is not clean:
+    /// `--sort changes` must rank it above one holding a single untracked
+    /// file. Regression: conflicted files were split out of staged/unstaged
+    /// into their own bucket and the summary total missed it, scoring a
+    /// conflict-only worktree 0 — a tie with genuinely pristine ones.
+    #[test]
+    fn test_sort_by_changes_counts_conflicted_files() {
+        let spec = SortSpec::parse("-changes").unwrap();
+        let mut conflict_only = info("conflict-only");
+        conflict_only.conflicted = 5;
+        let mut untracked_one = info("untracked-one");
+        untracked_one.untracked = 1;
+        let mut infos = vec![info("clean"), conflict_only, untracked_one];
+        spec.sort(&mut infos);
+        let names: Vec<&str> = infos.iter().map(|i| i.name.as_str()).collect();
+        assert_eq!(names, vec!["conflict-only", "untracked-one", "clean"]);
     }
 
     #[test]

--- a/src/core/worktree/branch_delete.rs
+++ b/src/core/worktree/branch_delete.rs
@@ -1208,6 +1208,13 @@ fn delete_single_branch(
     };
 
     let has_worktree = branch.worktree_path.is_some();
+    // Capture the identity key while the directory can still be probed:
+    // records are keyed on the private-gitdir id, not the branch, and a
+    // drifted record does not match the branch name we know here.
+    let identity_id = branch
+        .worktree_path
+        .as_deref()
+        .and_then(crate::core::worktree::identity_store::worktree_id_for);
     let stage_key = |id: StageId| StepKey::scoped(id, branch.name.clone());
 
     // Step 1: Cancel any running background jobs for this worktree, then
@@ -1485,7 +1492,7 @@ fn delete_single_branch(
         && let Some(store) =
             crate::core::worktree::identity_store::IdentityStore::open(&ctx.git_dir)
     {
-        store.forget_branch(&branch.name);
+        store.forget(identity_id.as_deref(), &branch.name);
     }
 
     result

--- a/src/core/worktree/branch_delete.rs
+++ b/src/core/worktree/branch_delete.rs
@@ -1481,6 +1481,12 @@ fn delete_single_branch(
     {
         seeds.delete_seeds_for_branch(&branch.name);
     }
+    if result.worktree_removed
+        && let Some(store) =
+            crate::core::worktree::identity_store::IdentityStore::open(&ctx.git_dir)
+    {
+        store.forget_branch(&branch.name);
+    }
 
     result
 }

--- a/src/core/worktree/checkout.rs
+++ b/src/core/worktree/checkout.rs
@@ -228,6 +228,11 @@ pub fn execute(
             existing_path.display()
         ));
         sink.on_step("Changing to existing worktree...");
+        // Observed attached to this branch — refresh the record opportunistically,
+        // which is also how worktrees daft did not create acquire one.
+        if let Some(store) = crate::core::worktree::identity_store::IdentityStore::open(&git_dir) {
+            store.record(&existing_path, &params.branch_name);
+        }
         change_directory(&existing_path)?;
 
         return Ok(CheckoutResult {
@@ -614,6 +619,12 @@ pub fn execute(
             worktree_path.display()
         )
         .into());
+    }
+    // Remember what this worktree is for, while we still know. Git records
+    // nothing that survives a later detached checkout, so this is the only
+    // moment the association is available for free. Best-effort.
+    if let Some(store) = crate::core::worktree::identity_store::IdentityStore::open(&git_dir) {
+        store.record(&worktree_path, &params.branch_name);
     }
     sink.on_stage(
         &StepKey::new(StageId::CreateWorktree),

--- a/src/core/worktree/checkout.rs
+++ b/src/core/worktree/checkout.rs
@@ -228,10 +228,13 @@ pub fn execute(
             existing_path.display()
         ));
         sink.on_step("Changing to existing worktree...");
-        // Observed attached to this branch — refresh the record opportunistically,
-        // which is also how worktrees daft did not create acquire one.
+        // Observed attached to this branch — an observation, not a
+        // redefinition: refresh the record's path/timestamp (and give
+        // worktrees daft did not create one), but never rewrite a recorded
+        // branch. Navigating into a drifted worktree would otherwise erase
+        // the drift before doctor could ever report it.
         if let Some(store) = crate::core::worktree::identity_store::IdentityStore::open(&git_dir) {
-            store.record(&existing_path, &params.branch_name);
+            store.observe_all([(existing_path.as_path(), params.branch_name.as_str())]);
         }
         change_directory(&existing_path)?;
 
@@ -1827,6 +1830,70 @@ mod timeline_tests {
                 && matches!(e, StageEvent::Note(n) if n == "\u{2190} PR #6")),
             "the CheckOut row notes the head-ref provenance: {:?}",
             sink.events
+        );
+    }
+
+    /// Navigating into an already-existing worktree is an observation, not a
+    /// redefinition of what the worktree is for: it must never rewrite the
+    /// recorded branch. Regression: this arm called record() (an upsert), so
+    /// `daft go <live-branch>` silently erased the very drift `daft list`
+    /// had just flagged and doctor --fix exists to resolve deliberately.
+    #[test]
+    #[serial]
+    fn navigating_to_an_existing_worktree_preserves_recorded_intent() {
+        // `execute` records the worktree's identity — without this, the
+        // write lands in the developer's real state dir (#697).
+        let _state = crate::store::paths::IsolatedStateDir::new();
+        let _cwd = CwdGuard::new();
+        let tmp = tempfile::tempdir().unwrap();
+        git(tmp.path(), &["init", "-q", "-b", "main"]);
+        git(tmp.path(), &["commit", "--allow-empty", "-q", "-m", "init"]);
+        git(tmp.path(), &["branch", "feat-x"]);
+        std::env::set_current_dir(tmp.path()).unwrap();
+
+        // Create the worktree through daft: intent recorded as feat-x.
+        let wt = tmp.path().join("feat-x-wt");
+        let git_cmd = GitCommand::new(true);
+        let mut sink = RecordingStageSink::default();
+        execute(
+            &params("feat-x", wt.clone(), false),
+            &git_cmd,
+            tmp.path(),
+            &mut sink,
+        )
+        .expect("creation succeeds");
+        let common = tmp.path().join(".git");
+        let records = crate::core::worktree::identity_store::read_identities(&common);
+        assert_eq!(records["feat-x-wt"].branch, "feat-x");
+
+        // Someone checks a different branch out into it. The record now
+        // (correctly) disagrees: that is drift, and daft list reports it.
+        git(&wt, &["checkout", "-q", "-b", "feat-y"]);
+
+        // `daft go feat-y` matches the worktree on its attached branch and
+        // navigates. The record must survive as feat-x.
+        let mut sink = RecordingStageSink::default();
+        let result = execute(
+            &params("feat-y", wt.clone(), false),
+            &git_cmd,
+            tmp.path(),
+            &mut sink,
+        )
+        .expect("navigation succeeds");
+        assert!(result.already_existed, "this is the navigation arm");
+        let records = crate::core::worktree::identity_store::read_identities(&common);
+        assert_eq!(
+            records["feat-x-wt"].branch, "feat-x",
+            "navigation must not redefine recorded intent — drift stays until doctor --fix"
+        );
+        // Canonicalize both sides: the nav arm records git's canonical path
+        // (`/private/var/...` on macOS), the fixture holds the symlinked one.
+        assert_eq!(
+            PathBuf::from(&records["feat-x-wt"].worktree_path)
+                .canonicalize()
+                .unwrap(),
+            wt.canonicalize().unwrap(),
+            "the observation still refreshes the path"
         );
     }
 }

--- a/src/core/worktree/checkout.rs
+++ b/src/core/worktree/checkout.rs
@@ -1117,6 +1117,9 @@ mod timeline_tests {
     #[test]
     #[serial]
     fn fetch_off_plans_no_fetch_row_and_resolves_the_annotation_up_front() {
+        // `execute` records the worktree's identity — without this, the
+        // write lands in the developer's real state dir (#697).
+        let _state = crate::store::paths::IsolatedStateDir::new();
         let _cwd = CwdGuard::new();
         let tmp = tempfile::tempdir().unwrap();
         git(tmp.path(), &["init", "-q", "-b", "main"]);
@@ -1170,6 +1173,9 @@ mod timeline_tests {
     #[test]
     #[serial]
     fn fetch_off_unknown_branch_errors_before_any_plan() {
+        // `execute` records the worktree's identity — without this, the
+        // write lands in the developer's real state dir (#697).
+        let _state = crate::store::paths::IsolatedStateDir::new();
         let _cwd = CwdGuard::new();
         let tmp = tempfile::tempdir().unwrap();
         git(tmp.path(), &["init", "-q", "-b", "main"]);
@@ -1196,6 +1202,9 @@ mod timeline_tests {
     #[test]
     #[serial]
     fn fetch_on_plans_the_fetch_row_and_notes_the_annotation() {
+        // `execute` records the worktree's identity — without this, the
+        // write lands in the developer's real state dir (#697).
+        let _state = crate::store::paths::IsolatedStateDir::new();
         let _cwd = CwdGuard::new();
         let tmp = tempfile::tempdir().unwrap();
         let origin = tmp.path().join("origin");
@@ -1275,6 +1284,9 @@ mod timeline_tests {
     #[test]
     #[serial]
     fn fetch_on_unknown_branch_errors_after_the_committed_plan() {
+        // `execute` records the worktree's identity — without this, the
+        // write lands in the developer's real state dir (#697).
+        let _state = crate::store::paths::IsolatedStateDir::new();
         let _cwd = CwdGuard::new();
         let tmp = tempfile::tempdir().unwrap();
         let origin = tmp.path().join("origin");
@@ -1309,6 +1321,9 @@ mod timeline_tests {
     #[test]
     #[serial]
     fn deferred_unknown_branch_commits_no_plan() {
+        // `execute` records the worktree's identity — without this, the
+        // write lands in the developer's real state dir (#697).
+        let _state = crate::store::paths::IsolatedStateDir::new();
         let _cwd = CwdGuard::new();
         let tmp = tempfile::tempdir().unwrap();
         let origin = tmp.path().join("origin");
@@ -1340,6 +1355,9 @@ mod timeline_tests {
     #[test]
     #[serial]
     fn deferred_fetch_leads_the_plan_pre_completed() {
+        // `execute` records the worktree's identity — without this, the
+        // write lands in the developer's real state dir (#697).
+        let _state = crate::store::paths::IsolatedStateDir::new();
         let _cwd = CwdGuard::new();
         let tmp = tempfile::tempdir().unwrap();
         let origin = tmp.path().join("origin");
@@ -1429,6 +1447,9 @@ mod timeline_tests {
     #[test]
     #[serial]
     fn same_repo_forge_leads_plan_with_resolve_receipt() {
+        // `execute` records the worktree's identity — without this, the
+        // write lands in the developer's real state dir (#697).
+        let _state = crate::store::paths::IsolatedStateDir::new();
         let _cwd = CwdGuard::new();
         let tmp = tempfile::tempdir().unwrap();
         let origin = tmp.path().join("origin");
@@ -1500,6 +1521,9 @@ mod timeline_tests {
     #[test]
     #[serial]
     fn fork_forge_creates_branch_from_pull_ref_and_configures_tracking() {
+        // `execute` records the worktree's identity — without this, the
+        // write lands in the developer's real state dir (#697).
+        let _state = crate::store::paths::IsolatedStateDir::new();
         let _cwd = CwdGuard::new();
         let tmp = tempfile::tempdir().unwrap();
         let origin = tmp.path().join("origin");
@@ -1578,6 +1602,9 @@ mod timeline_tests {
     #[test]
     #[serial]
     fn forge_state_note_warns_but_proceeds() {
+        // `execute` records the worktree's identity — without this, the
+        // write lands in the developer's real state dir (#697).
+        let _state = crate::store::paths::IsolatedStateDir::new();
         let _cwd = CwdGuard::new();
         let tmp = tempfile::tempdir().unwrap();
         let origin = tmp.path().join("origin");
@@ -1622,6 +1649,9 @@ mod timeline_tests {
     #[test]
     #[serial]
     fn fork_forge_missing_pull_ref_aborts_after_plan() {
+        // `execute` records the worktree's identity — without this, the
+        // write lands in the developer's real state dir (#697).
+        let _state = crate::store::paths::IsolatedStateDir::new();
         let _cwd = CwdGuard::new();
         let tmp = tempfile::tempdir().unwrap();
         let origin = tmp.path().join("origin");
@@ -1670,6 +1700,9 @@ mod timeline_tests {
     #[test]
     #[serial]
     fn same_repo_forge_uses_the_base_remote_not_the_settings_default() {
+        // `execute` records the worktree's identity — without this, the
+        // write lands in the developer's real state dir (#697).
+        let _state = crate::store::paths::IsolatedStateDir::new();
         let _cwd = CwdGuard::new();
         let tmp = tempfile::tempdir().unwrap();
         let origin = tmp.path().join("origin");
@@ -1733,6 +1766,9 @@ mod timeline_tests {
     #[test]
     #[serial]
     fn same_repo_forge_falls_back_to_the_head_ref_when_the_branch_is_gone() {
+        // `execute` records the worktree's identity — without this, the
+        // write lands in the developer's real state dir (#697).
+        let _state = crate::store::paths::IsolatedStateDir::new();
         let _cwd = CwdGuard::new();
         let tmp = tempfile::tempdir().unwrap();
         let origin = tmp.path().join("origin");

--- a/src/core/worktree/checkout_branch.rs
+++ b/src/core/worktree/checkout_branch.rs
@@ -240,6 +240,10 @@ pub fn execute(
         restore_stash_on_failure(stash_created, carry_source.as_deref(), git, sink);
         anyhow::bail!("Failed to create git worktree: {}", e);
     }
+    // Remember what this worktree is for (see checkout.rs). Best-effort.
+    if let Some(store) = crate::core::worktree::identity_store::IdentityStore::open(&git_dir) {
+        store.record(&worktree_path, &params.new_branch_name);
+    }
     sink.on_stage(
         &StepKey::new(StageId::CreateBranch),
         StageEvent::Completed { annotation: None },

--- a/src/core/worktree/checkout_branch.rs
+++ b/src/core/worktree/checkout_branch.rs
@@ -1306,6 +1306,9 @@ mod timeline_tests {
     #[test]
     #[serial]
     fn plan_commits_with_locked_row_set_and_push_skip() {
+        // `execute` records the worktree's identity — without this, the
+        // write lands in the developer's real state dir (#697).
+        let _state = crate::store::paths::IsolatedStateDir::new();
         let _cwd = CwdGuard::new();
         let tmp = tempfile::tempdir().unwrap();
         git(tmp.path(), &["init", "-q", "-b", "main"]);
@@ -1397,6 +1400,9 @@ mod timeline_tests {
     #[test]
     #[serial]
     fn fetch_rows_planned_first_and_resolved_base_noted_on_branch_row() {
+        // `execute` records the worktree's identity — without this, the
+        // write lands in the developer's real state dir (#697).
+        let _state = crate::store::paths::IsolatedStateDir::new();
         let _cwd = CwdGuard::new();
         let tmp = tempfile::tempdir().unwrap();
         git(tmp.path(), &["init", "-q", "-b", "main"]);
@@ -1491,6 +1497,9 @@ mod timeline_tests {
     #[test]
     #[serial]
     fn plan_shared_section_rows_resolve_by_outcome() {
+        // `execute` records the worktree's identity — without this, the
+        // write lands in the developer's real state dir (#697).
+        let _state = crate::store::paths::IsolatedStateDir::new();
         let _cwd = CwdGuard::new();
         let tmp = tempfile::tempdir().unwrap();
         git(tmp.path(), &["init", "-q", "-b", "main"]);

--- a/src/core/worktree/checkout_branch.rs
+++ b/src/core/worktree/checkout_branch.rs
@@ -628,6 +628,21 @@ fn stash_if_carry(
     };
 
     let carry_path = carry_source.as_ref().unwrap();
+    // Never stash a worktree paused mid-operation. `git stash push` on a
+    // half-done rebase can even succeed — reverting a resolved conflict back
+    // to the upstream content — after which `git rebase --continue` sees an
+    // empty patch and silently drops the commit from the branch. The lookup
+    // above can resolve such a worktree precisely because it recovers
+    // mid-operation identity (op_state), and the current-worktree arm can be
+    // sitting in one too.
+    if let Some(op) = crate::git::op_state::probe_op_state(carry_path) {
+        sink.on_step(&format!(
+            "Skipping carry: worktree at '{}' is {}",
+            carry_path.display(),
+            op.kind.label()
+        ));
+        return Ok((false, None));
+    }
     change_directory(carry_path)?;
 
     match git.has_uncommitted_changes() {
@@ -1586,6 +1601,87 @@ mod timeline_tests {
         assert!(
             worktree_path.join(".env").is_symlink(),
             "the link really happened"
+        );
+    }
+
+    /// A worktree paused mid-operation must never be a carry source: `git
+    /// stash push` on a half-done rebase can *succeed* — emptying a resolved
+    /// conflict back to the upstream content — after which `git rebase
+    /// --continue` sees an empty patch and silently drops the commit from
+    /// the branch. The base worktree here is detached, as it is for a
+    /// rebase's whole duration, so it is resolved through the
+    /// recovered-identity tier — exactly the lookup that makes it findable
+    /// as a carry source at all.
+    #[test]
+    #[serial]
+    fn carry_skips_a_base_worktree_paused_mid_rebase() {
+        // `execute` records the worktree's identity — without this, the
+        // write lands in the developer's real state dir (#697).
+        let _state = crate::store::paths::IsolatedStateDir::new();
+        let _cwd = CwdGuard::new();
+        let tmp = tempfile::tempdir().unwrap();
+        git(tmp.path(), &["init", "-q", "-b", "main"]);
+        std::fs::write(tmp.path().join("f.txt"), "base\n").unwrap();
+        git(tmp.path(), &["add", "f.txt"]);
+        git(tmp.path(), &["commit", "-q", "-m", "init"]);
+        git(tmp.path(), &["branch", "feat"]);
+        let feat_wt = tmp.path().join("feat-wt");
+        git(
+            tmp.path(),
+            &["worktree", "add", "-q", feat_wt.to_str().unwrap(), "feat"],
+        );
+        // Mid-rebase shape: HEAD detached (git's posture for the whole
+        // operation) plus the state files the stat-only probe reads.
+        git(&feat_wt, &["checkout", "-q", "--detach"]);
+        let private = crate::git::op_state::resolve_worktree_git_dir(&feat_wt).unwrap();
+        std::fs::create_dir_all(private.join("rebase-merge")).unwrap();
+        std::fs::write(private.join("rebase-merge/head-name"), "refs/heads/feat\n").unwrap();
+        // The "conflict resolved, staged, awaiting --continue" content that
+        // an unguarded carry would stash away.
+        std::fs::write(feat_wt.join("f.txt"), "resolved\n").unwrap();
+        std::env::set_current_dir(tmp.path()).unwrap();
+
+        let new_wt = tmp.path().join("new-wt");
+        let params = CheckoutBranchParams {
+            new_branch_name: "feat-next".to_string(),
+            base_branch_name: Some("feat".to_string()),
+            carry: true,
+            no_carry: false,
+            remote: None,
+            remote_name: "origin".to_string(),
+            multi_remote_enabled: false,
+            multi_remote_default: "origin".to_string(),
+            checkout_branch_carry: false,
+            checkout_push: false,
+            no_verify: false,
+            push_verify: PushVerify::Auto,
+            checkout_fetch: false,
+            layout: None,
+            at_path: Some(new_wt.clone()),
+        };
+        let git_cmd = GitCommand::new(true);
+        let mut sink = RecordingStageSink::default();
+        execute(&params, &git_cmd, tmp.path(), None, &mut sink)
+            .expect("checkout-branch succeeds with carry skipped");
+
+        assert!(new_wt.exists(), "the new worktree is still created");
+        assert_eq!(
+            std::fs::read_to_string(feat_wt.join("f.txt")).unwrap(),
+            "resolved\n",
+            "the paused worktree's resolved content must not be stashed away"
+        );
+        let stashes = crate::utils::git_command_at(&feat_wt)
+            .args(["stash", "list"])
+            .output()
+            .unwrap();
+        assert_eq!(
+            String::from_utf8_lossy(&stashes.stdout).trim(),
+            "",
+            "no stash was created"
+        );
+        assert!(
+            private.join("rebase-merge").is_dir(),
+            "the rebase state is untouched"
         );
     }
 }

--- a/src/core/worktree/clone.rs
+++ b/src/core/worktree/clone.rs
@@ -223,12 +223,13 @@ fn record_clone_identities(git: &GitCommand, git_dir: &Path) {
         return;
     };
     let entries = crate::core::worktree::porcelain::parse_worktree_list_porcelain(&porcelain);
-    store.record_all(
-        entries
-            .iter()
-            .filter(|e| !e.is_bare)
-            .filter_map(|e| Some((e.path.as_path(), e.branch.as_deref()?))),
-    );
+    // Creation, not observation: a clone defines what each worktree is for,
+    // so these are deliberate writes.
+    for entry in entries.iter().filter(|e| !e.is_bare) {
+        if let Some(branch) = entry.branch.as_deref() {
+            store.record(&entry.path, branch);
+        }
+    }
 }
 
 fn create_single_worktree(

--- a/src/core/worktree/clone.rs
+++ b/src/core/worktree/clone.rs
@@ -209,6 +209,28 @@ fn detect_branches(
     }
 }
 
+/// Record the intended branch of every worktree a clone just created.
+///
+/// Enumerates rather than threading the store through each creation helper:
+/// the worktrees are all attached at this point, so one enumeration observes
+/// exactly what needs recording. Best-effort — a clone must never fail
+/// because a display nicety could not be persisted.
+fn record_clone_identities(git: &GitCommand, git_dir: &Path) {
+    let Some(store) = crate::core::worktree::identity_store::IdentityStore::open(git_dir) else {
+        return;
+    };
+    let Ok(porcelain) = git.worktree_list_porcelain() else {
+        return;
+    };
+    let entries = crate::core::worktree::porcelain::parse_worktree_list_porcelain(&porcelain);
+    store.record_all(
+        entries
+            .iter()
+            .filter(|e| !e.is_bare)
+            .filter_map(|e| Some((e.path.as_path(), e.branch.as_deref()?))),
+    );
+}
+
 fn create_single_worktree(
     git: &GitCommand,
     branch: &str,
@@ -362,6 +384,12 @@ pub fn setup_bare_worktrees(
                 progress,
             )?;
         }
+
+        // Record what every freshly-created worktree is for, in one pass now
+        // that they all exist — clone builds them through several helpers
+        // (single / orphan / all-branches), and they are attached at this
+        // point, which is the only state safe to record from. Best-effort.
+        record_clone_identities(&git, &bare_result.git_dir);
 
         progress.on_step(&format!(
             "Changing directory to worktree: './{}'",

--- a/src/core/worktree/identity.rs
+++ b/src/core/worktree/identity.rs
@@ -30,7 +30,8 @@
 
 use super::porcelain::WorktreeListEntry;
 use crate::git::op_state::{OpKind, probe_op_state};
-use std::collections::HashSet;
+use crate::store::models::WorktreeIdentityRow;
+use std::collections::{HashMap, HashSet};
 
 /// The name shown when nothing can name the branch.
 pub const DETACHED_LABEL: &str = "(detached)";
@@ -42,6 +43,10 @@ pub enum IdentitySource {
     Attached,
     /// HEAD is detached; an in-progress operation records the branch.
     Recovered,
+    /// HEAD is detached with nothing to explain it, but daft recorded what
+    /// this worktree is for. The only tier that can be out of date, which is
+    /// why it ranks last.
+    Persisted,
     /// Nothing names a branch.
     None,
 }
@@ -52,6 +57,7 @@ impl IdentitySource {
         match self {
             Self::Attached => "attached",
             Self::Recovered => "recovered",
+            Self::Persisted => "persisted",
             Self::None => "none",
         }
     }
@@ -75,7 +81,16 @@ pub struct WorktreeIdentity {
     /// tag or SHA. Narrower than "detached": a worktree mid-operation is not
     /// a sandbox, which is what keeps it out of the dimmed, filtered-away
     /// class it used to fall into the moment a rebase started.
+    ///
+    /// A worktree whose name came from the persisted record is still a
+    /// sandbox: the record names it, but nothing *explains the detachment*,
+    /// which is what this flag is about.
     pub is_sandbox: bool,
+    /// The recorded branch disagrees with the branch actually checked out.
+    /// Someone checked out a different branch into this worktree, or renamed
+    /// one outside `daft rename`. Derived state still wins the name — this
+    /// only surfaces that the record has fallen behind.
+    pub drifted: bool,
 }
 
 impl WorktreeIdentity {
@@ -90,15 +105,31 @@ impl WorktreeIdentity {
             // sandbox — it is mid-flight.
             is_sandbox: op.is_none(),
             op,
+            drifted: false,
         }
     }
 }
 
-/// Resolve identity and operation state for each porcelain entry.
+/// Resolve identity and operation state for each porcelain entry, consulting
+/// only live git state.
 ///
 /// Bare entries yield `None` so callers can `zip` the result with their entry
 /// list positionally without filtering first.
 pub fn resolve_identities(entries: &[WorktreeListEntry]) -> Vec<Option<WorktreeIdentity>> {
+    resolve_identities_with(entries, &HashMap::new())
+}
+
+/// [`resolve_identities`], plus the persisted records as a last-resort tier
+/// and a cross-check for drift.
+///
+/// `records` is keyed by private-gitdir id (see
+/// [`super::identity_store::read_identities`]). It is consulted only where
+/// live git state has said nothing, and it never overrides an operation: the
+/// record can be stale, an in-progress rebase cannot.
+pub fn resolve_identities_with(
+    entries: &[WorktreeListEntry],
+    records: &HashMap<String, WorktreeIdentityRow>,
+) -> Vec<Option<WorktreeIdentity>> {
     // Pass 1: every attached worktree claims its branch name, before any
     // recovery runs. Recovery then cannot hand a name to a second row and
     // produce two rows claiming one branch — which would break everything
@@ -118,6 +149,10 @@ pub fn resolve_identities(entries: &[WorktreeListEntry]) -> Vec<Option<WorktreeI
             }
 
             if let Some(branch) = &entry.branch {
+                // Cross-check, never an override: a record that disagrees
+                // with a live checkout is the thing that is wrong.
+                let drifted = recorded_branch(records, &entry.path)
+                    .is_some_and(|recorded| recorded != *branch);
                 return Some(WorktreeIdentity {
                     name: branch.clone(),
                     branch: Some(branch.clone()),
@@ -126,11 +161,34 @@ pub fn resolve_identities(entries: &[WorktreeListEntry]) -> Vec<Option<WorktreeI
                     // attached worktree can still be mid-operation.
                     op: probe_op_state(&entry.path).map(|s| s.kind),
                     is_sandbox: false,
+                    drifted,
                 });
             }
 
             let Some(state) = probe_op_state(&entry.path) else {
-                return Some(WorktreeIdentity::unnamed(None));
+                // Nothing live explains this detachment. Fall back to what
+                // daft recorded the worktree was for — the row keeps its
+                // name and its branch-keyed cells, and stays a sandbox,
+                // because being *named* and being *explained* are different
+                // things.
+                return Some(match recorded_branch(records, &entry.path) {
+                    Some(branch) if !claimed.contains(branch.as_str()) => WorktreeIdentity {
+                        name: branch.clone(),
+                        branch: Some(branch),
+                        source: IdentitySource::Persisted,
+                        op: None,
+                        is_sandbox: true,
+                        drifted: false,
+                    },
+                    // A record naming a branch that is genuinely checked out
+                    // elsewhere is stale. Report the disagreement rather than
+                    // duplicating the name onto two rows.
+                    Some(_) => WorktreeIdentity {
+                        drifted: true,
+                        ..WorktreeIdentity::unnamed(None)
+                    },
+                    None => WorktreeIdentity::unnamed(None),
+                });
             };
 
             match state.branch {
@@ -143,11 +201,24 @@ pub fn resolve_identities(entries: &[WorktreeListEntry]) -> Vec<Option<WorktreeI
                     source: IdentitySource::Recovered,
                     op: Some(state.kind),
                     is_sandbox: false,
+                    drifted: false,
                 }),
                 _ => Some(WorktreeIdentity::unnamed(Some(state.kind))),
             }
         })
         .collect()
+}
+
+/// The branch daft recorded for the worktree at `path`, if any.
+fn recorded_branch(
+    records: &HashMap<String, WorktreeIdentityRow>,
+    path: &std::path::Path,
+) -> Option<String> {
+    if records.is_empty() {
+        return None;
+    }
+    let id = super::identity_store::worktree_id_for(path)?;
+    records.get(&id).map(|row| row.branch.clone())
 }
 
 #[cfg(test)]
@@ -315,5 +386,143 @@ mod tests {
         assert_eq!(ids.len(), 2);
         assert!(ids[0].is_none());
         assert_eq!(ids[1].as_ref().unwrap().name, "main");
+    }
+    // ── persisted records (fallback + drift) ────────────────────────────────
+
+    fn record(id: &str, branch: &str) -> (String, WorktreeIdentityRow) {
+        (
+            id.to_string(),
+            WorktreeIdentityRow {
+                repo_hash: "repo".into(),
+                worktree_id: id.into(),
+                branch: branch.into(),
+                worktree_path: String::from("/tmp/") + id,
+                updated_at: chrono::Utc::now(),
+            },
+        )
+    }
+
+    /// A linked worktree, so it has a private-gitdir id records can key on.
+    fn linked(root: &Path, id: &str) -> PathBuf {
+        let private = root.join("repo/.git/worktrees").join(id);
+        std::fs::create_dir_all(&private).unwrap();
+        let worktree = root.join(id);
+        std::fs::create_dir_all(&worktree).unwrap();
+        std::fs::write(
+            worktree.join(".git"),
+            String::from("gitdir: ") + private.to_str().unwrap() + "\n",
+        )
+        .unwrap();
+        worktree
+    }
+
+    /// The case the record exists for: detached with nothing to explain it.
+    #[test]
+    fn an_unexplained_detachment_falls_back_to_the_record() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wt = linked(tmp.path(), "wt-a");
+        let records = HashMap::from([record("wt-a", "feat/x")]);
+
+        let id = resolve_identities_with(&[entry(&wt, None)], &records)
+            .remove(0)
+            .unwrap();
+        assert_eq!(id.name, "feat/x");
+        assert_eq!(id.branch.as_deref(), Some("feat/x"));
+        assert_eq!(id.source, IdentitySource::Persisted);
+        assert!(
+            id.is_sandbox,
+            "the record names it, but nothing explains the detachment"
+        );
+        assert!(!id.drifted);
+    }
+
+    /// Live state always wins: an operation names the branch, so the record
+    /// is never consulted — even when it disagrees.
+    #[test]
+    fn an_operation_outranks_the_record() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wt = linked(tmp.path(), "wt-a");
+        // A linked worktree's state files live in its private gitdir, not
+        // under `<worktree>/.git` — which is a file here.
+        let head_name = tmp
+            .path()
+            .join("repo/.git/worktrees/wt-a/rebase-merge/head-name");
+        std::fs::create_dir_all(head_name.parent().unwrap()).unwrap();
+        std::fs::write(&head_name, "refs/heads/feat/live\n").unwrap();
+        let records = HashMap::from([record("wt-a", "feat/stale")]);
+
+        let id = resolve_identities_with(&[entry(&wt, None)], &records)
+            .remove(0)
+            .unwrap();
+        assert_eq!(id.name, "feat/live");
+        assert_eq!(id.source, IdentitySource::Recovered);
+    }
+
+    #[test]
+    fn an_attached_branch_outranks_the_record_and_flags_drift() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wt = linked(tmp.path(), "wt-a");
+        let records = HashMap::from([record("wt-a", "feat/recorded")]);
+
+        let id = resolve_identities_with(&[entry(&wt, Some("hotfix/urgent"))], &records)
+            .remove(0)
+            .unwrap();
+        assert_eq!(id.name, "hotfix/urgent", "the live checkout wins the name");
+        assert_eq!(id.source, IdentitySource::Attached);
+        assert!(id.drifted, "the record disagrees and should say so");
+    }
+
+    #[test]
+    fn a_record_that_agrees_is_not_drift() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wt = linked(tmp.path(), "wt-a");
+        let records = HashMap::from([record("wt-a", "feat/x")]);
+
+        let id = resolve_identities_with(&[entry(&wt, Some("feat/x"))], &records)
+            .remove(0)
+            .unwrap();
+        assert!(!id.drifted);
+    }
+
+    /// The collision the guard exists for, and the only way to actually
+    /// construct it: a stale record naming a branch that is genuinely checked
+    /// out somewhere else. Two rows must never claim one name — everything
+    /// downstream keys rows by name.
+    #[test]
+    fn a_stale_record_cannot_duplicate_a_live_checkout() {
+        let tmp = tempfile::tempdir().unwrap();
+        let detached = linked(tmp.path(), "wt-a");
+        let attached = linked(tmp.path(), "wt-b");
+        let records = HashMap::from([record("wt-a", "feat/x")]);
+
+        let ids = resolve_identities_with(
+            &[entry(&detached, None), entry(&attached, Some("feat/x"))],
+            &records,
+        );
+
+        let stale = ids[0].as_ref().unwrap();
+        assert_eq!(
+            stale.name, DETACHED_LABEL,
+            "the real checkout owns the name"
+        );
+        assert_eq!(stale.source, IdentitySource::None);
+        assert!(stale.drifted, "the disagreement is still worth surfacing");
+
+        assert_eq!(ids[1].as_ref().unwrap().name, "feat/x");
+        assert!(!ids[1].as_ref().unwrap().drifted);
+    }
+
+    #[test]
+    fn no_record_leaves_a_detached_worktree_exactly_as_before() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wt = linked(tmp.path(), "wt-a");
+
+        let id = resolve_identities_with(&[entry(&wt, None)], &HashMap::new())
+            .remove(0)
+            .unwrap();
+        assert_eq!(id.name, DETACHED_LABEL);
+        assert_eq!(id.source, IdentitySource::None);
+        assert!(id.is_sandbox);
+        assert!(!id.drifted);
     }
 }

--- a/src/core/worktree/identity.rs
+++ b/src/core/worktree/identity.rs
@@ -1,0 +1,319 @@
+//! Resolving what branch a worktree *is*, when git will not say.
+//!
+//! `git worktree list --porcelain` names a branch only while HEAD is attached.
+//! Git detaches HEAD for the entire duration of a rebase, so for as long as an
+//! interrupted rebase sits unresolved — often the exact moment someone runs
+//! `daft list` to get their bearings — the porcelain reports the worktree as
+//! detached and nothing else. Everything keyed on the branch name then goes
+//! blank: ahead/behind, owner, branch age, PR linkage; the row sorts out of
+//! place; and it gets classified as a throwaway sandbox.
+//!
+//! This module puts the name back, from evidence git keeps but does not print.
+//!
+//! # Resolution order
+//!
+//! 1. **Attached** — the porcelain names a branch. Always wins.
+//! 2. **Recovered** — HEAD is detached, but an in-progress operation records
+//!    the branch it is replaying ([`crate::git::op_state`]).
+//! 3. **None** — nothing names a branch: a genuine detached checkout.
+//!
+//! The ordering is the whole design. Live git state cannot be stale, so it
+//! outranks anything remembered; and every attached worktree claims its name
+//! before any recovery is attempted, so a recovered name can never displace a
+//! real checkout. (A persisted tier lands between 2 and 3 in a later commit;
+//! it is the only one that can be out of date, which is exactly why it ranks
+//! last.)
+//!
+//! An operation also *explains* a detachment even when it records no branch —
+//! `git am` writes no `head-name`. Such a worktree keeps `(detached)` as its
+//! name but is not a sandbox: something is happening in it.
+
+use super::porcelain::WorktreeListEntry;
+use crate::git::op_state::{OpKind, probe_op_state};
+use std::collections::HashSet;
+
+/// The name shown when nothing can name the branch.
+pub const DETACHED_LABEL: &str = "(detached)";
+
+/// Where a worktree's branch identity came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IdentitySource {
+    /// Git reports the branch as checked out.
+    Attached,
+    /// HEAD is detached; an in-progress operation records the branch.
+    Recovered,
+    /// Nothing names a branch.
+    None,
+}
+
+impl IdentitySource {
+    /// Stable machine-facing name, as emitted in structured output.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Attached => "attached",
+            Self::Recovered => "recovered",
+            Self::None => "none",
+        }
+    }
+}
+
+/// A worktree's resolved identity and operation state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorktreeIdentity {
+    /// Display name: the branch, or [`DETACHED_LABEL`].
+    pub name: String,
+    /// The resolved branch, when there is one. Everything branch-keyed
+    /// (ahead/behind, owner, age, upstream) should key on this rather than on
+    /// the porcelain's branch — mid-rebase `refs/heads/<branch>` still exists
+    /// and still points at the pre-rebase tip, so those queries stay valid.
+    pub branch: Option<String>,
+    pub source: IdentitySource,
+    /// The operation running in this worktree, if any. Present for attached
+    /// worktrees too: a merge and a cherry-pick never detach HEAD.
+    pub op: Option<OpKind>,
+    /// HEAD is detached and nothing explains why — a scratch checkout of a
+    /// tag or SHA. Narrower than "detached": a worktree mid-operation is not
+    /// a sandbox, which is what keeps it out of the dimmed, filtered-away
+    /// class it used to fall into the moment a rebase started.
+    pub is_sandbox: bool,
+}
+
+impl WorktreeIdentity {
+    /// The identity of a worktree nothing can name.
+    fn unnamed(op: Option<OpKind>) -> Self {
+        Self {
+            name: DETACHED_LABEL.to_string(),
+            branch: None,
+            source: IdentitySource::None,
+            // An operation explains the detachment even when it names no
+            // branch (`git am` records none), so such a worktree is not a
+            // sandbox — it is mid-flight.
+            is_sandbox: op.is_none(),
+            op,
+        }
+    }
+}
+
+/// Resolve identity and operation state for each porcelain entry.
+///
+/// Bare entries yield `None` so callers can `zip` the result with their entry
+/// list positionally without filtering first.
+pub fn resolve_identities(entries: &[WorktreeListEntry]) -> Vec<Option<WorktreeIdentity>> {
+    // Pass 1: every attached worktree claims its branch name, before any
+    // recovery runs. Recovery then cannot hand a name to a second row and
+    // produce two rows claiming one branch — which would break everything
+    // keyed by row name downstream (live-table patch routing, the
+    // `--branches` dedup, the size cache's per-branch slug).
+    let claimed: HashSet<&str> = entries
+        .iter()
+        .filter(|e| !e.is_bare)
+        .filter_map(|e| e.branch.as_deref())
+        .collect();
+
+    entries
+        .iter()
+        .map(|entry| {
+            if entry.is_bare {
+                return None;
+            }
+
+            if let Some(branch) = &entry.branch {
+                return Some(WorktreeIdentity {
+                    name: branch.clone(),
+                    branch: Some(branch.clone()),
+                    source: IdentitySource::Attached,
+                    // A merge or cherry-pick keeps HEAD attached, so an
+                    // attached worktree can still be mid-operation.
+                    op: probe_op_state(&entry.path).map(|s| s.kind),
+                    is_sandbox: false,
+                });
+            }
+
+            let Some(state) = probe_op_state(&entry.path) else {
+                return Some(WorktreeIdentity::unnamed(None));
+            };
+
+            match state.branch {
+                // Recovered — unless an attached worktree already holds that
+                // name, in which case the record is the stale one and the
+                // real checkout wins.
+                Some(branch) if !claimed.contains(branch.as_str()) => Some(WorktreeIdentity {
+                    name: branch.clone(),
+                    branch: Some(branch),
+                    source: IdentitySource::Recovered,
+                    op: Some(state.kind),
+                    is_sandbox: false,
+                }),
+                _ => Some(WorktreeIdentity::unnamed(Some(state.kind))),
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::{Path, PathBuf};
+
+    /// A worktree directory whose `.git` is a real directory, so the probe
+    /// reads state files placed under it.
+    fn worktree(root: &Path, name: &str) -> PathBuf {
+        let path = root.join(name);
+        std::fs::create_dir_all(path.join(".git")).unwrap();
+        path
+    }
+
+    fn rebasing(path: &Path, head_name: Option<&str>) {
+        let dir = path.join(".git/rebase-merge");
+        std::fs::create_dir_all(&dir).unwrap();
+        if let Some(name) = head_name {
+            std::fs::write(dir.join("head-name"), format!("{name}\n")).unwrap();
+        }
+    }
+
+    fn entry(path: &Path, branch: Option<&str>) -> WorktreeListEntry {
+        WorktreeListEntry {
+            path: path.to_path_buf(),
+            branch: branch.map(str::to_string),
+            is_bare: false,
+            is_detached: branch.is_none(),
+        }
+    }
+
+    fn resolve_one(entry: WorktreeListEntry) -> WorktreeIdentity {
+        resolve_identities(&[entry]).remove(0).unwrap()
+    }
+
+    #[test]
+    fn attached_worktrees_keep_their_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wt = worktree(tmp.path(), "main");
+        let id = resolve_one(entry(&wt, Some("main")));
+
+        assert_eq!(id.name, "main");
+        assert_eq!(id.branch.as_deref(), Some("main"));
+        assert_eq!(id.source, IdentitySource::Attached);
+        assert!(!id.is_sandbox);
+        assert_eq!(id.op, None);
+    }
+
+    /// The bug this module exists for: mid-rebase the porcelain says nothing,
+    /// and the row used to become an anonymous sandbox.
+    #[test]
+    fn a_rebasing_worktree_keeps_its_identity_and_is_not_a_sandbox() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wt = worktree(tmp.path(), "feat");
+        rebasing(&wt, Some("refs/heads/feat/x"));
+
+        let id = resolve_one(entry(&wt, None));
+        assert_eq!(id.name, "feat/x");
+        assert_eq!(id.branch.as_deref(), Some("feat/x"));
+        assert_eq!(id.source, IdentitySource::Recovered);
+        assert_eq!(id.op, Some(OpKind::Rebase));
+        assert!(
+            !id.is_sandbox,
+            "an operation explains the detachment — this is not a scratch checkout"
+        );
+    }
+
+    /// An operation with no recorded branch still explains the detachment.
+    #[test]
+    fn an_operation_without_a_branch_is_still_not_a_sandbox() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wt = worktree(tmp.path(), "amming");
+        let dir = wt.join(".git/rebase-apply");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("applying"), "").unwrap();
+
+        let id = resolve_one(entry(&wt, None));
+        assert_eq!(id.name, DETACHED_LABEL);
+        assert_eq!(id.branch, None);
+        assert_eq!(id.op, Some(OpKind::Am));
+        assert!(!id.is_sandbox);
+    }
+
+    #[test]
+    fn a_plain_detached_checkout_is_still_a_sandbox() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wt = worktree(tmp.path(), "scratch");
+
+        let id = resolve_one(entry(&wt, None));
+        assert_eq!(id.name, DETACHED_LABEL);
+        assert_eq!(id.source, IdentitySource::None);
+        assert_eq!(id.op, None);
+        assert!(id.is_sandbox, "nothing explains this detachment");
+    }
+
+    /// A merge keeps HEAD attached, so identity comes from the porcelain and
+    /// the operation rides along.
+    #[test]
+    fn an_attached_worktree_can_still_be_mid_operation() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wt = worktree(tmp.path(), "main");
+        std::fs::write(wt.join(".git/MERGE_HEAD"), "deadbeef\n").unwrap();
+
+        let id = resolve_one(entry(&wt, Some("main")));
+        assert_eq!(id.name, "main");
+        assert_eq!(id.source, IdentitySource::Attached);
+        assert_eq!(id.op, Some(OpKind::Merge));
+        assert!(!id.is_sandbox);
+    }
+
+    /// Attached checkouts claim their names before recovery runs, so a name
+    /// can never be claimed twice. Everything downstream that keys rows by
+    /// name depends on this.
+    #[test]
+    fn an_attached_checkout_outranks_a_recovered_claim_on_the_same_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        let attached = worktree(tmp.path(), "real");
+        let stale = worktree(tmp.path(), "stale");
+        // The detached worktree's operation claims a branch that is genuinely
+        // checked out elsewhere.
+        rebasing(&stale, Some("refs/heads/feat/x"));
+
+        let ids = resolve_identities(&[entry(&stale, None), entry(&attached, Some("feat/x"))]);
+
+        let recovered = ids[0].as_ref().unwrap();
+        assert_eq!(
+            recovered.name, DETACHED_LABEL,
+            "the real checkout owns the name; this row must not duplicate it"
+        );
+        assert_eq!(
+            recovered.op,
+            Some(OpKind::Rebase),
+            "the operation still shows"
+        );
+        assert!(!recovered.is_sandbox);
+
+        assert_eq!(ids[1].as_ref().unwrap().name, "feat/x");
+        assert_eq!(ids[1].as_ref().unwrap().source, IdentitySource::Attached);
+    }
+
+    #[test]
+    fn bare_entries_resolve_to_nothing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bare = WorktreeListEntry {
+            path: tmp.path().join(".git"),
+            branch: None,
+            is_bare: true,
+            is_detached: false,
+        };
+        assert_eq!(resolve_identities(&[bare]), vec![None]);
+    }
+
+    #[test]
+    fn results_line_up_positionally_with_the_entries() {
+        let tmp = tempfile::tempdir().unwrap();
+        let main = worktree(tmp.path(), "main");
+        let bare = WorktreeListEntry {
+            path: tmp.path().join(".git"),
+            branch: None,
+            is_bare: true,
+            is_detached: false,
+        };
+        let ids = resolve_identities(&[bare, entry(&main, Some("main"))]);
+        assert_eq!(ids.len(), 2);
+        assert!(ids[0].is_none());
+        assert_eq!(ids[1].as_ref().unwrap().name, "main");
+    }
+}

--- a/src/core/worktree/identity_store.rs
+++ b/src/core/worktree/identity_store.rs
@@ -130,9 +130,33 @@ impl IdentityStore {
         }
     }
 
-    /// Forget every record for `branch`. Called when a worktree is removed —
-    /// removal paths know the branch, not the private-gitdir id, because git
-    /// has usually unregistered the worktree by then.
+    /// Forget a removed worktree's record.
+    ///
+    /// `captured_id` is the private-gitdir id read via [`worktree_id_for`]
+    /// *before* the removal — records are keyed on it, so deleting by id
+    /// removes the record no matter what branch it names. That is what
+    /// removal wants: a drifted or externally-renamed worktree's record must
+    /// not outlive its worktree, and git reuses freed ids, so a leftover row
+    /// would paint spurious drift on the id's next tenant. When the
+    /// directory was already gone before the id could be read, fall back to
+    /// [`Self::forget_branch`].
+    pub fn forget(&self, captured_id: Option<&str>, branch: &str) {
+        let Some(id) = captured_id else {
+            self.forget_branch(branch);
+            return;
+        };
+        if let Err(e) =
+            self.write(|conn| WorktreeIdentitiesRepo::delete(conn, &self.repo_hash, id).map(|_| ()))
+        {
+            crate::log_debug!("could not forget worktree identity: {e}");
+        }
+    }
+
+    /// Forget every record naming `branch` — the fallback for removal paths
+    /// that could no longer read the private-gitdir id (the directory was
+    /// already gone). Over-broad (two records naming one branch both go) and
+    /// blind to drifted rows (the record names the intent, not the checkout),
+    /// which is why [`Self::forget`] prefers the id.
     pub fn forget_branch(&self, branch: &str) {
         if let Err(e) = self.write(|conn| {
             WorktreeIdentitiesRepo::delete_for_branch(conn, &self.repo_hash, branch).map(|_| ())
@@ -294,6 +318,66 @@ mod tests {
         store.record(&worktree, "feat/x");
 
         store.forget_branch("feat/x");
+        assert!(read_identities(&common).is_empty());
+    }
+
+    /// Removal deletes by the captured id, not the branch: a drifted record
+    /// does not match the live branch name the removal path knows, and a
+    /// second record legitimately naming the same branch must survive.
+    /// Regression: the by-branch sweep missed the drifted row (orphaning it
+    /// onto git's next reuse of the id) and deleted the innocent one.
+    #[test]
+    #[serial]
+    fn forget_prefers_the_captured_id_and_spares_same_branch_records() {
+        let _guard = crate::store::paths::IsolatedStateDir::new();
+        let (tmp, common, wt_a) = linked_worktree("wt-a");
+        let private_b = common.join("worktrees/wt-b");
+        std::fs::create_dir_all(&private_b).unwrap();
+        let wt_b = tmp.path().join("wt-b");
+        std::fs::create_dir_all(&wt_b).unwrap();
+        std::fs::write(
+            wt_b.join(".git"),
+            String::from("gitdir: ") + private_b.to_str().unwrap() + "\n",
+        )
+        .unwrap();
+        let store = IdentityStore::open(&common).unwrap();
+
+        // wt-a was created for feat/x but has drifted: the branch checked
+        // out (and being removed) is now `hotfix`. wt-b is feat/x's new home.
+        store.record(&wt_a, "feat/x");
+        store.record(&wt_b, "feat/x");
+
+        // The id is captured while the directory still exists…
+        let captured = worktree_id_for(&wt_a);
+        assert_eq!(captured.as_deref(), Some("wt-a"));
+        std::fs::remove_dir_all(&wt_a).unwrap();
+
+        // …so the drifted record dies with its worktree, by id, even though
+        // the removal path only knows the live branch name.
+        store.forget(captured.as_deref(), "hotfix");
+
+        let found = read_identities(&common);
+        assert!(
+            !found.contains_key("wt-a"),
+            "the removed worktree's record is gone"
+        );
+        assert_eq!(
+            found["wt-b"].branch, "feat/x",
+            "a same-branch record for another worktree survives"
+        );
+    }
+
+    /// When the directory was already gone before the id could be read, the
+    /// by-branch sweep is all that is left.
+    #[test]
+    #[serial]
+    fn forget_falls_back_to_the_branch_without_an_id() {
+        let _guard = crate::store::paths::IsolatedStateDir::new();
+        let (_tmp, common, worktree) = linked_worktree("wt-a");
+        let store = IdentityStore::open(&common).unwrap();
+        store.record(&worktree, "feat/x");
+
+        store.forget(None, "feat/x");
         assert!(read_identities(&common).is_empty());
     }
 

--- a/src/core/worktree/identity_store.rs
+++ b/src/core/worktree/identity_store.rs
@@ -1,0 +1,303 @@
+//! Remembering which branch a worktree was created for.
+//!
+//! Daft knows a worktree's intended branch at the moment it creates it, and
+//! every time it later observes the worktree with that branch attached. Git
+//! forgets as soon as HEAD detaches for a reason it does not record — a tag or
+//! SHA checkout. Recording the fact here is what lets `daft list` still name
+//! such a worktree instead of showing an anonymous `(detached)` row.
+//!
+//! **Derived state always wins.** These records are consulted only after live
+//! git state has nothing to say ([`super::identity`]), and cross-checked for
+//! drift. A record can be out of date; live state cannot.
+//!
+//! Everything here is **best-effort**, following the size cache
+//! ([`crate::commands::size_cache`]): identity is a display nicety, not
+//! correctness, so a missing store, a busy database or a schema from a newer
+//! build degrades to "no record" rather than failing a command. Reads never
+//! create the store; only writes do.
+
+use crate::store::models::WorktreeIdentityRow;
+use crate::store::repos::{WorktreeIdentitiesRepo, with_write_txn};
+use crate::store::{Pool, paths};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+/// The private-gitdir id for a worktree — the directory name under
+/// `<common-dir>/worktrees/`, which is what records are keyed on.
+///
+/// Stable across `git worktree move` and branch renames. The main worktree of
+/// a non-bare repo has no such directory (its git dir *is* the common dir), so
+/// it has no id and is never recorded — no loss, since a repo's main worktree
+/// is not something daft creates for a branch.
+pub fn worktree_id_for(worktree_path: &Path) -> Option<String> {
+    let git_dir = crate::git::op_state::resolve_worktree_git_dir(worktree_path).ok()?;
+    // Only linked worktrees live under `worktrees/<id>`.
+    if git_dir.parent()?.file_name()? != "worktrees" {
+        return None;
+    }
+    Some(git_dir.file_name()?.to_str()?.to_string())
+}
+
+/// Handle on one repo's identity records.
+///
+/// `None` from [`Self::open`] means "operate without records", never an error
+/// the caller has to handle.
+pub struct IdentityStore {
+    repo_hash: String,
+    db_path: PathBuf,
+}
+
+impl IdentityStore {
+    /// Open the identity records for the repo whose git common dir is
+    /// `git_common_dir`, for writing. Creates the store if absent.
+    pub fn open(git_common_dir: &Path) -> Option<Self> {
+        let repo_hash =
+            match crate::core::repo_identity::compute_repo_id_from_common_dir(git_common_dir) {
+                Ok(id) => id,
+                Err(e) => {
+                    crate::log_debug!("worktree identities unavailable (repo identity): {e:#}");
+                    return None;
+                }
+            };
+        let db_path = match paths::for_repo(&repo_hash) {
+            Ok(p) => p,
+            Err(e) => {
+                crate::log_debug!("worktree identities unavailable (store path): {e}");
+                return None;
+            }
+        };
+        Some(Self { repo_hash, db_path })
+    }
+
+    /// Record that `worktree_path` is for `branch`.
+    ///
+    /// Callers must only report worktrees they have observed *attached* to
+    /// that branch, or just created for it. Recording from a detached
+    /// observation would let a stale reading overwrite the good record it is
+    /// supposed to be the fallback for.
+    pub fn record(&self, worktree_path: &Path, branch: &str) {
+        let Some(worktree_id) = worktree_id_for(worktree_path) else {
+            return;
+        };
+        let row = WorktreeIdentityRow {
+            repo_hash: self.repo_hash.clone(),
+            worktree_id,
+            branch: branch.to_string(),
+            worktree_path: worktree_path.display().to_string(),
+            updated_at: chrono::Utc::now(),
+        };
+        if let Err(e) = self.write(|conn| WorktreeIdentitiesRepo::upsert(conn, &row)) {
+            crate::log_debug!("could not record worktree identity: {e}");
+        }
+    }
+
+    /// Record several observations in one transaction — the shape the list
+    /// and sync paths need, where every attached worktree is refreshed at
+    /// once.
+    pub fn record_all<'a>(&self, observations: impl IntoIterator<Item = (&'a Path, &'a str)>) {
+        let now = chrono::Utc::now();
+        let rows: Vec<WorktreeIdentityRow> = observations
+            .into_iter()
+            .filter_map(|(path, branch)| {
+                Some(WorktreeIdentityRow {
+                    repo_hash: self.repo_hash.clone(),
+                    worktree_id: worktree_id_for(path)?,
+                    branch: branch.to_string(),
+                    worktree_path: path.display().to_string(),
+                    updated_at: now,
+                })
+            })
+            .collect();
+        if rows.is_empty() {
+            return;
+        }
+        if let Err(e) = self.write(|conn| {
+            for row in &rows {
+                WorktreeIdentitiesRepo::upsert(conn, row)?;
+            }
+            Ok(())
+        }) {
+            crate::log_debug!("could not record worktree identities: {e}");
+        }
+    }
+
+    /// Forget every record for `branch`. Called when a worktree is removed —
+    /// removal paths know the branch, not the private-gitdir id, because git
+    /// has usually unregistered the worktree by then.
+    pub fn forget_branch(&self, branch: &str) {
+        if let Err(e) = self.write(|conn| {
+            WorktreeIdentitiesRepo::delete_for_branch(conn, &self.repo_hash, branch).map(|_| ())
+        }) {
+            crate::log_debug!("could not forget worktree identity: {e}");
+        }
+    }
+
+    fn write<T>(
+        &self,
+        f: impl FnOnce(&rusqlite::Transaction<'_>) -> crate::store::error::Result<T>,
+    ) -> crate::store::error::Result<T> {
+        let pool = Pool::open(&self.db_path)?;
+        let mut conn = pool.writer()?;
+        with_write_txn(&mut conn, f)
+    }
+}
+
+/// Every recorded identity for a repo, keyed by private-gitdir id.
+///
+/// A **pure read**: it does not create the store, so a repo that has never
+/// recorded anything (or a build that predates the table) yields an empty map
+/// rather than materializing a database from a read-only command.
+pub fn read_identities(git_common_dir: &Path) -> HashMap<String, WorktreeIdentityRow> {
+    read_inner(git_common_dir).unwrap_or_default()
+}
+
+fn read_inner(git_common_dir: &Path) -> Option<HashMap<String, WorktreeIdentityRow>> {
+    let repo_hash =
+        crate::core::repo_identity::compute_repo_id_from_common_dir(git_common_dir).ok()?;
+    let state_dir = crate::daft_state_dir().ok()?;
+    let db_path = state_dir
+        .join(paths::JOBS_SUBDIR)
+        .join(&repo_hash)
+        .join(paths::COORDINATOR_DB);
+    // Don't open (and thereby create) the store just to find it empty. The
+    // pool's read-write bootstrap is used rather than a bare read-only
+    // connection: a checkpointed coordinator.db with no -wal/-shm sidecar is
+    // SQLITE_CANTOPEN under SQLITE_OPEN_READ_ONLY (see size_cache).
+    if !db_path.exists() {
+        return None;
+    }
+    let pool = Pool::open(&db_path).ok()?;
+    let conn = pool.reader().ok()?;
+    let rows = WorktreeIdentitiesRepo::list_for_repo(&conn, &repo_hash).ok()?;
+    Some(
+        rows.into_iter()
+            .map(|row| (row.worktree_id.clone(), row))
+            .collect(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    /// Build a linked-worktree shape and return (tempdir, common dir, worktree).
+    fn linked_worktree(id: &str) -> (tempfile::TempDir, PathBuf, PathBuf) {
+        let tmp = tempfile::tempdir().unwrap();
+        let common = tmp.path().join("repo/.git");
+        let private = common.join("worktrees").join(id);
+        std::fs::create_dir_all(&private).unwrap();
+        let worktree = tmp.path().join(id);
+        std::fs::create_dir_all(&worktree).unwrap();
+        std::fs::write(
+            worktree.join(".git"),
+            String::from("gitdir: ") + private.to_str().unwrap() + "\n",
+        )
+        .unwrap();
+        (tmp, common, worktree)
+    }
+
+    #[test]
+    fn worktree_id_is_the_private_gitdir_name() {
+        let (_tmp, _common, worktree) = linked_worktree("wt-a");
+        assert_eq!(worktree_id_for(&worktree).as_deref(), Some("wt-a"));
+    }
+
+    /// A non-bare repo's main worktree has no `worktrees/<id>` entry, so it
+    /// has no id — and is never recorded.
+    #[test]
+    fn a_main_worktree_has_no_private_gitdir_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".git")).unwrap();
+        assert_eq!(worktree_id_for(tmp.path()), None);
+    }
+
+    #[test]
+    fn a_path_that_is_not_a_worktree_has_no_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert_eq!(worktree_id_for(tmp.path()), None);
+    }
+
+    #[test]
+    #[serial]
+    fn records_round_trip_through_the_store() {
+        let _guard = crate::store::paths::IsolatedStateDir::new();
+        let (_tmp, common, worktree) = linked_worktree("wt-a");
+
+        // A pure read on a repo that has recorded nothing must not create
+        // the store.
+        assert!(read_identities(&common).is_empty());
+
+        let store = IdentityStore::open(&common).expect("store opens");
+        store.record(&worktree, "feat/x");
+
+        let found = read_identities(&common);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found["wt-a"].branch, "feat/x");
+        assert_eq!(found["wt-a"].worktree_path, worktree.display().to_string());
+    }
+
+    #[test]
+    #[serial]
+    fn a_later_observation_replaces_the_earlier_one() {
+        let _guard = crate::store::paths::IsolatedStateDir::new();
+        let (_tmp, common, worktree) = linked_worktree("wt-a");
+        let store = IdentityStore::open(&common).unwrap();
+
+        store.record(&worktree, "feat/old");
+        store.record(&worktree, "feat/new");
+
+        let found = read_identities(&common);
+        assert_eq!(found.len(), 1, "the worktree has one identity, not two");
+        assert_eq!(found["wt-a"].branch, "feat/new");
+    }
+
+    #[test]
+    #[serial]
+    fn record_all_writes_every_observation() {
+        let _guard = crate::store::paths::IsolatedStateDir::new();
+        let (_tmp, common, wt_a) = linked_worktree("wt-a");
+        // A second worktree under the same common dir.
+        let private_b = common.join("worktrees/wt-b");
+        std::fs::create_dir_all(&private_b).unwrap();
+        let wt_b = common.parent().unwrap().parent().unwrap().join("wt-b");
+        std::fs::create_dir_all(&wt_b).unwrap();
+        std::fs::write(
+            wt_b.join(".git"),
+            String::from("gitdir: ") + private_b.to_str().unwrap() + "\n",
+        )
+        .unwrap();
+
+        let store = IdentityStore::open(&common).unwrap();
+        store.record_all([(wt_a.as_path(), "feat/a"), (wt_b.as_path(), "feat/b")]);
+
+        let found = read_identities(&common);
+        assert_eq!(found["wt-a"].branch, "feat/a");
+        assert_eq!(found["wt-b"].branch, "feat/b");
+    }
+
+    #[test]
+    #[serial]
+    fn forget_branch_removes_the_record() {
+        let _guard = crate::store::paths::IsolatedStateDir::new();
+        let (_tmp, common, worktree) = linked_worktree("wt-a");
+        let store = IdentityStore::open(&common).unwrap();
+        store.record(&worktree, "feat/x");
+
+        store.forget_branch("feat/x");
+        assert!(read_identities(&common).is_empty());
+    }
+
+    /// Paths with no private-gitdir id are silently skipped, not errors —
+    /// a main worktree or a vanished directory must not fail a command.
+    #[test]
+    #[serial]
+    fn unrecordable_paths_are_skipped_without_error() {
+        let _guard = crate::store::paths::IsolatedStateDir::new();
+        let (_tmp, common, _worktree) = linked_worktree("wt-a");
+        let store = IdentityStore::open(&common).unwrap();
+
+        store.record(Path::new("/nonexistent/worktree"), "feat/x");
+        assert!(read_identities(&common).is_empty());
+    }
+}

--- a/src/core/worktree/identity_store.rs
+++ b/src/core/worktree/identity_store.rs
@@ -120,7 +120,7 @@ impl IdentityStore {
         if rows.is_empty() {
             return;
         }
-        if let Err(e) = self.write(|conn| {
+        if let Err(e) = self.write_fail_fast(|conn| {
             for row in &rows {
                 WorktreeIdentitiesRepo::observe(conn, row)?;
             }
@@ -169,8 +169,37 @@ impl IdentityStore {
         &self,
         f: impl FnOnce(&rusqlite::Transaction<'_>) -> crate::store::error::Result<T>,
     ) -> crate::store::error::Result<T> {
+        self.write_inner(false, f)
+    }
+
+    /// Like [`Self::write`], but fail fast instead of waiting out the full
+    /// writer busy timeout. For writes on otherwise read-only interactive
+    /// paths (`daft list`'s observation pass): don't let a display-nicety
+    /// write block the prompt for 5s when a coordinator/sync process holds
+    /// the coordinator.db write lock — fail with SQLITE_BUSY (swallowed by
+    /// the caller) and let the next run observe instead. Same convention as
+    /// `size_cache::persist_inner` and the forge_cache writers (review 5).
+    /// Deliberate writes (record/forget) keep the patient default: they run
+    /// on mutating commands, where completing the write matters more.
+    fn write_fail_fast<T>(
+        &self,
+        f: impl FnOnce(&rusqlite::Transaction<'_>) -> crate::store::error::Result<T>,
+    ) -> crate::store::error::Result<T> {
+        self.write_inner(true, f)
+    }
+
+    fn write_inner<T>(
+        &self,
+        fail_fast: bool,
+        f: impl FnOnce(&rusqlite::Transaction<'_>) -> crate::store::error::Result<T>,
+    ) -> crate::store::error::Result<T> {
         let pool = Pool::open(&self.db_path)?;
         let mut conn = pool.writer()?;
+        if fail_fast {
+            conn.busy_timeout(std::time::Duration::from_millis(
+                crate::store::connection::READER_BUSY_TIMEOUT_MS as u64,
+            ))?;
+        }
         with_write_txn(&mut conn, f)
     }
 }

--- a/src/core/worktree/identity_store.rs
+++ b/src/core/worktree/identity_store.rs
@@ -69,12 +69,16 @@ impl IdentityStore {
         Some(Self { repo_hash, db_path })
     }
 
-    /// Record that `worktree_path` is for `branch`.
+    /// Record that `worktree_path` is for `branch` — a deliberate
+    /// (re)definition of intent.
     ///
-    /// Callers must only report worktrees they have observed *attached* to
-    /// that branch, or just created for it. Recording from a detached
-    /// observation would let a stale reading overwrite the good record it is
-    /// supposed to be the fallback for.
+    /// Reserved for the moments that *decide* what a worktree is for:
+    /// creation, `daft rename`, and `daft doctor --fix`. Merely seeing a
+    /// worktree attached to a branch is not one of them — that is an
+    /// observation and goes through [`Self::observe_all`], which never
+    /// rewrites the branch. Calling this from an observation path would
+    /// erase drift the moment a command touched the worktree, before doctor
+    /// could ever report it.
     pub fn record(&self, worktree_path: &Path, branch: &str) {
         let Some(worktree_id) = worktree_id_for(worktree_path) else {
             return;

--- a/src/core/worktree/identity_store.rs
+++ b/src/core/worktree/identity_store.rs
@@ -91,10 +91,15 @@ impl IdentityStore {
         }
     }
 
-    /// Record several observations in one transaction — the shape the list
-    /// and sync paths need, where every attached worktree is refreshed at
-    /// once.
-    pub fn record_all<'a>(&self, observations: impl IntoIterator<Item = (&'a Path, &'a str)>) {
+    /// Note several worktrees observed attached to their branches, in one
+    /// transaction — the shape the list paths need.
+    ///
+    /// Non-destructive: a worktree with no record gets one, and an existing
+    /// record has its path and timestamp refreshed but keeps its branch. An
+    /// observation is evidence of what is checked out *now*, which is not the
+    /// same claim as what the worktree is *for* — conflating them would let a
+    /// listing quietly redefine intent and erase drift before it was reported.
+    pub fn observe_all<'a>(&self, observations: impl IntoIterator<Item = (&'a Path, &'a str)>) {
         let now = chrono::Utc::now();
         let rows: Vec<WorktreeIdentityRow> = observations
             .into_iter()
@@ -113,7 +118,7 @@ impl IdentityStore {
         }
         if let Err(e) = self.write(|conn| {
             for row in &rows {
-                WorktreeIdentitiesRepo::upsert(conn, row)?;
+                WorktreeIdentitiesRepo::observe(conn, row)?;
             }
             Ok(())
         }) {
@@ -254,7 +259,7 @@ mod tests {
 
     #[test]
     #[serial]
-    fn record_all_writes_every_observation() {
+    fn observe_all_writes_every_observation() {
         let _guard = crate::store::paths::IsolatedStateDir::new();
         let (_tmp, common, wt_a) = linked_worktree("wt-a");
         // A second worktree under the same common dir.
@@ -269,7 +274,7 @@ mod tests {
         .unwrap();
 
         let store = IdentityStore::open(&common).unwrap();
-        store.record_all([(wt_a.as_path(), "feat/a"), (wt_b.as_path(), "feat/b")]);
+        store.observe_all([(wt_a.as_path(), "feat/a"), (wt_b.as_path(), "feat/b")]);
 
         let found = read_identities(&common);
         assert_eq!(found["wt-a"].branch, "feat/a");

--- a/src/core/worktree/list.rs
+++ b/src/core/worktree/list.rs
@@ -121,7 +121,16 @@ pub struct WorktreeInfo {
     /// Most recent mtime of changed/untracked files (None if clean or not computed).
     pub working_tree_mtime: Option<i64>,
     /// Whether this is a detached HEAD sandbox (no branch).
+    ///
+    /// Narrower than "HEAD is detached": a worktree paused mid-operation is
+    /// not a sandbox. See [`super::identity`].
     pub is_sandbox: bool,
+    /// The git operation paused in this worktree, if any. Present for
+    /// attached worktrees too — a merge never detaches HEAD.
+    pub op: Option<crate::git::op_state::OpKind>,
+    /// How this row's branch name was established. `None` for rows that are
+    /// not worktrees (their name comes straight from the ref).
+    pub identity_source: Option<super::identity::IdentitySource>,
     /// The PR/MR this branch tracks (from `branch.<name>.merge`), or `None`.
     /// Local config only — no network.
     pub forge_ref: Option<super::forge_ref::ForgeBranchRef>,
@@ -161,6 +170,8 @@ impl WorktreeInfo {
             size_bytes: None,
             working_tree_mtime: None,
             is_sandbox: false,
+            op: None,
+            identity_source: None,
             forge_ref: None,
         }
     }
@@ -197,6 +208,8 @@ impl WorktreeInfo {
             size_bytes: None,
             working_tree_mtime: None,
             is_sandbox: false,
+            op: None,
+            identity_source: None,
             forge_ref: None,
         }
     }
@@ -819,19 +832,22 @@ pub fn collect_worktree_info(
         .context("Failed to list worktrees")?;
 
     let entries = super::porcelain::parse_worktree_list_porcelain(&porcelain_output);
+    // Recover identity for worktrees git reports as detached because an
+    // operation is replaying commits in them, and note what that operation
+    // is. Bare entries resolve to `None` and are skipped.
+    let identities = super::identity::resolve_identities(&entries);
     let mut infos = Vec::new();
 
-    for entry in entries {
-        // Skip bare entries (the bare repo root)
-        if entry.is_bare {
+    for (entry, identity) in entries.into_iter().zip(identities) {
+        let Some(identity) = identity else {
             continue;
-        }
-
-        let branch_display = if entry.is_detached {
-            "(detached)".to_string()
-        } else {
-            entry.branch.clone().unwrap_or_default()
         };
+
+        let branch_display = identity.name.clone();
+        // Everything branch-keyed below reads the *resolved* branch, not the
+        // porcelain's: mid-rebase `refs/heads/<branch>` still exists and
+        // still points at the pre-rebase tip, so these queries stay valid.
+        let branch = identity.branch.clone();
 
         // Canonicalize for comparison (ignore errors, fall back to raw path)
         let canonical_entry = entry
@@ -841,17 +857,12 @@ pub fn collect_worktree_info(
         let is_current = current_worktree_path == Some(canonical_entry.as_path());
 
         // Ahead/behind relative to base branch
-        let (ahead, behind) = if !entry.is_detached {
-            if let Some(branch) = &entry.branch {
-                match get_ahead_behind(base_branch, branch, &entry.path) {
-                    Some((a, b)) => (Some(a), Some(b)),
-                    None => (None, None),
-                }
-            } else {
-                (None, None)
-            }
-        } else {
-            (None, None)
+        let (ahead, behind) = match branch
+            .as_deref()
+            .and_then(|b| get_ahead_behind(base_branch, b, &entry.path))
+        {
+            Some((a, b)) => (Some(a), Some(b)),
+            None => (None, None),
         };
 
         // Count staged, unstaged, untracked and conflicted files
@@ -864,62 +875,44 @@ pub fn collect_worktree_info(
         );
 
         // Ahead/behind relative to upstream tracking branch
-        let (remote_ahead, remote_behind) = if !entry.is_detached {
-            if let Some(branch) = &entry.branch {
-                match get_upstream_ahead_behind(branch, &entry.path) {
-                    Some((a, b)) => (Some(a), Some(b)),
-                    None => (None, None),
-                }
-            } else {
-                (None, None)
-            }
-        } else {
-            (None, None)
+        let (remote_ahead, remote_behind) = match branch
+            .as_deref()
+            .and_then(|b| get_upstream_ahead_behind(b, &entry.path))
+        {
+            Some((a, b)) => (Some(a), Some(b)),
+            None => (None, None),
         };
 
         // Last commit info
         let (last_commit_timestamp, last_commit_hash, last_commit_subject) =
             get_commit_metadata(&entry.path, git);
 
-        let owner = if !entry.is_detached {
+        let owner = branch.as_deref().and_then(|b| {
             ownership::resolve_owner_with_fallbacks(
                 base_branch,
-                &branch_display,
+                b,
                 &entry.path,
                 ownership_strategy,
                 user_email,
                 Some(remote_name),
             )
-        } else {
-            None
-        };
+        });
 
-        // Branch creation timestamp (only for non-detached worktrees)
-        let branch_creation_timestamp = if !entry.is_detached {
-            entry
-                .branch
-                .as_deref()
-                .and_then(|b| get_branch_creation_timestamp(b, &entry.path))
-        } else {
-            None
-        };
+        let branch_creation_timestamp = branch
+            .as_deref()
+            .and_then(|b| get_branch_creation_timestamp(b, &entry.path));
 
         // Whether this is the default (base) branch
-        let is_default_branch = entry.branch.as_deref().is_some_and(|b| b == base_branch);
+        let is_default_branch = branch.as_deref().is_some_and(|b| b == base_branch);
 
         // Line-level diff counts (only when stat is Lines)
-        let (base_lines_inserted, base_lines_deleted) = if stat == Stat::Lines && !entry.is_detached
+        let (base_lines_inserted, base_lines_deleted) = match (stat == Stat::Lines)
+            .then_some(branch.as_deref())
+            .flatten()
+            .and_then(|b| get_base_line_counts(base_branch, b, &entry.path))
         {
-            if let Some(branch) = &entry.branch {
-                match get_base_line_counts(base_branch, branch, &entry.path) {
-                    Some((ins, del)) => (Some(ins), Some(del)),
-                    None => (None, None),
-                }
-            } else {
-                (None, None)
-            }
-        } else {
-            (None, None)
+            Some((ins, del)) => (Some(ins), Some(del)),
+            None => (None, None),
         };
 
         let (
@@ -934,19 +927,14 @@ pub fn collect_worktree_info(
             (None, None, None, None)
         };
 
-        let (remote_lines_inserted, remote_lines_deleted) =
-            if stat == Stat::Lines && !entry.is_detached {
-                if let Some(branch) = &entry.branch {
-                    match get_remote_line_counts(branch, &entry.path) {
-                        Some((ins, del)) => (Some(ins), Some(del)),
-                        None => (None, None),
-                    }
-                } else {
-                    (None, None)
-                }
-            } else {
-                (None, None)
-            };
+        let (remote_lines_inserted, remote_lines_deleted) = match (stat == Stat::Lines)
+            .then_some(branch.as_deref())
+            .flatten()
+            .and_then(|b| get_remote_line_counts(b, &entry.path))
+        {
+            Some((ins, del)) => (Some(ins), Some(del)),
+            None => (None, None),
+        };
 
         let working_tree_mtime = if compute_mtime && !changed.paths.is_empty() {
             max_mtime_of_files(&entry.path, &changed.paths)
@@ -954,14 +942,10 @@ pub fn collect_worktree_info(
             None
         };
 
-        let forge_ref = if compute_forge_ref && !entry.is_detached {
-            entry
-                .branch
-                .as_deref()
-                .and_then(|b| get_forge_branch_ref(b, &entry.path))
-        } else {
-            None
-        };
+        let forge_ref = compute_forge_ref
+            .then_some(branch.as_deref())
+            .flatten()
+            .and_then(|b| get_forge_branch_ref(b, &entry.path));
 
         infos.push(WorktreeInfo {
             kind: EntryKind::Worktree,
@@ -992,7 +976,9 @@ pub fn collect_worktree_info(
             owner,
             size_bytes: None,
             working_tree_mtime,
-            is_sandbox: entry.is_detached,
+            is_sandbox: identity.is_sandbox,
+            op: identity.op,
+            identity_source: Some(identity.source),
             forge_ref,
         });
     }
@@ -1137,6 +1123,8 @@ pub fn collect_branch_info(
                 size_bytes: None,
                 working_tree_mtime: None,
                 is_sandbox: false,
+                op: None,
+                identity_source: None,
                 forge_ref: None,
             });
         }
@@ -1224,6 +1212,8 @@ pub fn collect_branch_info(
                 size_bytes: None,
                 working_tree_mtime: None,
                 is_sandbox: false,
+                op: None,
+                identity_source: None,
                 forge_ref: None,
             });
         }

--- a/src/core/worktree/list.rs
+++ b/src/core/worktree/list.rs
@@ -131,6 +131,8 @@ pub struct WorktreeInfo {
     /// How this row's branch name was established. `None` for rows that are
     /// not worktrees (their name comes straight from the ref).
     pub identity_source: Option<super::identity::IdentitySource>,
+    /// The recorded intended branch disagrees with what is checked out.
+    pub drifted: bool,
     /// The PR/MR this branch tracks (from `branch.<name>.merge`), or `None`.
     /// Local config only — no network.
     pub forge_ref: Option<super::forge_ref::ForgeBranchRef>,
@@ -172,6 +174,7 @@ impl WorktreeInfo {
             is_sandbox: false,
             op: None,
             identity_source: None,
+            drifted: false,
             forge_ref: None,
         }
     }
@@ -210,6 +213,7 @@ impl WorktreeInfo {
             is_sandbox: false,
             op: None,
             identity_source: None,
+            drifted: false,
             forge_ref: None,
         }
     }
@@ -835,7 +839,12 @@ pub fn collect_worktree_info(
     // Recover identity for worktrees git reports as detached because an
     // operation is replaying commits in them, and note what that operation
     // is. Bare entries resolve to `None` and are skipped.
-    let identities = super::identity::resolve_identities(&entries);
+    // Persisted records are a pure read: absent store, absent records, and
+    // the resolution falls through to live state exactly as before.
+    let records = crate::core::repo::get_git_common_dir()
+        .map(|dir| super::identity_store::read_identities(&dir))
+        .unwrap_or_default();
+    let identities = super::identity::resolve_identities_with(&entries, &records);
     let mut infos = Vec::new();
 
     for (entry, identity) in entries.into_iter().zip(identities) {
@@ -979,6 +988,7 @@ pub fn collect_worktree_info(
             is_sandbox: identity.is_sandbox,
             op: identity.op,
             identity_source: Some(identity.source),
+            drifted: identity.drifted,
             forge_ref,
         });
     }
@@ -1125,6 +1135,7 @@ pub fn collect_branch_info(
                 is_sandbox: false,
                 op: None,
                 identity_source: None,
+                drifted: false,
                 forge_ref: None,
             });
         }
@@ -1214,6 +1225,7 @@ pub fn collect_branch_info(
                 is_sandbox: false,
                 op: None,
                 identity_source: None,
+                drifted: false,
                 forge_ref: None,
             });
         }

--- a/src/core/worktree/list.rs
+++ b/src/core/worktree/list.rs
@@ -82,6 +82,9 @@ pub struct WorktreeInfo {
     pub unstaged: usize,
     /// Number of untracked files.
     pub untracked: usize,
+    /// Number of files with unresolved merge conflicts. Counted separately
+    /// from `staged`/`unstaged`, never in addition to them.
+    pub conflicted: usize,
     /// Commits ahead of the remote tracking branch (None if no upstream).
     pub remote_ahead: Option<usize>,
     /// Commits behind the remote tracking branch (None if no upstream).
@@ -139,6 +142,7 @@ impl WorktreeInfo {
             staged: 0,
             unstaged: 0,
             untracked: 0,
+            conflicted: 0,
             remote_ahead: None,
             remote_behind: None,
             last_commit_timestamp: None,
@@ -174,6 +178,7 @@ impl WorktreeInfo {
             staged: 0,
             unstaged: 0,
             untracked: 0,
+            conflicted: 0,
             remote_ahead: None,
             remote_behind: None,
             last_commit_timestamp: None,
@@ -284,10 +289,12 @@ impl WorktreeInfo {
                 staged,
                 unstaged,
                 untracked,
+                conflicted,
             } => {
                 self.staged = *staged;
                 self.unstaged = *unstaged;
                 self.untracked = *untracked;
+                self.conflicted = *conflicted;
                 FieldSet::CHANGES
             }
             P::LastCommit {
@@ -531,15 +538,32 @@ pub(crate) fn get_branch_creation_timestamp(branch: &str, worktree_path: &Path) 
 }
 
 /// Result of counting changed files in a worktree.
+#[derive(Debug, Default, PartialEq, Eq)]
 pub(crate) struct ChangedFiles {
     pub(crate) staged: usize,
     pub(crate) unstaged: usize,
     pub(crate) untracked: usize,
+    /// Files with unresolved merge conflicts. Counted on their own, never as
+    /// staged or unstaged — see [`classify_porcelain_status`].
+    pub(crate) conflicted: usize,
     /// Relative paths of all changed/untracked files (for mtime computation).
     pub(crate) paths: Vec<String>,
 }
 
-/// Count staged, unstaged, and untracked files in a worktree.
+/// The seven `XY` pairs `git status --porcelain` uses for unmerged paths.
+/// Both letters have to match: `AU` and `UA` are conflicts, but `AM` and `MA`
+/// are ordinary staged-and-modified files.
+const UNMERGED_PAIRS: [[u8; 2]; 7] = [
+    *b"DD", // both deleted
+    *b"AU", // added by us
+    *b"UD", // deleted by them
+    *b"UA", // added by them
+    *b"DU", // deleted by us
+    *b"AA", // both added
+    *b"UU", // both modified
+];
+
+/// Count staged, unstaged, untracked and conflicted files in a worktree.
 pub(crate) fn count_changed_files(worktree_path: &Path) -> ChangedFiles {
     let output = Command::new("git")
         .args(["status", "--porcelain"])
@@ -548,50 +572,58 @@ pub(crate) fn count_changed_files(worktree_path: &Path) -> ChangedFiles {
 
     match output {
         Ok(out) if out.status.success() => {
-            let stdout = String::from_utf8_lossy(&out.stdout);
-            let mut staged = 0;
-            let mut unstaged = 0;
-            let mut untracked = 0;
-            let mut paths = Vec::new();
-            for line in stdout.lines() {
-                if line.len() < 2 {
-                    continue;
-                }
-                let bytes = line.as_bytes();
-                let x = bytes[0]; // index (staged) status
-                let y = bytes[1]; // worktree (unstaged) status
-                if x == b'?' {
-                    untracked += 1;
-                } else {
-                    if x != b' ' && x != b'?' {
-                        staged += 1;
-                    }
-                    if y != b' ' && y != b'?' {
-                        unstaged += 1;
-                    }
-                }
-                // Extract filename (starts after "XY " at byte 3).
-                if line.len() > 3 {
-                    let path = &line[3..];
-                    // Renames show "old -> new"; take the new path.
-                    let path = path.rsplit_once(" -> ").map_or(path, |(_, new)| new);
-                    paths.push(path.to_string());
-                }
+            classify_porcelain_status(&String::from_utf8_lossy(&out.stdout))
+        }
+        _ => ChangedFiles::default(),
+    }
+}
+
+/// Classify `git status --porcelain` output into per-state counts.
+///
+/// Split from the git invocation so the `XY` classification — the part with
+/// the interesting edge cases — is testable without standing up a repo.
+///
+/// Conflicts are classified **first**, and exclusively. Their `XY` pairs
+/// otherwise read as "something in the index *and* something in the worktree",
+/// so a conflicted file used to be counted twice over — once as staged, once
+/// as unstaged — and a two-file conflict rendered as `+2 -2`, which reads like
+/// four files of ordinary work rather than two files needing a decision.
+pub(crate) fn classify_porcelain_status(stdout: &str) -> ChangedFiles {
+    let mut counts = ChangedFiles::default();
+
+    for line in stdout.lines() {
+        if line.len() < 2 {
+            continue;
+        }
+        let bytes = line.as_bytes();
+        let x = bytes[0]; // index (staged) status
+        let y = bytes[1]; // worktree (unstaged) status
+
+        if UNMERGED_PAIRS.contains(&[x, y]) {
+            counts.conflicted += 1;
+        } else if x == b'?' {
+            counts.untracked += 1;
+        } else {
+            if x != b' ' && x != b'?' {
+                counts.staged += 1;
             }
-            ChangedFiles {
-                staged,
-                unstaged,
-                untracked,
-                paths,
+            if y != b' ' && y != b'?' {
+                counts.unstaged += 1;
             }
         }
-        _ => ChangedFiles {
-            staged: 0,
-            unstaged: 0,
-            untracked: 0,
-            paths: Vec::new(),
-        },
+
+        // Extract filename (starts after "XY " at byte 3). Conflicted files
+        // are included: they are modified on disk, so they count toward the
+        // working-tree mtime like any other change.
+        if line.len() > 3 {
+            let path = &line[3..];
+            // Renames show "old -> new"; take the new path.
+            let path = path.rsplit_once(" -> ").map_or(path, |(_, new)| new);
+            counts.paths.push(path.to_string());
+        }
     }
+
+    counts
 }
 
 /// Get ahead/behind counts for a branch relative to its remote tracking branch.
@@ -822,9 +854,14 @@ pub fn collect_worktree_info(
             (None, None)
         };
 
-        // Count staged, unstaged, and untracked files
+        // Count staged, unstaged, untracked and conflicted files
         let changed = count_changed_files(&entry.path);
-        let (staged, unstaged, untracked) = (changed.staged, changed.unstaged, changed.untracked);
+        let (staged, unstaged, untracked, conflicted) = (
+            changed.staged,
+            changed.unstaged,
+            changed.untracked,
+            changed.conflicted,
+        );
 
         // Ahead/behind relative to upstream tracking branch
         let (remote_ahead, remote_behind) = if !entry.is_detached {
@@ -937,6 +974,7 @@ pub fn collect_worktree_info(
             staged,
             unstaged,
             untracked,
+            conflicted,
             remote_ahead,
             remote_behind,
             last_commit_timestamp,
@@ -1080,6 +1118,7 @@ pub fn collect_branch_info(
                 staged: 0,
                 unstaged: 0,
                 untracked: 0,
+                conflicted: 0,
                 remote_ahead,
                 remote_behind,
                 last_commit_timestamp,
@@ -1166,6 +1205,7 @@ pub fn collect_branch_info(
                 staged: 0,
                 unstaged: 0,
                 untracked: 0,
+                conflicted: 0,
                 remote_ahead: None,
                 remote_behind: None,
                 last_commit_timestamp,
@@ -1210,6 +1250,121 @@ mod tests {
     fn test_parse_numstat_empty() {
         assert_eq!(parse_numstat(""), (0, 0));
     }
+
+    // ── porcelain status classification ─────────────────────────────────────
+
+    /// Every `XY` pair git documents as unmerged counts as exactly one
+    /// conflict, and as nothing else. The regression: these pairs read as
+    /// "changed in the index" *and* "changed in the worktree", so each
+    /// conflicted file used to land in both the staged and the unstaged
+    /// tally — two conflicts rendered as `+2 -2`.
+    #[test]
+    fn every_unmerged_pair_counts_once_as_a_conflict() {
+        for pair in ["DD", "AU", "UD", "UA", "DU", "AA", "UU"] {
+            let counts = classify_porcelain_status(&format!("{pair} f.txt\n"));
+            assert_eq!(
+                counts,
+                ChangedFiles {
+                    conflicted: 1,
+                    staged: 0,
+                    unstaged: 0,
+                    untracked: 0,
+                    paths: vec!["f.txt".to_string()],
+                },
+                "porcelain pair {pair} misclassified"
+            );
+        }
+    }
+
+    /// The pairs that merely *look* unmerged because one letter matches.
+    /// `AM` is staged-add plus worktree-modify; `MA` and `MU` are not
+    /// conflicts either. Only both letters together make a conflict.
+    #[test]
+    fn lookalike_pairs_are_not_conflicts() {
+        let counts = classify_porcelain_status("AM a.txt\nMD b.txt\n");
+        assert_eq!(counts.conflicted, 0);
+        assert_eq!(counts.staged, 2);
+        assert_eq!(counts.unstaged, 2);
+    }
+
+    #[test]
+    fn ordinary_states_are_unchanged() {
+        // One staged, one unstaged, one both, one untracked.
+        let counts = classify_porcelain_status("M  a.txt\n M b.txt\nMM c.txt\n?? d.txt\n");
+        assert_eq!(counts.staged, 2, "a.txt and c.txt");
+        assert_eq!(counts.unstaged, 2, "b.txt and c.txt");
+        assert_eq!(counts.untracked, 1);
+        assert_eq!(counts.conflicted, 0);
+    }
+
+    #[test]
+    fn conflicts_mix_with_ordinary_changes_without_inflating_them() {
+        let counts = classify_porcelain_status("UU a.txt\nM  b.txt\n?? c.txt\n");
+        assert_eq!(counts.conflicted, 1);
+        assert_eq!(counts.staged, 1, "only b.txt — never the conflicted a.txt");
+        assert_eq!(counts.unstaged, 0);
+        assert_eq!(counts.untracked, 1);
+    }
+
+    /// Conflicted files are still modified on disk, so they must keep
+    /// contributing to the working-tree mtime like any other change.
+    #[test]
+    fn conflicted_paths_are_still_collected_for_mtime() {
+        let counts = classify_porcelain_status("UU src/a.txt\n");
+        assert_eq!(counts.paths, vec!["src/a.txt".to_string()]);
+    }
+
+    #[test]
+    fn rename_entries_report_the_new_path() {
+        let counts = classify_porcelain_status("R  old.txt -> new.txt\n");
+        assert_eq!(counts.paths, vec!["new.txt".to_string()]);
+        assert_eq!(counts.staged, 1);
+    }
+
+    #[test]
+    fn empty_and_truncated_lines_are_skipped() {
+        assert_eq!(classify_porcelain_status(""), ChangedFiles::default());
+        let counts = classify_porcelain_status("\nM\nM  a.txt\n");
+        assert_eq!(counts.staged, 1);
+        assert_eq!(counts.paths, vec!["a.txt".to_string()]);
+    }
+
+    /// End-to-end against a real repo: a conflicting merge, read through the
+    /// actual `git status --porcelain` invocation rather than a fixture
+    /// string, so the classification is pinned to git's real output.
+    #[test]
+    fn counts_a_real_conflict_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path();
+        let git = |args: &[&str]| {
+            let out = crate::utils::git_command_at(path)
+                .args(args)
+                .env("GIT_AUTHOR_NAME", "Test")
+                .env("GIT_AUTHOR_EMAIL", "test@test.com")
+                .env("GIT_COMMITTER_NAME", "Test")
+                .env("GIT_COMMITTER_EMAIL", "test@test.com")
+                .output()
+                .expect("git");
+            out.status.success()
+        };
+        assert!(git(&["init", "-q", "-b", "main"]));
+        std::fs::write(path.join("f.txt"), "base\n").unwrap();
+        assert!(git(&["add", "f.txt"]));
+        assert!(git(&["commit", "-qm", "base"]));
+        assert!(git(&["checkout", "-qb", "other"]));
+        std::fs::write(path.join("f.txt"), "other\n").unwrap();
+        assert!(git(&["commit", "-qam", "other"]));
+        assert!(git(&["checkout", "-q", "main"]));
+        std::fs::write(path.join("f.txt"), "main\n").unwrap();
+        assert!(git(&["commit", "-qam", "main"]));
+        // Expected to fail — that is the conflict we are counting.
+        assert!(!git(&["merge", "other"]));
+
+        let counts = count_changed_files(path);
+        assert_eq!(counts.conflicted, 1);
+        assert_eq!(counts.staged, 0, "a conflict is not a staged change");
+        assert_eq!(counts.unstaged, 0, "nor an unstaged one");
+    }
 }
 
 #[cfg(test)]
@@ -1249,6 +1404,7 @@ mod apply_patch_tests {
             staged: 2,
             unstaged: 1,
             untracked: 4,
+            conflicted: 0,
         });
         assert_eq!((info.staged, info.unstaged, info.untracked), (2, 1, 4));
         assert_eq!(touched, FieldSet::CHANGES);

--- a/src/core/worktree/list_stream.rs
+++ b/src/core/worktree/list_stream.rs
@@ -252,7 +252,8 @@ fn run_worker(
         emit!(P::Changes {
             staged: c.staged,
             unstaged: c.unstaged,
-            untracked: c.untracked
+            untracked: c.untracked,
+            conflicted: c.conflicted
         });
     }
 

--- a/src/core/worktree/merge.rs
+++ b/src/core/worktree/merge.rs
@@ -28,6 +28,7 @@
 //! failure modes.
 
 use crate::git::GitCommand;
+use crate::git::op_state::OpKind;
 use anyhow::{Context, Result};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -878,46 +879,11 @@ impl InProgressOp {
 
 /// Resolve the real `.git` directory for `worktree`.
 ///
-/// In the main worktree `.git` is itself a directory. In a linked worktree,
-/// `.git` is a file whose first line is `gitdir: <path>` pointing at the
-/// per-worktree git dir (e.g. `.git/worktrees/<name>`). Returns an error if
-/// the `.git` file is malformed or the resolved directory does not exist.
-///
-/// This is the canonical resolution used by both [`detect_in_progress`] and the
-/// intent-marker read/write paths so the marker location is always consistent
-/// with the detection path.
-pub fn resolve_worktree_git_dir(worktree: &Path) -> Result<PathBuf> {
-    let git_entry = worktree.join(".git");
-    let git_dir = if git_entry.is_file() {
-        let content = std::fs::read_to_string(&git_entry)
-            .with_context(|| format!("failed to read .git at {}", git_entry.display()))?;
-        let rel = content
-            .lines()
-            .next()
-            .and_then(|l| l.strip_prefix("gitdir: "))
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "malformed .git file at {}: expected 'gitdir: <path>' on first line",
-                    git_entry.display()
-                )
-            })?
-            .trim();
-        let p = PathBuf::from(rel);
-        // Path::join replaces when its argument is absolute, so this is
-        // correct whether the pointer is absolute or relative.
-        if p.is_absolute() { p } else { worktree.join(p) }
-    } else {
-        git_entry
-    };
-
-    if !git_dir.is_dir() {
-        anyhow::bail!(
-            "target worktree at '{}' has no valid .git directory",
-            worktree.display()
-        );
-    }
-    Ok(git_dir)
-}
+/// Re-exported from the git layer, where it lives alongside the operation
+/// probe that shares it ([`crate::git::op_state`]). Kept here so the merge
+/// module's own callers — and the intent-marker read/write paths, whose
+/// location must stay consistent with the detection path — keep one import.
+pub use crate::git::op_state::resolve_worktree_git_dir;
 
 /// Check whether the index of `worktree` has staged (cached) changes.
 ///
@@ -945,35 +911,47 @@ pub fn has_staged_changes(worktree: &Path) -> Result<bool> {
 /// (e.g. `.git/worktrees/<name>`); in the main worktree, `.git` is itself
 /// a directory. Both shapes are handled.
 ///
-/// We intentionally check for directory/file *existence* rather than
-/// parsing contents — git populates these atomically and their presence
-/// alone is the signal git itself uses (see `git status` output).
+/// The state-file reads are shared with [`crate::git::op_state`], which every
+/// other consumer (the list's identity recovery, the hook conditions) uses
+/// too; this function adds the two things that are merge-preflight-specific:
+/// the `SQUASH_MSG` state, which needs a subprocess to confirm, and the
+/// mapping onto [`InProgressOp`].
 pub fn detect_in_progress(worktree: &Path) -> Result<Option<InProgressOp>> {
     let git_dir = resolve_worktree_git_dir(worktree)?;
+    let op = crate::git::op_state::probe_op_state_in_git_dir(&git_dir);
 
-    if git_dir.join("MERGE_HEAD").exists() {
+    if matches!(op.as_ref().map(|o| o.kind), Some(OpKind::Merge)) {
         return Ok(Some(InProgressOp::Merge));
     }
 
     // Squash-staged: `git merge --squash` writes SQUASH_MSG but NOT MERGE_HEAD.
     // Require staged changes to avoid false positives on a stale SQUASH_MSG
     // (e.g. a previous squash that was committed successfully but whose
-    // SQUASH_MSG somehow remained).
+    // SQUASH_MSG somehow remained). It ranks below a real merge and above a
+    // rebase — the probe knows nothing about it (no subprocesses there), so
+    // the ordering lives here.
     let squash_msg = git_dir.join("SQUASH_MSG");
     if squash_msg.exists() && has_staged_changes(worktree)? {
         return Ok(Some(InProgressOp::SquashStaged));
     }
 
-    if git_dir.join("rebase-merge").is_dir() || git_dir.join("rebase-apply").is_dir() {
-        return Ok(Some(InProgressOp::Rebase));
-    }
-    if git_dir.join("CHERRY_PICK_HEAD").exists() {
-        return Ok(Some(InProgressOp::CherryPick));
-    }
-    if git_dir.join("BISECT_LOG").exists() {
-        return Ok(Some(InProgressOp::Bisect));
-    }
-    Ok(None)
+    Ok(op.and_then(|state| match state.kind {
+        OpKind::Merge => Some(InProgressOp::Merge),
+        // `git am` has always counted as a rebase here — it is the same
+        // "finish or abort before merging" situation, and the apply backend
+        // shares its directory.
+        OpKind::Rebase | OpKind::Am => Some(InProgressOp::Rebase),
+        OpKind::CherryPick => Some(InProgressOp::CherryPick),
+        OpKind::Bisect => Some(InProgressOp::Bisect),
+        // A revert has never blocked the merge preflight, and this refactor
+        // deliberately does not change that. The probe classifies it (the
+        // list surfaces it); here it only steps aside, so a concurrent
+        // bisect — which the probe reports after a revert — still registers.
+        OpKind::Revert => git_dir
+            .join("BISECT_LOG")
+            .exists()
+            .then_some(InProgressOp::Bisect),
+    }))
 }
 
 /// On-disk state of an in-progress merge or rebase, used to dispatch
@@ -991,14 +969,12 @@ pub enum InProgressState {
 /// This is a coarser variant of [`detect_in_progress`]: that one returns rich
 /// descriptions for bail messages; this one classifies for dispatch.
 pub fn detect_in_progress_state(path: &Path) -> Option<InProgressState> {
-    let git_dir = resolve_worktree_git_dir(path).ok()?;
-    if git_dir.join("MERGE_HEAD").exists() {
-        return Some(InProgressState::Merge);
+    match crate::git::op_state::probe_op_state(path)?.kind {
+        OpKind::Merge => Some(InProgressState::Merge),
+        OpKind::Rebase | OpKind::Am => Some(InProgressState::Rebase),
+        // The sequencer states have no `--continue`/`--abort` dispatch here.
+        OpKind::CherryPick | OpKind::Revert | OpKind::Bisect => None,
     }
-    if git_dir.join("rebase-merge").is_dir() || git_dir.join("rebase-apply").is_dir() {
-        return Some(InProgressState::Rebase);
-    }
-    None
 }
 
 /// Resolve each source ref to its full commit SHA via `git rev-parse`.

--- a/src/core/worktree/mod.rs
+++ b/src/core/worktree/mod.rs
@@ -22,6 +22,7 @@ pub mod flow_adopt;
 pub mod flow_eject;
 pub mod forge_ref;
 pub mod identity;
+pub mod identity_store;
 pub mod info_field;
 pub mod init;
 pub mod list;

--- a/src/core/worktree/mod.rs
+++ b/src/core/worktree/mod.rs
@@ -21,6 +21,7 @@ pub mod fetch;
 pub mod flow_adopt;
 pub mod flow_eject;
 pub mod forge_ref;
+pub mod identity;
 pub mod info_field;
 pub mod init;
 pub mod list;

--- a/src/core/worktree/prune.rs
+++ b/src/core/worktree/prune.rs
@@ -913,6 +913,11 @@ fn remove_worktree(
     // Pre-remove hook
     run_removal_hook(HookType::PreRemove, ctx, wt_path, branch_name, sink);
 
+    // Capture the identity key while the directory can still be probed:
+    // records are keyed on the private-gitdir id, not the branch, and a
+    // drifted record does not match the branch name we know here.
+    let identity_id = crate::core::worktree::identity_store::worktree_id_for(wt_path);
+
     if wt_path.exists() {
         sink.on_step("Removing worktree...");
         if let Err(e) = ctx.git.worktree_remove(wt_path, force) {
@@ -951,7 +956,7 @@ fn remove_worktree(
     }
     // ...and its recorded identity, for the same reason.
     if let Some(store) = crate::core::worktree::identity_store::IdentityStore::open(&ctx.git_dir) {
-        store.forget_branch(branch_name);
+        store.forget(identity_id.as_deref(), branch_name);
     }
 
     RemoveOutcome::Removed

--- a/src/core/worktree/prune.rs
+++ b/src/core/worktree/prune.rs
@@ -949,6 +949,10 @@ fn remove_worktree(
     if let Some(seeds) = seeds.as_ref() {
         seeds.delete_seeds_for_branch(branch_name);
     }
+    // ...and its recorded identity, for the same reason.
+    if let Some(store) = crate::core::worktree::identity_store::IdentityStore::open(&ctx.git_dir) {
+        store.forget_branch(branch_name);
+    }
 
     RemoveOutcome::Removed
 }

--- a/src/core/worktree/rename.rs
+++ b/src/core/worktree/rename.rs
@@ -249,6 +249,13 @@ pub fn execute(
         )
     })?;
 
+    // The worktree keeps its private-gitdir id across a move, so this updates
+    // the existing record in place rather than orphaning it under the old
+    // branch name. Best-effort.
+    if let Some(store) = crate::core::worktree::identity_store::IdentityStore::open(&git_dir) {
+        store.record(&new_path, &params.new_branch);
+    }
+
     // Step 6b: Run setup hooks (pre-create + post-create) with new identity.
     run_setup_hooks(&move_params, sink);
 

--- a/src/core/worktree/sync_dag.rs
+++ b/src/core/worktree/sync_dag.rs
@@ -515,6 +515,7 @@ pub enum WorktreeInfoPatch {
         staged: usize,
         unstaged: usize,
         untracked: usize,
+        conflicted: usize,
     },
     LastCommit {
         timestamp: Option<i64>,

--- a/src/doctor/repository.rs
+++ b/src/doctor/repository.rs
@@ -178,6 +178,11 @@ pub fn check_worktree_identity_drift(ctx: &RepoContext) -> CheckResult {
         .collect();
     let fix_targets = drifted.clone();
     let dry_details = details.clone();
+    // Capture the checked repo's dir by move: fixes run *after* doctor has
+    // restored the original cwd (and under --all-repos, from a different
+    // repo entirely), so a cwd-derived lookup here would write these targets
+    // into some other repo's store.
+    let fix_dir = ctx.git_common_dir.clone();
 
     CheckResult::warning(
         "Worktree identities",
@@ -186,8 +191,7 @@ pub fn check_worktree_identity_drift(ctx: &RepoContext) -> CheckResult {
     .with_details(details)
     .with_suggestion("run with --fix to update the records to match what is checked out")
     .with_fix(Box::new(move || {
-        let ctx_dir = crate::core::repo::get_git_common_dir().map_err(|e| e.to_string())?;
-        let store = crate::core::worktree::identity_store::IdentityStore::open(&ctx_dir)
+        let store = crate::core::worktree::identity_store::IdentityStore::open(&fix_dir)
             .ok_or_else(|| "identity records unavailable".to_string())?;
         for (path, checked_out, _) in &fix_targets {
             store.record(path, checked_out);
@@ -468,6 +472,60 @@ mod tests {
     fn test_is_common_dir_bare_no_config() {
         let temp = tempfile::tempdir().unwrap();
         assert!(!is_common_dir_bare(temp.path()));
+    }
+
+    /// The deferred --fix closure must write into the repo the check was
+    /// built from, not whatever the process cwd names when apply_fixes later
+    /// runs: doctor restores the original cwd between collect and fix, so
+    /// under --all-repos a cwd-derived store lookup wrote repo B's drift
+    /// targets into repo A's store — same-named ids (`master`) even
+    /// overwrite A's real records via upsert — while B's drift survived
+    /// behind a green "done".
+    #[test]
+    #[serial_test::serial]
+    fn identity_fix_writes_into_the_checked_repo_not_the_cwd() {
+        let _state = crate::store::paths::IsolatedStateDir::new();
+        let orig_cwd = std::env::current_dir().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        git(&repo, &["init", "-q", "-b", "main"]);
+        git(&repo, &["commit", "--allow-empty", "-q", "-m", "init"]);
+        git(&repo, &["branch", "feat-x"]);
+        let wt = tmp.path().join("wt");
+        git(
+            &repo,
+            &["worktree", "add", "-q", wt.to_str().unwrap(), "feat-x"],
+        );
+        let common = repo.join(".git");
+
+        // A record disagreeing with the checkout: drift.
+        let store = crate::core::worktree::identity_store::IdentityStore::open(&common).unwrap();
+        store.record(&wt, "feat-recorded");
+
+        // The check runs with cwd inside the repo, as doctor's collect pass
+        // arranges…
+        std::env::set_current_dir(&repo).unwrap();
+        let ctx = RepoContext {
+            git_common_dir: common.clone(),
+            project_root: repo.clone(),
+            current_worktree: repo.clone(),
+            is_bare: false,
+        };
+        let result = check_worktree_identity_drift(&ctx);
+        std::env::set_current_dir(&orig_cwd).unwrap();
+        assert_eq!(result.status, CheckStatus::Warning);
+        let fix = result.fix.expect("drift offers a fix");
+
+        // …but the fix runs after doctor restored the original cwd.
+        fix().expect("fix succeeds away from the repo's cwd");
+
+        let records = crate::core::worktree::identity_store::read_identities(&common);
+        let id = crate::core::worktree::identity_store::worktree_id_for(&wt).unwrap();
+        assert_eq!(
+            records[&id].branch, "feat-x",
+            "the record is reconciled to the checkout, in the checked repo's store"
+        );
     }
 
     #[test]

--- a/src/doctor/repository.rs
+++ b/src/doctor/repository.rs
@@ -120,6 +120,92 @@ pub fn check_worktree_layout(ctx: &RepoContext) -> CheckResult {
     )
 }
 
+/// Check that every recorded worktree identity still matches reality.
+///
+/// Daft records what branch each worktree was created for, so `daft list` can
+/// still name a worktree whose HEAD is detached for a reason git does not
+/// record. A record that disagrees with the branch actually checked out —
+/// someone checked out a different branch into the worktree, or renamed one
+/// outside `daft rename` — is not wrong in a way that breaks anything today
+/// (live state always wins the name), but it means the fallback would name
+/// the wrong branch the moment that worktree detaches. Reconciling is a
+/// one-way update: the checkout is the truth, the record follows it.
+pub fn check_worktree_identity_drift(ctx: &RepoContext) -> CheckResult {
+    let records = crate::core::worktree::identity_store::read_identities(&ctx.git_common_dir);
+    if records.is_empty() {
+        return CheckResult::pass("Worktree identities", "no records to check");
+    }
+
+    let git = GitCommand::new(true);
+    let porcelain = match git.worktree_list_porcelain() {
+        Ok(output) => output,
+        Err(e) => {
+            return CheckResult::warning(
+                "Worktree identities",
+                &format!("could not list worktrees: {e}"),
+            );
+        }
+    };
+
+    // Only attached worktrees can disagree: a detached one is exactly the
+    // case the record exists to answer, not a contradiction of it.
+    let drifted: Vec<(PathBuf, String, String)> = parse_worktree_list_porcelain(&porcelain)
+        .into_iter()
+        .filter(|e| !e.is_bare)
+        .filter_map(|entry| {
+            let checked_out = entry.branch.clone()?;
+            let id = crate::core::worktree::identity_store::worktree_id_for(&entry.path)?;
+            let recorded = records.get(&id)?.branch.clone();
+            (recorded != checked_out).then_some((entry.path, checked_out, recorded))
+        })
+        .collect();
+
+    if drifted.is_empty() {
+        return CheckResult::pass(
+            "Worktree identities",
+            &format!("all {} record(s) match their checkout", records.len()),
+        );
+    }
+
+    let details: Vec<String> = drifted
+        .iter()
+        .map(|(path, checked_out, recorded)| {
+            format!(
+                "{}: checked out {checked_out}, recorded {recorded}",
+                path.display()
+            )
+        })
+        .collect();
+    let fix_targets = drifted.clone();
+    let dry_details = details.clone();
+
+    CheckResult::warning(
+        "Worktree identities",
+        &format!("{} worktree(s) drifted from their record", drifted.len()),
+    )
+    .with_details(details)
+    .with_suggestion("run with --fix to update the records to match what is checked out")
+    .with_fix(Box::new(move || {
+        let ctx_dir = crate::core::repo::get_git_common_dir().map_err(|e| e.to_string())?;
+        let store = crate::core::worktree::identity_store::IdentityStore::open(&ctx_dir)
+            .ok_or_else(|| "identity records unavailable".to_string())?;
+        for (path, checked_out, _) in &fix_targets {
+            store.record(path, checked_out);
+        }
+        Ok(())
+    }))
+    .with_dry_run_fix(Box::new(move || {
+        dry_details
+            .iter()
+            .map(|detail| FixAction {
+                description: String::from("Update record: ") + detail,
+                would_succeed: true,
+                failure_reason: None,
+            })
+            .collect()
+    }))
+}
+
 /// Check that all worktree paths exist on disk.
 pub fn check_worktree_consistency(_ctx: &RepoContext) -> CheckResult {
     let git = GitCommand::new(true);

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -5,6 +5,7 @@ mod branch;
 pub mod cancel;
 mod clone;
 mod config;
+pub mod op_state;
 pub(crate) mod oxide;
 #[cfg(unix)]
 pub(crate) mod process_tree;

--- a/src/git/op_state.rs
+++ b/src/git/op_state.rs
@@ -1,0 +1,481 @@
+//! Filesystem probe for in-progress git operations.
+//!
+//! When a merge / rebase / cherry-pick / revert / bisect pauses awaiting user
+//! input, git records that fact as state files inside the worktree's private
+//! git directory. This module reads them.
+//!
+//! Two properties make this the right shape for the perf-sensitive callers
+//! (`daft list` runs it once per worktree, including on the live-render seed
+//! path):
+//!
+//! - **No subprocesses.** A handful of `stat()`s plus at most one small file
+//!   read per worktree. `git status` reads exactly these files to print
+//!   "interactive rebase in progress"; shell prompts do the same.
+//! - **Backend-agnostic.** These are file reads either way, so the gitoxide
+//!   flip (#733) does not fork this code path. `gix::state::InProgress` models
+//!   the same states, but adopting it would still leave `head-name` as a file
+//!   read.
+//!
+//! The load-bearing recovery is [`OpState::branch`]: mid-rebase git detaches
+//! HEAD to replay commits, so `git worktree list --porcelain` reports no
+//! `branch` line — but `rebase-merge/head-name` still names the branch being
+//! rebased, for the entire operation. Recovering it is what keeps a worktree's
+//! identity from vanishing in `daft list` (#736).
+
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+
+/// An in-progress git operation, identified by the state files git writes into
+/// a worktree's private git directory.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OpKind {
+    /// A rebase (either backend — `rebase-merge/` or `rebase-apply/`).
+    Rebase,
+    /// `git am` — a mailbox apply. Shares `rebase-apply/` with the rebase
+    /// backend and is distinguished by the `applying` marker file, so it is
+    /// never mislabeled as a rebase.
+    Am,
+    /// A merge (`MERGE_HEAD`). HEAD stays attached throughout.
+    Merge,
+    /// A cherry-pick (`CHERRY_PICK_HEAD`). HEAD stays attached.
+    CherryPick,
+    /// A revert (`REVERT_HEAD`). HEAD stays attached.
+    Revert,
+    /// A bisect (`BISECT_LOG`).
+    Bisect,
+}
+
+impl OpKind {
+    /// Present-continuous label, as rendered in the `status` column.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Rebase => "rebasing",
+            Self::Am => "applying",
+            Self::Merge => "merging",
+            Self::CherryPick => "cherry-picking",
+            Self::Revert => "reverting",
+            Self::Bisect => "bisecting",
+        }
+    }
+
+    /// Stable machine-facing name, as emitted in structured output.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Rebase => "rebase",
+            Self::Am => "am",
+            Self::Merge => "merge",
+            Self::CherryPick => "cherry-pick",
+            Self::Revert => "revert",
+            Self::Bisect => "bisect",
+        }
+    }
+}
+
+/// An in-progress operation, plus the branch git recorded it against.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OpState {
+    pub kind: OpKind,
+    /// The branch the operation is being applied to, when git records one:
+    /// `head-name` for a rebase, `BISECT_START` for a bisect. `None` for
+    /// operations that keep HEAD attached (the porcelain already names the
+    /// branch), for `git am` (which writes no `head-name`), and whenever the
+    /// recorded value is not a `refs/heads/` ref — a rebase started from a
+    /// detached HEAD records the literal `detached HEAD`, which names nothing.
+    pub branch: Option<String>,
+}
+
+/// Resolve the real `.git` directory for `worktree`.
+///
+/// In the main worktree `.git` is itself a directory. In a linked worktree,
+/// `.git` is a file whose first line is `gitdir: <path>` pointing at the
+/// per-worktree git dir (e.g. `.git/worktrees/<name>`). Returns an error if
+/// the `.git` file is malformed or the resolved directory does not exist.
+///
+/// This is the canonical resolution for anything that reads per-worktree git
+/// state: the operation probe below, the merge module's in-progress detection
+/// and intent markers, and the hook conditions. Probing `worktree/.git` as a
+/// directory instead silently reads nothing in a linked worktree — daft's
+/// default layout — which is the bug this helper exists to prevent.
+pub fn resolve_worktree_git_dir(worktree: &Path) -> Result<PathBuf> {
+    let git_entry = worktree.join(".git");
+    let git_dir = if git_entry.is_file() {
+        let content = std::fs::read_to_string(&git_entry)
+            .with_context(|| format!("failed to read .git at {}", git_entry.display()))?;
+        let rel = content
+            .lines()
+            .next()
+            .and_then(|l| l.strip_prefix("gitdir: "))
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "malformed .git file at {}: expected 'gitdir: <path>' on first line",
+                    git_entry.display()
+                )
+            })?
+            .trim();
+        let p = PathBuf::from(rel);
+        // Path::join replaces when its argument is absolute, so this is
+        // correct whether the pointer is absolute or relative.
+        if p.is_absolute() { p } else { worktree.join(p) }
+    } else {
+        git_entry
+    };
+
+    if !git_dir.is_dir() {
+        anyhow::bail!(
+            "target worktree at '{}' has no valid .git directory",
+            worktree.display()
+        );
+    }
+    Ok(git_dir)
+}
+
+/// The in-progress operation in `worktree`, or `None` when it is idle.
+///
+/// Best-effort by design: a worktree whose `.git` pointer is missing or
+/// malformed reports `None` rather than erroring, so one broken entry cannot
+/// fail a whole `daft list`. Callers that need the distinction (the merge
+/// preflight) resolve the git dir themselves and use
+/// [`probe_op_state_in_git_dir`].
+pub fn probe_op_state(worktree: &Path) -> Option<OpState> {
+    let git_dir = resolve_worktree_git_dir(worktree).ok()?;
+    probe_op_state_in_git_dir(&git_dir)
+}
+
+/// [`probe_op_state`] against an already-resolved private git directory.
+///
+/// Probe order follows git's own (`wt-status.c`): `MERGE_HEAD` first, then
+/// rebase, then the sequencer states. The orders cannot actually collide — a
+/// conflicted rebase writes `REBASE_HEAD` and `rebase-merge/`, never
+/// `MERGE_HEAD` — but matching git keeps the classification honest if that
+/// ever changes.
+pub fn probe_op_state_in_git_dir(git_dir: &Path) -> Option<OpState> {
+    if git_dir.join("MERGE_HEAD").exists() {
+        return Some(OpState {
+            kind: OpKind::Merge,
+            branch: None,
+        });
+    }
+
+    // The merge backend (git's default since 2.26) — the branch being rebased
+    // is in `head-name` for the whole operation.
+    if git_dir.join("rebase-merge").is_dir() {
+        return Some(OpState {
+            kind: OpKind::Rebase,
+            branch: head_name_branch(&git_dir.join("rebase-merge")),
+        });
+    }
+
+    // The apply backend shares its directory with `git am`. `applying` is
+    // git's own marker for the latter (it is what makes `git status` print
+    // "You are in the middle of an am session"), and an am writes no
+    // `head-name` — so it recovers no branch.
+    if git_dir.join("rebase-apply").is_dir() {
+        let dir = git_dir.join("rebase-apply");
+        let kind = if dir.join("applying").exists() {
+            OpKind::Am
+        } else {
+            OpKind::Rebase
+        };
+        return Some(OpState {
+            kind,
+            branch: head_name_branch(&dir),
+        });
+    }
+
+    if git_dir.join("CHERRY_PICK_HEAD").exists() {
+        return Some(OpState {
+            kind: OpKind::CherryPick,
+            branch: None,
+        });
+    }
+    if git_dir.join("REVERT_HEAD").exists() {
+        return Some(OpState {
+            kind: OpKind::Revert,
+            branch: None,
+        });
+    }
+    if git_dir.join("BISECT_LOG").exists() {
+        return Some(OpState {
+            kind: OpKind::Bisect,
+            branch: bisect_start_branch(git_dir),
+        });
+    }
+
+    None
+}
+
+/// The short branch name from `<dir>/head-name`, which git writes as a full
+/// `refs/heads/<branch>` ref with a trailing newline. Anything else — the
+/// literal `detached HEAD` a detached-start rebase records, a truncated write
+/// — names no branch.
+fn head_name_branch(dir: &Path) -> Option<String> {
+    let raw = read_trimmed(&dir.join("head-name"))?;
+    raw.strip_prefix("refs/heads/")
+        .filter(|b| !b.is_empty())
+        .map(str::to_string)
+}
+
+/// The branch a bisect started from, per `BISECT_START`. Git writes either the
+/// short branch name or, when the bisect began on a detached HEAD, a commit
+/// SHA — which names no branch.
+fn bisect_start_branch(git_dir: &Path) -> Option<String> {
+    let raw = read_trimmed(&git_dir.join("BISECT_START"))?;
+    // Defensive: accept a fully-qualified ref too, though git writes the short
+    // form here (unlike `head-name`).
+    let name = raw.strip_prefix("refs/heads/").unwrap_or(&raw);
+    if name.is_empty() || is_hex_sha(name) {
+        return None;
+    }
+    Some(name.to_string())
+}
+
+fn is_hex_sha(s: &str) -> bool {
+    s.len() >= 40 && s.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+/// Read a small state file, trimming the trailing newline git writes. `None`
+/// when the file is absent or unreadable — every caller treats that as "git
+/// recorded nothing", never as an error.
+fn read_trimmed(path: &Path) -> Option<String> {
+    let content = std::fs::read_to_string(path).ok()?;
+    let trimmed = content.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A main-worktree shape: `.git` is a real directory.
+    fn main_worktree() -> (tempfile::TempDir, PathBuf) {
+        let tmp = tempfile::tempdir().unwrap();
+        let git_dir = tmp.path().join(".git");
+        std::fs::create_dir_all(&git_dir).unwrap();
+        (tmp, git_dir)
+    }
+
+    fn write(path: &Path, contents: &str) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, contents).unwrap();
+    }
+
+    #[test]
+    fn rebase_recovers_branch_from_head_name() {
+        let (tmp, git_dir) = main_worktree();
+        // Exactly what git writes: a full ref with a trailing newline.
+        write(
+            &git_dir.join("rebase-merge/head-name"),
+            "refs/heads/feat/x\n",
+        );
+        assert_eq!(
+            probe_op_state(tmp.path()),
+            Some(OpState {
+                kind: OpKind::Rebase,
+                branch: Some("feat/x".to_string()),
+            })
+        );
+    }
+
+    #[test]
+    fn rebase_without_head_name_still_reports_the_operation() {
+        let (tmp, git_dir) = main_worktree();
+        std::fs::create_dir_all(git_dir.join("rebase-merge")).unwrap();
+        assert_eq!(
+            probe_op_state(tmp.path()),
+            Some(OpState {
+                kind: OpKind::Rebase,
+                branch: None,
+            })
+        );
+    }
+
+    #[test]
+    fn detached_start_rebase_recovers_no_branch() {
+        // `git rebase` from a detached HEAD records the literal string rather
+        // than a ref — it names nothing, but the operation is still real.
+        let (tmp, git_dir) = main_worktree();
+        write(&git_dir.join("rebase-merge/head-name"), "detached HEAD\n");
+        let state = probe_op_state(tmp.path()).unwrap();
+        assert_eq!(state.kind, OpKind::Rebase);
+        assert_eq!(state.branch, None);
+    }
+
+    #[test]
+    fn empty_head_name_recovers_no_branch() {
+        let (tmp, git_dir) = main_worktree();
+        write(&git_dir.join("rebase-merge/head-name"), "refs/heads/\n");
+        assert_eq!(probe_op_state(tmp.path()).unwrap().branch, None);
+    }
+
+    #[test]
+    fn rebase_apply_backend_is_a_rebase() {
+        let (tmp, git_dir) = main_worktree();
+        write(
+            &git_dir.join("rebase-apply/head-name"),
+            "refs/heads/legacy\n",
+        );
+        assert_eq!(
+            probe_op_state(tmp.path()),
+            Some(OpState {
+                kind: OpKind::Rebase,
+                branch: Some("legacy".to_string()),
+            })
+        );
+    }
+
+    #[test]
+    fn am_session_is_not_a_rebase() {
+        // `git am` shares rebase-apply/ but writes `applying` and no head-name.
+        let (tmp, git_dir) = main_worktree();
+        write(&git_dir.join("rebase-apply/applying"), "");
+        assert_eq!(
+            probe_op_state(tmp.path()),
+            Some(OpState {
+                kind: OpKind::Am,
+                branch: None,
+            })
+        );
+    }
+
+    #[test]
+    fn merge_is_detected_and_names_no_branch() {
+        // A merge keeps HEAD attached, so the porcelain already has the name.
+        let (tmp, git_dir) = main_worktree();
+        write(&git_dir.join("MERGE_HEAD"), "deadbeef\n");
+        assert_eq!(
+            probe_op_state(tmp.path()),
+            Some(OpState {
+                kind: OpKind::Merge,
+                branch: None,
+            })
+        );
+    }
+
+    #[test]
+    fn cherry_pick_and_revert_are_distinguished() {
+        let (tmp, git_dir) = main_worktree();
+        write(&git_dir.join("CHERRY_PICK_HEAD"), "c0ffee\n");
+        assert_eq!(probe_op_state(tmp.path()).unwrap().kind, OpKind::CherryPick);
+
+        let (tmp2, git_dir2) = main_worktree();
+        write(&git_dir2.join("REVERT_HEAD"), "c0ffee\n");
+        assert_eq!(probe_op_state(tmp2.path()).unwrap().kind, OpKind::Revert);
+    }
+
+    #[test]
+    fn bisect_recovers_the_original_branch() {
+        let (tmp, git_dir) = main_worktree();
+        write(&git_dir.join("BISECT_LOG"), "git bisect start\n");
+        write(&git_dir.join("BISECT_START"), "main\n");
+        assert_eq!(
+            probe_op_state(tmp.path()),
+            Some(OpState {
+                kind: OpKind::Bisect,
+                branch: Some("main".to_string()),
+            })
+        );
+    }
+
+    #[test]
+    fn bisect_from_detached_head_recovers_no_branch() {
+        let (tmp, git_dir) = main_worktree();
+        write(&git_dir.join("BISECT_LOG"), "git bisect start\n");
+        write(
+            &git_dir.join("BISECT_START"),
+            "1234567890abcdef1234567890abcdef12345678\n",
+        );
+        assert_eq!(probe_op_state(tmp.path()).unwrap().branch, None);
+    }
+
+    #[test]
+    fn clean_worktree_reports_no_operation() {
+        let (tmp, _git_dir) = main_worktree();
+        assert_eq!(probe_op_state(tmp.path()), None);
+    }
+
+    // ── linked-worktree shapes (`.git` is a FILE) ────────────────────────────
+    // daft's default layout. Probing `worktree/.git` as a directory silently
+    // finds nothing here, which is exactly the class of bug this covers.
+
+    /// A linked worktree: `.git` is a file pointing at `<common>/worktrees/<id>`.
+    /// Returns (tempdir, worktree path, private git dir).
+    fn linked_worktree(absolute_pointer: bool) -> (tempfile::TempDir, PathBuf, PathBuf) {
+        let tmp = tempfile::tempdir().unwrap();
+        let common = tmp.path().join("repo/.git");
+        let private = common.join("worktrees/wt-a");
+        std::fs::create_dir_all(&private).unwrap();
+        let worktree = tmp.path().join("wt-a");
+        std::fs::create_dir_all(&worktree).unwrap();
+        let pointer = if absolute_pointer {
+            private.display().to_string()
+        } else {
+            // Git writes an absolute path, but the resolver accepts a relative
+            // one too — pin that so the fallback can't rot.
+            "../repo/.git/worktrees/wt-a".to_string()
+        };
+        std::fs::write(worktree.join(".git"), format!("gitdir: {pointer}\n")).unwrap();
+        (tmp, worktree, private)
+    }
+
+    #[test]
+    fn linked_worktree_with_absolute_pointer_is_probed() {
+        let (_tmp, worktree, private) = linked_worktree(true);
+        write(
+            &private.join("rebase-merge/head-name"),
+            "refs/heads/feat/y\n",
+        );
+        assert_eq!(
+            probe_op_state(&worktree),
+            Some(OpState {
+                kind: OpKind::Rebase,
+                branch: Some("feat/y".to_string()),
+            })
+        );
+    }
+
+    #[test]
+    fn linked_worktree_with_relative_pointer_is_probed() {
+        let (_tmp, worktree, private) = linked_worktree(false);
+        write(&private.join("MERGE_HEAD"), "deadbeef\n");
+        assert_eq!(probe_op_state(&worktree).unwrap().kind, OpKind::Merge);
+    }
+
+    #[test]
+    fn linked_worktree_resolves_to_its_private_git_dir() {
+        let (_tmp, worktree, private) = linked_worktree(true);
+        assert_eq!(
+            resolve_worktree_git_dir(&worktree).unwrap(),
+            private,
+            "the resolved dir is the private gitdir, not the common dir"
+        );
+    }
+
+    #[test]
+    fn malformed_git_file_errors_but_probe_degrades_to_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let worktree = tmp.path().join("wt");
+        std::fs::create_dir_all(&worktree).unwrap();
+        std::fs::write(worktree.join(".git"), "not a gitdir pointer\n").unwrap();
+
+        assert!(resolve_worktree_git_dir(&worktree).is_err());
+        // Best-effort: one broken worktree must not fail a whole `daft list`.
+        assert_eq!(probe_op_state(&worktree), None);
+    }
+
+    #[test]
+    fn dangling_gitdir_pointer_degrades_to_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let worktree = tmp.path().join("wt");
+        std::fs::create_dir_all(&worktree).unwrap();
+        std::fs::write(
+            worktree.join(".git"),
+            "gitdir: /nonexistent/worktrees/gone\n",
+        )
+        .unwrap();
+
+        assert!(resolve_worktree_git_dir(&worktree).is_err());
+        assert_eq!(probe_op_state(&worktree), None);
+    }
+}

--- a/src/git/op_state.rs
+++ b/src/git/op_state.rs
@@ -69,6 +69,20 @@ impl OpKind {
             Self::Bisect => "bisect",
         }
     }
+
+    /// The annotation-column glyph for this operation. Shared by both
+    /// renderers so the plain table and the live TUI cannot drift.
+    pub fn symbol(self) -> &'static str {
+        use term_styles::op_symbols as sym;
+        match self {
+            Self::Rebase => sym::REBASE,
+            Self::Am => sym::AM,
+            Self::Merge => sym::MERGE,
+            Self::CherryPick => sym::CHERRY_PICK,
+            Self::Revert => sym::REVERT,
+            Self::Bisect => sym::BISECT,
+        }
+    }
 }
 
 /// An in-progress operation, plus the branch git recorded it against.

--- a/src/git/op_state.rs
+++ b/src/git/op_state.rs
@@ -141,6 +141,18 @@ pub fn probe_op_state(worktree: &Path) -> Option<OpState> {
     probe_op_state_in_git_dir(&git_dir)
 }
 
+/// The branch a worktree is operating on, when an in-progress operation
+/// records one and the porcelain does not.
+///
+/// This is the recovery `git worktree list --porcelain` cannot do for itself:
+/// mid-rebase it reports the worktree as detached, with no `branch` line,
+/// even though `refs/heads/<branch>` still exists and the worktree is still
+/// that branch's. Callers resolving a branch to its worktree consult this
+/// only after an attached match fails, so a real checkout always wins.
+pub fn recovered_branch(worktree: &Path) -> Option<String> {
+    probe_op_state(worktree)?.branch
+}
+
 /// [`probe_op_state`] against an already-resolved private git directory.
 ///
 /// Probe order follows git's own (`wt-status.c`): `MERGE_HEAD` first, then

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -1,8 +1,48 @@
 use super::GitCommand;
 use crate::utils::git_command_at;
 use anyhow::{Context, Result};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
+
+/// One `git worktree list --porcelain` stanza, in the shape this layer's
+/// branch→worktree lookups need.
+///
+/// git-layer: parsed here rather than via `core::worktree::porcelain` — the
+/// `git` adapter sits below `core` and must not depend on it (core → git,
+/// never the reverse). Deliberately minimal; `core`'s parser is the richer
+/// one every consumer above this layer uses.
+struct PorcelainEntry {
+    path: PathBuf,
+    /// Short branch name, from a `branch refs/heads/<name>` line.
+    branch: Option<String>,
+    /// The worktree has a detached HEAD (`detached` line). Bare entries are
+    /// neither detached nor branched.
+    detached: bool,
+}
+
+fn parse_porcelain_entries(porcelain: &str) -> Vec<PorcelainEntry> {
+    let mut entries: Vec<PorcelainEntry> = Vec::new();
+
+    for line in porcelain.lines() {
+        if let Some(path) = line.strip_prefix("worktree ") {
+            entries.push(PorcelainEntry {
+                path: PathBuf::from(path),
+                branch: None,
+                detached: false,
+            });
+        } else if let Some(branch_ref) = line.strip_prefix("branch refs/heads/") {
+            if let Some(entry) = entries.last_mut() {
+                entry.branch = Some(branch_ref.to_string());
+            }
+        } else if line == "detached"
+            && let Some(entry) = entries.last_mut()
+        {
+            entry.detached = true;
+        }
+    }
+
+    entries
+}
 
 impl GitCommand {
     pub fn worktree_add(&self, path: &Path, branch: &str) -> Result<()> {
@@ -133,97 +173,78 @@ impl GitCommand {
     /// Find the worktree path for a given branch name.
     /// Returns None if no worktree is checked out on that branch.
     ///
-    /// git-layer: parses the porcelain inline rather than delegating to
-    /// `core::worktree::porcelain` — the `git` adapter sits below `core` and
-    /// must not depend on it (core → git, never the reverse). The same applies
-    /// to `resolve_worktree_path` below and the gix path in `oxide.rs`.
+    /// A worktree paused mid-rebase reports no branch — git detaches HEAD to
+    /// replay commits — so a porcelain-only match loses it, and callers fall
+    /// back to "this branch has no worktree" while its worktree sits right
+    /// there. Attached checkouts are matched first and win outright; only
+    /// then are detached entries asked what operation they are under
+    /// ([`crate::git::op_state`]).
     pub fn find_worktree_for_branch(
         &self,
         branch_name: &str,
     ) -> Result<Option<std::path::PathBuf>> {
-        let porcelain_output = self.worktree_list_porcelain()?;
+        let entries = parse_porcelain_entries(&self.worktree_list_porcelain()?);
 
-        let mut current_path: Option<std::path::PathBuf> = None;
-
-        for line in porcelain_output.lines() {
-            if let Some(worktree_path) = line.strip_prefix("worktree ") {
-                current_path = Some(std::path::PathBuf::from(worktree_path));
-            } else if let Some(branch_ref) = line.strip_prefix("branch ") {
-                if let Some(branch) = branch_ref.strip_prefix("refs/heads/")
-                    && branch == branch_name
-                {
-                    return Ok(current_path.take());
-                }
-                current_path = None;
-            } else if line.is_empty() {
-                current_path = None;
-            }
+        if let Some(entry) = entries
+            .iter()
+            .find(|e| e.branch.as_deref() == Some(branch_name))
+        {
+            return Ok(Some(entry.path.clone()));
         }
 
-        Ok(None)
+        Ok(entries
+            .iter()
+            .filter(|e| e.detached)
+            .find(|e| {
+                crate::git::op_state::recovered_branch(&e.path).as_deref() == Some(branch_name)
+            })
+            .map(|e| e.path.clone()))
     }
 
     /// Resolve a target (worktree name or branch name) to a worktree path.
-    /// Priority: worktree name (directory name) > branch name
+    ///
+    /// Priority: path under the project root > checked-out branch > branch
+    /// recovered from an in-progress operation > worktree directory name.
+    /// The recovered tier sits with the other branch matching and below every
+    /// real checkout, so a paused rebase can never shadow an attached
+    /// worktree — it only rescues a lookup that would otherwise fail.
     pub fn resolve_worktree_path(
         &self,
         target: &str,
         project_root: &Path,
     ) -> Result<std::path::PathBuf> {
-        let porcelain_output = self.worktree_list_porcelain()?;
-
-        // Parse worktree list porcelain output
-        // Format:
-        // worktree /path/to/worktree
-        // HEAD <sha>
-        // branch refs/heads/branch-name
-        // <blank line>
-        let mut worktrees: Vec<(std::path::PathBuf, Option<String>)> = Vec::new();
-        let mut current_path: Option<std::path::PathBuf> = None;
-        let mut current_branch: Option<String> = None;
-
-        for line in porcelain_output.lines() {
-            if let Some(worktree_path) = line.strip_prefix("worktree ") {
-                // Save previous worktree if any
-                if let Some(path) = current_path.take() {
-                    worktrees.push((path, current_branch.take()));
-                }
-                current_path = Some(std::path::PathBuf::from(worktree_path));
-                current_branch = None;
-            } else if let Some(branch_ref) = line.strip_prefix("branch ") {
-                // Extract branch name from refs/heads/branch-name
-                current_branch = branch_ref.strip_prefix("refs/heads/").map(String::from);
-            }
-        }
-        // Don't forget the last worktree
-        if let Some(path) = current_path.take() {
-            worktrees.push((path, current_branch.take()));
-        }
+        let worktrees = parse_porcelain_entries(&self.worktree_list_porcelain()?);
 
         // First, check if target is a path relative to project root (most precise)
         let potential_path = project_root.join(target);
-        for (path, _) in &worktrees {
-            if path == &potential_path {
-                return Ok(path.clone());
-            }
+        if let Some(entry) = worktrees.iter().find(|e| e.path == potential_path) {
+            return Ok(entry.path.clone());
         }
 
         // Second, check if target matches a branch name
-        for (path, branch) in &worktrees {
-            if let Some(branch_name) = branch
-                && branch_name == target
-            {
-                return Ok(path.clone());
-            }
+        if let Some(entry) = worktrees
+            .iter()
+            .find(|e| e.branch.as_deref() == Some(target))
+        {
+            return Ok(entry.path.clone());
         }
 
-        // Third, check if target matches a worktree directory name (convenience shorthand)
-        for (path, _) in &worktrees {
-            if let Some(name) = path.file_name().and_then(|n| n.to_str())
-                && name == target
-            {
-                return Ok(path.clone());
-            }
+        // Third, the same question for worktrees git reports as detached
+        // because an operation is replaying commits in them.
+        if let Some(entry) = worktrees
+            .iter()
+            .filter(|e| e.detached)
+            .find(|e| crate::git::op_state::recovered_branch(&e.path).as_deref() == Some(target))
+        {
+            return Ok(entry.path.clone());
+        }
+
+        // Fourth, check if target matches a worktree directory name (convenience shorthand)
+        if let Some(entry) = worktrees
+            .iter()
+            .find(|e| e.path.file_name().and_then(|n| n.to_str()) == Some(target))
+        {
+            return Ok(entry.path.clone());
         }
 
         anyhow::bail!("No worktree found for '{}'", target)

--- a/src/hooks/conditions.rs
+++ b/src/hooks/conditions.rs
@@ -8,6 +8,7 @@ use super::yaml_config::{
     JobDef, OnlyCondition, OnlyRule, OnlyRuleStructured, SkipCondition, SkipRule,
     SkipRuleStructured, TargetOs,
 };
+use crate::git::op_state::{OpKind, probe_op_state};
 use std::path::Path;
 
 /// Information about why a job was skipped.
@@ -269,32 +270,19 @@ fn is_env_truthy(var: &str) -> bool {
 
 /// Check if git is currently in a merge state.
 fn is_in_merge(worktree: &Path) -> bool {
-    let git_dir = worktree.join(".git");
-    // MERGE_HEAD exists during a merge
-    git_dir.join("MERGE_HEAD").exists()
-        || std::process::Command::new("git")
-            .args(["rev-parse", "--verify", "MERGE_HEAD"])
-            .current_dir(worktree)
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status()
-            .map(|s| s.success())
-            .unwrap_or(false)
+    matches!(probe_op_state(worktree), Some(state) if state.kind == OpKind::Merge)
 }
 
 /// Check if git is currently in a rebase state.
+///
+/// `git am` counts, as it always has here: it shares the apply backend's
+/// directory, and a hook that wants to stay out of a rebase's way wants to
+/// stay out of an am's way too.
 fn is_in_rebase(worktree: &Path) -> bool {
-    let git_dir = worktree.join(".git");
-    git_dir.join("rebase-merge").exists()
-        || git_dir.join("rebase-apply").exists()
-        || std::process::Command::new("git")
-            .args(["rev-parse", "--verify", "REBASE_HEAD"])
-            .current_dir(worktree)
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status()
-            .map(|s| s.success())
-            .unwrap_or(false)
+    matches!(
+        probe_op_state(worktree),
+        Some(state) if matches!(state.kind, OpKind::Rebase | OpKind::Am)
+    )
 }
 
 /// Get the current branch/ref name.
@@ -558,5 +546,63 @@ mod tests {
         );
         let cond = SkipCondition::Platform(map);
         assert!(should_skip(&cond, Path::new(".")).is_none());
+    }
+
+    /// Build a linked worktree — `.git` is a *file* pointing at the private
+    /// gitdir, which is daft's default layout — and return (tempdir, worktree
+    /// path, private gitdir).
+    fn linked_worktree() -> (tempfile::TempDir, std::path::PathBuf, std::path::PathBuf) {
+        let tmp = tempfile::tempdir().unwrap();
+        let private = tmp.path().join("repo/.git/worktrees/wt-a");
+        std::fs::create_dir_all(&private).unwrap();
+        let worktree = tmp.path().join("wt-a");
+        std::fs::create_dir_all(&worktree).unwrap();
+        std::fs::write(
+            worktree.join(".git"),
+            format!("gitdir: {}\n", private.display()),
+        )
+        .unwrap();
+        (tmp, worktree, private)
+    }
+
+    /// Regression: the merge/rebase conditions used to join `<worktree>/.git`
+    /// as a directory, so in a linked worktree — every daft worktree — the
+    /// state files were invisible and the conditions silently read "no
+    /// operation in progress".
+    #[test]
+    fn detects_merge_in_a_linked_worktree() {
+        let (_tmp, worktree, private) = linked_worktree();
+        std::fs::write(private.join("MERGE_HEAD"), "deadbeef\n").unwrap();
+
+        let cond = SkipCondition::Rules(vec![SkipRule::Named("merge".to_string())]);
+        assert!(
+            should_skip(&cond, &worktree).is_some(),
+            "a paused merge in a linked worktree must satisfy `skip: [merge]`"
+        );
+    }
+
+    #[test]
+    fn detects_rebase_in_a_linked_worktree() {
+        let (_tmp, worktree, private) = linked_worktree();
+        std::fs::create_dir_all(private.join("rebase-merge")).unwrap();
+
+        let cond = SkipCondition::Rules(vec![SkipRule::Named("rebase".to_string())]);
+        assert!(
+            should_skip(&cond, &worktree).is_some(),
+            "a paused rebase in a linked worktree must satisfy `skip: [rebase]`"
+        );
+    }
+
+    #[test]
+    fn idle_linked_worktree_matches_no_operation_condition() {
+        let (_tmp, worktree, _private) = linked_worktree();
+
+        for name in ["merge", "rebase"] {
+            let cond = SkipCondition::Rules(vec![SkipRule::Named(name.to_string())]);
+            assert!(
+                should_skip(&cond, &worktree).is_none(),
+                "an idle worktree must not satisfy `skip: [{name}]`"
+            );
+        }
     }
 }

--- a/src/output/annotation.rs
+++ b/src/output/annotation.rs
@@ -1,0 +1,261 @@
+//! The annotation column's sub-position layout, shared by both list renderers.
+//!
+//! The annotation column is a row of narrow slots carrying the *state* of a
+//! row — what it is, not what it contains. Slots materialize per run: a slot
+//! costs its width only when some row in this run actually uses it, so a
+//! listing with no default branch and no operations spends nothing on either.
+//!
+//! Both the plain table (`commands::list`) and the live TUI
+//! (`output::tui::render`) lay the column out from here. They differ only in
+//! how they paint a glyph — ANSI escapes versus ratatui styles — so the two
+//! surfaces cannot drift on *which* slots exist or what goes in them, which
+//! is what happened before: the TUI had two hardcoded sub-positions while the
+//! plain table computed three.
+
+use crate::core::worktree::list::WorktreeInfo;
+use crate::git::op_state::OpKind;
+use crate::styles;
+
+/// What occupies one annotation slot for one row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AnnotationGlyph {
+    /// The worktree the user is currently inside.
+    Current,
+    /// The repository's default branch.
+    DefaultBranch,
+    /// A detached checkout nothing explains.
+    Sandbox,
+    /// A paused git operation.
+    Operation(OpKind),
+}
+
+impl AnnotationGlyph {
+    /// The character to draw. Colour is the renderer's business.
+    pub fn symbol(self) -> &'static str {
+        match self {
+            Self::Current => styles::CURRENT_WORKTREE_SYMBOL,
+            Self::DefaultBranch => styles::DEFAULT_BRANCH_SYMBOL,
+            Self::Sandbox => styles::SANDBOX_SYMBOL,
+            Self::Operation(op) => op.symbol(),
+        }
+    }
+}
+
+/// Which annotation slots this run needs, in display order.
+///
+/// Computed once from the full row set — never per row, and never per frame:
+/// the live renderer recomputes column widths continuously, so a slot set that
+/// tracked current row state would make the whole table reflow the moment an
+/// operation appeared or ended.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct AnnotationSlots {
+    /// Slot 1 — the current-worktree marker.
+    pub current: bool,
+    /// Slot 2 — what this row *is*: default branch, or unexplained detachment.
+    pub identity: bool,
+    /// Slot 3 — what is *happening* to it: a paused operation.
+    pub state: bool,
+}
+
+impl AnnotationSlots {
+    /// The slots needed to annotate `infos`.
+    pub fn for_rows(infos: &[WorktreeInfo]) -> Self {
+        Self {
+            current: infos.iter().any(|i| i.is_current),
+            identity: infos.iter().any(|i| i.is_default_branch || i.is_sandbox),
+            state: infos.iter().any(|i| i.op.is_some()),
+        }
+    }
+
+    /// How many slots are in play.
+    pub fn count(self) -> usize {
+        usize::from(self.current) + usize::from(self.identity) + usize::from(self.state)
+    }
+
+    /// True when no row needs annotating at all — the column can be dropped.
+    pub fn is_empty(self) -> bool {
+        self.count() == 0
+    }
+
+    /// The rendered width of the column: one column per slot, plus a single
+    /// space between adjacent slots.
+    pub fn width(self) -> usize {
+        match self.count() {
+            0 => 0,
+            n => n * 2 - 1,
+        }
+    }
+
+    /// What each active slot holds for `info`, in display order. `None` is an
+    /// active slot this row does not fill — it still occupies its width, so
+    /// glyphs stay in vertical columns down the table.
+    pub fn glyphs(self, info: &WorktreeInfo) -> Vec<Option<AnnotationGlyph>> {
+        let mut out = Vec::with_capacity(self.count());
+        if self.current {
+            out.push(info.is_current.then_some(AnnotationGlyph::Current));
+        }
+        if self.identity {
+            // The default-branch marker outranks the sandbox marker: a row can
+            // only be one of them in practice, and this keeps the precedence
+            // explicit rather than accidental.
+            out.push(if info.is_default_branch {
+                Some(AnnotationGlyph::DefaultBranch)
+            } else if info.is_sandbox {
+                Some(AnnotationGlyph::Sandbox)
+            } else {
+                None
+            });
+        }
+        if self.state {
+            out.push(info.op.map(AnnotationGlyph::Operation));
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(name: &str) -> WorktreeInfo {
+        WorktreeInfo::empty(name)
+    }
+
+    #[test]
+    fn a_run_with_nothing_to_say_uses_no_slots() {
+        let slots = AnnotationSlots::for_rows(&[row("a"), row("b")]);
+        assert!(slots.is_empty());
+        assert_eq!(slots.width(), 0);
+        assert!(slots.glyphs(&row("a")).is_empty());
+    }
+
+    #[test]
+    fn slots_materialize_only_for_states_present_in_this_run() {
+        let mut current = row("a");
+        current.is_current = true;
+        let slots = AnnotationSlots::for_rows(&[current, row("b")]);
+
+        assert_eq!(
+            slots,
+            AnnotationSlots {
+                current: true,
+                identity: false,
+                state: false,
+            }
+        );
+        assert_eq!(slots.count(), 1);
+        assert_eq!(slots.width(), 1, "a lone slot needs no separator");
+    }
+
+    #[test]
+    fn an_operation_opens_the_state_slot() {
+        let mut rebasing = row("feat/x");
+        rebasing.op = Some(OpKind::Rebase);
+        let slots = AnnotationSlots::for_rows(&[rebasing.clone(), row("main")]);
+
+        assert!(slots.state);
+        assert!(
+            !slots.identity,
+            "no default branch and no sandbox in this run"
+        );
+        assert_eq!(
+            slots.glyphs(&rebasing),
+            vec![Some(AnnotationGlyph::Operation(OpKind::Rebase))]
+        );
+        // The row without an operation still occupies the slot, so glyphs
+        // stay aligned down the column.
+        assert_eq!(slots.glyphs(&row("main")), vec![None]);
+    }
+
+    #[test]
+    fn all_three_slots_can_be_in_play_at_once() {
+        let mut current = row("here");
+        current.is_current = true;
+        let mut default = row("main");
+        default.is_default_branch = true;
+        let mut rebasing = row("feat/x");
+        rebasing.op = Some(OpKind::Rebase);
+
+        let slots =
+            AnnotationSlots::for_rows(&[current.clone(), default.clone(), rebasing.clone()]);
+        assert_eq!(slots.count(), 3);
+        assert_eq!(slots.width(), 5, "three glyphs plus two separators");
+
+        assert_eq!(
+            slots.glyphs(&current),
+            vec![Some(AnnotationGlyph::Current), None, None]
+        );
+        assert_eq!(
+            slots.glyphs(&default),
+            vec![None, Some(AnnotationGlyph::DefaultBranch), None]
+        );
+        assert_eq!(
+            slots.glyphs(&rebasing),
+            vec![None, None, Some(AnnotationGlyph::Operation(OpKind::Rebase))]
+        );
+    }
+
+    /// A sandbox and a rebasing worktree use *different* slots — the whole
+    /// point of separating "what it is" from "what is happening to it".
+    #[test]
+    fn sandbox_and_operation_occupy_different_slots() {
+        let mut sandbox = row("(detached)");
+        sandbox.is_sandbox = true;
+        let mut rebasing = row("feat/x");
+        rebasing.op = Some(OpKind::Rebase);
+
+        let slots = AnnotationSlots::for_rows(&[sandbox.clone(), rebasing.clone()]);
+        assert_eq!(slots.count(), 2);
+        assert_eq!(
+            slots.glyphs(&sandbox),
+            vec![Some(AnnotationGlyph::Sandbox), None]
+        );
+        assert_eq!(
+            slots.glyphs(&rebasing),
+            vec![None, Some(AnnotationGlyph::Operation(OpKind::Rebase))]
+        );
+    }
+
+    /// A worktree can be mid-operation *and* be the default branch (a merge
+    /// keeps HEAD attached), so both slots fill on the same row.
+    #[test]
+    fn a_merging_default_branch_fills_two_slots() {
+        let mut merging = row("main");
+        merging.is_default_branch = true;
+        merging.op = Some(OpKind::Merge);
+
+        let slots = AnnotationSlots::for_rows(&[merging.clone()]);
+        assert_eq!(
+            slots.glyphs(&merging),
+            vec![
+                Some(AnnotationGlyph::DefaultBranch),
+                Some(AnnotationGlyph::Operation(OpKind::Merge)),
+            ]
+        );
+    }
+
+    #[test]
+    fn every_operation_has_a_distinct_glyph() {
+        let kinds = [
+            OpKind::Rebase,
+            OpKind::Am,
+            OpKind::Merge,
+            OpKind::CherryPick,
+            OpKind::Revert,
+            OpKind::Bisect,
+        ];
+        let symbols: Vec<&str> = kinds
+            .iter()
+            .map(|k| AnnotationGlyph::Operation(*k).symbol())
+            .collect();
+        let unique: std::collections::HashSet<&&str> = symbols.iter().collect();
+        assert_eq!(unique.len(), kinds.len(), "glyphs collide: {symbols:?}");
+
+        // And none of them collides with the identity markers sharing the row.
+        for s in &symbols {
+            assert_ne!(*s, styles::SANDBOX_SYMBOL);
+            assert_ne!(*s, styles::DEFAULT_BRANCH_SYMBOL);
+            assert_ne!(*s, styles::CURRENT_WORKTREE_SYMBOL);
+        }
+    }
+}

--- a/src/output/annotation.rs
+++ b/src/output/annotation.rs
@@ -27,6 +27,8 @@ pub enum AnnotationGlyph {
     Sandbox,
     /// A paused git operation.
     Operation(OpKind),
+    /// The recorded intended branch disagrees with the checked-out branch.
+    Drift,
 }
 
 impl AnnotationGlyph {
@@ -37,6 +39,7 @@ impl AnnotationGlyph {
             Self::DefaultBranch => styles::DEFAULT_BRANCH_SYMBOL,
             Self::Sandbox => styles::SANDBOX_SYMBOL,
             Self::Operation(op) => op.symbol(),
+            Self::Drift => styles::DRIFT_SYMBOL,
         }
     }
 }
@@ -63,7 +66,7 @@ impl AnnotationSlots {
         Self {
             current: infos.iter().any(|i| i.is_current),
             identity: infos.iter().any(|i| i.is_default_branch || i.is_sandbox),
-            state: infos.iter().any(|i| i.op.is_some()),
+            state: infos.iter().any(|i| i.op.is_some() || i.drifted),
         }
     }
 
@@ -107,7 +110,12 @@ impl AnnotationSlots {
             });
         }
         if self.state {
-            out.push(info.op.map(AnnotationGlyph::Operation));
+            // An operation outranks drift: it is the transient, actionable
+            // state, and drift keeps until the operation concludes.
+            out.push(match info.op {
+                Some(op) => Some(AnnotationGlyph::Operation(op)),
+                None => info.drifted.then_some(AnnotationGlyph::Drift),
+            });
         }
         out
     }

--- a/src/output/format.rs
+++ b/src/output/format.rs
@@ -349,6 +349,9 @@ pub fn tilde_path(path: &str) -> String {
 /// Pre-computed plain-text column values for a single worktree row.
 /// No ANSI codes — renderers apply their own styling.
 pub struct ColumnValues {
+    /// Paused operation and conflict state in words, for the `status` column.
+    /// Empty when there is nothing to report.
+    pub status: String,
     pub branch: String,
     pub path: String,
     pub size: String,
@@ -435,11 +438,44 @@ pub fn format_human_size(bytes: u64) -> String {
     }
 }
 
+/// The `status` column's text: the paused operation, qualified by how far
+/// through it the user is.
+///
+/// The qualifier is the part the other columns cannot express. A conflict
+/// count already shows as `!N` under Changes, but its *absence* is ambiguous
+/// — an operation with nothing conflicted might be untouched or might be
+/// resolved and waiting for `--continue`. Saying "resolved" is the whole
+/// reason this column spells things out.
+pub fn format_worktree_status(info: &WorktreeInfo) -> String {
+    let Some(op) = info.op else {
+        return String::new();
+    };
+    let label = op.label();
+
+    if info.conflicted > 0 {
+        let noun = if info.conflicted == 1 {
+            "conflict"
+        } else {
+            "conflicts"
+        };
+        return format!("{label} · {} {noun}", info.conflicted);
+    }
+
+    // Nothing conflicted, but the operation is still open and the index holds
+    // resolutions: the user has done the work and needs to continue.
+    if info.staged > 0 {
+        return format!("{label} · resolved");
+    }
+
+    label.to_string()
+}
+
 /// Compute plain-text column values for a single `WorktreeInfo`.
 ///
 /// Respects `ctx.stat`: Summary mode uses commit/file counts, Lines mode
 /// uses line-level insertion/deletion counts for Base, Changes, and Remote.
 pub fn compute_column_values(info: &WorktreeInfo, ctx: &ColumnContext) -> ColumnValues {
+    let status = format_worktree_status(info);
     let branch = info.name.clone();
 
     let path = info
@@ -522,6 +558,7 @@ pub fn compute_column_values(info: &WorktreeInfo, ctx: &ColumnContext) -> Column
     };
 
     ColumnValues {
+        status,
         branch,
         path,
         size,
@@ -960,5 +997,83 @@ mod tests {
         // ANSI bytes preserved at the start; trailing spaces appended after RESET.
         assert!(padded.starts_with("\x1b[31mfailed!\x1b[0m"));
         assert!(padded.ends_with("   "));
+    }
+    // ── status column text ──────────────────────────────────────────────────
+
+    fn status_of(
+        op: Option<crate::git::op_state::OpKind>,
+        conflicted: usize,
+        staged: usize,
+    ) -> String {
+        let mut info = WorktreeInfo::empty("feat/x");
+        info.op = op;
+        info.conflicted = conflicted;
+        info.staged = staged;
+        format_worktree_status(&info)
+    }
+
+    #[test]
+    fn a_worktree_with_no_operation_has_no_status() {
+        assert_eq!(status_of(None, 0, 0), "");
+        // Ordinary uncommitted work is not a status either.
+        assert_eq!(status_of(None, 0, 3), "");
+    }
+
+    #[test]
+    fn an_operation_reports_its_conflict_count() {
+        use crate::git::op_state::OpKind;
+        assert_eq!(
+            status_of(Some(OpKind::Rebase), 2, 0),
+            "rebasing · 2 conflicts"
+        );
+        assert_eq!(status_of(Some(OpKind::Merge), 1, 0), "merging · 1 conflict");
+    }
+
+    /// The state no other column can express: nothing is conflicted any more,
+    /// but the operation is still open and the resolutions are staged. `!N`
+    /// renders as nothing here, so without these words the row looks idle.
+    #[test]
+    fn a_resolved_but_unfinished_operation_says_so() {
+        use crate::git::op_state::OpKind;
+        assert_eq!(status_of(Some(OpKind::Rebase), 0, 2), "rebasing · resolved");
+    }
+
+    #[test]
+    fn an_untouched_operation_is_just_the_operation() {
+        use crate::git::op_state::OpKind;
+        assert_eq!(status_of(Some(OpKind::Bisect), 0, 0), "bisecting");
+        assert_eq!(status_of(Some(OpKind::CherryPick), 0, 0), "cherry-picking");
+    }
+
+    /// Conflicts outrank the resolved qualifier: if anything is still
+    /// unmerged the user is not ready to continue, whatever else is staged.
+    #[test]
+    fn outstanding_conflicts_outrank_staged_resolutions() {
+        use crate::git::op_state::OpKind;
+        assert_eq!(
+            status_of(Some(OpKind::Rebase), 1, 5),
+            "rebasing · 1 conflict"
+        );
+    }
+
+    #[test]
+    fn the_status_value_reaches_the_column_values() {
+        use crate::git::op_state::OpKind;
+        let mut info = WorktreeInfo::empty("feat/x");
+        info.op = Some(OpKind::Rebase);
+        info.conflicted = 2;
+        let ctx = ColumnContext {
+            project_root: Path::new("/"),
+            cwd: Path::new("/"),
+            now: 0,
+            stat: Stat::Summary,
+            forge_prs: None,
+            colors: false,
+        };
+        let vals = compute_column_values(&info, &ctx);
+        assert_eq!(vals.status, "rebasing · 2 conflicts");
+        // The branch cell stays pure identity — no badge appended.
+        assert_eq!(vals.branch, "feat/x");
+        assert_eq!(vals.changes, "!2");
     }
 }

--- a/src/output/format.rs
+++ b/src/output/format.rs
@@ -40,12 +40,25 @@ pub fn format_ahead_behind(ahead: Option<usize>, behind: Option<usize>, use_colo
 
 /// Format head status indicators: `+` staged, `-` unstaged, `?` untracked.
 pub fn format_head_status(
+    conflicted: usize,
     staged: usize,
     unstaged: usize,
     untracked: usize,
     use_color: bool,
 ) -> String {
     let mut parts = Vec::new();
+
+    // Conflicts lead: they are the one state in this cell that blocks the
+    // user rather than merely describing work, and bold red separates them
+    // from the plain red of unstaged changes.
+    if conflicted > 0 {
+        let text = format!("!{conflicted}");
+        if use_color {
+            parts.push(styles::bold_red(&text));
+        } else {
+            parts.push(text);
+        }
+    }
 
     if staged > 0 {
         let text = format!("+{staged}");
@@ -381,6 +394,12 @@ pub fn format_head_status_lines(info: &WorktreeInfo) -> String {
     let ins = info.staged_lines_inserted.unwrap_or(0) + info.unstaged_lines_inserted.unwrap_or(0);
     let del = info.staged_lines_deleted.unwrap_or(0) + info.unstaged_lines_deleted.unwrap_or(0);
     let mut parts = Vec::new();
+    // A conflict count is a file count, not a line count — but it stays in
+    // this cell in `--stat lines` too. Choosing a stat mode should not make
+    // "these files need a decision" disappear.
+    if info.conflicted > 0 {
+        parts.push(format!("!{}", info.conflicted));
+    }
     if ins > 0 {
         parts.push(format!("+{ins}"));
     }
@@ -440,7 +459,13 @@ pub fn compute_column_values(info: &WorktreeInfo, ctx: &ColumnContext) -> Column
     } else {
         (
             format_ahead_behind(info.ahead, info.behind, false),
-            format_head_status(info.staged, info.unstaged, info.untracked, false),
+            format_head_status(
+                info.conflicted,
+                info.staged,
+                info.unstaged,
+                info.untracked,
+                false,
+            ),
             format_remote_status(info.remote_ahead, info.remote_behind, false),
         )
     };

--- a/src/output/format.rs
+++ b/src/output/format.rs
@@ -448,6 +448,19 @@ pub fn format_human_size(bytes: u64) -> String {
 /// reason this column spells things out.
 pub fn format_worktree_status(info: &WorktreeInfo) -> String {
     let Some(op) = info.op else {
+        // No operation: report the two states the record can surface.
+        // Drift first — a record disagreeing with a live checkout is a
+        // problem to fix, where a named detached checkout is merely a fact.
+        if info.drifted {
+            return "drifted".to_string();
+        }
+        if info.identity_source == Some(crate::core::worktree::identity::IdentitySource::Persisted)
+        {
+            return match &info.last_commit_hash {
+                Some(hash) => String::from("detached @ ") + hash,
+                None => "detached".to_string(),
+            };
+        }
         return String::new();
     };
     let label = op.label();

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -17,6 +17,7 @@
 //! }
 //! ```
 
+pub mod annotation;
 mod buffering;
 mod cli;
 pub mod deferred_warn;

--- a/src/output/tui/columns.rs
+++ b/src/output/tui/columns.rs
@@ -6,10 +6,15 @@ use crate::output::format::ColumnValues;
 /// Columns available in the worktree table, in canonical display order.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Column {
-    /// Sync/prune status indicator.
+    /// Sync/prune per-task progress indicator (queued / running / done).
+    /// Pinned as the first column by those TUIs and not user-selectable —
+    /// distinct from [`Column::BranchStatus`], which reports git state.
     Status,
     /// Current/default branch annotation.
     Annotation,
+    /// Paused git operation and conflict state, in words. The opt-in
+    /// `daft list --columns +status` column.
+    BranchStatus,
     /// Branch name.
     Branch,
     /// Worktree path.
@@ -44,6 +49,7 @@ impl Column {
         match self {
             Self::Status => "Status",
             Self::Annotation => "",
+            Self::BranchStatus => "Status",
             Self::Branch => "Branch",
             Self::Path => "Path",
             Self::Size => "Size",
@@ -62,6 +68,7 @@ impl Column {
     pub fn from_list_column(lc: ListColumn) -> Self {
         match lc {
             ListColumn::Annotation => Column::Annotation,
+            ListColumn::Status => Column::BranchStatus,
             ListColumn::Branch => Column::Branch,
             ListColumn::Path => Column::Path,
             ListColumn::Size => Column::Size,
@@ -83,6 +90,7 @@ impl Column {
         match self {
             Self::Status => None,
             Self::Annotation => Some(ListColumn::Annotation),
+            Self::BranchStatus => Some(ListColumn::Status),
             Self::Branch => Some(ListColumn::Branch),
             Self::Path => Some(ListColumn::Path),
             Self::Size => Some(ListColumn::Size),
@@ -187,6 +195,7 @@ pub(super) fn column_content_width(
             // Exactly the slots this run materialized — the annotation cell
             // is painted from the same value, so the two cannot disagree.
             Column::Annotation => annotation_slots.width() as u16,
+            Column::BranchStatus => v.status.chars().count() as u16,
             Column::Branch => v.branch.len() as u16,
             Column::Path => v.path.len() as u16,
             Column::Size => v.size.len() as u16,

--- a/src/output/tui/columns.rs
+++ b/src/output/tui/columns.rs
@@ -163,6 +163,7 @@ pub(super) fn column_content_width(
     vals: &[ColumnValues],
     sort_spec: Option<&SortSpec>,
     extra_width: u16,
+    annotation_slots: crate::output::annotation::AnnotationSlots,
 ) -> u16 {
     // Account for sort indicator (" ↓" / " ↑" = 2 visible chars) in header width.
     let sort_extra: u16 = col
@@ -183,7 +184,9 @@ pub(super) fn column_content_width(
         .map(|(wt, v)| match col {
             // Pre-allocate for the longest possible status to avoid layout jumps.
             Column::Status => status_display_width(&wt.status).max(STATUS_MAX_WIDTH),
-            Column::Annotation => 3,
+            // Exactly the slots this run materialized — the annotation cell
+            // is painted from the same value, so the two cannot disagree.
+            Column::Annotation => annotation_slots.width() as u16,
             Column::Branch => v.branch.len() as u16,
             Column::Path => v.path.len() as u16,
             Column::Size => v.size.len() as u16,
@@ -313,7 +316,14 @@ mod tests {
     /// and the TOTAL cell got truncated.
     #[test]
     fn column_content_width_honors_extra_width_when_wider() {
-        let w = column_content_width(Column::Size, &[], &[], None, /* extra_width */ 6);
+        let w = column_content_width(
+            Column::Size,
+            &[],
+            &[],
+            None,
+            /* extra_width */ 6,
+            Default::default(),
+        );
         assert_eq!(
             w, 6,
             "extra_width must dominate when wider than header/data"
@@ -323,7 +333,7 @@ mod tests {
     #[test]
     fn column_content_width_ignores_extra_width_when_narrower() {
         // "Size" header is 4 chars; extra_width=2 should not shrink the column.
-        let w = column_content_width(Column::Size, &[], &[], None, 2);
+        let w = column_content_width(Column::Size, &[], &[], None, 2, Default::default());
         assert_eq!(w, 4, "extra_width must not shrink below header width");
     }
 
@@ -331,7 +341,7 @@ mod tests {
     fn column_content_width_status_keeps_minimum_with_extra_width() {
         // Status has a hard floor (STATUS_MAX_WIDTH); extra_width below it
         // shouldn't shrink the column.
-        let w = column_content_width(Column::Status, &[], &[], None, 3);
+        let w = column_content_width(Column::Status, &[], &[], None, 3, Default::default());
         assert_eq!(w, STATUS_MAX_WIDTH);
     }
 

--- a/src/output/tui/live_table.rs
+++ b/src/output/tui/live_table.rs
@@ -44,6 +44,11 @@ pub struct LiveTableConfig {
     /// the bit set but no seed value render as "final empty" rather than
     /// shimmering.
     pub seeded_fields: FieldSet,
+    /// Annotation sub-positions this run renders, computed once from the
+    /// seeded rows and then held fixed. Column widths are recomputed every
+    /// frame, so deriving this from current row state would reflow the whole
+    /// table the moment an operation appeared or ended.
+    pub annotation_slots: crate::output::annotation::AnnotationSlots,
     /// Forge-PR cache decorations for the PR column (outbound PR numbers +
     /// CI states). Loaded once by `daft list` before the TUI starts and
     /// post-set after `TuiState::new` (like `unowned_start_index`); `None`
@@ -380,6 +385,7 @@ mod tests {
             project_root: PathBuf::from("/tmp"),
             cwd: PathBuf::from("/tmp"),
             seeded_fields: FieldSet::EMPTY,
+            annotation_slots: Default::default(),
             forge_prs: None,
             forge_prs_loading: false,
         }

--- a/src/output/tui/render.rs
+++ b/src/output/tui/render.rs
@@ -1,3 +1,5 @@
+use crate::output::annotation::{AnnotationGlyph, AnnotationSlots};
+
 use super::columns::{
     ALL_COLUMNS, Column, column_content_width, fit_widths_to_available, truncate_with_ellipsis,
 };
@@ -244,7 +246,14 @@ pub fn render_table(state: &TuiState, frame: &mut Frame, area: Rect) {
             } else {
                 0
             };
-            column_content_width(*col, &state.live.rows, &row_vals, sort_ref, extra)
+            column_content_width(
+                *col,
+                &state.live.rows,
+                &row_vals,
+                sort_ref,
+                extra,
+                state.live.cfg.annotation_slots,
+            )
         })
         .collect();
     let assigned_widths = fit_widths_to_available(&columns, &natural_widths, table_area.width);
@@ -381,6 +390,7 @@ pub fn render_table(state: &TuiState, frame: &mut Frame, area: Rect) {
                             state.tick,
                             state.live.cfg.stat,
                             assigned_widths[i],
+                            state.live.cfg.annotation_slots,
                             |fs| state.live.is_cell_loading(row_idx, fs),
                             |fs| state.live.is_cell_unloaded(row_idx, fs),
                             |fs| state.live.is_cell_stale(row_idx, fs),
@@ -402,6 +412,7 @@ pub fn render_table(state: &TuiState, frame: &mut Frame, area: Rect) {
                         state.tick,
                         state.live.cfg.stat,
                         assigned_widths[i],
+                        state.live.cfg.annotation_slots,
                         |fs| state.live.is_cell_loading(row_idx, fs),
                         |fs| state.live.is_cell_unloaded(row_idx, fs),
                         |fs| state.live.is_cell_stale(row_idx, fs),
@@ -731,13 +742,14 @@ fn render_cell(
     tick: usize,
     stat: Stat,
     width: u16,
+    annotation_slots: AnnotationSlots,
     is_cell_loading: impl Fn(FieldSet) -> bool,
     is_cell_unloaded: impl Fn(FieldSet) -> bool,
     is_cell_stale: impl Fn(FieldSet) -> bool,
 ) -> Cell<'static> {
     match col {
         Column::Status => render_status_cell(wt, tick),
-        Column::Annotation => render_annotation_cell(&wt.info),
+        Column::Annotation => render_annotation_cell(&wt.info, annotation_slots),
         Column::Branch => Cell::from(vals.branch.clone()),
         Column::Path => Cell::from(vals.path.clone()),
         Column::Size => {
@@ -1157,39 +1169,33 @@ fn format_pruned_overlay(
     Line::from(Span::styled(text, style))
 }
 
-/// Render the annotation cell (current worktree indicator and default branch marker).
+/// Render the annotation cell.
 ///
-/// Matches `list` column layout: two fixed sub-positions `[> ][✦]` so that
-/// the `>` and `✦` markers stay in separate visual columns.
-fn render_annotation_cell(info: &WorktreeInfo) -> Cell<'static> {
+/// Slot layout comes from [`AnnotationSlots`], shared with the plain table so
+/// the two renderers cannot disagree about which sub-positions exist. This
+/// only maps each glyph to a ratatui style and pads unfilled slots, keeping
+/// markers in vertical columns down the table.
+fn render_annotation_cell(info: &WorktreeInfo, slots: AnnotationSlots) -> Cell<'static> {
     let mut spans: Vec<Span<'static>> = Vec::new();
 
-    // Sub-position 1: current worktree marker
-    if info.is_current {
-        spans.push(Span::styled(
-            styles::CURRENT_WORKTREE_SYMBOL,
-            Style::default().fg(Color::Cyan),
-        ));
-    } else {
-        spans.push(Span::raw(" "));
-    }
-
-    // Spacer between the two sub-positions
-    spans.push(Span::raw(" "));
-
-    // Sub-position 2: default branch marker (bright purple) or sandbox marker (dim)
-    if info.is_default_branch {
-        spans.push(Span::styled(
-            styles::DEFAULT_BRANCH_SYMBOL,
-            Style::default().fg(Color::LightMagenta),
-        ));
-    } else if info.is_sandbox {
-        spans.push(Span::styled(
-            styles::SANDBOX_SYMBOL,
-            Style::default().fg(Color::DarkGray),
-        ));
-    } else {
-        spans.push(Span::raw(" "));
+    for (i, glyph) in slots.glyphs(info).into_iter().enumerate() {
+        if i > 0 {
+            spans.push(Span::raw(" "));
+        }
+        match glyph {
+            None => spans.push(Span::raw(" ")),
+            Some(glyph) => {
+                let color = match glyph {
+                    AnnotationGlyph::Current => Color::Cyan,
+                    AnnotationGlyph::DefaultBranch => Color::LightMagenta,
+                    AnnotationGlyph::Sandbox => Color::DarkGray,
+                    // Operations share the attention colour with the status
+                    // column, and with the plain renderer's yellow.
+                    AnnotationGlyph::Operation(_) => Color::Yellow,
+                };
+                spans.push(Span::styled(glyph.symbol(), Style::default().fg(color)));
+            }
+        }
     }
 
     Cell::from(Line::from(spans))
@@ -1456,6 +1462,7 @@ mod tests {
                         0,
                         Stat::Lines,
                         10,
+                        Default::default(),
                         |_fs| false, // not loading (cancelled implies collection_complete)
                         |_fs| true,  // is_cell_unloaded → true
                         |_fs| false, // not stale
@@ -1507,6 +1514,7 @@ mod tests {
                     0,
                     Stat::Lines,
                     10,
+                    Default::default(),
                     |_fs| false, // not loading
                     |_fs| false, // not unloaded — received
                     |_fs| false, // not stale
@@ -1562,6 +1570,7 @@ mod tests {
                     0,
                     Stat::Summary,
                     10,
+                    Default::default(),
                     |_fs| false, // not loading
                     |_fs| false, // not unloaded
                     |_fs| true,  // stale → dim
@@ -1793,6 +1802,100 @@ mod tests {
         assert!(
             !full_buffer.contains("15.0 ") && !full_buffer.contains("15.0\n"),
             "TOTAL must not render as truncated \"15.0\" — got buffer:\n{full_buffer}"
+        );
+    }
+    /// The annotation cell and the annotation column's width are computed
+    /// from the same slot set, so a glyph can never render into space the
+    /// layout did not reserve (or leave a ragged gap where it did).
+    #[test]
+    fn annotation_cell_width_matches_the_slot_layout() {
+        use crate::git::op_state::OpKind;
+
+        let mut current = WorktreeInfo::empty("here");
+        current.is_current = true;
+        let mut default = WorktreeInfo::empty("main");
+        default.is_default_branch = true;
+        let mut rebasing = WorktreeInfo::empty("feat/x");
+        rebasing.op = Some(OpKind::Rebase);
+
+        // Every combination of rows that can occur, from "nothing to say" up
+        // to all three slots in play.
+        let cases: Vec<Vec<WorktreeInfo>> = vec![
+            vec![WorktreeInfo::empty("plain")],
+            vec![current.clone()],
+            vec![rebasing.clone()],
+            vec![current.clone(), default.clone()],
+            vec![current.clone(), default.clone(), rebasing.clone()],
+        ];
+
+        for rows in cases {
+            let slots = AnnotationSlots::for_rows(&rows);
+            let expected = slots.width();
+
+            for info in &rows {
+                let backend = TestBackend::new(16, 1);
+                let mut terminal = Terminal::new(backend).unwrap();
+                let cell = render_annotation_cell(info, slots);
+                terminal
+                    .draw(|frame| {
+                        let table =
+                            Table::new(vec![Row::new(vec![cell])], &[Constraint::Length(16)]);
+                        frame.render_widget(table, frame.area());
+                    })
+                    .unwrap();
+                let buffer = terminal.backend().buffer();
+                let rendered: String = (0..16).map(|x| buffer[(x, 0)].symbol()).collect();
+
+                assert_eq!(
+                    rendered.trim_end().chars().count(),
+                    expected.min(rendered.trim_end().chars().count()),
+                    "row {:?} rendered {rendered:?}, wider than the {expected}-wide column",
+                    info.name
+                );
+                assert!(
+                    rendered.chars().count() >= expected,
+                    "row {:?} rendered {rendered:?}, narrower than {expected}",
+                    info.name
+                );
+            }
+        }
+    }
+
+    /// A rebasing worktree paints its operation glyph, and a plain row in the
+    /// same run pads the slot instead of shifting the columns after it.
+    #[test]
+    fn the_operation_glyph_reaches_the_annotation_cell() {
+        use crate::git::op_state::OpKind;
+
+        let mut rebasing = WorktreeInfo::empty("feat/x");
+        rebasing.op = Some(OpKind::Rebase);
+        let plain = WorktreeInfo::empty("main");
+        let rows = vec![rebasing.clone(), plain.clone()];
+        let slots = AnnotationSlots::for_rows(&rows);
+
+        let draw = |info: &WorktreeInfo| {
+            let backend = TestBackend::new(8, 1);
+            let mut terminal = Terminal::new(backend).unwrap();
+            let cell = render_annotation_cell(info, slots);
+            terminal
+                .draw(|frame| {
+                    let table = Table::new(vec![Row::new(vec![cell])], &[Constraint::Length(8)]);
+                    frame.render_widget(table, frame.area());
+                })
+                .unwrap();
+            let buffer = terminal.backend().buffer();
+            (0..8)
+                .map(|x| buffer[(x, 0)].symbol().to_string())
+                .collect::<String>()
+        };
+
+        assert!(
+            draw(&rebasing).contains(OpKind::Rebase.symbol()),
+            "the rebase glyph must render"
+        );
+        assert!(
+            draw(&plain).trim().is_empty(),
+            "a row with no operation leaves its slot blank, not shifted"
         );
     }
 }

--- a/src/output/tui/render.rs
+++ b/src/output/tui/render.rs
@@ -1201,9 +1201,9 @@ fn render_annotation_cell(info: &WorktreeInfo, slots: AnnotationSlots) -> Cell<'
                     AnnotationGlyph::Current => Color::Cyan,
                     AnnotationGlyph::DefaultBranch => Color::LightMagenta,
                     AnnotationGlyph::Sandbox => Color::DarkGray,
-                    // Operations share the attention colour with the status
-                    // column, and with the plain renderer's yellow.
-                    AnnotationGlyph::Operation(_) => Color::Yellow,
+                    // Operations and drift share the attention colour with
+                    // the status column, and with the plain renderer's yellow.
+                    AnnotationGlyph::Operation(_) | AnnotationGlyph::Drift => Color::Yellow,
                 };
                 spans.push(Span::styled(glyph.symbol(), Style::default().fg(color)));
             }

--- a/src/output/tui/render.rs
+++ b/src/output/tui/render.rs
@@ -750,6 +750,17 @@ fn render_cell(
     match col {
         Column::Status => render_status_cell(wt, tick),
         Column::Annotation => render_annotation_cell(&wt.info, annotation_slots),
+        Column::BranchStatus => {
+            if vals.status.is_empty() {
+                Cell::from("")
+            } else {
+                // Same attention colour as the operation glyph next to it.
+                Cell::from(Span::styled(
+                    vals.status.clone(),
+                    Style::default().fg(Color::Yellow),
+                ))
+            }
+        }
         Column::Branch => Cell::from(vals.branch.clone()),
         Column::Path => Cell::from(vals.path.clone()),
         Column::Size => {
@@ -1097,6 +1108,7 @@ fn format_job_line(
 /// Extract the plain-text content for a column from pre-computed values.
 fn column_plain_text(col: &Column, vals: &ColumnValues) -> String {
     match col {
+        Column::BranchStatus => vals.status.clone(),
         Column::Branch => vals.branch.clone(),
         Column::Path => vals.path.clone(),
         Column::Size => vals.size.clone(),

--- a/src/output/tui/render.rs
+++ b/src/output/tui/render.rs
@@ -572,11 +572,24 @@ fn render_base_cell(info: &WorktreeInfo, stat: Stat) -> Cell<'static> {
 /// Render the Changes column cell with colored indicators.
 fn render_changes_cell(info: &WorktreeInfo, stat: Stat) -> Cell<'static> {
     let mut spans = Vec::new();
+    // Conflicts lead in both stat modes, mirroring the blocking renderer
+    // (`format_head_status` / `format_head_status_lines`): they are the one
+    // state here that blocks the user, and a conflict count is a file count
+    // even under `--stat lines`.
+    if info.conflicted > 0 {
+        spans.push(Span::styled(
+            format!("!{}", info.conflicted),
+            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+        ));
+    }
     if stat == Stat::Lines {
         let ins =
             info.staged_lines_inserted.unwrap_or(0) + info.unstaged_lines_inserted.unwrap_or(0);
         let del = info.staged_lines_deleted.unwrap_or(0) + info.unstaged_lines_deleted.unwrap_or(0);
         if ins > 0 {
+            if !spans.is_empty() {
+                spans.push(Span::raw(" "));
+            }
             spans.push(Span::styled(
                 format!("+{ins}"),
                 Style::default().fg(Color::Green),
@@ -593,6 +606,9 @@ fn render_changes_cell(info: &WorktreeInfo, stat: Stat) -> Cell<'static> {
         }
     } else {
         if info.staged > 0 {
+            if !spans.is_empty() {
+                spans.push(Span::raw(" "));
+            }
             spans.push(Span::styled(
                 format!("+{}", info.staged),
                 Style::default().fg(Color::Green),
@@ -789,7 +805,8 @@ fn render_cell(
             }
         }
         Column::Changes => {
-            let unfilled = wt.info.staged + wt.info.unstaged + wt.info.untracked == 0;
+            let unfilled =
+                wt.info.staged + wt.info.unstaged + wt.info.untracked + wt.info.conflicted == 0;
             if unfilled && is_cell_unloaded(FieldSet::CHANGES) {
                 not_loaded_cell(width)
             } else if unfilled && is_cell_loading(FieldSet::CHANGES) {
@@ -1255,6 +1272,52 @@ mod tests {
             .unwrap();
         let buffer = terminal.backend().buffer();
         assert_eq!(buffer[(0, 0)].symbol(), " ");
+    }
+
+    /// Render one cell into a tiny table and return the row's text.
+    fn render_cell_text(cell: Cell<'static>, width: u16) -> (String, ratatui::buffer::Buffer) {
+        let backend = TestBackend::new(width, 1);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                let table = Table::new(vec![Row::new(vec![cell])], &[Constraint::Length(width)]);
+                frame.render_widget(table, frame.area());
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        let row: String = (0..width)
+            .map(|x| buffer[(x, 0)].symbol().to_string())
+            .collect();
+        (row, buffer)
+    }
+
+    /// The Changes cell must lead with `!N` — mirroring the blocking
+    /// renderer's `format_head_status` — in both stat modes. Regression:
+    /// conflicted files were split out of staged/unstaged and this cell was
+    /// never taught the new bucket, so a conflict-only worktree rendered an
+    /// empty cell on the default TTY renderer.
+    #[test]
+    fn changes_cell_leads_with_conflicts() {
+        let mut info = WorktreeInfo::empty("feat");
+        info.conflicted = 2;
+        info.staged = 1;
+
+        let (row, buffer) = render_cell_text(render_changes_cell(&info, Stat::Summary), 12);
+        assert!(
+            row.contains("!2 +1"),
+            "summary mode leads with conflicts, separated: got {row:?}"
+        );
+        // Bold red separates blocking conflicts from plain-red unstaged.
+        assert_eq!(buffer[(0, 0)].fg, Color::Red);
+        assert!(buffer[(0, 0)].modifier.contains(Modifier::BOLD));
+
+        // A conflict count is a file count, but it survives `--stat lines`
+        // too — these files need a decision regardless of stat mode.
+        let (row, _) = render_cell_text(render_changes_cell(&info, Stat::Lines), 12);
+        assert!(
+            row.contains("!2"),
+            "lines mode keeps conflicts: got {row:?}"
+        );
     }
 
     #[test]

--- a/src/output/tui/state.rs
+++ b/src/output/tui/state.rs
@@ -199,6 +199,7 @@ impl TuiState {
             project_root,
             cwd,
             seeded_fields,
+            annotation_slots: crate::output::annotation::AnnotationSlots::for_rows(&worktree_infos),
             // Post-set by `daft list` when the PR column is selected (same
             // pattern as `unowned_start_index` below).
             forge_prs: None,

--- a/src/store/migrate.rs
+++ b/src/store/migrate.rs
@@ -54,11 +54,12 @@ pub fn coordinator_set() -> MigrationSet {
             M::up(include_str!("migrations/006_forge_prs.sql")),
             M::up(include_str!("migrations/007_forge_health.sql")),
             M::up(include_str!("migrations/008_forge_pr_row_fields.sql")),
+            M::up(include_str!("migrations/009_worktree_identities.sql")),
         ]),
         // rusqlite_migration's version counter is `migrations.len() as u32`
         // after every migration is applied. Kept as i64 for consistency with
         // the on-disk `user_version` PRAGMA type.
-        current_version: 8,
+        current_version: 9,
     }
 }
 
@@ -310,6 +311,22 @@ mod tests {
             )
             .unwrap();
         assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn worktree_identities_table_exists_after_migration() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("db.sqlite");
+        let mut conn = connection::open_for_test(&path).unwrap();
+        run(&mut conn, &path).unwrap();
+        let name: String = conn
+            .query_row(
+                "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'worktree_identities'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(name, "worktree_identities");
     }
 
     #[test]

--- a/src/store/migrations/009_worktree_identities.sql
+++ b/src/store/migrations/009_worktree_identities.sql
@@ -1,0 +1,33 @@
+-- The branch each worktree was created for, so `daft list` can still name a
+-- worktree whose HEAD is detached for a reason git records nowhere.
+--
+-- Identity is normally derived live: the porcelain names the checked-out
+-- branch, and a paused rebase records the branch it is replaying (see
+-- src/git/op_state.rs). That covers everything git itself knows. What it does
+-- not cover is a plain detached checkout — someone checked out a tag or a SHA
+-- in this worktree — where nothing on disk connects the worktree back to the
+-- branch it exists for. This table remembers that one fact.
+--
+-- **Derived state always wins.** These rows are a fallback consulted only
+-- after live git state has nothing to say, and a cross-check for drift (the
+-- record disagreeing with an attached HEAD). Live state cannot be stale; a row
+-- here can. Treat it as a hint, never as authority — and never let it
+-- contradict an operation in progress.
+--
+-- Keyed on the worktree's private-gitdir id — the directory name under
+-- `<common-dir>/worktrees/` — rather than the path or the branch. That id
+-- survives both `git worktree move` and a branch rename, which is exactly what
+-- a record of *intent* has to survive to stay useful. Path is stored for
+-- display and eviction only.
+--
+-- Conventions follow 001_initial.sql: TEXT ISO-8601 UTC timestamps, composite
+-- primary key, no blobs. `branch` may contain slashes ("feat/x") — it is an
+-- opaque TEXT value.
+CREATE TABLE worktree_identities (
+    repo_hash     TEXT NOT NULL,
+    worktree_id   TEXT NOT NULL,
+    branch        TEXT NOT NULL,
+    worktree_path TEXT NOT NULL,
+    updated_at    TEXT NOT NULL,
+    PRIMARY KEY (repo_hash, worktree_id)
+);

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -30,10 +30,10 @@ pub mod repos;
 pub use error::{Result, StoreError};
 pub use models::{
     CatalogRepoRow, InvocationRow, JobRow, RepoPolicyRow, RepoSizeRow, VisitorSeedRow,
-    WorktreeSizeRow,
+    WorktreeIdentityRow, WorktreeSizeRow,
 };
 pub use pool::Pool;
 pub use repos::{
     CatalogReposRepo, InvocationsRepo, JobsRepo, RepoPoliciesRepo, RepoSizesRepo, VisitorSeedsRepo,
-    WorktreeSizesRepo,
+    WorktreeIdentitiesRepo, WorktreeSizesRepo,
 };

--- a/src/store/models/mod.rs
+++ b/src/store/models/mod.rs
@@ -15,6 +15,7 @@ pub mod job;
 pub mod repo_policy;
 pub mod repo_size;
 pub mod visitor_seed;
+pub mod worktree_identity;
 pub mod worktree_size;
 
 pub use catalog_repo::CatalogRepoRow;
@@ -27,4 +28,5 @@ pub use job::JobRow;
 pub use repo_policy::RepoPolicyRow;
 pub use repo_size::RepoSizeRow;
 pub use visitor_seed::VisitorSeedRow;
+pub use worktree_identity::WorktreeIdentityRow;
 pub use worktree_size::WorktreeSizeRow;

--- a/src/store/models/worktree_identity.rs
+++ b/src/store/models/worktree_identity.rs
@@ -1,0 +1,22 @@
+//! Row model for the `worktree_identities` table.
+
+use chrono::{DateTime, Utc};
+
+/// The branch a worktree was created for.
+///
+/// Read only when live git state cannot name the branch — a plain detached
+/// checkout — and as a cross-check for drift. Derived state always wins: this
+/// row can be out of date, and an in-progress operation never can.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorktreeIdentityRow {
+    pub repo_hash: String,
+    /// The worktree's private-gitdir id: the directory name under
+    /// `<common-dir>/worktrees/`. Stable across `git worktree move` and
+    /// branch renames, which is why it is the key rather than the path.
+    pub worktree_id: String,
+    /// The branch this worktree is for, e.g. `feat/x`.
+    pub branch: String,
+    /// Absolute worktree path, for display and eviction.
+    pub worktree_path: String,
+    pub updated_at: DateTime<Utc>,
+}

--- a/src/store/repos/mod.rs
+++ b/src/store/repos/mod.rs
@@ -20,6 +20,7 @@ pub mod jobs;
 pub mod repo_policies;
 pub mod repo_sizes;
 pub mod visitor_seeds;
+pub mod worktree_identities;
 pub mod worktree_sizes;
 
 pub use catalog_repos::CatalogReposRepo;
@@ -32,6 +33,7 @@ pub use jobs::JobsRepo;
 pub use repo_policies::RepoPoliciesRepo;
 pub use repo_sizes::RepoSizesRepo;
 pub use visitor_seeds::VisitorSeedsRepo;
+pub use worktree_identities::WorktreeIdentitiesRepo;
 pub use worktree_sizes::WorktreeSizesRepo;
 
 /// Run a closure inside a deferred transaction on `conn`, commit on

--- a/src/store/repos/worktree_identities.rs
+++ b/src/store/repos/worktree_identities.rs
@@ -31,6 +31,37 @@ impl WorktreeIdentitiesRepo {
         Ok(())
     }
 
+    /// Record an *observation* of a worktree attached to a branch.
+    ///
+    /// Fills in a worktree that has no record yet — which is how worktrees
+    /// daft did not create acquire one — and refreshes the path and timestamp
+    /// of one that does. It deliberately never rewrites `branch`: the record
+    /// holds what the worktree is *for*, and seeing a different branch checked
+    /// out is the definition of drift, not a correction of it. Silently
+    /// adopting the new branch would erase the disagreement before anyone
+    /// could be told about it.
+    ///
+    /// [`Self::upsert`] is the deliberate path — creation, `daft rename`, and
+    /// `daft doctor --fix` — where the caller means to redefine the intent.
+    pub fn observe(conn: &Connection, row: &WorktreeIdentityRow) -> Result<()> {
+        conn.execute(
+            "INSERT INTO worktree_identities
+                 (repo_hash, worktree_id, branch, worktree_path, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5)
+             ON CONFLICT(repo_hash, worktree_id) DO UPDATE SET
+                 worktree_path = excluded.worktree_path,
+                 updated_at    = excluded.updated_at",
+            params![
+                row.repo_hash,
+                row.worktree_id,
+                row.branch,
+                row.worktree_path,
+                row.updated_at.to_rfc3339(),
+            ],
+        )?;
+        Ok(())
+    }
+
     pub fn get(
         conn: &Connection,
         repo_hash: &str,
@@ -222,6 +253,47 @@ mod tests {
             .map(|r| r.worktree_id)
             .collect();
         assert_eq!(remaining, vec!["wt-b"]);
+    }
+
+    /// Observation fills in what is missing and refreshes the path, but the
+    /// recorded branch is intent — only a deliberate write redefines it.
+    /// Without this, drift would erase itself on the next `daft list`.
+    #[test]
+    fn observation_never_rewrites_the_recorded_branch() {
+        let (_tmp, conn) = fresh_db();
+        WorktreeIdentitiesRepo::upsert(&conn, &sample("wt-a", "feat/x")).unwrap();
+
+        let mut observed = sample("wt-a", "hotfix/urgent");
+        observed.worktree_path = "/tmp/wt/moved".into();
+        WorktreeIdentitiesRepo::observe(&conn, &observed).unwrap();
+
+        let row = WorktreeIdentitiesRepo::get(&conn, "repo", "wt-a")
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.branch, "feat/x", "intent survives an observation");
+        assert_eq!(row.worktree_path, "/tmp/wt/moved", "but the path refreshes");
+
+        // A deliberate write is what changes intent.
+        WorktreeIdentitiesRepo::upsert(&conn, &observed).unwrap();
+        assert_eq!(
+            WorktreeIdentitiesRepo::get(&conn, "repo", "wt-a")
+                .unwrap()
+                .unwrap()
+                .branch,
+            "hotfix/urgent"
+        );
+    }
+
+    #[test]
+    fn observation_records_a_worktree_that_has_none() {
+        let (_tmp, conn) = fresh_db();
+        WorktreeIdentitiesRepo::observe(&conn, &sample("wt-new", "feat/new")).unwrap();
+        assert_eq!(
+            WorktreeIdentitiesRepo::get(&conn, "repo", "wt-new")
+                .unwrap()
+                .map(|r| r.branch),
+            Some("feat/new".to_string())
+        );
     }
 
     /// Removal paths know the branch, not the private-gitdir id: git has

--- a/src/store/repos/worktree_identities.rs
+++ b/src/store/repos/worktree_identities.rs
@@ -1,0 +1,246 @@
+//! Queries against the `worktree_identities` table (a worktree's intended branch).
+
+use crate::store::error::Result;
+use crate::store::models::WorktreeIdentityRow;
+use crate::store::repos::invocations::parse_rfc3339;
+use rusqlite::{Connection, OptionalExtension, params};
+
+pub struct WorktreeIdentitiesRepo;
+
+impl WorktreeIdentitiesRepo {
+    /// Record what branch a worktree is for. The latest observation wins:
+    /// a worktree's intent changes when it is renamed or re-purposed, and
+    /// there is no first-seen worth preserving.
+    pub fn upsert(conn: &Connection, row: &WorktreeIdentityRow) -> Result<()> {
+        conn.execute(
+            "INSERT INTO worktree_identities
+                 (repo_hash, worktree_id, branch, worktree_path, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5)
+             ON CONFLICT(repo_hash, worktree_id) DO UPDATE SET
+                 branch        = excluded.branch,
+                 worktree_path = excluded.worktree_path,
+                 updated_at    = excluded.updated_at",
+            params![
+                row.repo_hash,
+                row.worktree_id,
+                row.branch,
+                row.worktree_path,
+                row.updated_at.to_rfc3339(),
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub fn get(
+        conn: &Connection,
+        repo_hash: &str,
+        worktree_id: &str,
+    ) -> Result<Option<WorktreeIdentityRow>> {
+        let row = conn
+            .query_row(
+                "SELECT repo_hash, worktree_id, branch, worktree_path, updated_at
+                 FROM worktree_identities
+                 WHERE repo_hash = ?1 AND worktree_id = ?2",
+                params![repo_hash, worktree_id],
+                row_to_identity,
+            )
+            .optional()?;
+        Ok(row)
+    }
+
+    /// Every recorded identity for a repo, ordered by id for stable output.
+    /// The list reads the whole set once rather than querying per worktree.
+    pub fn list_for_repo(conn: &Connection, repo_hash: &str) -> Result<Vec<WorktreeIdentityRow>> {
+        let mut stmt = conn.prepare(
+            "SELECT repo_hash, worktree_id, branch, worktree_path, updated_at
+             FROM worktree_identities
+             WHERE repo_hash = ?1
+             ORDER BY worktree_id ASC",
+        )?;
+        let rows = stmt
+            .query_map(params![repo_hash], row_to_identity)?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(rows)
+    }
+
+    /// Forget a worktree's identity, when the worktree itself is gone.
+    /// Returns rows deleted (0 or 1).
+    pub fn delete(conn: &Connection, repo_hash: &str, worktree_id: &str) -> Result<usize> {
+        let n = conn.execute(
+            "DELETE FROM worktree_identities WHERE repo_hash = ?1 AND worktree_id = ?2",
+            params![repo_hash, worktree_id],
+        )?;
+        Ok(n)
+    }
+
+    /// Forget every identity recorded for a branch, whichever worktree held
+    /// it. Removal paths know the branch they are deleting, not the
+    /// private-gitdir id — git has usually already unregistered the worktree
+    /// by the time they can clean up.
+    pub fn delete_for_branch(conn: &Connection, repo_hash: &str, branch: &str) -> Result<usize> {
+        let n = conn.execute(
+            "DELETE FROM worktree_identities WHERE repo_hash = ?1 AND branch = ?2",
+            params![repo_hash, branch],
+        )?;
+        Ok(n)
+    }
+}
+
+fn row_to_identity(row: &rusqlite::Row<'_>) -> rusqlite::Result<WorktreeIdentityRow> {
+    let updated_at_str: String = row.get("updated_at")?;
+    Ok(WorktreeIdentityRow {
+        repo_hash: row.get("repo_hash")?,
+        worktree_id: row.get("worktree_id")?,
+        branch: row.get("branch")?,
+        worktree_path: row.get("worktree_path")?,
+        updated_at: parse_rfc3339(&updated_at_str, "updated_at")?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::connection;
+    use crate::store::migrate;
+    use chrono::{TimeZone, Utc};
+    use tempfile::TempDir;
+
+    fn fresh_db() -> (TempDir, Connection) {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("db.sqlite");
+        let mut conn = connection::open_for_test(&path).unwrap();
+        migrate::run(&mut conn, &path).unwrap();
+        (tmp, conn)
+    }
+
+    fn sample(worktree_id: &str, branch: &str) -> WorktreeIdentityRow {
+        WorktreeIdentityRow {
+            repo_hash: "repo".into(),
+            worktree_id: worktree_id.into(),
+            branch: branch.into(),
+            // Deliberately not `format!`: the repo layer bans that macro so
+            // no SQL can ever be built by interpolation (mise-tasks/lint/
+            // repos-no-format), and the grep does not exempt test code.
+            worktree_path: String::from("/tmp/wt/") + worktree_id,
+            updated_at: Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap(),
+        }
+    }
+
+    #[test]
+    fn upsert_then_get_round_trips() {
+        let (_tmp, conn) = fresh_db();
+        let row = sample("wt-a", "feat/x");
+        WorktreeIdentitiesRepo::upsert(&conn, &row).unwrap();
+        assert_eq!(
+            WorktreeIdentitiesRepo::get(&conn, "repo", "wt-a").unwrap(),
+            Some(row)
+        );
+    }
+
+    #[test]
+    fn get_returns_none_for_an_unknown_worktree() {
+        let (_tmp, conn) = fresh_db();
+        assert_eq!(
+            WorktreeIdentitiesRepo::get(&conn, "repo", "nope").unwrap(),
+            None
+        );
+    }
+
+    /// A worktree renamed to another branch keeps its key — the private-gitdir
+    /// id survives a rename — and the row is updated, not duplicated.
+    #[test]
+    fn a_rename_updates_in_place_under_the_same_key() {
+        let (_tmp, conn) = fresh_db();
+        WorktreeIdentitiesRepo::upsert(&conn, &sample("wt-a", "feat/old")).unwrap();
+
+        let mut renamed = sample("wt-a", "feat/new");
+        renamed.worktree_path = "/tmp/wt/renamed".into();
+        renamed.updated_at = Utc.with_ymd_and_hms(2026, 2, 2, 0, 0, 0).unwrap();
+        WorktreeIdentitiesRepo::upsert(&conn, &renamed).unwrap();
+
+        assert_eq!(
+            WorktreeIdentitiesRepo::list_for_repo(&conn, "repo").unwrap(),
+            vec![renamed],
+            "the rename must replace the record, not add a second one"
+        );
+    }
+
+    #[test]
+    fn repos_are_isolated_from_each_other() {
+        let (_tmp, conn) = fresh_db();
+        WorktreeIdentitiesRepo::upsert(&conn, &sample("wt-a", "feat/x")).unwrap();
+        let mut other = sample("wt-a", "other/branch");
+        other.repo_hash = "other-repo".into();
+        WorktreeIdentitiesRepo::upsert(&conn, &other).unwrap();
+
+        // Same worktree id, different repo — both survive, each visible only
+        // to its own repo.
+        assert_eq!(
+            WorktreeIdentitiesRepo::get(&conn, "repo", "wt-a")
+                .unwrap()
+                .map(|r| r.branch),
+            Some("feat/x".to_string())
+        );
+        assert_eq!(
+            WorktreeIdentitiesRepo::list_for_repo(&conn, "other-repo").unwrap(),
+            vec![other]
+        );
+    }
+
+    #[test]
+    fn list_for_repo_is_ordered_and_scoped() {
+        let (_tmp, conn) = fresh_db();
+        for id in ["wt-c", "wt-a", "wt-b"] {
+            WorktreeIdentitiesRepo::upsert(&conn, &sample(id, "feat/x")).unwrap();
+        }
+        let ids: Vec<String> = WorktreeIdentitiesRepo::list_for_repo(&conn, "repo")
+            .unwrap()
+            .into_iter()
+            .map(|r| r.worktree_id)
+            .collect();
+        assert_eq!(ids, vec!["wt-a", "wt-b", "wt-c"]);
+    }
+
+    #[test]
+    fn delete_removes_only_the_named_worktree() {
+        let (_tmp, conn) = fresh_db();
+        WorktreeIdentitiesRepo::upsert(&conn, &sample("wt-a", "feat/x")).unwrap();
+        WorktreeIdentitiesRepo::upsert(&conn, &sample("wt-b", "feat/y")).unwrap();
+
+        assert_eq!(
+            WorktreeIdentitiesRepo::delete(&conn, "repo", "wt-a").unwrap(),
+            1
+        );
+        assert_eq!(
+            WorktreeIdentitiesRepo::delete(&conn, "repo", "wt-a").unwrap(),
+            0,
+            "deleting twice is not an error"
+        );
+        let remaining: Vec<String> = WorktreeIdentitiesRepo::list_for_repo(&conn, "repo")
+            .unwrap()
+            .into_iter()
+            .map(|r| r.worktree_id)
+            .collect();
+        assert_eq!(remaining, vec!["wt-b"]);
+    }
+
+    /// Removal paths know the branch, not the private-gitdir id: git has
+    /// usually unregistered the worktree before daft can clean up.
+    #[test]
+    fn delete_for_branch_forgets_every_worktree_of_that_branch() {
+        let (_tmp, conn) = fresh_db();
+        WorktreeIdentitiesRepo::upsert(&conn, &sample("wt-a", "feat/x")).unwrap();
+        WorktreeIdentitiesRepo::upsert(&conn, &sample("wt-b", "feat/y")).unwrap();
+
+        assert_eq!(
+            WorktreeIdentitiesRepo::delete_for_branch(&conn, "repo", "feat/x").unwrap(),
+            1
+        );
+        let remaining: Vec<String> = WorktreeIdentitiesRepo::list_for_repo(&conn, "repo")
+            .unwrap()
+            .into_iter()
+            .map(|r| r.branch)
+            .collect();
+        assert_eq!(remaining, vec!["feat/y"]);
+    }
+}

--- a/term-styles/src/lib.rs
+++ b/term-styles/src/lib.rs
@@ -102,6 +102,27 @@ pub const DEFAULT_BRANCH_SYMBOL: &str = "\u{2726}";
 /// Symbol for sandbox (detached HEAD) worktrees.
 pub const SANDBOX_SYMBOL: &str = "\u{25cb}";
 
+/// Symbols for a git operation paused in a worktree, shown in the annotation
+/// column's state slot. One glyph per operation, so the shape alone says which
+/// — the `status` column spells it out for anyone who wants words.
+///
+/// A worktree can only be in one of these at a time, and each is a state the
+/// user has to finish or abort, so they share a slot and a color.
+pub mod op_symbols {
+    /// Rebase — a cycle, for commits being replayed.
+    pub const REBASE: &str = "\u{27f2}";
+    /// `git am` — a mailbox apply.
+    pub const AM: &str = "\u{2709}";
+    /// Merge — two histories joining.
+    pub const MERGE: &str = "\u{21c4}";
+    /// Cherry-pick — a commit lifted onto this branch.
+    pub const CHERRY_PICK: &str = "\u{2937}";
+    /// Revert — an undo.
+    pub const REVERT: &str = "\u{238c}";
+    /// Bisect — a search halving the range.
+    pub const BISECT: &str = "\u{25d0}";
+}
+
 /// Wraps text in bold styling.
 pub fn bold(text: &str) -> String {
     format!("{BOLD}{text}{RESET}")

--- a/term-styles/src/lib.rs
+++ b/term-styles/src/lib.rs
@@ -102,6 +102,10 @@ pub const DEFAULT_BRANCH_SYMBOL: &str = "\u{2726}";
 /// Symbol for sandbox (detached HEAD) worktrees.
 pub const SANDBOX_SYMBOL: &str = "\u{25cb}";
 
+/// Symbol for a worktree whose recorded branch disagrees with what is
+/// checked out — a record that has fallen behind reality.
+pub const DRIFT_SYMBOL: &str = "\u{26a0}";
+
 /// Symbols for a git operation paused in a worktree, shown in the annotation
 /// column's state slot. One glyph per operation, so the shape alone says which
 /// — the `status` column spells it out for anyone who wants words.

--- a/tests/integration/test_list.sh
+++ b/tests/integration/test_list.sh
@@ -218,6 +218,63 @@ test_list_detached_head() {
     return 0
 }
 
+# Test that a worktree paused mid-rebase keeps its identity (#736)
+test_list_rebase_keeps_identity() {
+    git-worktree-init --layout contained rebase-identity-test || return 1
+    cd "rebase-identity-test"
+
+    cd master
+    echo "base" > conflict.txt
+    git add conflict.txt
+    git commit -m "Initial commit" >/dev/null 2>&1
+    git branch feat/x
+    echo "master side" > conflict.txt
+    git commit -am "master change" >/dev/null 2>&1
+    cd ..
+
+    git worktree add feat-wt feat/x >/dev/null 2>&1 || {
+        log_error "Failed to create worktree for feat/x"
+        return 1
+    }
+    cd feat-wt
+    echo "feature side" > conflict.txt
+    git commit -am "feature change" >/dev/null 2>&1
+    # Expected to stop on the conflict — that is the state under test.
+    git rebase master >/dev/null 2>&1
+    cd ..
+
+    # Precondition: git really detached HEAD, so this is not silently
+    # exercising the ordinary attached path.
+    if git worktree list --porcelain | grep -q "branch refs/heads/feat/x"; then
+        log_error "Expected git to report the rebasing worktree as detached"
+        return 1
+    fi
+
+    cd master
+    local output
+    output=$(NO_COLOR=1 git-worktree-list 2>&1)
+
+    if ! echo "$output" | grep -q "feat/x"; then
+        log_error "List should keep the branch name through a rebase"
+        log_error "Output: $output"
+        return 1
+    fi
+    if echo "$output" | grep -q "(detached)"; then
+        log_error "A rebasing worktree must not render as '(detached)'"
+        log_error "Output: $output"
+        return 1
+    fi
+    # The conflicted file is counted once, as a conflict.
+    if ! echo "$output" | grep -q '!1'; then
+        log_error "List should report the conflicted file as '!1'"
+        log_error "Output: $output"
+        return 1
+    fi
+
+    log_success "Identity and conflicts survive a rebase"
+    return 0
+}
+
 # Test ahead/behind counts
 test_list_ahead_behind() {
     local remote_repo=$(create_test_remote "test-repo-list-ahead" "main")
@@ -1116,6 +1173,7 @@ run_list_tests() {
     run_test "list_dirty_marker" "test_list_dirty_marker"
     run_test "list_json" "test_list_json"
     run_test "list_detached_head" "test_list_detached_head"
+    run_test "list_rebase_keeps_identity" "test_list_rebase_keeps_identity"
     run_test "list_ahead_behind" "test_list_ahead_behind"
     run_test "list_outside_repo" "test_list_outside_repo"
     run_test "list_help" "test_list_help"

--- a/tests/manual/scenarios/list/identity-drift.yml
+++ b/tests/manual/scenarios/list/identity-drift.yml
@@ -1,0 +1,101 @@
+name: Recorded identity, fallback and drift
+description: >
+  Daft records what branch a worktree was created for. When the worktree is
+  later detached with nothing to explain it, the record still names the row;
+  when a different branch is checked out into it, the live checkout wins and the
+  disagreement is reported as drift.
+
+steps:
+  - name: Init a test repo
+    run: git-worktree-init --layout contained identity-drift
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/identity-drift/master"
+
+  - name: Create an initial commit
+    run: |
+      cd $WORK_DIR/identity-drift/master
+      echo "content" > README.md
+      git add README.md
+      git commit -m "Initial commit"
+    expect:
+      exit_code: 0
+
+  - name: Create a worktree for feat/z through daft, so its identity is recorded
+    run: daft start feat/z 2>&1
+    cwd: "$WORK_DIR/identity-drift/master"
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/identity-drift/feat/z"
+
+  - name: Detach that worktree with nothing to explain it
+    run: |
+      cd $WORK_DIR/identity-drift/feat/z
+      git checkout --detach HEAD
+    expect:
+      exit_code: 0
+
+  - name: The record still names the row, and reports the detached SHA
+    run: NO_COLOR=1 git-worktree-list --columns +status 2>&1
+    cwd: "$WORK_DIR/identity-drift/master"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "feat/z"
+        - "detached @"
+      output_not_contains:
+        # The name came back from the record; the placeholder must not appear.
+        - "(detached)"
+
+  - name: Structured output marks the identity as persisted
+    run: NO_COLOR=1 git-worktree-list --format json 2>&1
+    cwd: "$WORK_DIR/identity-drift/master"
+    expect:
+      exit_code: 0
+      output_contains:
+        - '"identity_source": "persisted"'
+        # Named, but the detachment is still unexplained — so still a sandbox.
+        - '"is_sandbox": true'
+
+  - name: Check out a different branch into that worktree
+    run: |
+      cd $WORK_DIR/identity-drift/feat/z
+      git checkout -b hotfix/urgent
+    expect:
+      exit_code: 0
+
+  - name: The live checkout wins the name and the row reports drift
+    run: NO_COLOR=1 git-worktree-list --columns +status 2>&1
+    cwd: "$WORK_DIR/identity-drift/master"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "hotfix/urgent"
+        - "drifted"
+
+  - name: Doctor reports the same disagreement
+    run: NO_COLOR=1 daft doctor 2>&1
+    cwd: "$WORK_DIR/identity-drift/master"
+    expect:
+      output_contains:
+        - "Worktree identities"
+        - "drifted from their record"
+
+  - name: Doctor --fix reconciles the record to the checkout
+    run: NO_COLOR=1 daft doctor --fix 2>&1
+    cwd: "$WORK_DIR/identity-drift/master"
+    expect:
+      output_contains:
+        - "Worktree identities"
+
+  - name: Drift is gone once the record matches
+    run: NO_COLOR=1 git-worktree-list --columns +status 2>&1
+    cwd: "$WORK_DIR/identity-drift/master"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "hotfix/urgent"
+      output_not_contains:
+        - "drifted"

--- a/tests/manual/scenarios/list/rebase-conflict-identity.yml
+++ b/tests/manual/scenarios/list/rebase-conflict-identity.yml
@@ -1,0 +1,116 @@
+name: Identity survives a conflicted rebase
+description: >
+  A worktree paused mid-rebase keeps its branch name, is not classified as a
+  sandbox, and reports its conflicts — git detaches HEAD to replay commits, so
+  before #736 the row went anonymous exactly when it mattered most.
+
+steps:
+  - name: Init a test repo
+    run: git-worktree-init --layout contained rebase-identity
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/rebase-identity/master"
+
+  - name: Create an initial commit
+    run: |
+      cd $WORK_DIR/rebase-identity/master
+      echo "base" > conflict.txt
+      git add conflict.txt
+      git commit -m "Initial commit"
+    expect:
+      exit_code: 0
+
+  - name: Branch feat/x off master, then diverge both sides on one file
+    run: |
+      cd $WORK_DIR/rebase-identity/master
+      git branch feat/x
+      echo "master side" > conflict.txt
+      git commit -am "master change"
+      cd $WORK_DIR/rebase-identity
+      git worktree add feat-wt feat/x
+      cd feat-wt
+      echo "feature side" > conflict.txt
+      git commit -am "feature change"
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/rebase-identity/feat-wt"
+
+  - name: Start a rebase that stops on the conflict (non-zero expected)
+    run: |
+      cd $WORK_DIR/rebase-identity/feat-wt
+      git rebase master
+    expect:
+      exit_code: 1
+
+  - name: Git itself reports the worktree as detached
+    # Precondition: without this, the assertions below could pass simply
+    # because git never detached and the ordinary attached path was used.
+    run: git worktree list --porcelain
+    cwd: "$WORK_DIR/rebase-identity/master"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "detached"
+      output_not_contains:
+        - "branch refs/heads/feat/x"
+
+  - name: List keeps the branch name and shows the conflict
+    run: NO_COLOR=1 git-worktree-list 2>&1
+    cwd: "$WORK_DIR/rebase-identity/master"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "feat/x"
+        # One conflicted file, counted once — not as staged AND unstaged.
+        - "!1"
+      output_not_contains:
+        - "(detached)"
+
+  - name: The status column spells the operation out
+    run: NO_COLOR=1 git-worktree-list --columns +status 2>&1
+    cwd: "$WORK_DIR/rebase-identity/master"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "rebasing"
+        - "1 conflict"
+
+  - name: Structured output carries the operation and identity source
+    run: NO_COLOR=1 git-worktree-list --format json 2>&1
+    cwd: "$WORK_DIR/rebase-identity/master"
+    expect:
+      exit_code: 0
+      output_contains:
+        - '"operation": "rebase"'
+        - '"identity_source": "recovered"'
+        - '"conflicted": 1'
+        # The narrowed meaning: mid-operation is no longer a sandbox.
+        - '"is_sandbox": false'
+
+  - name: A rebase is not a merge, so --merging does not match it
+    run: NO_COLOR=1 git-worktree-list --merging 2>&1
+    cwd: "$WORK_DIR/rebase-identity/master"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "No worktrees have a merge in progress."
+
+  - name: Aborting the rebase returns the row to normal
+    run: |
+      cd $WORK_DIR/rebase-identity/feat-wt
+      git rebase --abort
+    expect:
+      exit_code: 0
+
+  - name: No operation is reported once the rebase is over
+    run: NO_COLOR=1 git-worktree-list --columns +status 2>&1
+    cwd: "$WORK_DIR/rebase-identity/master"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "feat/x"
+      output_not_contains:
+        - "rebasing"
+        - "(detached)"

--- a/tests/manual/scenarios/list/rebase-resolved.yml
+++ b/tests/manual/scenarios/list/rebase-resolved.yml
@@ -1,0 +1,94 @@
+name: Rebase resolved but not yet continued
+description: >
+  Once conflicts are resolved and staged, the conflict count renders as nothing
+  — so only the status column can distinguish "resolved, awaiting --continue"
+  from an untouched operation. That is the state the column exists for.
+
+steps:
+  - name: Init a test repo
+    run: git-worktree-init --layout contained rebase-resolved
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/rebase-resolved/master"
+
+  - name: Create an initial commit
+    run: |
+      cd $WORK_DIR/rebase-resolved/master
+      echo "base" > conflict.txt
+      git add conflict.txt
+      git commit -m "Initial commit"
+    expect:
+      exit_code: 0
+
+  - name: Diverge master and feat/y on the same file
+    run: |
+      cd $WORK_DIR/rebase-resolved/master
+      git branch feat/y
+      echo "master side" > conflict.txt
+      git commit -am "master change"
+      cd $WORK_DIR/rebase-resolved
+      git worktree add feat-wt feat/y
+      cd feat-wt
+      echo "feature side" > conflict.txt
+      git commit -am "feature change"
+    expect:
+      exit_code: 0
+
+  - name: Start a rebase that stops on the conflict (non-zero expected)
+    run: |
+      cd $WORK_DIR/rebase-resolved/feat-wt
+      git rebase master
+    expect:
+      exit_code: 1
+
+  - name: While conflicted, the count is visible
+    run: NO_COLOR=1 git-worktree-list --columns +status 2>&1
+    cwd: "$WORK_DIR/rebase-resolved/master"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "rebasing"
+        - "1 conflict"
+
+  - name: Resolve the conflict and stage it, without continuing
+    run: |
+      cd $WORK_DIR/rebase-resolved/feat-wt
+      echo "resolved content" > conflict.txt
+      git add conflict.txt
+    expect:
+      exit_code: 0
+
+  - name: The status column reports resolved, awaiting continue
+    run: NO_COLOR=1 git-worktree-list --columns +status 2>&1
+    cwd: "$WORK_DIR/rebase-resolved/master"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "feat/y"
+        - "rebasing"
+        - "resolved"
+      output_not_contains:
+        # Nothing is conflicted any more — which is exactly why the word
+        # "resolved" has to carry this state.
+        - "conflict"
+        - "(detached)"
+
+  - name: Finishing the rebase clears the status
+    run: |
+      cd $WORK_DIR/rebase-resolved/feat-wt
+      GIT_EDITOR=true git rebase --continue
+    expect:
+      exit_code: 0
+
+  - name: The row is ordinary again
+    run: NO_COLOR=1 git-worktree-list --columns +status 2>&1
+    cwd: "$WORK_DIR/rebase-resolved/master"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "feat/y"
+      output_not_contains:
+        - "rebasing"
+        - "resolved"
+        - "(detached)"


### PR DESCRIPTION
`daft list` loses a worktree's identity the moment git detaches its HEAD — which
git does for the whole of a rebase. The row shows `(detached)`, gets
sandbox-classified (`○`, dimmed), sorts out of place, and every branch-keyed cell
goes blank. Conflicted files made it worse by double-counting as both staged and
unstaged. Git records the rebased branch in the worktree's private gitdir
(`rebase-merge/head-name`); recovering it was on daft.

Two layers, one PR.

## Derive

A stat-only, backend-agnostic probe (`src/git/op_state.rs`) reads git's own state
files and reports the paused operation plus the branch it belongs to. Resolution
runs attached branch → op-recovered → persisted record → `(detached)`, with a
two-pass collision guard so a stale record can never claim a name an attached
checkout already owns.

Presentation follows the settled design: the Branch column stays pure identity,
operation state is a glyph in the annotations column (`⟲ ⇄ ⤷ ⎌ ◐ ✉`), and an
opt-in `status` column (`--columns +status`) spells it out — `rebasing · 1
conflict`, `rebasing · resolved`, `detached @ <sha>`, `drifted`. Conflicts render
as `!N` in Changes and now count once, as conflicts.

## Persist

Migration 009 adds `worktree_identities`, keyed on the private-gitdir id — the one
handle that survives both `git worktree move` and `git branch -m`. Creation,
rename and delete maintain it; `daft list` only ever *observes* through it.

That split is load-bearing: `observe` refreshes path and timestamp and never
rewrites a recorded branch, while `upsert` is reserved for deliberate
redefinition (creation, `daft rename`, `daft doctor --fix`). With a plain upsert,
`daft list` silently reconciled drift the instant it displayed it, and the new
doctor check could never fire.

Derived state always wins; the record is fallback and cross-check only.

## Bugs fixed in passing

Each is regression-tested:

- `--merging` was never applied on a TTY — `should_use_live` ignored it, so it
  listed everything.
- `hooks/conditions.rs` probed `<worktree>/.git` as a directory, so merge/rebase
  conditions never fired in linked worktrees.
- `UU` double-counted as staged *and* unstaged.
- `find_worktree_for_branch` missed mid-rebase worktrees, so `daft go feat/x`
  failed while `feat/x` was rebasing.

## Review

`/code-review max` (170 agents, three-lens adversarial panel) found 12 defects;
all 12 are fixed in the last 10 commits, each with a regression test.

The critical one was a chain this PR created: recovering identity made
`find_worktree_for_branch` return a mid-rebase worktree, and `stash_if_carry` had
no in-progress guard — so `daft start <new> <base>` would stash a paused rebase.
With conflicts resolved and staged the stash *succeeds*, reverting the resolution,
and `git rebase --continue` then sees an empty patch and silently drops the commit.
`b57d1ede` guards the carry source on `probe_op_state`; its test was verified to
fail without the guard.

## Testing

- `fmt` · `clippy` · `test:unit` green after every commit, and on the rebased tip
- `man:verify` and `docs:cli:verify` green
- Scenario suites over every touched surface: list + doctor 66/258 steps;
  checkout + checkout-branch + prune + branch-delete 135/527
- `test_list.sh` integration, including a new conflicted-rebase case
- Manual smoke in a scratch repo: mid-rebase row keeps its name, renders `⟲` and
  `!1`, and JSON carries `"status": "rebasing · 1 conflict"`

## Notes

Op state is seed-frozen per run — a rebase finishing mid-render keeps its glyph
until the next run. Catalog surfaces (`repo list` / `repo info`) still label
detached worktrees generically; that's a follow-up.

Fixes #736
