### PR TITLE
fix: skip pre-push hooks on remote-branch deletes

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -613,9 +613,14 @@ repo's git-level `pre-push` hook (native `.git/hooks` or `core.hooksPath`
 managers like lefthook/husky/pre-commit), reported as a `pre-push` phase. A
 failing hook blocks the push and the command exits non-zero — any worktree it
 created is still completed and usable, and the error names the recovery command.
-Exception: the automatic upstream push on `daft start`/`daft go -b` runs the
-hook only when it introduces new commits; a ref-only push skips it
-(`daft.checkout.pushVerify`: `auto` default, `always`, `never`). Pass
+Exceptions — pushes that provably carry no content skip the hook by default
+(`daft.pushVerify`: `auto` default, `always`, `never`): the automatic upstream
+push on `daft start`/`daft go -b` runs the hook only when it introduces new
+commits, and remote-branch deletes (`daft remove` with remote deletion on,
+`daft rename`'s old-name cleanup, `daft multi-remote move --delete-old`) skip it
+outright since a delete pushes zero objects. Set `daft.pushVerify always` when
+pre-push hooks enforce ref policy (e.g. protected-branch delete guards);
+`daft.checkout.pushVerify` overrides the base for the upstream push alone. Pass
 `--no-verify` to the pushing command to skip the hook once. `--skip-hooks` does
 NOT affect git-level hooks — it only filters daft's own jobs.
 
@@ -990,7 +995,8 @@ invocation.
 | `daft.remote`                    | `"origin"`            | Default remote name                                                                                                                                                         |
 | `daft.checkout.fetch`            | `false`               | Fetch from remote before checking out an existing branch                                                                                                                    |
 | `daft.checkout.push`             | `false`               | Push new branches to remote after creation                                                                                                                                  |
-| `daft.checkout.pushVerify`       | `"auto"`              | Run git pre-push hooks on the automatic upstream push (`auto`, `always`, `never`)                                                                                           |
+| `daft.pushVerify`                | `"auto"`              | Run git pre-push hooks on ref-only pushes — remote-branch deletes and the upstream push (`auto`, `always`, `never`)                                                         |
+| `daft.checkout.pushVerify`       | `daft.pushVerify`     | Checkout-scoped override of `daft.pushVerify` for the automatic upstream push                                                                                               |
 | `daft.branchDelete.remote`       | `false`               | Delete the remote branch when removing a local branch                                                                                                                       |
 | `daft.checkout.upstream`         | `true`                | Set upstream tracking                                                                                                                                                       |
 | `daft.checkout.carry`            | `false`               | Carry uncommitted changes on checkout                                                                                                                                       |

--- a/SKILL.md
+++ b/SKILL.md
@@ -617,12 +617,18 @@ Exceptions — pushes that provably carry no content skip the hook by default
 (`daft.pushVerify`: `auto` default, `always`, `never`): the automatic upstream
 push on `daft start`/`daft go -b` runs the hook only when it introduces new
 commits, and remote-branch deletes (`daft remove` with remote deletion on,
-`daft rename`'s old-name cleanup, `daft multi-remote move --delete-old`) skip it
-outright since a delete pushes zero objects. Set `daft.pushVerify always` when
-pre-push hooks enforce ref policy (e.g. protected-branch delete guards);
-`daft.checkout.pushVerify` overrides the base for the upstream push alone. Pass
-`--no-verify` to the pushing command to skip the hook once. `--skip-hooks` does
-NOT affect git-level hooks — it only filters daft's own jobs.
+`daft rename`'s old-name cleanup, `daft merge`'s post-merge cleanup,
+`daft multi-remote move --delete-old`) skip it outright since a delete pushes
+zero objects. Set `daft.pushVerify always` when pre-push hooks enforce ref
+policy (e.g. protected-branch delete guards); `daft.checkout.pushVerify`
+overrides the base for the upstream push alone. Note that `never` is
+unconditional, unlike `auto`/`always` which decide per push: setting
+`daft.pushVerify never` to quiet deletes also disarms the hook on an upstream
+push that does carry commits, so re-arm it with `daft.checkout.pushVerify auto`.
+Pass `--no-verify` to the pushing command to skip the hook once — every pushing
+command accepts it except `daft merge`, whose cleanup delete is governed by
+`daft.pushVerify` alone. `--skip-hooks` does NOT affect git-level hooks — it
+only filters daft's own jobs.
 
 To push a branch from outside its worktree with the hook still running in the
 RIGHT tree, use `daft push <branch>`: it resolves the branch's worktree and runs
@@ -995,7 +1001,7 @@ invocation.
 | `daft.remote`                    | `"origin"`            | Default remote name                                                                                                                                                         |
 | `daft.checkout.fetch`            | `false`               | Fetch from remote before checking out an existing branch                                                                                                                    |
 | `daft.checkout.push`             | `false`               | Push new branches to remote after creation                                                                                                                                  |
-| `daft.pushVerify`                | `"auto"`              | Run git pre-push hooks on ref-only pushes — remote-branch deletes and the upstream push (`auto`, `always`, `never`)                                                         |
+| `daft.pushVerify`                | `"auto"`              | Base: run git pre-push hooks on daft's suppressible pushes — remote-branch deletes and the upstream push (`auto`, `always`, `never`; `never` is unconditional)              |
 | `daft.checkout.pushVerify`       | `daft.pushVerify`     | Checkout-scoped override of `daft.pushVerify` for the automatic upstream push                                                                                               |
 | `daft.branchDelete.remote`       | `false`               | Delete the remote branch when removing a local branch                                                                                                                       |
 | `daft.checkout.upstream`         | `true`                | Set upstream tracking                                                                                                                                                       |

--- a/docs/cli/daft-multi-remote.md
+++ b/docs/cli/daft-multi-remote.md
@@ -137,6 +137,10 @@ records are updated accordingly.
 Options like --set-upstream can update the branch's tracking configuration
 to match the new remote organization.
 
+--push honors the repo's pre-push hook; the --delete-old delete pushes no
+content and skips it by default (configurable via daft.pushVerify: auto,
+always, or never). Pass --no-verify to skip both unconditionally.
+
 ```
 daft multi-remote move [OPTIONS] <BRANCH>
 ```

--- a/docs/cli/daft-multi-remote.md
+++ b/docs/cli/daft-multi-remote.md
@@ -139,7 +139,10 @@ to match the new remote organization.
 
 --push honors the repo's pre-push hook; the --delete-old delete pushes no
 content and skips it by default (configurable via daft.pushVerify: auto,
-always, or never). Pass --no-verify to skip both unconditionally.
+always, or never). daft.pushVerify is the base setting every daft push reads,
+so setting it also affects the branch-creation upstream push;
+daft.checkout.pushVerify overrides it for that push alone. Pass --no-verify to
+skip both unconditionally.
 
 ```
 daft multi-remote move [OPTIONS] <BRANCH>

--- a/docs/cli/daft-remove.md
+++ b/docs/cli/daft-remove.md
@@ -33,6 +33,11 @@ can also pass `--remote` to delete only the remote branch while keeping the
 local worktree and branch, or `--local` to skip the remote entirely regardless
 of config.
 
+The remote delete pushes no content, so the repo's pre-push hook is skipped by
+default (configurable via `daft.pushVerify`; `--no-verify` skips it
+unconditionally). See
+[Git Hooks](/reference/configuration#git-hooks) for details.
+
 Safety checks prevent accidental data loss. Use `-f` (`--force`) to override.
 For the default branch (e.g. main), `-f` removes its worktree only -- the
 local branch ref and remote branch are always preserved.

--- a/docs/cli/daft-remove.md
+++ b/docs/cli/daft-remove.md
@@ -35,7 +35,9 @@ of config.
 
 The remote delete pushes no content, so the repo's pre-push hook is skipped by
 default (configurable via `daft.pushVerify`; `--no-verify` skips it
-unconditionally). See
+unconditionally). `daft.pushVerify` is the base setting every daft push reads,
+so it also affects the branch-creation upstream push; scope it to that push
+alone with `daft.checkout.pushVerify`. See
 [Git Hooks](/reference/configuration#git-hooks) for details.
 
 Safety checks prevent accidental data loss. Use `-f` (`--force`) to override.

--- a/docs/cli/daft-rename.md
+++ b/docs/cli/daft-rename.md
@@ -26,7 +26,8 @@ being renamed, the shell wrapper will cd to the new location after the
 rename completes.
 
 The new-name push honors the repo's pre-push hook; the old-name delete pushes
-no content and skips it by default (configurable via `daft.pushVerify`). See
+no content and skips it by default (configurable via `daft.pushVerify`, the
+base setting every daft push reads). See
 [Git Hooks](/reference/configuration#git-hooks) for details.
 
 Empty parent directories left behind by the move are automatically cleaned up.

--- a/docs/cli/daft-rename.md
+++ b/docs/cli/daft-rename.md
@@ -25,6 +25,10 @@ worktree (absolute or relative). If you are currently inside the worktree
 being renamed, the shell wrapper will cd to the new location after the
 rename completes.
 
+The new-name push honors the repo's pre-push hook; the old-name delete pushes
+no content and skips it by default (configurable via `daft.pushVerify`). See
+[Git Hooks](/reference/configuration#git-hooks) for details.
+
 Empty parent directories left behind by the move are automatically cleaned up.
 
 ## Arguments

--- a/docs/cli/git-worktree-branch-delete.md
+++ b/docs/cli/git-worktree-branch-delete.md
@@ -49,7 +49,10 @@ removal if the repository is trusted. See git-daft(1) for hook management.
 When remote deletion is enabled, the remote-branch delete pushes no content,
 so the repo's pre-push hook is skipped by default (configurable via
 daft.pushVerify: auto, always, or never; use always for hooks that gate
-deletes by ref name). Pass --no-verify to skip it unconditionally.
+deletes by ref name). daft.pushVerify is the base setting every daft push
+reads, so setting it also affects the branch-creation upstream push;
+daft.checkout.pushVerify overrides it for that push alone. Pass --no-verify
+to skip it unconditionally.
 
 ## Usage
 

--- a/docs/cli/git-worktree-branch-delete.md
+++ b/docs/cli/git-worktree-branch-delete.md
@@ -46,6 +46,11 @@ are deleted.
 Pre-remove and post-remove lifecycle hooks are executed for each worktree
 removal if the repository is trusted. See git-daft(1) for hook management.
 
+When remote deletion is enabled, the remote-branch delete pushes no content,
+so the repo's pre-push hook is skipped by default (configurable via
+daft.pushVerify: auto, always, or never; use always for hooks that gate
+deletes by ref name). Pass --no-verify to skip it unconditionally.
+
 ## Usage
 
 ```

--- a/docs/cli/git-worktree-branch.md
+++ b/docs/cli/git-worktree-branch.md
@@ -55,12 +55,19 @@ deleted.
 Pre-remove and post-remove lifecycle hooks are executed for each worktree
 removal if the repository is trusted. See git-daft(1) for hook management.
 
+When remote deletion is enabled, the remote-branch delete pushes no content,
+so the repo's pre-push hook is skipped by default (configurable via
+daft.pushVerify: auto, always, or never; use always for hooks that gate
+deletes by ref name). Pass --no-verify to skip it unconditionally.
+
 RENAME MODE (-m)
 
 Renames a local branch and moves its associated worktree directory to match
 the new branch name. If the branch has a remote tracking branch, the remote
 branch is also renamed (push new name, delete old name) unless --no-remote
-is specified.
+is specified. The new-name push honors the repo's pre-push hook; the old-name
+delete pushes no content and skips it by default (configurable via
+daft.pushVerify).
 
 The source can be specified as a branch name or a path to an existing
 worktree (absolute or relative).

--- a/docs/cli/git-worktree-branch.md
+++ b/docs/cli/git-worktree-branch.md
@@ -58,7 +58,10 @@ removal if the repository is trusted. See git-daft(1) for hook management.
 When remote deletion is enabled, the remote-branch delete pushes no content,
 so the repo's pre-push hook is skipped by default (configurable via
 daft.pushVerify: auto, always, or never; use always for hooks that gate
-deletes by ref name). Pass --no-verify to skip it unconditionally.
+deletes by ref name). daft.pushVerify is the base setting every daft push
+reads, so setting it also affects the branch-creation upstream push;
+daft.checkout.pushVerify overrides it for that push alone. Pass --no-verify
+to skip it unconditionally.
 
 RENAME MODE (-m)
 

--- a/docs/cli/git-worktree-checkout.md
+++ b/docs/cli/git-worktree-checkout.md
@@ -28,7 +28,8 @@ operation. The new branch is based on the current branch, or on `<base-branch>`
 if specified. After creating the branch locally, it is pushed to the remote
 and upstream tracking is configured. The repo's pre-push hook runs only when
 that push introduces new commits; a ref-only push of already-pushed commits
-skips it (configurable via daft.checkout.pushVerify: auto, always, or never).
+skips it (configurable via daft.checkout.pushVerify, which defaults to the
+base daft.pushVerify: auto, always, or never).
 
 With --start (or -s), if the specified branch does not exist locally or on the
 remote, a new branch and worktree are created automatically, as if 'daft start'

--- a/docs/cli/git-worktree-merge.md
+++ b/docs/cli/git-worktree-merge.md
@@ -24,6 +24,11 @@ Multiple sources invoke git's octopus strategy, announced explicitly.
 Finish commands (--abort, --continue, --quit) take an optional positional
 <worktree|branch>; default to the current worktree's branch.
 
+When post-merge cleanup deletes a merged branch's remote ref (enabled via
+daft.branchDelete.remote), that delete pushes no content, so the repo's
+pre-push hook is skipped by default. Set daft.pushVerify to always for hooks
+that gate deletes by ref name; merge has no per-invocation bypass.
+
 ## Usage
 
 ```

--- a/docs/hooks/index.md
+++ b/docs/hooks/index.md
@@ -55,12 +55,13 @@ pre-push gate blocks the push and fails the command; its run is reported as a
 carry no content are the conditional sites: the automatic upstream push on
 branch creation consults the hook only when it would publish commits the remote
 does not already have, and remote-branch deletes (`daft remove`, `daft rename`'s
-old-name cleanup) skip it outright — a delete pushes zero objects, so a content
-gate has nothing to validate. Both are tunable via `daft.pushVerify` (set
-`always` for ref-policy hooks such as protected-branch delete guards;
-`daft.checkout.pushVerify` scopes the upstream push alone). Pass `--no-verify`
-to any pushing command to skip the hook for one invocation. And because the
-shared hook always runs in the pushed branch's own worktree under
+old-name cleanup, `daft merge`'s post-merge cleanup) skip it outright — a delete
+pushes zero objects, so a content gate has nothing to validate. Both are tunable
+via `daft.pushVerify` (set `always` for ref-policy hooks such as
+protected-branch delete guards; `daft.checkout.pushVerify` scopes the upstream
+push alone). Pass `--no-verify` to any pushing command to skip the hook for one
+invocation — `daft merge` is the exception, gated by the config key alone. And
+because the shared hook always runs in the pushed branch's own worktree under
 [daft push](/reference/cli/daft-push), that command is the way to push another
 worktree's branch without the hook validating the wrong tree. See
 [Git Hooks](/reference/configuration#git-hooks) for the details.

--- a/docs/hooks/index.md
+++ b/docs/hooks/index.md
@@ -51,15 +51,19 @@ daft's hooks do not replace git's own. Every daft-initiated `git push` honors
 the repository's `pre-push` hook — whether it lives in `.git/hooks` or is
 managed by lefthook, husky, or pre-commit via `core.hooksPath`. A failing
 pre-push gate blocks the push and fails the command; its run is reported as a
-`pre-push` phase on the same surface lifecycle hooks use. The one conditional
-site is the automatic upstream push on branch creation: it consults the hook
-only when it would publish commits the remote does not already have, so
-branching off a fully-pushed base skips it (tunable via
-`daft.checkout.pushVerify`). Pass `--no-verify` to any pushing command to skip
-it for one invocation. And because the shared hook always runs in the pushed
-branch's own worktree under [daft push](/reference/cli/daft-push), that command
-is the way to push another worktree's branch without the hook validating the
-wrong tree. See [Git Hooks](/reference/configuration#git-hooks) for the details.
+`pre-push` phase on the same surface lifecycle hooks use. Pushes that provably
+carry no content are the conditional sites: the automatic upstream push on
+branch creation consults the hook only when it would publish commits the remote
+does not already have, and remote-branch deletes (`daft remove`, `daft rename`'s
+old-name cleanup) skip it outright — a delete pushes zero objects, so a content
+gate has nothing to validate. Both are tunable via `daft.pushVerify` (set
+`always` for ref-policy hooks such as protected-branch delete guards;
+`daft.checkout.pushVerify` scopes the upstream push alone). Pass `--no-verify`
+to any pushing command to skip the hook for one invocation. And because the
+shared hook always runs in the pushed branch's own worktree under
+[daft push](/reference/cli/daft-push), that command is the way to push another
+worktree's branch without the hook validating the wrong tree. See
+[Git Hooks](/reference/configuration#git-hooks) for the details.
 
 ## Where to next
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -77,12 +77,13 @@ By default, daft does not contact the remote during worktree management. All
 remote operations are opt-in. Use `daft config remote-sync` to toggle these
 settings interactively, or set them directly with `git config`.
 
-| Key                        | Default | Description                                                                                            |
-| -------------------------- | ------- | ------------------------------------------------------------------------------------------------------ |
-| `daft.checkout.fetch`      | `false` | Fetch from remote before creating a worktree for an existing branch                                    |
-| `daft.checkout.push`       | `false` | Push new branches to remote after creation                                                             |
-| `daft.checkout.pushVerify` | `auto`  | When that push runs the repo's pre-push hook (`auto`, `always`, `never`) — see [Git Hooks](#git-hooks) |
-| `daft.branchDelete.remote` | `false` | Delete the remote branch when removing a local branch                                                  |
+| Key                        | Default           | Description                                                                                                         |
+| -------------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `daft.checkout.fetch`      | `false`           | Fetch from remote before creating a worktree for an existing branch                                                 |
+| `daft.checkout.push`       | `false`           | Push new branches to remote after creation                                                                          |
+| `daft.pushVerify`          | `auto`            | When ref-only pushes (remote-branch deletes, the upstream push) run the pre-push hook — see [Git Hooks](#git-hooks) |
+| `daft.checkout.pushVerify` | `daft.pushVerify` | Checkout-scoped override of `daft.pushVerify` for the automatic upstream push (`auto`, `always`, `never`)           |
+| `daft.branchDelete.remote` | `false`           | Delete the remote branch when removing a local branch                                                               |
 
 ### Enabling Remote Sync
 
@@ -374,22 +375,33 @@ on `git push` fires on daft's pushes too. The hook run is reported as a
 `pre-push` phase with the hook's output, using the same surface as daft's
 lifecycle hooks.
 
-The automatic upstream push on `daft start` / `git worktree-checkout -b` is the
-one conditional site: it runs the hook only when the push introduces commits the
-target remote does not already have. Branching off a fully-pushed base is a
-ref-only push -- a new branch name pointing at commits the remote already has --
-so there is nothing for a content gate to validate, and the hook is skipped.
-Control this with `daft.checkout.pushVerify`:
+Pushes that provably carry no content are the conditional sites: the hook runs
+only when there is something for a content gate to validate. Two kinds of push
+qualify as ref-only:
 
-| Value    | Behavior                                                       |
-| -------- | -------------------------------------------------------------- |
-| `auto`   | (default) Run the hook only when the push carries new commits  |
-| `always` | Run the hook on every upstream push, including ref-only pushes |
-| `never`  | Never run the hook on the automatic upstream push              |
+- **The automatic upstream push** on `daft start` / `git worktree-checkout -b`,
+  when branching off a fully-pushed base -- a new branch name pointing at
+  commits the remote already has.
+- **Remote-branch deletes** -- `daft remove` / `git worktree-branch -d` with
+  remote deletion enabled, `daft rename`'s old-name cleanup, and
+  `daft multi-remote move --delete-old`. A delete pushes a null ref update and
+  zero objects, so it is ref-only by construction.
+
+Control this with `daft.pushVerify` (the base setting every such site reads;
+`daft.checkout.pushVerify` overrides it for the upstream push alone):
+
+| Value    | Behavior                                                      |
+| -------- | ------------------------------------------------------------- |
+| `auto`   | (default) Run the hook only when the push carries new commits |
+| `always` | Run the hook on every such push, including ref-only ones      |
+| `never`  | Never run the hook on these pushes                            |
 
 `always` is for repositories whose pre-push hooks act on the ref rather than the
-content (branch-naming policies, protected-branch guards): daft cannot classify
-an opaque hook, so the automatic skip is based purely on pushed content.
+content (branch-naming policies, protected-branch guards that reject deleting
+`release/*` and friends): daft cannot classify an opaque hook, so the automatic
+skip is based purely on pushed content. Content-carrying pushes -- `daft push`,
+`daft sync --push`, and `daft rename`'s new-name push -- always verify and do
+not consult these settings.
 
 Pass `--no-verify` to skip the hook for one invocation. Every command that can
 push accepts it: `daft push`, `daft sync --push`, `daft start` / `daft go -b` /
@@ -403,7 +415,8 @@ Remote operations are disabled by default. When enabled (via
   upstream tracking (controlled by `daft.checkout.push`; pre-push hook gating
   per `daft.checkout.pushVerify` above)
 - **`daft remove` / `git worktree-branch -d`** -- pushes `--delete` to remove
-  the remote branch (controlled by `daft.branchDelete.remote`)
+  the remote branch (controlled by `daft.branchDelete.remote`; pre-push hook
+  gating per `daft.pushVerify` above)
 - **`daft multi-remote move --push`** -- pushes an existing branch to a new
   remote
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -77,13 +77,13 @@ By default, daft does not contact the remote during worktree management. All
 remote operations are opt-in. Use `daft config remote-sync` to toggle these
 settings interactively, or set them directly with `git config`.
 
-| Key                        | Default           | Description                                                                                                         |
-| -------------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `daft.checkout.fetch`      | `false`           | Fetch from remote before creating a worktree for an existing branch                                                 |
-| `daft.checkout.push`       | `false`           | Push new branches to remote after creation                                                                          |
-| `daft.pushVerify`          | `auto`            | When ref-only pushes (remote-branch deletes, the upstream push) run the pre-push hook — see [Git Hooks](#git-hooks) |
-| `daft.checkout.pushVerify` | `daft.pushVerify` | Checkout-scoped override of `daft.pushVerify` for the automatic upstream push (`auto`, `always`, `never`)           |
-| `daft.branchDelete.remote` | `false`           | Delete the remote branch when removing a local branch                                                               |
+| Key                        | Default           | Description                                                                                                                                  |
+| -------------------------- | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `daft.checkout.fetch`      | `false`           | Fetch from remote before creating a worktree for an existing branch                                                                          |
+| `daft.checkout.push`       | `false`           | Push new branches to remote after creation                                                                                                   |
+| `daft.pushVerify`          | `auto`            | Base setting: when daft's suppressible pushes (remote-branch deletes, the upstream push) run the pre-push hook — see [Git Hooks](#git-hooks) |
+| `daft.checkout.pushVerify` | `daft.pushVerify` | Checkout-scoped override of `daft.pushVerify` for the automatic upstream push (`auto`, `always`, `never`)                                    |
+| `daft.branchDelete.remote` | `false`           | Delete the remote branch when removing a local branch                                                                                        |
 
 ### Enabling Remote Sync
 
@@ -390,11 +390,17 @@ qualify as ref-only:
 Control this with `daft.pushVerify` (the base setting every such site reads;
 `daft.checkout.pushVerify` overrides it for the upstream push alone):
 
-| Value    | Behavior                                                      |
-| -------- | ------------------------------------------------------------- |
-| `auto`   | (default) Run the hook only when the push carries new commits |
-| `always` | Run the hook on every such push, including ref-only ones      |
-| `never`  | Never run the hook on these pushes                            |
+| Value    | Behavior                                                                        |
+| -------- | ------------------------------------------------------------------------------- |
+| `auto`   | (default) Run the hook only when the push carries new commits                   |
+| `always` | Run the hook on every such push, including ref-only ones                        |
+| `never`  | Never run the hook on these pushes, even when the upstream push carries commits |
+
+Note the asymmetry in `never`: `auto` and `always` decide per push from what it
+transmits, but `never` is unconditional. Setting `daft.pushVerify` to `never` to
+quiet the hook on deletes therefore also disarms it on the upstream push when
+that push does carry new commits. Scope the base key to deletes by re-arming the
+other site with `daft.checkout.pushVerify = auto`.
 
 `always` is for repositories whose pre-push hooks act on the ref rather than the
 content (branch-naming policies, protected-branch guards that reject deleting
@@ -403,10 +409,11 @@ skip is based purely on pushed content. Content-carrying pushes -- `daft push`,
 `daft sync --push`, and `daft rename`'s new-name push -- always verify and do
 not consult these settings.
 
-Pass `--no-verify` to skip the hook for one invocation. Every command that can
-push accepts it: `daft push`, `daft sync --push`, `daft start` / `daft go -b` /
-`git worktree-checkout -b`, `daft rename`, `daft remove` /
-`git worktree-branch -d/-D`, and `daft multi-remote move`.
+Pass `--no-verify` to skip the hook for one invocation: `daft push`,
+`daft sync --push`, `daft start` / `daft go -b` / `git worktree-checkout -b`,
+`daft rename`, `daft remove` / `git worktree-branch -d/-D`, and
+`daft multi-remote move` all accept it. `daft merge` is the exception -- its
+post-merge cleanup delete is governed by `daft.pushVerify` alone.
 
 Remote operations are disabled by default. When enabled (via
 `daft config remote-sync --on` or by setting the individual keys), this affects:
@@ -417,6 +424,10 @@ Remote operations are disabled by default. When enabled (via
 - **`daft remove` / `git worktree-branch -d`** -- pushes `--delete` to remove
   the remote branch (controlled by `daft.branchDelete.remote`; pre-push hook
   gating per `daft.pushVerify` above)
+- **`daft merge`** -- post-merge cleanup deletes the merged branch's remote ref
+  on the same `daft.branchDelete.remote` setting, gated by `daft.pushVerify`.
+  Unlike the other sites, `daft merge` has no `--no-verify`, so the config key
+  is the only control there.
 - **`daft multi-remote move --push`** -- pushes an existing branch to a new
   remote
 

--- a/man/daft-go.1
+++ b/man/daft-go.1
@@ -34,8 +34,9 @@ With \-b, creates a new branch and worktree in a single operation. The new
 branch is based on the current branch, or on `<base\-branch>` if specified. It
 is pushed to the remote and upstream tracking is configured; the pre\-push hook
 runs only when that push introduces new commits, skipping ref\-only pushes
-(configurable via daft.checkout.pushVerify: auto, always, or never). Prefer
-\*(Aqdaft start\*(Aq for creating new branches.
+(configurable via daft.checkout.pushVerify, which defaults to the base
+daft.pushVerify: auto, always, or never). Prefer \*(Aqdaft start\*(Aq for creating
+new branches.
 .PP
 With \-s (\-\-start), if the specified branch does not exist locally or on the
 remote, a new branch and worktree are created automatically. This can also

--- a/man/daft-merge.1
+++ b/man/daft-merge.1
@@ -17,6 +17,11 @@ Multiple sources invoke git\*(Aqs octopus strategy, announced explicitly.
 .PP
 Finish commands (\-\-abort, \-\-continue, \-\-quit) take an optional positional
 <worktree|branch>; default to the current worktree\*(Aqs branch.
+.PP
+When post\-merge cleanup deletes a merged branch\*(Aqs remote ref (enabled via
+daft.branchDelete.remote), that delete pushes no content, so the repo\*(Aqs
+pre\-push hook is skipped by default. Set daft.pushVerify to always for hooks
+that gate deletes by ref name; merge has no per\-invocation bypass.
 .SH OPTIONS
 .TP
 \fB\-\-into\fR \fI<TARGET>\fR

--- a/man/daft-remove.1
+++ b/man/daft-remove.1
@@ -41,6 +41,11 @@ deleted.
 .PP
 Pre\-remove and post\-remove lifecycle hooks are executed for each worktree
 removal if the repository is trusted. See daft\-hooks(1) for hook management.
+.PP
+When remote deletion is enabled, the remote\-branch delete pushes no content,
+so the repo\*(Aqs pre\-push hook is skipped by default (configurable via
+daft.pushVerify: auto, always, or never; use always for hooks that gate
+deletes by ref name). Pass \-\-no\-verify to skip it unconditionally.
 .SH OPTIONS
 .TP
 \fB\-f\fR, \fB\-\-force\fR

--- a/man/daft-remove.1
+++ b/man/daft-remove.1
@@ -45,7 +45,10 @@ removal if the repository is trusted. See daft\-hooks(1) for hook management.
 When remote deletion is enabled, the remote\-branch delete pushes no content,
 so the repo\*(Aqs pre\-push hook is skipped by default (configurable via
 daft.pushVerify: auto, always, or never; use always for hooks that gate
-deletes by ref name). Pass \-\-no\-verify to skip it unconditionally.
+deletes by ref name). daft.pushVerify is the base setting every daft push
+reads, so setting it also affects the branch\-creation upstream push;
+daft.checkout.pushVerify overrides it for that push alone. Pass \-\-no\-verify
+to skip it unconditionally.
 .SH OPTIONS
 .TP
 \fB\-f\fR, \fB\-\-force\fR

--- a/man/daft-rename.1
+++ b/man/daft-rename.1
@@ -10,7 +10,9 @@ daft rename \- Rename a branch and move its worktree
 Renames a local branch and moves its associated worktree directory to match
 the new branch name. If the branch has a remote tracking branch, the remote
 branch is also renamed (push new name, delete old name) unless \-\-no\-remote
-is specified.
+is specified. The new\-name push honors the repo\*(Aqs pre\-push hook; the old\-name
+delete pushes no content and skips it by default (configurable via
+daft.pushVerify: auto, always, or never).
 .PP
 The source can be specified as a branch name or a path to an existing
 worktree (absolute or relative).

--- a/man/git-worktree-branch-delete.1
+++ b/man/git-worktree-branch-delete.1
@@ -42,7 +42,10 @@ removal if the repository is trusted. See git\-daft(1) for hook management.
 When remote deletion is enabled, the remote\-branch delete pushes no content,
 so the repo\*(Aqs pre\-push hook is skipped by default (configurable via
 daft.pushVerify: auto, always, or never; use always for hooks that gate
-deletes by ref name). Pass \-\-no\-verify to skip it unconditionally.
+deletes by ref name). daft.pushVerify is the base setting every daft push
+reads, so setting it also affects the branch\-creation upstream push;
+daft.checkout.pushVerify overrides it for that push alone. Pass \-\-no\-verify
+to skip it unconditionally.
 .SH OPTIONS
 .TP
 \fB\-D\fR, \fB\-\-force\fR

--- a/man/git-worktree-branch-delete.1
+++ b/man/git-worktree-branch-delete.1
@@ -38,6 +38,11 @@ are deleted.
 .PP
 Pre\-remove and post\-remove lifecycle hooks are executed for each worktree
 removal if the repository is trusted. See git\-daft(1) for hook management.
+.PP
+When remote deletion is enabled, the remote\-branch delete pushes no content,
+so the repo\*(Aqs pre\-push hook is skipped by default (configurable via
+daft.pushVerify: auto, always, or never; use always for hooks that gate
+deletes by ref name). Pass \-\-no\-verify to skip it unconditionally.
 .SH OPTIONS
 .TP
 \fB\-D\fR, \fB\-\-force\fR

--- a/man/git-worktree-branch.1
+++ b/man/git-worktree-branch.1
@@ -50,7 +50,10 @@ removal if the repository is trusted. See git\-daft(1) for hook management.
 When remote deletion is enabled, the remote\-branch delete pushes no content,
 so the repo\*(Aqs pre\-push hook is skipped by default (configurable via
 daft.pushVerify: auto, always, or never; use always for hooks that gate
-deletes by ref name). Pass \-\-no\-verify to skip it unconditionally.
+deletes by ref name). daft.pushVerify is the base setting every daft push
+reads, so setting it also affects the branch\-creation upstream push;
+daft.checkout.pushVerify overrides it for that push alone. Pass \-\-no\-verify
+to skip it unconditionally.
 .PP
 RENAME MODE (\-m)
 .PP

--- a/man/git-worktree-branch.1
+++ b/man/git-worktree-branch.1
@@ -47,12 +47,19 @@ deleted.
 Pre\-remove and post\-remove lifecycle hooks are executed for each worktree
 removal if the repository is trusted. See git\-daft(1) for hook management.
 .PP
+When remote deletion is enabled, the remote\-branch delete pushes no content,
+so the repo\*(Aqs pre\-push hook is skipped by default (configurable via
+daft.pushVerify: auto, always, or never; use always for hooks that gate
+deletes by ref name). Pass \-\-no\-verify to skip it unconditionally.
+.PP
 RENAME MODE (\-m)
 .PP
 Renames a local branch and moves its associated worktree directory to match
 the new branch name. If the branch has a remote tracking branch, the remote
 branch is also renamed (push new name, delete old name) unless \-\-no\-remote
-is specified.
+is specified. The new\-name push honors the repo\*(Aqs pre\-push hook; the old\-name
+delete pushes no content and skips it by default (configurable via
+daft.pushVerify).
 .PP
 The source can be specified as a branch name or a path to an existing
 worktree (absolute or relative).

--- a/man/git-worktree-checkout.1
+++ b/man/git-worktree-checkout.1
@@ -20,7 +20,8 @@ operation. The new branch is based on the current branch, or on `<base\-branch>`
 if specified. After creating the branch locally, it is pushed to the remote
 and upstream tracking is configured. The repo\*(Aqs pre\-push hook runs only when
 that push introduces new commits; a ref\-only push of already\-pushed commits
-skips it (configurable via daft.checkout.pushVerify: auto, always, or never).
+skips it (configurable via daft.checkout.pushVerify, which defaults to the
+base daft.pushVerify: auto, always, or never).
 .PP
 With \-\-start (or \-s), if the specified branch does not exist locally or on the
 remote, a new branch and worktree are created automatically, as if \*(Aqdaft start\*(Aq

--- a/man/git-worktree-merge.1
+++ b/man/git-worktree-merge.1
@@ -17,6 +17,11 @@ Multiple sources invoke git\*(Aqs octopus strategy, announced explicitly.
 .PP
 Finish commands (\-\-abort, \-\-continue, \-\-quit) take an optional positional
 <worktree|branch>; default to the current worktree\*(Aqs branch.
+.PP
+When post\-merge cleanup deletes a merged branch\*(Aqs remote ref (enabled via
+daft.branchDelete.remote), that delete pushes no content, so the repo\*(Aqs
+pre\-push hook is skipped by default. Set daft.pushVerify to always for hooks
+that gate deletes by ref name; merge has no per\-invocation bypass.
 .SH OPTIONS
 .TP
 \fB\-\-into\fR \fI<TARGET>\fR

--- a/src/commands/branch_delete.rs
+++ b/src/commands/branch_delete.rs
@@ -51,7 +51,10 @@ removal if the repository is trusted. See git-daft(1) for hook management.
 When remote deletion is enabled, the remote-branch delete pushes no content,
 so the repo's pre-push hook is skipped by default (configurable via
 daft.pushVerify: auto, always, or never; use always for hooks that gate
-deletes by ref name). Pass --no-verify to skip it unconditionally.
+deletes by ref name). daft.pushVerify is the base setting every daft push
+reads, so setting it also affects the branch-creation upstream push;
+daft.checkout.pushVerify overrides it for that push alone. Pass --no-verify
+to skip it unconditionally.
 "#)]
 pub struct Args {
     #[arg(required = true, help = "Branches to delete (names or worktree paths)")]

--- a/src/commands/branch_delete.rs
+++ b/src/commands/branch_delete.rs
@@ -47,6 +47,11 @@ are deleted.
 
 Pre-remove and post-remove lifecycle hooks are executed for each worktree
 removal if the repository is trusted. See git-daft(1) for hook management.
+
+When remote deletion is enabled, the remote-branch delete pushes no content,
+so the repo's pre-push hook is skipped by default (configurable via
+daft.pushVerify: auto, always, or never; use always for hooks that gate
+deletes by ref name). Pass --no-verify to skip it unconditionally.
 "#)]
 pub struct Args {
     #[arg(required = true, help = "Branches to delete (names or worktree paths)")]
@@ -114,6 +119,7 @@ fn run_branch_delete(args: &Args, output: &mut dyn Output, settings: &DaftSettin
         remote_only: args.remote,
         keep_local_branch: false,
         no_verify: args.no_verify,
+        push_verify: settings.push_verify,
         prune_cd_target: settings.prune_cd_target,
         command_label: "branch-delete".to_string(),
         skip_merge_validation: false,

--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -46,7 +46,8 @@ operation. The new branch is based on the current branch, or on `<base-branch>`
 if specified. After creating the branch locally, it is pushed to the remote
 and upstream tracking is configured. The repo's pre-push hook runs only when
 that push introduces new commits; a ref-only push of already-pushed commits
-skips it (configurable via daft.checkout.pushVerify: auto, always, or never).
+skips it (configurable via daft.checkout.pushVerify, which defaults to the
+base daft.pushVerify: auto, always, or never).
 
 With --start (or -s), if the specified branch does not exist locally or on the
 remote, a new branch and worktree are created automatically, as if 'daft start'
@@ -190,8 +191,9 @@ With -b, creates a new branch and worktree in a single operation. The new
 branch is based on the current branch, or on `<base-branch>` if specified. It
 is pushed to the remote and upstream tracking is configured; the pre-push hook
 runs only when that push introduces new commits, skipping ref-only pushes
-(configurable via daft.checkout.pushVerify: auto, always, or never). Prefer
-'daft start' for creating new branches.
+(configurable via daft.checkout.pushVerify, which defaults to the base
+daft.pushVerify: auto, always, or never). Prefer 'daft start' for creating
+new branches.
 
 With -s (--start), if the specified branch does not exist locally or on the
 remote, a new branch and worktree are created automatically. This can also
@@ -1826,6 +1828,7 @@ fn run_create_branch_core(
         },
         no_verify: args.no_verify,
         push_verify: settings.checkout_push_verify,
+        push_verify_key: settings.checkout_push_verify_key,
         checkout_fetch: if args.local {
             false
         } else {

--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -1181,6 +1181,7 @@ pub fn run() -> Result<()> {
                         remote_only: false,
                         keep_local_branch,
                         no_verify: false,
+                        push_verify: settings.push_verify,
                         prune_cd_target: settings.prune_cd_target,
                         // Expose DAFT_COMMAND=merge so hook scripts can
                         // distinguish merge cleanup from standalone daft remove.

--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -40,6 +40,11 @@ Multiple sources invoke git's octopus strategy, announced explicitly.
 
 Finish commands (--abort, --continue, --quit) take an optional positional
 <worktree|branch>; default to the current worktree's branch.
+
+When post-merge cleanup deletes a merged branch's remote ref (enabled via
+daft.branchDelete.remote), that delete pushes no content, so the repo's
+pre-push hook is skipped by default. Set daft.pushVerify to always for hooks
+that gate deletes by ref name; merge has no per-invocation bypass.
 "#)]
 pub struct Args {
     /// Source branches/commits to merge (start mode), OR optional target worktree/branch

--- a/src/commands/multi_remote.rs
+++ b/src/commands/multi_remote.rs
@@ -5,7 +5,7 @@
 use crate::{
     core::OutputSink,
     core::worktree::ports::NoopStageRunner,
-    core::worktree::push::{HookVerdict, PushAction, push_with_hooks},
+    core::worktree::push::{HookVerdict, PushAction, push_with_hooks, resolve_delete_pre_push},
     get_project_root,
     git::GitCommand,
     is_git_repository,
@@ -126,6 +126,10 @@ records are updated accordingly.
 
 Options like --set-upstream can update the branch's tracking configuration
 to match the new remote organization.
+
+--push honors the repo's pre-push hook; the --delete-old delete pushes no
+content and skips it by default (configurable via daft.pushVerify: auto,
+always, or never). Pass --no-verify to skip both unconditionally.
 "#)]
     Move {
         #[arg(help = "Branch name or worktree path to move")]
@@ -740,7 +744,9 @@ fn cmd_move(
     }
 
     // Delete from old remote if requested (skipped if the push was gated —
-    // the same hook would gate this push too).
+    // the same hook would gate this push too). A delete pushes no content,
+    // so under the default `pushVerify = auto` the pre-push gate is skipped
+    // (#747); `always` re-arms it for ref-policy hooks.
     if delete_old
         && push_gate_error.is_none()
         && let Some(old_remote) = current_remote
@@ -750,6 +756,10 @@ fn cmd_move(
             old_remote, branch_name
         ));
 
+        let hook_plan = resolve_delete_pre_push(&git, &new_path, settings.push_verify, no_verify);
+        if let Some(reason) = hook_plan.skip_reason {
+            output.step(reason);
+        }
         match push_with_hooks(
             &git,
             PushAction::Delete {
@@ -757,24 +767,36 @@ fn cmd_move(
                 branch: &branch_name,
             },
             &new_path,
-            !no_verify,
+            hook_plan.verify,
             &NoopStageRunner,
             push_presenter.as_ref(),
-            None,
+            hook_plan.hook_present,
         ) {
             Ok(outcome) => {
                 if let Some(msg) = outcome.failure {
-                    if matches!(outcome.hook, HookVerdict::Rejected | HookVerdict::Passed) {
+                    // #747: `Bypassed` (skipped or --no-verify) escalates too —
+                    // a gate that never ran cannot have refused the push, yet
+                    // the branch survives on the old remote. Only hook-less
+                    // failures keep the legacy warn-and-continue.
+                    if matches!(
+                        outcome.hook,
+                        HookVerdict::Rejected | HookVerdict::Passed | HookVerdict::Bypassed
+                    ) {
                         let hint = if outcome.hook.no_verify_might_help() {
                             " (or re-run with --no-verify to bypass the hook)"
                         } else {
                             ""
                         };
+                        // A skipped/bypassed gate has nothing to add to the
+                        // cause line — the git error in `msg` is the story.
+                        let cause = match outcome.hook {
+                            HookVerdict::Bypassed => String::new(),
+                            _ => format!(" ({})", outcome.hook.failure_cause()),
+                        };
                         push_gate_error = Some(format!(
-                            "Could not delete '{old_remote}/{branch_name}': {msg} ({}). \
+                            "Could not delete '{old_remote}/{branch_name}': {msg}{cause}. \
                              Delete it manually with: \
                              git push {old_remote} --delete {branch_name}{hint}",
-                            outcome.hook.failure_cause(),
                         ));
                     } else {
                         output.warning(&format!("Failed to delete from old remote: {}", msg));

--- a/src/commands/multi_remote.rs
+++ b/src/commands/multi_remote.rs
@@ -5,7 +5,9 @@
 use crate::{
     core::OutputSink,
     core::worktree::ports::NoopStageRunner,
-    core::worktree::push::{HookVerdict, PushAction, push_with_hooks, resolve_delete_pre_push},
+    core::worktree::push::{
+        HookVerdict, PushAction, delete_failure_escalates, push_with_hooks, resolve_delete_pre_push,
+    },
     get_project_root,
     git::GitCommand,
     is_git_repository,
@@ -18,7 +20,7 @@ use crate::{
         CliOutput, Output, OutputConfig,
         emit::{self, Cell, EmitArgs, EmitPayload, Section, Table},
     },
-    settings::DaftSettings,
+    settings::{DaftSettings, PushVerify},
 };
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
@@ -129,7 +131,10 @@ to match the new remote organization.
 
 --push honors the repo's pre-push hook; the --delete-old delete pushes no
 content and skips it by default (configurable via daft.pushVerify: auto,
-always, or never). Pass --no-verify to skip both unconditionally.
+always, or never). daft.pushVerify is the base setting every daft push reads,
+so setting it also affects the branch-creation upstream push;
+daft.checkout.pushVerify overrides it for that push alone. Pass --no-verify to
+skip both unconditionally.
 "#)]
     Move {
         #[arg(help = "Branch name or worktree path to move")]
@@ -689,8 +694,14 @@ fn cmd_move(
 
     // Remote pushes honor the repo's pre-push hook (#599); a failure with
     // the hook in effect escalates after the move's local steps complete.
+    //
+    // A delete only renders the hook under `always` — its verify decision is
+    // static (#747), so a `--delete-old`-only move under `auto`/`never` needs
+    // no presenter at all and must not pay for the hook probe here just to
+    // have `resolve_delete_pre_push` repeat it below.
+    let delete_may_render = delete_old && settings.push_verify == PushVerify::Always;
     let push_presenter: Option<std::sync::Arc<dyn crate::executor::presenter::JobPresenter>> =
-        if (push || delete_old) && !no_verify && git.pre_push_hook_exists(&new_path) {
+        if (push || delete_may_render) && !no_verify && git.pre_push_hook_exists(&new_path) {
             let p: std::sync::Arc<dyn crate::executor::presenter::JobPresenter> =
                 crate::executor::cli_presenter::CliPresenter::auto(
                     &crate::settings::HookOutputConfig::default(),
@@ -757,7 +768,7 @@ fn cmd_move(
         ));
 
         let hook_plan = resolve_delete_pre_push(&git, &new_path, settings.push_verify, no_verify);
-        if let Some(reason) = hook_plan.skip_reason {
+        if let Some(reason) = &hook_plan.skip_reason {
             output.step(reason);
         }
         match push_with_hooks(
@@ -774,14 +785,11 @@ fn cmd_move(
         ) {
             Ok(outcome) => {
                 if let Some(msg) = outcome.failure {
-                    // #747: `Bypassed` (skipped or --no-verify) escalates too —
-                    // a gate that never ran cannot have refused the push, yet
-                    // the branch survives on the old remote. Only hook-less
-                    // failures keep the legacy warn-and-continue.
-                    if matches!(
-                        outcome.hook,
-                        HookVerdict::Rejected | HookVerdict::Passed | HookVerdict::Bypassed
-                    ) {
+                    // #747: daft's own ref-only skip must not downgrade a real
+                    // failure to a warning, but an explicit `--no-verify`
+                    // keeps the legacy warn-and-continue — see
+                    // `delete_failure_escalates`.
+                    if delete_failure_escalates(outcome.hook, no_verify) {
                         let hint = if outcome.hook.no_verify_might_help() {
                             " (or re-run with --no-verify to bypass the hook)"
                         } else {

--- a/src/commands/worktree_branch.rs
+++ b/src/commands/worktree_branch.rs
@@ -12,7 +12,7 @@ use crate::{
         CliOutput, Output, OutputConfig,
         timeline::{Timeline, TimelineMode},
     },
-    settings::DaftSettings,
+    settings::{DaftSettings, PushVerify},
 };
 use anyhow::Result;
 use clap::Parser;
@@ -62,12 +62,19 @@ deleted.
 Pre-remove and post-remove lifecycle hooks are executed for each worktree
 removal if the repository is trusted. See git-daft(1) for hook management.
 
+When remote deletion is enabled, the remote-branch delete pushes no content,
+so the repo's pre-push hook is skipped by default (configurable via
+daft.pushVerify: auto, always, or never; use always for hooks that gate
+deletes by ref name). Pass --no-verify to skip it unconditionally.
+
 RENAME MODE (-m)
 
 Renames a local branch and moves its associated worktree directory to match
 the new branch name. If the branch has a remote tracking branch, the remote
 branch is also renamed (push new name, delete old name) unless --no-remote
-is specified.
+is specified. The new-name push honors the repo's pre-push hook; the old-name
+delete pushes no content and skips it by default (configurable via
+daft.pushVerify).
 
 The source can be specified as a branch name or a path to an existing
 worktree (absolute or relative).
@@ -179,6 +186,11 @@ deleted.
 
 Pre-remove and post-remove lifecycle hooks are executed for each worktree
 removal if the repository is trusted. See daft-hooks(1) for hook management.
+
+When remote deletion is enabled, the remote-branch delete pushes no content,
+so the repo's pre-push hook is skipped by default (configurable via
+daft.pushVerify: auto, always, or never; use always for hooks that gate
+deletes by ref name). Pass --no-verify to skip it unconditionally.
 "#)]
 pub struct RemoveArgs {
     #[arg(required = true, help = "Branches or worktree paths to delete")]
@@ -330,7 +342,9 @@ fn prepare_out_of_repo_paths(args: &mut Vec<String>, command_name: &str) -> Resu
 Renames a local branch and moves its associated worktree directory to match
 the new branch name. If the branch has a remote tracking branch, the remote
 branch is also renamed (push new name, delete old name) unless --no-remote
-is specified.
+is specified. The new-name push honors the repo's pre-push hook; the old-name
+delete pushes no content and skips it by default (configurable via
+daft.pushVerify: auto, always, or never).
 
 The source can be specified as a branch name or a path to an existing
 worktree (absolute or relative).
@@ -495,6 +509,7 @@ fn run_branch_delete(
         remote_only,
         keep_local_branch: false,
         no_verify,
+        push_verify: settings.push_verify,
         prune_cd_target: settings.prune_cd_target,
         command_label: "branch-delete".to_string(),
         skip_merge_validation: false,
@@ -521,9 +536,13 @@ fn run_branch_delete(
     // rail it embeds under each branch's active DeleteRemote row (re-resolved
     // per phase from the push target). Off the rail, keep the legacy #599
     // behavior: presenter only when the hook will fire, spinner otherwise.
+    // Unlike checkout's probe-dependent upper bound, a delete's verify
+    // decision is static (#747): the hook can only fire under
+    // `pushVerify = always`, so the gate is exact.
     let probe_git = GitCommand::new(quiet).with_gitoxide(settings.use_gitoxide);
     let push_hook_will_render = params.delete_remote
         && !params.no_verify
+        && params.push_verify == PushVerify::Always
         && std::env::current_dir()
             .map(|cwd| probe_git.pre_push_hook_exists(&cwd))
             .unwrap_or(false);
@@ -674,6 +693,7 @@ fn run_rename_inner(
         multi_remote_enabled: settings.multi_remote_enabled,
         multi_remote_default: settings.multi_remote_default.clone(),
         no_verify,
+        push_verify: settings.push_verify,
     };
 
     let mut hooks_config = crate::core::settings::load_hooks_config()?;

--- a/src/commands/worktree_branch.rs
+++ b/src/commands/worktree_branch.rs
@@ -65,7 +65,10 @@ removal if the repository is trusted. See git-daft(1) for hook management.
 When remote deletion is enabled, the remote-branch delete pushes no content,
 so the repo's pre-push hook is skipped by default (configurable via
 daft.pushVerify: auto, always, or never; use always for hooks that gate
-deletes by ref name). Pass --no-verify to skip it unconditionally.
+deletes by ref name). daft.pushVerify is the base setting every daft push
+reads, so setting it also affects the branch-creation upstream push;
+daft.checkout.pushVerify overrides it for that push alone. Pass --no-verify
+to skip it unconditionally.
 
 RENAME MODE (-m)
 
@@ -190,7 +193,10 @@ removal if the repository is trusted. See daft-hooks(1) for hook management.
 When remote deletion is enabled, the remote-branch delete pushes no content,
 so the repo's pre-push hook is skipped by default (configurable via
 daft.pushVerify: auto, always, or never; use always for hooks that gate
-deletes by ref name). Pass --no-verify to skip it unconditionally.
+deletes by ref name). daft.pushVerify is the base setting every daft push
+reads, so setting it also affects the branch-creation upstream push;
+daft.checkout.pushVerify overrides it for that push alone. Pass --no-verify
+to skip it unconditionally.
 "#)]
 pub struct RemoveArgs {
     #[arg(required = true, help = "Branches or worktree paths to delete")]
@@ -536,9 +542,15 @@ fn run_branch_delete(
     // rail it embeds under each branch's active DeleteRemote row (re-resolved
     // per phase from the push target). Off the rail, keep the legacy #599
     // behavior: presenter only when the hook will fire, spinner otherwise.
-    // Unlike checkout's probe-dependent upper bound, a delete's verify
-    // decision is static (#747): the hook can only fire under
-    // `pushVerify = always`, so the gate is exact.
+    //
+    // Unlike checkout's probe-dependent upper bound, a delete's *verify*
+    // decision is static (#747) — the hook can only fire under
+    // `pushVerify = always` — so that half of the gate is exact. The
+    // hook-presence half is not: the delete probes each branch's own worktree
+    // while this runs before the branches are resolved and can only ask about
+    // the cwd, and a relative `core.hooksPath` resolves per worktree. The
+    // residue is cosmetic — a miss renders the hook through the fallback
+    // spinner path instead of the reported pre-push phase.
     let probe_git = GitCommand::new(quiet).with_gitoxide(settings.use_gitoxide);
     let push_hook_will_render = params.delete_remote
         && !params.no_verify

--- a/src/core/settings.rs
+++ b/src/core/settings.rs
@@ -89,15 +89,24 @@ impl PruneCdTarget {
     }
 }
 
-/// When the automatic upstream push consults the repo's `pre-push` hook.
+/// When a daft-initiated push consults the repo's `pre-push` hook.
+///
+/// Read as the base `daft.pushVerify` by every site that can prove its push
+/// carries no content: the branch-creation upstream push (#679, via the
+/// `daft.checkout.pushVerify` override) and remote-branch deletes (#747).
+/// Content-carrying pushes (`daft sync --push`, `daft push`, rename's
+/// new-name push) always verify and never consult this setting.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PushVerify {
     /// Run the hook only when the push introduces commits the target remote
-    /// does not already have; skip it for ref-only pushes (#679).
+    /// does not already have; skip it for ref-only pushes (#679) — which a
+    /// remote-branch delete statically is (#747).
     Auto,
-    /// Always run the hook, even for ref-only pushes.
+    /// Always run the hook, even for ref-only pushes and deletes. The escape
+    /// hatch for ref-policy hooks (e.g. "don't delete release/*") that act
+    /// on the ref name rather than the content.
     Always,
-    /// Never run the hook on the automatic upstream push.
+    /// Never run the hook on these pushes.
     Never,
 }
 
@@ -307,7 +316,11 @@ pub mod defaults {
     /// Default value for checkout.upstream setting.
     pub const CHECKOUT_UPSTREAM: bool = true;
 
-    /// Default value for checkout.pushVerify setting.
+    /// Default value for the base pushVerify setting (#747).
+    pub const PUSH_VERIFY: PushVerify = PushVerify::Auto;
+
+    /// Default value for checkout.pushVerify setting (follows the base
+    /// `daft.pushVerify` when unset).
     pub const CHECKOUT_PUSH_VERIFY: PushVerify = PushVerify::Auto;
 
     /// Default value for remote setting.
@@ -400,7 +413,12 @@ pub mod keys {
     /// Config key for checkout.upstream setting.
     pub const CHECKOUT_UPSTREAM: &str = "daft.checkout.upstream";
 
-    /// Config key for checkout.pushVerify setting.
+    /// Config key for the base pushVerify setting — read by every push site
+    /// that can prove its push is ref-only (#747).
+    pub const PUSH_VERIFY: &str = "daft.pushVerify";
+
+    /// Config key for checkout.pushVerify setting (checkout-scoped override
+    /// of `daft.pushVerify` for the branch-creation upstream push).
     pub const CHECKOUT_PUSH_VERIFY: &str = "daft.checkout.pushVerify";
 
     /// Config key for remote setting.
@@ -616,7 +634,12 @@ pub struct DaftSettings {
     /// Set upstream tracking for branches.
     pub checkout_upstream: bool,
 
+    /// When daft-initiated ref-only-capable pushes (remote-branch deletes)
+    /// run the repo's pre-push hook. Base value every push site reads (#747).
+    pub push_verify: PushVerify,
+
     /// When the automatic upstream push runs the repo's pre-push hook.
+    /// Follows `push_verify` unless `daft.checkout.pushVerify` is set.
     pub checkout_push_verify: PushVerify,
 
     /// Default remote name for operations.
@@ -767,6 +790,7 @@ impl Default for DaftSettings {
             checkout_push: defaults::CHECKOUT_PUSH,
             checkout_fetch: defaults::CHECKOUT_FETCH,
             checkout_upstream: defaults::CHECKOUT_UPSTREAM,
+            push_verify: defaults::PUSH_VERIFY,
             checkout_push_verify: defaults::CHECKOUT_PUSH_VERIFY,
             remote: defaults::REMOTE.to_string(),
             checkout_branch_carry: defaults::CHECKOUT_BRANCH_CARRY,
@@ -846,18 +870,14 @@ impl DaftSettings {
             settings.checkout_upstream = parse_bool(&value, defaults::CHECKOUT_UPSTREAM);
         }
 
-        if let Some(value) = git.config_get(keys::CHECKOUT_PUSH_VERIFY)?
-            && !value.is_empty()
-        {
-            match PushVerify::parse(&value) {
-                Some(verify) => settings.checkout_push_verify = verify,
-                None => eprintln!(
-                    "daft: unknown value for {}: {:?} — using default",
-                    keys::CHECKOUT_PUSH_VERIFY,
-                    value
-                ),
-            }
-        }
+        let base_push_verify =
+            parse_push_verify_value(keys::PUSH_VERIFY, git.config_get(keys::PUSH_VERIFY)?);
+        let checkout_push_verify = parse_push_verify_value(
+            keys::CHECKOUT_PUSH_VERIFY,
+            git.config_get(keys::CHECKOUT_PUSH_VERIFY)?,
+        );
+        (settings.push_verify, settings.checkout_push_verify) =
+            resolve_push_verify(base_push_verify, checkout_push_verify);
 
         if let Some(value) = git.config_get(keys::REMOTE)?
             && !value.is_empty()
@@ -1101,18 +1121,14 @@ impl DaftSettings {
             settings.checkout_upstream = parse_bool(&value, defaults::CHECKOUT_UPSTREAM);
         }
 
-        if let Some(value) = git.config_get_global(keys::CHECKOUT_PUSH_VERIFY)?
-            && !value.is_empty()
-        {
-            match PushVerify::parse(&value) {
-                Some(verify) => settings.checkout_push_verify = verify,
-                None => eprintln!(
-                    "daft: unknown value for {}: {:?} — using default",
-                    keys::CHECKOUT_PUSH_VERIFY,
-                    value
-                ),
-            }
-        }
+        let base_push_verify =
+            parse_push_verify_value(keys::PUSH_VERIFY, git.config_get_global(keys::PUSH_VERIFY)?);
+        let checkout_push_verify = parse_push_verify_value(
+            keys::CHECKOUT_PUSH_VERIFY,
+            git.config_get_global(keys::CHECKOUT_PUSH_VERIFY)?,
+        );
+        (settings.push_verify, settings.checkout_push_verify) =
+            resolve_push_verify(base_push_verify, checkout_push_verify);
 
         if let Some(value) = git.config_get_global(keys::REMOTE)?
             && !value.is_empty()
@@ -1409,6 +1425,34 @@ pub(crate) fn parse_bool(value: &str, default: bool) -> bool {
     }
 }
 
+/// Parse one pushVerify config value, warning (and yielding `None`) on an
+/// unknown spelling so the caller falls back to the resolution defaults.
+fn parse_push_verify_value(key: &str, value: Option<String>) -> Option<PushVerify> {
+    let value = value?;
+    if value.is_empty() {
+        return None;
+    }
+    match PushVerify::parse(&value) {
+        Some(verify) => Some(verify),
+        None => {
+            eprintln!("daft: unknown value for {key}: {value:?} — using default");
+            None
+        }
+    }
+}
+
+/// Resolve `(push_verify, checkout_push_verify)` from the two config keys:
+/// `daft.pushVerify` is the base every push site reads, and the more specific
+/// `daft.checkout.pushVerify` overrides it for the branch-creation upstream
+/// push regardless of which config scope set either key (#747).
+fn resolve_push_verify(
+    base: Option<PushVerify>,
+    checkout_override: Option<PushVerify>,
+) -> (PushVerify, PushVerify) {
+    let base = base.unwrap_or(defaults::PUSH_VERIFY);
+    (base, checkout_override.unwrap_or(base))
+}
+
 /// Configuration for hook output display.
 #[derive(Debug, Clone)]
 pub struct HookOutputConfig {
@@ -1701,6 +1745,31 @@ mod tests {
         assert_eq!(settings.governor_mode, GovernorMode::Auto);
         assert_eq!(settings.governor_jobs, GovernorJobs::Auto);
         assert_eq!(settings.governor_memory_reserve, MemoryReserve::Auto);
+        assert_eq!(settings.push_verify, PushVerify::Auto);
+        assert_eq!(settings.checkout_push_verify, PushVerify::Auto);
+    }
+
+    /// #747: `daft.pushVerify` is the base every push site reads;
+    /// `daft.checkout.pushVerify` overrides it for the checkout upstream push
+    /// only, and each falls back independently when unset.
+    #[test]
+    fn test_resolve_push_verify_base_and_override() {
+        assert_eq!(
+            resolve_push_verify(None, None),
+            (PushVerify::Auto, PushVerify::Auto)
+        );
+        assert_eq!(
+            resolve_push_verify(Some(PushVerify::Never), None),
+            (PushVerify::Never, PushVerify::Never)
+        );
+        assert_eq!(
+            resolve_push_verify(Some(PushVerify::Never), Some(PushVerify::Always)),
+            (PushVerify::Never, PushVerify::Always)
+        );
+        assert_eq!(
+            resolve_push_verify(None, Some(PushVerify::Never)),
+            (PushVerify::Auto, PushVerify::Never)
+        );
     }
 
     /// #733: `daft.gitoxide` is an opt-out — an explicit false must override

--- a/src/core/settings.rs
+++ b/src/core/settings.rs
@@ -642,6 +642,12 @@ pub struct DaftSettings {
     /// Follows `push_verify` unless `daft.checkout.pushVerify` is set.
     pub checkout_push_verify: PushVerify,
 
+    /// Config key `checkout_push_verify` came from — `daft.pushVerify` when
+    /// it was inherited, `daft.checkout.pushVerify` when explicitly overridden.
+    /// The `never` skip reason quotes this so it names a key the user can
+    /// actually unset (#747).
+    pub checkout_push_verify_key: &'static str,
+
     /// Default remote name for operations.
     pub remote: String,
 
@@ -792,6 +798,7 @@ impl Default for DaftSettings {
             checkout_upstream: defaults::CHECKOUT_UPSTREAM,
             push_verify: defaults::PUSH_VERIFY,
             checkout_push_verify: defaults::CHECKOUT_PUSH_VERIFY,
+            checkout_push_verify_key: keys::PUSH_VERIFY,
             remote: defaults::REMOTE.to_string(),
             checkout_branch_carry: defaults::CHECKOUT_BRANCH_CARRY,
             checkout_carry: defaults::CHECKOUT_CARRY,
@@ -876,8 +883,10 @@ impl DaftSettings {
             keys::CHECKOUT_PUSH_VERIFY,
             git.config_get(keys::CHECKOUT_PUSH_VERIFY)?,
         );
-        (settings.push_verify, settings.checkout_push_verify) =
-            resolve_push_verify(base_push_verify, checkout_push_verify);
+        let resolved = resolve_push_verify(base_push_verify, checkout_push_verify);
+        settings.push_verify = resolved.base;
+        settings.checkout_push_verify = resolved.checkout;
+        settings.checkout_push_verify_key = resolved.checkout_key;
 
         if let Some(value) = git.config_get(keys::REMOTE)?
             && !value.is_empty()
@@ -1127,8 +1136,10 @@ impl DaftSettings {
             keys::CHECKOUT_PUSH_VERIFY,
             git.config_get_global(keys::CHECKOUT_PUSH_VERIFY)?,
         );
-        (settings.push_verify, settings.checkout_push_verify) =
-            resolve_push_verify(base_push_verify, checkout_push_verify);
+        let resolved = resolve_push_verify(base_push_verify, checkout_push_verify);
+        settings.push_verify = resolved.base;
+        settings.checkout_push_verify = resolved.checkout;
+        settings.checkout_push_verify_key = resolved.checkout_key;
 
         if let Some(value) = git.config_get_global(keys::REMOTE)?
             && !value.is_empty()
@@ -1427,6 +1438,14 @@ pub(crate) fn parse_bool(value: &str, default: bool) -> bool {
 
 /// Parse one pushVerify config value, warning (and yielding `None`) on an
 /// unknown spelling so the caller falls back to the resolution defaults.
+///
+/// An unparseable key is *ignored*, which is not the same as "replaced by the
+/// built-in default": an ignored key falls through the same cascade an unset
+/// one does, and for the checkout override that cascade ends at
+/// `daft.pushVerify`, not at `auto`. The warning has to say so — promising
+/// the default while delivering the base value is precisely what would hide a
+/// typo'd `daft.checkout.pushVerify = alwyas` under `daft.pushVerify = never`,
+/// leaving the gate off on a push the user was trying to re-arm (#747).
 fn parse_push_verify_value(key: &str, value: Option<String>) -> Option<PushVerify> {
     let value = value?;
     if value.is_empty() {
@@ -1435,22 +1454,54 @@ fn parse_push_verify_value(key: &str, value: Option<String>) -> Option<PushVerif
     match PushVerify::parse(&value) {
         Some(verify) => Some(verify),
         None => {
-            eprintln!("daft: unknown value for {key}: {value:?} — using default");
+            let fallback = if key == keys::CHECKOUT_PUSH_VERIFY {
+                keys::PUSH_VERIFY
+            } else {
+                "the built-in default (auto)"
+            };
+            eprintln!(
+                "daft: unknown value for {key}: {value:?} — ignoring it, falling back to {fallback}"
+            );
             None
         }
     }
 }
 
-/// Resolve `(push_verify, checkout_push_verify)` from the two config keys:
-/// `daft.pushVerify` is the base every push site reads, and the more specific
+/// The effective pushVerify settings plus the provenance a skip reason needs.
+#[derive(Debug, PartialEq, Eq)]
+struct ResolvedPushVerify {
+    /// Base value every push site reads.
+    base: PushVerify,
+    /// Value governing the checkout upstream push.
+    checkout: PushVerify,
+    /// The config key that produced `checkout`. The `never` skip reason
+    /// doubles as an undo hint, so it must name the key the user actually
+    /// set — naming the scope it applies to would send them to unset a key
+    /// `git config --get` reports as absent (#747).
+    checkout_key: &'static str,
+}
+
+/// Resolve the pushVerify settings from the two config keys: `daft.pushVerify`
+/// is the base every push site reads, and the more specific
 /// `daft.checkout.pushVerify` overrides it for the branch-creation upstream
 /// push regardless of which config scope set either key (#747).
 fn resolve_push_verify(
     base: Option<PushVerify>,
     checkout_override: Option<PushVerify>,
-) -> (PushVerify, PushVerify) {
+) -> ResolvedPushVerify {
     let base = base.unwrap_or(defaults::PUSH_VERIFY);
-    (base, checkout_override.unwrap_or(base))
+    match checkout_override {
+        Some(checkout) => ResolvedPushVerify {
+            base,
+            checkout,
+            checkout_key: keys::CHECKOUT_PUSH_VERIFY,
+        },
+        None => ResolvedPushVerify {
+            base,
+            checkout: base,
+            checkout_key: keys::PUSH_VERIFY,
+        },
+    }
 }
 
 /// Configuration for hook output display.
@@ -1747,6 +1798,7 @@ mod tests {
         assert_eq!(settings.governor_memory_reserve, MemoryReserve::Auto);
         assert_eq!(settings.push_verify, PushVerify::Auto);
         assert_eq!(settings.checkout_push_verify, PushVerify::Auto);
+        assert_eq!(settings.checkout_push_verify_key, keys::PUSH_VERIFY);
     }
 
     /// #747: `daft.pushVerify` is the base every push site reads;
@@ -1754,22 +1806,58 @@ mod tests {
     /// only, and each falls back independently when unset.
     #[test]
     fn test_resolve_push_verify_base_and_override() {
+        use PushVerify::{Always, Auto, Never};
+
+        let resolved = resolve_push_verify(None, None);
+        assert_eq!((resolved.base, resolved.checkout), (Auto, Auto));
+
+        let resolved = resolve_push_verify(Some(Never), None);
+        assert_eq!((resolved.base, resolved.checkout), (Never, Never));
+
+        let resolved = resolve_push_verify(Some(Never), Some(Always));
+        assert_eq!((resolved.base, resolved.checkout), (Never, Always));
+
+        let resolved = resolve_push_verify(None, Some(Never));
+        assert_eq!((resolved.base, resolved.checkout), (Auto, Never));
+    }
+
+    /// #747: the `never` skip reason doubles as the undo hint, so the
+    /// resolution has to report which key produced the checkout value — an
+    /// inherited value must point at the base key, not at the unset override.
+    #[test]
+    fn test_resolve_push_verify_reports_governing_key() {
+        use PushVerify::Never;
+
         assert_eq!(
-            resolve_push_verify(None, None),
-            (PushVerify::Auto, PushVerify::Auto)
+            resolve_push_verify(Some(Never), None).checkout_key,
+            keys::PUSH_VERIFY,
         );
         assert_eq!(
-            resolve_push_verify(Some(PushVerify::Never), None),
-            (PushVerify::Never, PushVerify::Never)
+            resolve_push_verify(Some(Never), Some(Never)).checkout_key,
+            keys::CHECKOUT_PUSH_VERIFY,
         );
+        // Nothing set: the value is the built-in default, and the base key is
+        // the one that would change it.
         assert_eq!(
-            resolve_push_verify(Some(PushVerify::Never), Some(PushVerify::Always)),
-            (PushVerify::Never, PushVerify::Always)
+            resolve_push_verify(None, None).checkout_key,
+            keys::PUSH_VERIFY,
         );
-        assert_eq!(
-            resolve_push_verify(None, Some(PushVerify::Never)),
-            (PushVerify::Auto, PushVerify::Never)
+    }
+
+    /// #747: an unparseable value is ignored, so the checkout override falls
+    /// through to the base key exactly as an unset one does — including the
+    /// provenance, so the undo hint still names a key that is really set.
+    #[test]
+    fn test_unparseable_checkout_override_falls_through_to_base() {
+        let checkout = parse_push_verify_value(
+            keys::CHECKOUT_PUSH_VERIFY,
+            Some("alwyas".to_string()), // typo
         );
+        assert_eq!(checkout, None);
+
+        let resolved = resolve_push_verify(Some(PushVerify::Never), checkout);
+        assert_eq!(resolved.checkout, PushVerify::Never);
+        assert_eq!(resolved.checkout_key, keys::PUSH_VERIFY);
     }
 
     /// #733: `daft.gitoxide` is an opt-out — an explicit false must override

--- a/src/core/worktree/branch_delete.rs
+++ b/src/core/worktree/branch_delete.rs
@@ -4,7 +4,7 @@
 
 use crate::core::stage::{PlanCommit, Row, StageEvent, StageId, StepKey, StepSpec};
 use crate::core::worktree::ports::{ForgeMergedWitness, NoopStageRunner};
-use crate::core::worktree::push::{PushAction, push_with_hooks};
+use crate::core::worktree::push::{PushAction, push_with_hooks, resolve_delete_pre_push};
 use crate::core::{
     ConflictSide, ConsolidationChoice, ConsolidationPrompter, ConsolidationRequest, HookRunner,
     ProgressSink, RefinedFileSummary,
@@ -14,7 +14,7 @@ use crate::git::GitCommand;
 use crate::hooks::visitor_seeds::{self, FileClass, SeedsContext};
 use crate::hooks::{HookContext, HookType, RemovalReason};
 use crate::remote::get_default_branch_local;
-use crate::settings::PruneCdTarget;
+use crate::settings::{PruneCdTarget, PushVerify};
 use crate::{get_git_common_dir, get_project_root};
 use anyhow::{Context, Result};
 use std::collections::HashMap;
@@ -46,6 +46,10 @@ pub struct BranchDeleteParams {
     /// Skip the repo's pre-push hook when deleting the remote branch
     /// (`--no-verify`).
     pub no_verify: bool,
+    /// When the remote-branch delete runs the repo's pre-push hook
+    /// (`daft.pushVerify`). A delete is statically ref-only, so `auto`
+    /// skips the hook (#747); `always` re-arms it for ref-policy gates.
+    pub push_verify: PushVerify,
     /// Where to cd after deleting the current worktree.
     pub prune_cd_target: PruneCdTarget,
     /// Label exposed to hook scripts as `DAFT_COMMAND`. Defaults to
@@ -130,6 +134,8 @@ struct BranchDeleteContext<'a> {
     default_branch: String,
     /// Skip the repo's pre-push hook on the remote-branch delete.
     no_verify: bool,
+    /// When the remote-branch delete runs the repo's pre-push hook (#747).
+    push_verify: PushVerify,
     /// Reports the pre-push hook run on the remote-branch delete (#599).
     presenter: Option<&'a Arc<dyn JobPresenter>>,
 }
@@ -209,6 +215,7 @@ pub fn execute(
         source_worktree: std::env::current_dir()?,
         default_branch,
         no_verify: params.no_verify,
+        push_verify: params.push_verify,
         presenter,
     };
 
@@ -1256,6 +1263,15 @@ fn delete_single_branch(
             .as_deref()
             .filter(|p| p.is_dir())
             .unwrap_or(&ctx.project_root);
+        // A delete pushes no content, so under the default `pushVerify =
+        // auto` the pre-push gate has nothing to validate and is skipped
+        // (#747); `always` re-arms it. A failed delete still lands in
+        // `result.errors` below regardless of the hook verdict — a skipped
+        // gate must not soften a genuine transport or server-side failure.
+        let hook_plan = resolve_delete_pre_push(ctx.git, push_cwd, ctx.push_verify, ctx.no_verify);
+        if let Some(reason) = hook_plan.skip_reason {
+            sink.on_step(reason);
+        }
         match push_with_hooks(
             ctx.git,
             PushAction::Delete {
@@ -1263,10 +1279,10 @@ fn delete_single_branch(
                 branch: remote_branch,
             },
             push_cwd,
-            !ctx.no_verify,
+            hook_plan.verify,
             &NoopStageRunner,
             ctx.presenter,
-            None,
+            hook_plan.hook_present,
         )
         .and_then(crate::core::worktree::push::PushOutcome::into_result)
         {
@@ -1642,6 +1658,7 @@ mod tests {
             remote_only: false,
             keep_local_branch: false,
             no_verify: false,
+            push_verify: crate::settings::PushVerify::Auto,
             prune_cd_target: crate::settings::PruneCdTarget::Root,
             command_label: "branch-delete".to_string(),
             skip_merge_validation: false,
@@ -1681,6 +1698,7 @@ mod tests {
             remote_only: false,
             keep_local_branch: false,
             no_verify: false,
+            push_verify: crate::settings::PushVerify::Auto,
             prune_cd_target: crate::settings::PruneCdTarget::Root,
             command_label: "branch-delete".to_string(),
             skip_merge_validation: false,
@@ -1988,6 +2006,7 @@ mod tests {
             remote_only: false,
             keep_local_branch: true,
             no_verify: false,
+            push_verify: crate::settings::PushVerify::Auto,
             prune_cd_target: crate::settings::PruneCdTarget::Root,
             command_label: "branch-delete".to_string(),
             skip_merge_validation: false,
@@ -2057,6 +2076,7 @@ mod tests {
             remote_only: false,
             keep_local_branch: true,
             no_verify: false,
+            push_verify: crate::settings::PushVerify::Auto,
             prune_cd_target: crate::settings::PruneCdTarget::Root,
             command_label: "branch-delete".to_string(),
             skip_merge_validation: false,
@@ -2101,6 +2121,7 @@ mod tests {
             remote_only: false,
             keep_local_branch: false,
             no_verify: false,
+            push_verify: crate::settings::PushVerify::Auto,
             prune_cd_target: crate::settings::PruneCdTarget::Root,
             command_label: "branch-delete".to_string(),
             skip_merge_validation: false,
@@ -2184,6 +2205,7 @@ mod tests {
             remote_only: false,
             keep_local_branch: false,
             no_verify: false,
+            push_verify: crate::settings::PushVerify::Auto,
             prune_cd_target: crate::settings::PruneCdTarget::Root,
             command_label: "branch-delete".to_string(),
             skip_merge_validation: false,
@@ -2290,6 +2312,7 @@ mod tests {
             remote_only: false,
             keep_local_branch: false,
             no_verify: false,
+            push_verify: crate::settings::PushVerify::Auto,
             prune_cd_target: crate::settings::PruneCdTarget::Root,
             command_label: "branch-delete".to_string(),
             skip_merge_validation: false,
@@ -2378,6 +2401,7 @@ mod tests {
             remote_only: false,
             keep_local_branch: true,
             no_verify: false,
+            push_verify: crate::settings::PushVerify::Auto,
             prune_cd_target: crate::settings::PruneCdTarget::Root,
             command_label: "merge".to_string(),
             skip_merge_validation: false,
@@ -2533,6 +2557,7 @@ mod tests {
             remote_only: false,
             keep_local_branch: false,
             no_verify: false,
+            push_verify: crate::settings::PushVerify::Auto,
             prune_cd_target: crate::settings::PruneCdTarget::Root,
             command_label: "branch-delete".to_string(),
             skip_merge_validation: false,
@@ -2623,6 +2648,7 @@ mod tests {
             remote_only: false,
             keep_local_branch: false,
             no_verify: false,
+            push_verify: crate::settings::PushVerify::Auto,
             prune_cd_target: crate::settings::PruneCdTarget::Root,
             command_label: "branch-delete".to_string(),
             skip_merge_validation: false,
@@ -2725,6 +2751,7 @@ mod tests {
             remote_only: false,
             keep_local_branch: false,
             no_verify: false,
+            push_verify: crate::settings::PushVerify::Auto,
             prune_cd_target: crate::settings::PruneCdTarget::Root,
             command_label: "branch-delete".to_string(),
             skip_merge_validation: false,

--- a/src/core/worktree/branch_delete.rs
+++ b/src/core/worktree/branch_delete.rs
@@ -1268,8 +1268,14 @@ fn delete_single_branch(
         // (#747); `always` re-arms it. A failed delete still lands in
         // `result.errors` below regardless of the hook verdict — a skipped
         // gate must not soften a genuine transport or server-side failure.
+        //
+        // The plan is resolved per branch, not hoisted out of the loop: it
+        // probes `push_cwd`, and a relative `core.hooksPath` resolves against
+        // each worktree separately, so two branches in one invocation can
+        // genuinely have different hooks. One `rev-parse` per branch is the
+        // price of asking about the directory the hook would really run in.
         let hook_plan = resolve_delete_pre_push(ctx.git, push_cwd, ctx.push_verify, ctx.no_verify);
-        if let Some(reason) = hook_plan.skip_reason {
+        if let Some(reason) = &hook_plan.skip_reason {
             sink.on_step(reason);
         }
         match push_with_hooks(

--- a/src/core/worktree/checkout_branch.rs
+++ b/src/core/worktree/checkout_branch.rs
@@ -7,7 +7,9 @@ use crate::core::layout::{Layout, auto_gitignore_if_needed};
 use crate::core::settings::PushVerify;
 use crate::core::stage::{PlanCommit, Row, StageEvent, StageId, StepKey, StepSpec};
 use crate::core::worktree::ports::NoopStageRunner;
-use crate::core::worktree::push::{HookVerdict, PushAction, push_with_hooks};
+use crate::core::worktree::push::{
+    HookVerdict, PrePushDecision, PushAction, PushPayload, push_with_hooks, resolve_pre_push,
+};
 use crate::core::{HookOutcome, HookRunner, ProgressSink};
 use crate::executor::presenter::JobPresenter;
 use crate::git::GitCommand;
@@ -779,7 +781,7 @@ fn push_if_enabled(
         params.push_verify,
         params.no_verify,
         hook_present.unwrap_or(false),
-        unpushed_count,
+        PushPayload::Commits { unpushed_count },
     ) {
         PrePushDecision::Verify => true,
         PrePushDecision::Skip(reason) => {
@@ -919,61 +921,9 @@ fn push_if_enabled(
     (false, false, None)
 }
 
-/// Verdict on whether git should dispatch the repo's `pre-push` hook for the
-/// automatic upstream push (#679).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum PrePushDecision {
-    /// Let git run the hook.
-    Verify,
-    /// Suppress the hook; `Some(reason)` is reported as a progress step
-    /// (`None` for the explicit `--no-verify` flag, which stays silent as it
-    /// always has).
-    Skip(Option<&'static str>),
-}
-
-/// Pure decision core for [`push_if_enabled`]'s hook handling: the
-/// `--no-verify` flag wins unconditionally; otherwise `daft.checkout.pushVerify`
-/// rules, with `auto` skipping only a proven ref-only push (hook present and
-/// zero commits absent from the target remote). On a failed probe
-/// (`unpushed_count = None`) `auto` falls back to verifying — a probe that could
-/// not answer must never silently drop the hook.
-///
-/// The `auto` skip trusts a count derived from local remote-tracking refs, which
-/// are only as fresh as the last fetch (`daft.checkout.fetch`, off by default).
-/// If the remote was rewound or force-pushed since then, a stale-ahead tracking
-/// ref can report zero unpushed commits for a push that does carry content,
-/// skipping the hook — the same trade-off pre-commit's pre-push driver makes.
-/// Set `pushVerify = always` for a hook that must run on every push regardless.
-fn resolve_pre_push(
-    setting: PushVerify,
-    no_verify_flag: bool,
-    hook_present: bool,
-    unpushed_count: Option<u64>,
-) -> PrePushDecision {
-    if no_verify_flag {
-        return PrePushDecision::Skip(None);
-    }
-    match setting {
-        // Only announce the skip when there is actually a hook to skip; a
-        // hook-less repo stays silent, matching `auto`.
-        PushVerify::Never if hook_present => PrePushDecision::Skip(Some(
-            "Skipping pre-push hook (daft.checkout.pushVerify = never)",
-        )),
-        PushVerify::Never => PrePushDecision::Skip(None),
-        PushVerify::Always => PrePushDecision::Verify,
-        PushVerify::Auto => {
-            if hook_present && unpushed_count == Some(0) {
-                PrePushDecision::Skip(Some("Skipping pre-push hook (no new commits to push)"))
-            } else {
-                PrePushDecision::Verify
-            }
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{CheckoutBranchParams, PrePushDecision, push_if_enabled, resolve_pre_push};
+    use super::{CheckoutBranchParams, push_if_enabled};
     use crate::core::ProgressSink;
     use crate::core::settings::PushVerify;
     use crate::core::stage::{StageEvent, StageId, StepKey};
@@ -985,71 +935,8 @@ mod tests {
     use std::process::Stdio;
     use std::sync::Arc;
 
-    #[test]
-    fn no_verify_flag_skips_silently_regardless_of_setting() {
-        for setting in [PushVerify::Auto, PushVerify::Always, PushVerify::Never] {
-            assert_eq!(
-                resolve_pre_push(setting, true, true, Some(5)),
-                PrePushDecision::Skip(None)
-            );
-        }
-    }
-
-    #[test]
-    fn never_skips_with_a_reason_even_when_the_push_carries_commits() {
-        let decision = resolve_pre_push(PushVerify::Never, false, true, Some(3));
-        assert!(matches!(decision, PrePushDecision::Skip(Some(_))));
-    }
-
-    #[test]
-    fn never_without_a_hook_skips_silently() {
-        // Nothing to announce when there is no hook to skip (#679 review): the
-        // `never` arm must stay quiet hook-lessly, like `auto` does.
-        assert_eq!(
-            resolve_pre_push(PushVerify::Never, false, false, None),
-            PrePushDecision::Skip(None)
-        );
-    }
-
-    #[test]
-    fn always_verifies_even_for_ref_only_pushes() {
-        assert_eq!(
-            resolve_pre_push(PushVerify::Always, false, true, Some(0)),
-            PrePushDecision::Verify
-        );
-    }
-
-    #[test]
-    fn auto_skips_a_ref_only_push_when_a_hook_is_present() {
-        let decision = resolve_pre_push(PushVerify::Auto, false, true, Some(0));
-        assert!(matches!(decision, PrePushDecision::Skip(Some(_))));
-    }
-
-    #[test]
-    fn auto_verifies_when_the_push_carries_new_commits() {
-        assert_eq!(
-            resolve_pre_push(PushVerify::Auto, false, true, Some(2)),
-            PrePushDecision::Verify
-        );
-    }
-
-    #[test]
-    fn auto_verifies_when_the_probe_fails() {
-        assert_eq!(
-            resolve_pre_push(PushVerify::Auto, false, true, None),
-            PrePushDecision::Verify
-        );
-    }
-
-    #[test]
-    fn auto_without_a_hook_verifies_trivially() {
-        // The wiring never probes the count without a hook, but the pure fn
-        // must not skip on hook-less inputs either.
-        assert_eq!(
-            resolve_pre_push(PushVerify::Auto, false, false, Some(0)),
-            PrePushDecision::Verify
-        );
-    }
+    // The pure `resolve_pre_push` decision tests live with the fn in
+    // `core::worktree::push` since it moved there for the delete sites (#747).
 
     // --- integration: spinner coordination around the pre-push render (#679) ---
 
@@ -1077,7 +964,11 @@ mod tests {
     }
 
     fn git_in(dir: &Path, args: &[&str]) {
+        // commit.gpgsign=false: a global signing config would route fixture
+        // commits through the real gpg agent, which flakes under parallel
+        // test load (same rationale as git::mod's seeding tests).
         let status = git_command_at(dir)
+            .args(["-c", "commit.gpgsign=false"])
             .args(args)
             .env("GIT_AUTHOR_NAME", "Test")
             .env("GIT_AUTHOR_EMAIL", "test@test.com")

--- a/src/core/worktree/checkout_branch.rs
+++ b/src/core/worktree/checkout_branch.rs
@@ -8,7 +8,7 @@ use crate::core::settings::PushVerify;
 use crate::core::stage::{PlanCommit, Row, StageEvent, StageId, StepKey, StepSpec};
 use crate::core::worktree::ports::NoopStageRunner;
 use crate::core::worktree::push::{
-    HookVerdict, PrePushDecision, PushAction, PushPayload, push_with_hooks, resolve_pre_push,
+    HookVerdict, PushAction, PushPayload, push_with_hooks, resolve_pre_push_plan,
 };
 use crate::core::{HookOutcome, HookRunner, ProgressSink};
 use crate::executor::presenter::JobPresenter;
@@ -48,6 +48,9 @@ pub struct CheckoutBranchParams {
     pub no_verify: bool,
     /// When the upstream push runs the repo's pre-push hook (from settings).
     pub push_verify: PushVerify,
+    /// Config key `push_verify` came from, quoted in the `never` skip reason
+    /// so it names a key the user can actually unset (#747).
+    pub push_verify_key: &'static str,
     /// Whether to fetch from remote before creating the worktree.
     pub checkout_fetch: bool,
     /// Optional layout for computing the worktree path.
@@ -743,54 +746,32 @@ fn push_if_enabled(
     ));
     sink.on_stage(&push_key, StageEvent::Started);
 
-    // Probe lazily: hook existence only when `auto` can act on it, and the
-    // unpushed-commit count only when a hook is actually present (with no
-    // hook, verify and skip are behaviorally identical). The probe uses the
-    // fully-qualified branch ref — a same-named tag would shadow the short
-    // name in rev-list's resolution.
-    let (hook_present, unpushed_count) = match params.push_verify {
-        // `--no-verify` skips silently regardless of hook presence, so don't probe.
-        _ if params.no_verify => (None, None),
-        PushVerify::Auto => {
-            let present = git.pre_push_hook_exists(worktree_path);
-            let count = if present {
-                match git.count_commits_not_on_remote(
-                    &format!("refs/heads/{}", params.new_branch_name),
-                    &params.remote_name,
-                    worktree_path,
-                ) {
-                    Ok(count) => Some(count),
-                    Err(e) => {
-                        crate::log_debug!("pre-push ref-only probe failed: {e}");
-                        None
-                    }
-                }
-            } else {
-                None
-            };
-            (Some(present), count)
-        }
-        // `never` announces the skip only when a hook actually exists, so probe
-        // its presence (a cheap stat). `always` verifies unconditionally and
-        // lets push_with_hooks resolve presence for its own verdict.
-        PushVerify::Never => (Some(git.pre_push_hook_exists(worktree_path)), None),
-        PushVerify::Always => (None, None),
-    };
-
-    let verify = match resolve_pre_push(
+    // Both probes are lazy — see `resolve_pre_push_plan` for the policy. The
+    // commit count uses the fully-qualified branch ref: a same-named tag
+    // would shadow the short name in rev-list's resolution.
+    let plan = resolve_pre_push_plan(
         params.push_verify,
         params.no_verify,
-        hook_present.unwrap_or(false),
-        PushPayload::Commits { unpushed_count },
-    ) {
-        PrePushDecision::Verify => true,
-        PrePushDecision::Skip(reason) => {
-            if let Some(reason) = reason {
-                sink.on_step(reason);
-            }
-            false
-        }
-    };
+        params.push_verify_key,
+        || git.pre_push_hook_exists(worktree_path),
+        || PushPayload::Commits {
+            unpushed_count: match git.count_commits_not_on_remote(
+                &format!("refs/heads/{}", params.new_branch_name),
+                &params.remote_name,
+                worktree_path,
+            ) {
+                Ok(count) => Some(count),
+                Err(e) => {
+                    crate::log_debug!("pre-push ref-only probe failed: {e}");
+                    None
+                }
+            },
+        },
+    );
+    if let Some(reason) = &plan.skip_reason {
+        sink.on_step(reason);
+    }
+    let (verify, hook_present) = (plan.verify, plan.hook_present);
 
     // When the hook renders through the presenter its `MultiProgress` owns the
     // terminal, so pause the outer "Creating worktree..." spinner across the
@@ -1028,6 +1009,7 @@ mod tests {
             checkout_push: true,
             no_verify: false,
             push_verify,
+            push_verify_key: crate::settings::keys::CHECKOUT_PUSH_VERIFY,
             checkout_fetch: false,
             layout: None,
             at_path: None,
@@ -1176,7 +1158,11 @@ mod timeline_tests {
     /// GIT_WORK_TREE misses the rest — the Test Hygiene rule exists for
     /// exactly this). Local test identity only, never global config.
     fn git(dir: &Path, args: &[&str]) {
-        crate::utils::git_command_at(dir)
+        let status = crate::utils::git_command_at(dir)
+            // A developer's global commit.gpgsign=true would make every
+            // fixture commit sign via the real gpg agent, which flakes under
+            // parallel test load (same rationale as `git_in` above).
+            .args(["-c", "commit.gpgsign=false"])
             .args(args)
             .env("GIT_AUTHOR_NAME", "Test")
             .env("GIT_AUTHOR_EMAIL", "test@test.com")
@@ -1186,6 +1172,10 @@ mod timeline_tests {
             .stderr(Stdio::null())
             .status()
             .unwrap();
+        // Assert here rather than letting a silently-failed fixture command
+        // surface later as an unrelated assertion ("no upstream", "branch not
+        // found") that sends the reader hunting in the wrong place.
+        assert!(status.success(), "fixture git {args:?} failed in {dir:?}");
     }
 
     struct CwdGuard {
@@ -1235,6 +1225,7 @@ mod timeline_tests {
             checkout_push: false,
             no_verify: false,
             push_verify: PushVerify::Auto,
+            push_verify_key: crate::settings::keys::PUSH_VERIFY,
             checkout_fetch: false,
             layout: None,
             at_path: Some(worktree_path.clone()),
@@ -1336,6 +1327,7 @@ mod timeline_tests {
             checkout_push: false,
             no_verify: false,
             push_verify: PushVerify::Auto,
+            push_verify_key: crate::settings::keys::PUSH_VERIFY,
             checkout_fetch: true,
             layout: None,
             at_path: Some(worktree_path.clone()),
@@ -1436,6 +1428,7 @@ mod timeline_tests {
             checkout_push: false,
             no_verify: false,
             push_verify: PushVerify::Auto,
+            push_verify_key: crate::settings::keys::PUSH_VERIFY,
             checkout_fetch: false,
             layout: None,
             at_path: Some(worktree_path.clone()),
@@ -1546,6 +1539,7 @@ mod timeline_tests {
             checkout_push: false,
             no_verify: false,
             push_verify: PushVerify::Auto,
+            push_verify_key: crate::settings::keys::PUSH_VERIFY,
             checkout_fetch: false,
             layout: None,
             at_path: Some(new_wt.clone()),

--- a/src/core/worktree/push.rs
+++ b/src/core/worktree/push.rs
@@ -6,6 +6,7 @@
 //! routes through to honor and report `pre-push` hooks (#599).
 
 use crate::core::ProgressSink;
+use crate::core::settings::PushVerify;
 use crate::core::worktree::fetch;
 use crate::core::worktree::ports::{PushRef, StageRunner};
 use crate::executor::presenter::JobPresenter;
@@ -274,6 +275,139 @@ impl HookVerdict {
     /// rejection.
     pub fn no_verify_might_help(self) -> bool {
         matches!(self, HookVerdict::Rejected)
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// resolve_pre_push — the shared decision core for suppressible hooks
+// ─────────────────────────────────────────────────────────────────────────
+
+/// Verdict on whether git should dispatch the repo's `pre-push` hook for a
+/// daft-initiated push that can prove itself ref-only (#679, #747).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrePushDecision {
+    /// Let git run the hook.
+    Verify,
+    /// Suppress the hook; `Some(reason)` is reported as a progress step
+    /// (`None` for the explicit `--no-verify` flag, which stays silent as it
+    /// always has).
+    Skip(Option<&'static str>),
+}
+
+/// What the push would transmit — the evidence `auto` weighs, and the site
+/// flavor the skip reasons name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PushPayload {
+    /// The branch-creation upstream push: may carry commits.
+    /// `unpushed_count` is the ref-only probe's answer (`None` = probe
+    /// failed or was not run → treat as carrying content).
+    Commits { unpushed_count: Option<u64> },
+    /// A remote-branch delete: statically ref-only — the ref update's new
+    /// OID is null and zero objects are pushed (#747).
+    Delete,
+}
+
+/// Pure decision core for the pre-push hook on suppressible pushes: the
+/// `--no-verify` flag wins unconditionally; otherwise the `pushVerify`
+/// setting rules ([`PushVerify`]), with `auto` skipping only a proven
+/// ref-only push — zero commits absent from the target remote, which a
+/// delete is by construction. On a failed probe (`unpushed_count = None`)
+/// `auto` falls back to verifying — a probe that could not answer must
+/// never silently drop the hook.
+///
+/// The `auto` skip for [`PushPayload::Commits`] trusts a count derived from
+/// local remote-tracking refs, which are only as fresh as the last fetch
+/// (`daft.checkout.fetch`, off by default). If the remote was rewound or
+/// force-pushed since then, a stale-ahead tracking ref can report zero
+/// unpushed commits for a push that does carry content, skipping the hook —
+/// the same trade-off pre-commit's pre-push driver makes. Set
+/// `pushVerify = always` for a hook that must run on every push regardless;
+/// `always` is also what keeps ref-policy hooks (protected-branch delete
+/// gates) firing on deletes, since those act on the ref name, not content.
+pub fn resolve_pre_push(
+    setting: PushVerify,
+    no_verify_flag: bool,
+    hook_present: bool,
+    payload: PushPayload,
+) -> PrePushDecision {
+    if no_verify_flag {
+        return PrePushDecision::Skip(None);
+    }
+    match setting {
+        // Only announce the skip when there is actually a hook to skip; a
+        // hook-less repo stays silent, matching `auto`. The reason names the
+        // most specific key governing this site — the one an undo would set.
+        PushVerify::Never if hook_present => PrePushDecision::Skip(Some(match payload {
+            PushPayload::Commits { .. } => {
+                "Skipping pre-push hook (daft.checkout.pushVerify = never)"
+            }
+            PushPayload::Delete => "Skipping pre-push hook (daft.pushVerify = never)",
+        })),
+        PushVerify::Never => PrePushDecision::Skip(None),
+        PushVerify::Always => PrePushDecision::Verify,
+        PushVerify::Auto => match payload {
+            PushPayload::Commits {
+                unpushed_count: Some(0),
+            } if hook_present => {
+                PrePushDecision::Skip(Some("Skipping pre-push hook (no new commits to push)"))
+            }
+            PushPayload::Delete if hook_present => PrePushDecision::Skip(Some(
+                "Skipping pre-push hook (a remote-branch delete pushes no content)",
+            )),
+            _ => PrePushDecision::Verify,
+        },
+    }
+}
+
+/// Resolved hook handling for one remote-branch delete: what to pass to
+/// [`push_with_hooks`] and what to tell the user.
+pub struct DeletePrePush {
+    /// `verify` argument for [`push_with_hooks`].
+    pub verify: bool,
+    /// The hook-existence probe's answer when it ran (forward to
+    /// [`push_with_hooks`] so the probe is not repeated).
+    pub hook_present: Option<bool>,
+    /// Skip reason to report as a progress step, when the skip should be
+    /// announced.
+    pub skip_reason: Option<&'static str>,
+}
+
+/// Decide the pre-push hook handling for a remote-branch delete (#747).
+///
+/// A delete is statically ref-only, so unlike the checkout upstream push
+/// there is no `rev-list` probe — the knob alone decides: `auto` and
+/// `never` skip, `always` verifies (the ref-policy escape hatch), and
+/// `--no-verify` wins silently. Hook existence is probed lazily, mirroring
+/// checkout's `push_if_enabled`: only when the decision can act on it
+/// (`auto`/`never`); `always` lets [`push_with_hooks`] resolve presence for
+/// its own verdict, and `--no-verify` skips without probing.
+pub fn resolve_delete_pre_push(
+    git: &GitCommand,
+    cwd: &Path,
+    setting: PushVerify,
+    no_verify_flag: bool,
+) -> DeletePrePush {
+    let hook_present = if no_verify_flag || setting == PushVerify::Always {
+        None
+    } else {
+        Some(git.pre_push_hook_exists(cwd))
+    };
+    match resolve_pre_push(
+        setting,
+        no_verify_flag,
+        hook_present.unwrap_or(false),
+        PushPayload::Delete,
+    ) {
+        PrePushDecision::Verify => DeletePrePush {
+            verify: true,
+            hook_present,
+            skip_reason: None,
+        },
+        PrePushDecision::Skip(reason) => DeletePrePush {
+            verify: false,
+            hook_present,
+            skip_reason: reason,
+        },
     }
 }
 
@@ -1276,6 +1410,235 @@ mod tests {
         }
     }
 
+    // ── resolve_pre_push decision core (#679 upstream, #747 deletes) ────
+
+    #[test]
+    fn no_verify_flag_skips_silently_regardless_of_setting_and_payload() {
+        for setting in [PushVerify::Auto, PushVerify::Always, PushVerify::Never] {
+            for payload in [
+                PushPayload::Commits {
+                    unpushed_count: Some(5),
+                },
+                PushPayload::Delete,
+            ] {
+                assert_eq!(
+                    resolve_pre_push(setting, true, true, payload),
+                    PrePushDecision::Skip(None)
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn never_skips_with_a_reason_even_when_the_push_carries_commits() {
+        let decision = resolve_pre_push(
+            PushVerify::Never,
+            false,
+            true,
+            PushPayload::Commits {
+                unpushed_count: Some(3),
+            },
+        );
+        assert!(matches!(decision, PrePushDecision::Skip(Some(_))));
+    }
+
+    #[test]
+    fn never_without_a_hook_skips_silently() {
+        // Nothing to announce when there is no hook to skip (#679 review): the
+        // `never` arm must stay quiet hook-lessly, like `auto` does.
+        for payload in [
+            PushPayload::Commits {
+                unpushed_count: None,
+            },
+            PushPayload::Delete,
+        ] {
+            assert_eq!(
+                resolve_pre_push(PushVerify::Never, false, false, payload),
+                PrePushDecision::Skip(None)
+            );
+        }
+    }
+
+    #[test]
+    fn never_reason_names_the_key_governing_the_site() {
+        // The reason doubles as the undo hint, so it must name the key that
+        // actually governs each site: the checkout-scoped override for the
+        // upstream push, the base key for deletes (#747).
+        assert_eq!(
+            resolve_pre_push(
+                PushVerify::Never,
+                false,
+                true,
+                PushPayload::Commits {
+                    unpushed_count: Some(0),
+                },
+            ),
+            PrePushDecision::Skip(Some(
+                "Skipping pre-push hook (daft.checkout.pushVerify = never)"
+            ))
+        );
+        assert_eq!(
+            resolve_pre_push(PushVerify::Never, false, true, PushPayload::Delete),
+            PrePushDecision::Skip(Some("Skipping pre-push hook (daft.pushVerify = never)"))
+        );
+    }
+
+    #[test]
+    fn always_verifies_even_for_ref_only_pushes_and_deletes() {
+        // `always` is the ref-policy escape hatch: hooks gating protected-ref
+        // deletes act on the ref name, not content, and must keep firing.
+        for payload in [
+            PushPayload::Commits {
+                unpushed_count: Some(0),
+            },
+            PushPayload::Delete,
+        ] {
+            assert_eq!(
+                resolve_pre_push(PushVerify::Always, false, true, payload),
+                PrePushDecision::Verify
+            );
+        }
+    }
+
+    #[test]
+    fn auto_skips_a_ref_only_push_when_a_hook_is_present() {
+        let decision = resolve_pre_push(
+            PushVerify::Auto,
+            false,
+            true,
+            PushPayload::Commits {
+                unpushed_count: Some(0),
+            },
+        );
+        assert!(matches!(decision, PrePushDecision::Skip(Some(_))));
+    }
+
+    #[test]
+    fn auto_verifies_when_the_push_carries_new_commits() {
+        assert_eq!(
+            resolve_pre_push(
+                PushVerify::Auto,
+                false,
+                true,
+                PushPayload::Commits {
+                    unpushed_count: Some(2),
+                },
+            ),
+            PrePushDecision::Verify
+        );
+    }
+
+    #[test]
+    fn auto_verifies_when_the_probe_fails() {
+        assert_eq!(
+            resolve_pre_push(
+                PushVerify::Auto,
+                false,
+                true,
+                PushPayload::Commits {
+                    unpushed_count: None,
+                },
+            ),
+            PrePushDecision::Verify
+        );
+    }
+
+    #[test]
+    fn auto_without_a_hook_verifies_trivially() {
+        // The wiring never probes the count without a hook, but the pure fn
+        // must not skip on hook-less inputs either — and a hook-less delete
+        // must not announce a phantom skip (#747 acceptance).
+        for payload in [
+            PushPayload::Commits {
+                unpushed_count: Some(0),
+            },
+            PushPayload::Delete,
+        ] {
+            assert_eq!(
+                resolve_pre_push(PushVerify::Auto, false, false, payload),
+                PrePushDecision::Verify
+            );
+        }
+    }
+
+    #[test]
+    fn auto_skips_a_delete_when_a_hook_is_present() {
+        // A delete is statically ref-only — the knob alone decides, no
+        // rev-list probe input exists to consult (#747).
+        assert_eq!(
+            resolve_pre_push(PushVerify::Auto, false, true, PushPayload::Delete),
+            PrePushDecision::Skip(Some(
+                "Skipping pre-push hook (a remote-branch delete pushes no content)"
+            ))
+        );
+    }
+
+    // ── resolve_delete_pre_push wiring (#747) ───────────────────────────
+
+    #[test]
+    fn delete_plan_auto_skips_and_reports_when_a_hook_exists() {
+        let repo = test_repo();
+        install_pre_push(&repo, "#!/bin/sh\nexit 0\n");
+        let git = GitCommand::new(false);
+        let plan = resolve_delete_pre_push(&git, &repo.work, PushVerify::Auto, false);
+        assert!(!plan.verify);
+        assert_eq!(plan.hook_present, Some(true));
+        assert!(plan.skip_reason.is_some());
+    }
+
+    #[test]
+    fn delete_plan_auto_verifies_quietly_without_a_hook() {
+        // Hook-less repos render nothing extra: no phantom skip line, and
+        // verify stays on (nothing fires anyway) so the verdict grades NoHook.
+        let repo = test_repo();
+        let git = GitCommand::new(false);
+        let plan = resolve_delete_pre_push(&git, &repo.work, PushVerify::Auto, false);
+        assert!(plan.verify);
+        assert_eq!(plan.hook_present, Some(false));
+        assert!(plan.skip_reason.is_none());
+    }
+
+    #[test]
+    fn delete_plan_always_verifies_without_probing() {
+        // `always` leaves the existence probe to push_with_hooks, mirroring
+        // checkout's lazy-probe shape.
+        let repo = test_repo();
+        install_pre_push(&repo, "#!/bin/sh\nexit 1\n");
+        let git = GitCommand::new(false);
+        let plan = resolve_delete_pre_push(&git, &repo.work, PushVerify::Always, false);
+        assert!(plan.verify);
+        assert_eq!(plan.hook_present, None);
+        assert!(plan.skip_reason.is_none());
+    }
+
+    #[test]
+    fn delete_plan_no_verify_flag_skips_silently_without_probing() {
+        let repo = test_repo();
+        install_pre_push(&repo, "#!/bin/sh\nexit 1\n");
+        let git = GitCommand::new(false);
+        let plan = resolve_delete_pre_push(&git, &repo.work, PushVerify::Auto, true);
+        assert!(!plan.verify);
+        assert_eq!(plan.hook_present, None);
+        assert!(plan.skip_reason.is_none());
+    }
+
+    #[test]
+    fn delete_plan_never_announces_only_with_a_hook() {
+        let repo = test_repo();
+        let git = GitCommand::new(false);
+        let hookless = resolve_delete_pre_push(&git, &repo.work, PushVerify::Never, false);
+        assert!(!hookless.verify);
+        assert!(hookless.skip_reason.is_none());
+
+        install_pre_push(&repo, "#!/bin/sh\nexit 1\n");
+        let hooked = resolve_delete_pre_push(&git, &repo.work, PushVerify::Never, false);
+        assert!(!hooked.verify);
+        assert_eq!(
+            hooked.skip_reason,
+            Some("Skipping pre-push hook (daft.pushVerify = never)")
+        );
+    }
+
     // ── End-to-end against real git in isolated temp repos ──────────────
 
     struct TestRepo {
@@ -1286,7 +1649,11 @@ mod tests {
 
     fn git_in(dir: &Path, args: &[&str]) -> std::process::Output {
         let mut cmd = git_command_at(dir);
-        cmd.args(args)
+        // A developer's global commit.gpgsign=true would make every fixture
+        // commit sign via the real gpg agent, which flakes under parallel
+        // test load (same rationale as git::mod's seeding tests).
+        cmd.args(["-c", "commit.gpgsign=false"])
+            .args(args)
             .envs([
                 ("GIT_AUTHOR_NAME", "Test"),
                 ("GIT_AUTHOR_EMAIL", "test@test.com"),

--- a/src/core/worktree/push.rs
+++ b/src/core/worktree/push.rs
@@ -284,14 +284,14 @@ impl HookVerdict {
 
 /// Verdict on whether git should dispatch the repo's `pre-push` hook for a
 /// daft-initiated push that can prove itself ref-only (#679, #747).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PrePushDecision {
     /// Let git run the hook.
     Verify,
     /// Suppress the hook; `Some(reason)` is reported as a progress step
     /// (`None` for the explicit `--no-verify` flag, which stays silent as it
     /// always has).
-    Skip(Option<&'static str>),
+    Skip(Option<String>),
 }
 
 /// What the push would transmit — the evidence `auto` weighs, and the site
@@ -324,44 +324,47 @@ pub enum PushPayload {
 /// `pushVerify = always` for a hook that must run on every push regardless;
 /// `always` is also what keeps ref-policy hooks (protected-branch delete
 /// gates) firing on deletes, since those act on the ref name, not content.
+/// `governing_key` is the config key whose value `setting` came from. The
+/// `never` reason quotes it verbatim as an undo hint, so the caller must pass
+/// the key that is really set rather than the one scoped to this site: with
+/// only `daft.pushVerify` set, the checkout push is governed by the base key,
+/// and pointing the user at the unset `daft.checkout.pushVerify` would send
+/// them to unset a key `git config --get` reports as absent (#747).
 pub fn resolve_pre_push(
     setting: PushVerify,
     no_verify_flag: bool,
     hook_present: bool,
     payload: PushPayload,
+    governing_key: &str,
 ) -> PrePushDecision {
     if no_verify_flag {
         return PrePushDecision::Skip(None);
     }
     match setting {
         // Only announce the skip when there is actually a hook to skip; a
-        // hook-less repo stays silent, matching `auto`. The reason names the
-        // most specific key governing this site — the one an undo would set.
-        PushVerify::Never if hook_present => PrePushDecision::Skip(Some(match payload {
-            PushPayload::Commits { .. } => {
-                "Skipping pre-push hook (daft.checkout.pushVerify = never)"
-            }
-            PushPayload::Delete => "Skipping pre-push hook (daft.pushVerify = never)",
-        })),
+        // hook-less repo stays silent, matching `auto`.
+        PushVerify::Never if hook_present => PrePushDecision::Skip(Some(format!(
+            "Skipping pre-push hook ({governing_key} = never)"
+        ))),
         PushVerify::Never => PrePushDecision::Skip(None),
         PushVerify::Always => PrePushDecision::Verify,
         PushVerify::Auto => match payload {
             PushPayload::Commits {
                 unpushed_count: Some(0),
-            } if hook_present => {
-                PrePushDecision::Skip(Some("Skipping pre-push hook (no new commits to push)"))
-            }
+            } if hook_present => PrePushDecision::Skip(Some(
+                "Skipping pre-push hook (no new commits to push)".to_string(),
+            )),
             PushPayload::Delete if hook_present => PrePushDecision::Skip(Some(
-                "Skipping pre-push hook (a remote-branch delete pushes no content)",
+                "Skipping pre-push hook (a remote-branch delete pushes no content)".to_string(),
             )),
             _ => PrePushDecision::Verify,
         },
     }
 }
 
-/// Resolved hook handling for one remote-branch delete: what to pass to
-/// [`push_with_hooks`] and what to tell the user.
-pub struct DeletePrePush {
+/// Resolved hook handling for one push: what to pass to [`push_with_hooks`]
+/// and what to tell the user.
+pub struct PrePushPlan {
     /// `verify` argument for [`push_with_hooks`].
     pub verify: bool,
     /// The hook-existence probe's answer when it ran (forward to
@@ -369,45 +372,110 @@ pub struct DeletePrePush {
     pub hook_present: Option<bool>,
     /// Skip reason to report as a progress step, when the skip should be
     /// announced.
-    pub skip_reason: Option<&'static str>,
+    pub skip_reason: Option<String>,
 }
 
-/// Decide the pre-push hook handling for a remote-branch delete (#747).
+/// Resolve the complete pre-push plan for one push: probe policy, decision,
+/// and what to announce. Every suppressible push site goes through here so
+/// the probe policy lives in exactly one place (#747).
 ///
-/// A delete is statically ref-only, so unlike the checkout upstream push
-/// there is no `rev-list` probe — the knob alone decides: `auto` and
-/// `never` skip, `always` verifies (the ref-policy escape hatch), and
-/// `--no-verify` wins silently. Hook existence is probed lazily, mirroring
-/// checkout's `push_if_enabled`: only when the decision can act on it
-/// (`auto`/`never`); `always` lets [`push_with_hooks`] resolve presence for
-/// its own verdict, and `--no-verify` skips without probing.
-pub fn resolve_delete_pre_push(
-    git: &GitCommand,
-    cwd: &Path,
+/// Both probes are lazy, because both cost a subprocess and neither is worth
+/// paying for when the answer cannot change the decision:
+///
+/// - `probe_hook` runs only when the decision can act on hook presence
+///   (`auto`/`never`). `always` verifies unconditionally and lets
+///   [`push_with_hooks`] resolve presence for its own verdict; `--no-verify`
+///   skips silently without probing at all.
+/// - `probe_payload` runs only for `auto` with a hook actually present — the
+///   one case whose outcome depends on what the push transmits. A delete
+///   passes a closure that answers [`PushPayload::Delete`] without doing any
+///   work, since a delete is ref-only by construction.
+pub fn resolve_pre_push_plan(
     setting: PushVerify,
     no_verify_flag: bool,
-) -> DeletePrePush {
+    governing_key: &str,
+    probe_hook: impl FnOnce() -> bool,
+    probe_payload: impl FnOnce() -> PushPayload,
+) -> PrePushPlan {
     let hook_present = if no_verify_flag || setting == PushVerify::Always {
         None
     } else {
-        Some(git.pre_push_hook_exists(cwd))
+        Some(probe_hook())
+    };
+    let payload = if setting == PushVerify::Auto && hook_present == Some(true) {
+        probe_payload()
+    } else {
+        // Unreachable as evidence: every path that skips the probe ignores
+        // the payload entirely. Spell it as "carries content" anyway so a
+        // future arm that starts reading it fails safe — toward verifying.
+        PushPayload::Commits {
+            unpushed_count: None,
+        }
     };
     match resolve_pre_push(
         setting,
         no_verify_flag,
         hook_present.unwrap_or(false),
-        PushPayload::Delete,
+        payload,
+        governing_key,
     ) {
-        PrePushDecision::Verify => DeletePrePush {
+        PrePushDecision::Verify => PrePushPlan {
             verify: true,
             hook_present,
             skip_reason: None,
         },
-        PrePushDecision::Skip(reason) => DeletePrePush {
+        PrePushDecision::Skip(reason) => PrePushPlan {
             verify: false,
             hook_present,
             skip_reason: reason,
         },
+    }
+}
+
+/// Decide the pre-push hook handling for a remote-branch delete (#747).
+///
+/// A delete is statically ref-only, so unlike the checkout upstream push
+/// there is no `rev-list` probe — the knob alone decides: `auto` and `never`
+/// skip, `always` verifies (the ref-policy escape hatch), and `--no-verify`
+/// wins silently. `daft.pushVerify` is always the governing key here; the
+/// checkout-scoped override does not reach delete sites.
+pub fn resolve_delete_pre_push(
+    git: &GitCommand,
+    cwd: &Path,
+    setting: PushVerify,
+    no_verify_flag: bool,
+) -> PrePushPlan {
+    resolve_pre_push_plan(
+        setting,
+        no_verify_flag,
+        crate::settings::keys::PUSH_VERIFY,
+        || git.pre_push_hook_exists(cwd),
+        || PushPayload::Delete,
+    )
+}
+
+/// Should a failed remote-branch delete escalate to a command failure, or
+/// stay the legacy warn-and-continue?
+///
+/// `Rejected`/`Passed` escalate as they always have (#599) — the gate ran, so
+/// the failure is real. The subtle case is `Bypassed`, which covers two very
+/// different situations that must not be graded alike (#747):
+///
+/// - **daft suppressed the gate** (the ref-only skip). Before #747 the hook
+///   ran here and a failure escalated; keeping it a warning would let the
+///   skip silently downgrade a genuine transport / auth / server-side refusal
+///   into a success. It must still escalate.
+/// - **the user passed `--no-verify`**. That path warned and exited 0 long
+///   before #747, and the flag says nothing about how failures are graded.
+///   Escalating would be an unrelated regression, so it stays a warning.
+///
+/// `NoHook` keeps warn-and-continue — an asymmetry inherited from #599, not
+/// introduced here.
+pub fn delete_failure_escalates(hook: HookVerdict, no_verify_flag: bool) -> bool {
+    match hook {
+        HookVerdict::Rejected | HookVerdict::Passed => true,
+        HookVerdict::Bypassed => !no_verify_flag,
+        HookVerdict::NoHook => false,
     }
 }
 
@@ -1412,6 +1480,13 @@ mod tests {
 
     // ── resolve_pre_push decision core (#679 upstream, #747 deletes) ────
 
+    /// Governing key for cases that do not exercise the undo hint itself.
+    const ANY_KEY: &str = crate::settings::keys::PUSH_VERIFY;
+
+    fn skipped(reason: &str) -> PrePushDecision {
+        PrePushDecision::Skip(Some(reason.to_string()))
+    }
+
     #[test]
     fn no_verify_flag_skips_silently_regardless_of_setting_and_payload() {
         for setting in [PushVerify::Auto, PushVerify::Always, PushVerify::Never] {
@@ -1422,7 +1497,7 @@ mod tests {
                 PushPayload::Delete,
             ] {
                 assert_eq!(
-                    resolve_pre_push(setting, true, true, payload),
+                    resolve_pre_push(setting, true, true, payload, ANY_KEY),
                     PrePushDecision::Skip(None)
                 );
             }
@@ -1438,6 +1513,7 @@ mod tests {
             PushPayload::Commits {
                 unpushed_count: Some(3),
             },
+            ANY_KEY,
         );
         assert!(matches!(decision, PrePushDecision::Skip(Some(_))));
     }
@@ -1453,33 +1529,53 @@ mod tests {
             PushPayload::Delete,
         ] {
             assert_eq!(
-                resolve_pre_push(PushVerify::Never, false, false, payload),
+                resolve_pre_push(PushVerify::Never, false, false, payload, ANY_KEY),
                 PrePushDecision::Skip(None)
             );
         }
     }
 
     #[test]
-    fn never_reason_names_the_key_governing_the_site() {
-        // The reason doubles as the undo hint, so it must name the key that
-        // actually governs each site: the checkout-scoped override for the
-        // upstream push, the base key for deletes (#747).
+    fn never_reason_names_the_key_the_caller_says_governs() {
+        // The reason doubles as the undo hint, so it quotes the key that
+        // actually holds the value — never one inferred from the site. With
+        // only `daft.pushVerify` set, the checkout push is governed by the
+        // base key, and naming the unset checkout override would send the
+        // user to `git config --unset` a key that is not there (#747).
+        let commits = PushPayload::Commits {
+            unpushed_count: Some(0),
+        };
         assert_eq!(
             resolve_pre_push(
                 PushVerify::Never,
                 false,
                 true,
-                PushPayload::Commits {
-                    unpushed_count: Some(0),
-                },
+                commits,
+                crate::settings::keys::CHECKOUT_PUSH_VERIFY,
             ),
-            PrePushDecision::Skip(Some(
-                "Skipping pre-push hook (daft.checkout.pushVerify = never)"
-            ))
+            skipped("Skipping pre-push hook (daft.checkout.pushVerify = never)")
+        );
+        // Same payload, value inherited from the base key: the hint follows
+        // the key, not the site.
+        assert_eq!(
+            resolve_pre_push(
+                PushVerify::Never,
+                false,
+                true,
+                commits,
+                crate::settings::keys::PUSH_VERIFY,
+            ),
+            skipped("Skipping pre-push hook (daft.pushVerify = never)")
         );
         assert_eq!(
-            resolve_pre_push(PushVerify::Never, false, true, PushPayload::Delete),
-            PrePushDecision::Skip(Some("Skipping pre-push hook (daft.pushVerify = never)"))
+            resolve_pre_push(
+                PushVerify::Never,
+                false,
+                true,
+                PushPayload::Delete,
+                crate::settings::keys::PUSH_VERIFY,
+            ),
+            skipped("Skipping pre-push hook (daft.pushVerify = never)")
         );
     }
 
@@ -1494,7 +1590,7 @@ mod tests {
             PushPayload::Delete,
         ] {
             assert_eq!(
-                resolve_pre_push(PushVerify::Always, false, true, payload),
+                resolve_pre_push(PushVerify::Always, false, true, payload, ANY_KEY),
                 PrePushDecision::Verify
             );
         }
@@ -1509,6 +1605,7 @@ mod tests {
             PushPayload::Commits {
                 unpushed_count: Some(0),
             },
+            ANY_KEY,
         );
         assert!(matches!(decision, PrePushDecision::Skip(Some(_))));
     }
@@ -1523,6 +1620,7 @@ mod tests {
                 PushPayload::Commits {
                     unpushed_count: Some(2),
                 },
+                ANY_KEY,
             ),
             PrePushDecision::Verify
         );
@@ -1538,6 +1636,7 @@ mod tests {
                 PushPayload::Commits {
                     unpushed_count: None,
                 },
+                ANY_KEY,
             ),
             PrePushDecision::Verify
         );
@@ -1555,7 +1654,7 @@ mod tests {
             PushPayload::Delete,
         ] {
             assert_eq!(
-                resolve_pre_push(PushVerify::Auto, false, false, payload),
+                resolve_pre_push(PushVerify::Auto, false, false, payload, ANY_KEY),
                 PrePushDecision::Verify
             );
         }
@@ -1566,11 +1665,46 @@ mod tests {
         // A delete is statically ref-only — the knob alone decides, no
         // rev-list probe input exists to consult (#747).
         assert_eq!(
-            resolve_pre_push(PushVerify::Auto, false, true, PushPayload::Delete),
-            PrePushDecision::Skip(Some(
-                "Skipping pre-push hook (a remote-branch delete pushes no content)"
-            ))
+            resolve_pre_push(PushVerify::Auto, false, true, PushPayload::Delete, ANY_KEY),
+            skipped("Skipping pre-push hook (a remote-branch delete pushes no content)")
         );
+    }
+
+    // ── delete_failure_escalates severity grading (#599 + #747) ─────────
+
+    #[test]
+    fn a_gate_that_ran_always_escalates_a_delete_failure() {
+        for no_verify in [false, true] {
+            for hook in [HookVerdict::Rejected, HookVerdict::Passed] {
+                assert!(delete_failure_escalates(hook, no_verify));
+            }
+        }
+    }
+
+    #[test]
+    fn daft_skipping_the_gate_preserves_the_pre_747_severity() {
+        // Before #747 a delete ran the hook, so a transport / auth /
+        // server-side failure graded `Passed` and escalated. The ref-only
+        // skip must not quietly demote that to a warning just because the
+        // verdict is now `Bypassed`.
+        assert!(delete_failure_escalates(HookVerdict::Bypassed, false));
+    }
+
+    #[test]
+    fn an_explicit_no_verify_keeps_its_long_standing_warning() {
+        // `--no-verify` warned and exited 0 long before #747, and the flag
+        // says nothing about how failures are graded — escalating here would
+        // be an unrelated regression for anyone scripting against it.
+        assert!(!delete_failure_escalates(HookVerdict::Bypassed, true));
+    }
+
+    #[test]
+    fn a_hookless_delete_failure_stays_a_warning() {
+        // Asymmetry inherited from #599, pinned here so a future change to
+        // it is a deliberate one.
+        for no_verify in [false, true] {
+            assert!(!delete_failure_escalates(HookVerdict::NoHook, no_verify));
+        }
     }
 
     // ── resolve_delete_pre_push wiring (#747) ───────────────────────────
@@ -1634,7 +1768,7 @@ mod tests {
         let hooked = resolve_delete_pre_push(&git, &repo.work, PushVerify::Never, false);
         assert!(!hooked.verify);
         assert_eq!(
-            hooked.skip_reason,
+            hooked.skip_reason.as_deref(),
             Some("Skipping pre-push hook (daft.pushVerify = never)")
         );
     }

--- a/src/core/worktree/rename.rs
+++ b/src/core/worktree/rename.rs
@@ -9,7 +9,7 @@ use crate::core::multi_remote::path::{
 use crate::core::settings::PushVerify;
 use crate::core::worktree::ports::NoopStageRunner;
 use crate::core::worktree::push::{
-    HookVerdict, PushAction, push_with_hooks, resolve_delete_pre_push,
+    HookVerdict, PushAction, delete_failure_escalates, push_with_hooks, resolve_delete_pre_push,
 };
 use crate::core::{HookRunner, ProgressSink};
 use crate::executor::presenter::JobPresenter;
@@ -297,6 +297,7 @@ pub fn execute(
                     &new_path,
                     !params.no_verify,
                     None,
+                    params.no_verify,
                     presenter,
                 ) {
                     Ok(()) => {
@@ -314,7 +315,7 @@ pub fn execute(
                             params.push_verify,
                             params.no_verify,
                         );
-                        if let Some(reason) = hook_plan.skip_reason {
+                        if let Some(reason) = &hook_plan.skip_reason {
                             sink.on_step(reason);
                         }
                         match run_remote_rename_push(
@@ -326,6 +327,7 @@ pub fn execute(
                             &new_path,
                             hook_plan.verify,
                             hook_plan.hook_present,
+                            params.no_verify,
                             presenter,
                         ) {
                             Ok(()) => {
@@ -430,13 +432,16 @@ enum PushFailure {
 
 /// `verify`/`hook_present` come from the caller: the new-name push passes
 /// `!params.no_verify` (a content push, out of #747's scope), the old-name
-/// delete passes its [`resolve_delete_pre_push`] plan.
+/// delete passes its [`resolve_delete_pre_push`] plan. `no_verify_flag` is
+/// what the *user* asked for, which the delete's grading needs to tell apart
+/// from daft's own ref-only skip — see [`delete_failure_escalates`].
 fn run_remote_rename_push(
     git: &GitCommand,
     action: PushAction<'_>,
     cwd: &Path,
     verify: bool,
     hook_present: Option<bool>,
+    no_verify_flag: bool,
     presenter: Option<&Arc<dyn JobPresenter>>,
 ) -> std::result::Result<(), PushFailure> {
     match push_with_hooks(
@@ -451,16 +456,17 @@ fn run_remote_rename_push(
         Ok(outcome) => match outcome.failure {
             None => Ok(()),
             Some(msg) => {
-                // #747: a delete whose hook was skipped or bypassed but which
-                // then genuinely failed (transport, auth, server-side reject)
-                // must still fail the command — a gate that never ran cannot
-                // have refused the push, yet the old branch survives on the
-                // remote. The new-name push keeps warn-and-continue for
-                // `Bypassed` (its #679-shape escalation is out of scope), and
-                // hook-less failures stay warnings everywhere.
-                let escalates = matches!(outcome.hook, HookVerdict::Rejected | HookVerdict::Passed)
-                    || (matches!(action, PushAction::Delete { .. })
-                        && outcome.hook == HookVerdict::Bypassed);
+                // The new-name push keeps the #599 rule verbatim (its
+                // #679-shape escalation is out of scope); the delete grades
+                // through the shared #747 rule so daft's own ref-only skip
+                // does not quietly downgrade a real failure, while an
+                // explicit `--no-verify` keeps its long-standing warning.
+                let escalates = match action {
+                    PushAction::Delete { .. } => {
+                        delete_failure_escalates(outcome.hook, no_verify_flag)
+                    }
+                    _ => matches!(outcome.hook, HookVerdict::Rejected | HookVerdict::Passed),
+                };
                 if escalates {
                     Err(PushFailure::Gated(msg, outcome.hook))
                 } else {

--- a/src/core/worktree/rename.rs
+++ b/src/core/worktree/rename.rs
@@ -6,8 +6,11 @@
 use crate::core::multi_remote::path::{
     calculate_worktree_path, extract_remote_from_path, resolve_remote_for_branch,
 };
+use crate::core::settings::PushVerify;
 use crate::core::worktree::ports::NoopStageRunner;
-use crate::core::worktree::push::{HookVerdict, PushAction, push_with_hooks};
+use crate::core::worktree::push::{
+    HookVerdict, PushAction, push_with_hooks, resolve_delete_pre_push,
+};
 use crate::core::{HookRunner, ProgressSink};
 use crate::executor::presenter::JobPresenter;
 use crate::git::GitCommand;
@@ -41,6 +44,10 @@ pub struct RenameParams {
     pub multi_remote_default: String,
     /// Skip the repo's pre-push hook on remote operations (`--no-verify`).
     pub no_verify: bool,
+    /// When the old-name remote delete runs the repo's pre-push hook
+    /// (`daft.pushVerify`, #747). The new-name push is a content push and
+    /// always verifies.
+    pub push_verify: PushVerify,
 }
 
 /// Result of a rename operation.
@@ -288,15 +295,28 @@ pub fn execute(
                         force_with_lease: false,
                     },
                     &new_path,
-                    params,
+                    !params.no_verify,
+                    None,
                     presenter,
                 ) {
                     Ok(()) => {
-                        // Delete old remote branch.
+                        // Delete old remote branch. A delete pushes no
+                        // content, so under the default `pushVerify = auto`
+                        // the pre-push gate is skipped (#747); `always`
+                        // re-arms it for ref-policy hooks.
                         sink.on_step(&format!(
                             "Deleting old remote branch '{}/{}'...",
                             remote, old_branch
                         ));
+                        let hook_plan = resolve_delete_pre_push(
+                            &git,
+                            &new_path,
+                            params.push_verify,
+                            params.no_verify,
+                        );
+                        if let Some(reason) = hook_plan.skip_reason {
+                            sink.on_step(reason);
+                        }
                         match run_remote_rename_push(
                             &git,
                             PushAction::Delete {
@@ -304,7 +324,8 @@ pub fn execute(
                                 branch: &old_branch,
                             },
                             &new_path,
-                            params,
+                            hook_plan.verify,
+                            hook_plan.hook_present,
                             presenter,
                         ) {
                             Ok(()) => {
@@ -317,13 +338,19 @@ pub fn execute(
                                 } else {
                                     ""
                                 };
+                                // A skipped/bypassed gate has nothing to add
+                                // to the cause line (#747) — the git error in
+                                // `msg` is the whole story.
+                                let cause = match verdict {
+                                    HookVerdict::Bypassed => String::new(),
+                                    _ => format!(" ({})", verdict.failure_cause()),
+                                };
                                 push_gate_error = Some(format!(
                                     "Could not delete old remote branch '{remote}/{old_branch}': \
-                                     {msg} ({cause}). The branch was renamed locally and \
+                                     {msg}{cause}. The branch was renamed locally and \
                                      '{remote}/{new}' was pushed; delete the old remote branch \
                                      manually with: git push {remote} --delete {old_branch}{hint}",
                                     new = params.new_branch,
-                                    cause = verdict.failure_cause(),
                                 ));
                             }
                             Err(PushFailure::Other(e)) => {
@@ -401,26 +428,40 @@ enum PushFailure {
     Other(String),
 }
 
+/// `verify`/`hook_present` come from the caller: the new-name push passes
+/// `!params.no_verify` (a content push, out of #747's scope), the old-name
+/// delete passes its [`resolve_delete_pre_push`] plan.
 fn run_remote_rename_push(
     git: &GitCommand,
     action: PushAction<'_>,
     cwd: &Path,
-    params: &RenameParams,
+    verify: bool,
+    hook_present: Option<bool>,
     presenter: Option<&Arc<dyn JobPresenter>>,
 ) -> std::result::Result<(), PushFailure> {
     match push_with_hooks(
         git,
         action,
         cwd,
-        !params.no_verify,
+        verify,
         &NoopStageRunner,
         presenter,
-        None,
+        hook_present,
     ) {
         Ok(outcome) => match outcome.failure {
             None => Ok(()),
             Some(msg) => {
-                if matches!(outcome.hook, HookVerdict::Rejected | HookVerdict::Passed) {
+                // #747: a delete whose hook was skipped or bypassed but which
+                // then genuinely failed (transport, auth, server-side reject)
+                // must still fail the command — a gate that never ran cannot
+                // have refused the push, yet the old branch survives on the
+                // remote. The new-name push keeps warn-and-continue for
+                // `Bypassed` (its #679-shape escalation is out of scope), and
+                // hook-less failures stay warnings everywhere.
+                let escalates = matches!(outcome.hook, HookVerdict::Rejected | HookVerdict::Passed)
+                    || (matches!(action, PushAction::Delete { .. })
+                        && outcome.hook == HookVerdict::Bypassed);
+                if escalates {
                     Err(PushFailure::Gated(msg, outcome.hook))
                 } else {
                     Err(PushFailure::Other(msg))

--- a/tests/manual/scenarios/push-hooks/branch-delete-remote-push-verify-always.yml
+++ b/tests/manual/scenarios/push-hooks/branch-delete-remote-push-verify-always.yml
@@ -1,8 +1,10 @@
-name: branch-delete's remote delete is gated by the pre-push hook
+name: pushVerify=always keeps the pre-push gate on remote-branch deletes
 description:
-  "A failing pre-push hook gates the remote-branch delete (remote deletes are
-  pushes too): the command reports the failure and exits non-zero, and the
-  remote branch survives. --no-verify bypasses the gate."
+  "Remote deletes skip the pre-push hook by default (#747), but
+  daft.pushVerify=always re-arms the gate — the escape hatch for ref-policy
+  hooks that gate deletes by ref name: the command reports the failure and exits
+  non-zero, and the remote branch survives. --no-verify still bypasses the gate
+  silently."
 
 repos:
   - name: delete-gate-repo
@@ -16,12 +18,13 @@ steps:
       dirs_exist:
         - "$WORK_DIR/delete-gate-repo/main"
 
-  - name: Install a failing pre-push hook via core.hooksPath
+  - name: Install a failing pre-push hook and re-arm the delete gate
     run: |
       mkdir -p $WORK_DIR/test-hooks
       printf '#!/bin/sh\necho "GATE SAYS NO" >&2\nexit 1\n' > $WORK_DIR/test-hooks/pre-push
       chmod +x $WORK_DIR/test-hooks/pre-push
       git config core.hooksPath $WORK_DIR/test-hooks
+      git config daft.pushVerify always
     cwd: "$WORK_DIR/delete-gate-repo/main"
     expect: { exit_code: 0 }
 
@@ -45,6 +48,8 @@ steps:
     cwd: "$WORK_DIR/delete-gate-repo/main"
     expect:
       exit_code: 0
+      output_not_contains:
+        - "Skipping pre-push hook"
 
   - name: The remote branch is gone
     run: git ls-remote --heads origin 2>/dev/null

--- a/tests/manual/scenarios/push-hooks/branch-delete-remote-skips-pre-push.yml
+++ b/tests/manual/scenarios/push-hooks/branch-delete-remote-skips-pre-push.yml
@@ -1,0 +1,81 @@
+name: remote-branch deletes skip the pre-push hook by default
+description:
+  "A remote-branch delete pushes no content, so under the default
+  pushVerify=auto the repo's pre-push hook has nothing to gate and is skipped
+  (#747): a hook that would fail loudly does not block the remote delete, the
+  remote branch is deleted, the command exits zero, and the skip is reported in
+  verbose mode. Hook-less repos render no phantom skip line."
+
+repos:
+  - name: delete-skip-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone the repository
+    run: git-worktree-clone --layout contained $REMOTE_DELETE_SKIP_REPO
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/delete-skip-repo/main"
+
+  - name: Create a merged branch on the remote and check out its worktree
+    run: |
+      git push --quiet origin main:feature/merged-case
+      git-worktree-checkout feature/merged-case
+    cwd: "$WORK_DIR/delete-skip-repo/main"
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/delete-skip-repo/feature/merged-case"
+
+  - name: Hook-less remote delete renders no phantom skip line
+    run: git-worktree-branch -d develop --remote --verbose 2>&1
+    cwd: "$WORK_DIR/delete-skip-repo/main"
+    expect:
+      exit_code: 0
+      output_not_contains:
+        - "Skipping pre-push hook"
+
+  - name: Install a failing pre-push hook via core.hooksPath
+    run: |
+      mkdir -p $WORK_DIR/test-hooks
+      printf '#!/bin/sh\necho "GATE SAYS NO" >&2\nexit 1\n' > $WORK_DIR/test-hooks/pre-push
+      chmod +x $WORK_DIR/test-hooks/pre-push
+      git config core.hooksPath $WORK_DIR/test-hooks
+    cwd: "$WORK_DIR/delete-skip-repo/main"
+    expect: { exit_code: 0 }
+
+  - name: daft remove deletes the remote branch without running the hook
+    run: |
+      git config daft.branchDelete.remote true
+      daft remove feature/merged-case --verbose 2>&1
+    cwd: "$WORK_DIR/delete-skip-repo/main"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "Skipping pre-push hook (a remote-branch delete pushes no content)"
+      output_not_contains:
+        - "GATE SAYS NO"
+      files_not_exist:
+        - "$WORK_DIR/delete-skip-repo/feature/merged-case/README.md"
+
+  - name: Both remote branches were deleted through the failing hook
+    run: git ls-remote --heads origin 2>/dev/null
+    cwd: "$WORK_DIR/delete-skip-repo/main"
+    expect:
+      exit_code: 0
+      output_not_contains: ["feature/merged-case", "develop"]
+
+  - name: A remote-only delete skips the hook without verbose too
+    run: git-worktree-branch -d feature/test-feature --remote 2>&1
+    cwd: "$WORK_DIR/delete-skip-repo/main"
+    expect:
+      exit_code: 0
+      output_not_contains: ["GATE SAYS NO"]
+
+  - name: The last remote branch is gone
+    run: git ls-remote --heads origin 2>/dev/null
+    cwd: "$WORK_DIR/delete-skip-repo/main"
+    expect:
+      exit_code: 0
+      output_not_contains: ["feature/test-feature"]

--- a/tests/manual/scenarios/push-hooks/rename-old-name-delete-skips-pre-push.yml
+++ b/tests/manual/scenarios/push-hooks/rename-old-name-delete-skips-pre-push.yml
@@ -1,0 +1,60 @@
+name: rename's old-name remote delete skips the pre-push hook
+description:
+  "daft rename pushes the new name (a content push — the hook fires) and then
+  deletes the old remote name (statically ref-only — the hook is skipped under
+  the default pushVerify=auto, #747): a counting hook runs exactly once, the
+  remote ends up with only the new name, and the skip is reported in verbose
+  mode."
+
+repos:
+  - name: rename-skip-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone the repository
+    run: git-worktree-clone --layout contained $REMOTE_RENAME_SKIP_REPO
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/rename-skip-repo/main"
+
+  - name: Checkout the feature branch
+    run: git-worktree-checkout feature/test-feature
+    cwd: "$WORK_DIR/rename-skip-repo/main"
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/rename-skip-repo/feature/test-feature"
+
+  - name: Install a counting pre-push hook via core.hooksPath
+    run: |
+      mkdir -p $WORK_DIR/test-hooks
+      printf '#!/bin/sh\necho hook-ran >> %s/hook-runs.txt\nexit 0\n' "$WORK_DIR" > $WORK_DIR/test-hooks/pre-push
+      chmod +x $WORK_DIR/test-hooks/pre-push
+      git config core.hooksPath $WORK_DIR/test-hooks
+    cwd: "$WORK_DIR/rename-skip-repo/main"
+    expect: { exit_code: 0 }
+
+  - name: Rename runs the hook for the new-name push but not the delete
+    run: daft rename feature/test-feature feature/renamed --verbose 2>&1
+    cwd: "$WORK_DIR/rename-skip-repo/main"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "Skipping pre-push hook (a remote-branch delete pushes no content)"
+      dirs_exist:
+        - "$WORK_DIR/rename-skip-repo/feature/renamed"
+
+  - name: The hook ran exactly once
+    run: test "$(grep -c hook-ran $WORK_DIR/hook-runs.txt)" = "1"
+    cwd: "$WORK_DIR/rename-skip-repo/main"
+    expect:
+      exit_code: 0
+
+  - name: The remote has only the new name
+    run: git ls-remote --heads origin 2>/dev/null
+    cwd: "$WORK_DIR/rename-skip-repo/feature/renamed"
+    expect:
+      exit_code: 0
+      output_contains: ["feature/renamed"]
+      output_not_contains: ["feature/test-feature"]


### PR DESCRIPTION
A remote-branch delete transmits a null ref update and zero objects, so a
pre-push *content* gate has nothing to validate — yet all three
`PushAction::Delete` sites ran the hook unconditionally. A field report on
v1.22.0 paid 3.4s of pre-push to delete an already-merged branch.

#679 solved the equivalent problem for the branch-creation upstream push and
explicitly deferred the delete sites. This is that deferred leg.

## Behavior

Under the default `auto`, a delete now skips the hook at all three sites:
`daft remove` / `git worktree-branch -d` (and `daft merge`'s cleanup, which
shares the choke point), `daft rename`'s old-name delete, and
`daft multi-remote move --delete-old`. `always` re-arms it for ref-policy
hooks — protected-branch delete guards act on the ref name, not content, so
they must keep firing. `--no-verify` still skips silently, and a hook-less
repo renders no phantom skip line.

## Configuration

A new base `daft.pushVerify` (`auto` | `always` | `never`) is the setting
every suppressible push reads; `daft.checkout.pushVerify` is retained as a
checkout-scoped override. Resolution happens at load time, with the
more-specific key winning regardless of config scope.

Note `never` is unconditional, unlike `auto`/`always` which decide per push
from what it transmits — setting the base key to `never` also disarms the
hook on an upstream push that carries commits. The docs and command help
call that out, and `daft.checkout.pushVerify = auto` scopes it back.

## Failure grading

The skip must not change how failures are reported. Before this change a
delete ran the hook, graded `Passed`, and a transport / auth / server-side
refusal failed the command; leaving it a warning would have turned a real
failure into a silent success. `delete_failure_escalates` keeps that
severity for daft's own skip while preserving `--no-verify`'s long-standing
warn-and-continue — the two are distinct despite both grading `Bypassed`.

## Tests

Three new YAML scenarios: the field-report regression (failing hook,
`daft remove` exits 0, skip line under `--verbose`, no phantom line
hook-lessly), the `pushVerify = always` re-arm, and a counting-hook rename
proving the hook fires exactly once (new-name push) and not for the delete.
The decision core and severity grading are covered by unit tests.

`multi-remote move --delete-old` has no scenario: `daft multi-remote enable`
is broken for every current clone layout (its migration list includes the
main working tree, which `git worktree move` refuses). That predates this
work and needs its own issue; the site is covered by the shared decision
core and unit tests.

Fixes #747
Refs #679, #599