### PR TITLE
fix(output): stop VS16 emoji in child output ghosting live rail rows

### DIFF
--- a/src/core/worktree/exec/rail_presenter.rs
+++ b/src/core/worktree/exec/rail_presenter.rs
@@ -20,25 +20,6 @@ use std::collections::HashMap;
 use std::sync::Mutex;
 use std::time::Duration;
 
-/// Normalize a captured child-output line to a single, control-free line
-/// before it rides a rail bar or lands in the receipt — a raw line from a
-/// chatty command (`cargo`/`npm`/`docker`, which repaint with `\r` and ANSI)
-/// would otherwise return the cursor to column 0 or inject escapes mid-row and
-/// corrupt the live rail and its scrollback. The rail row/window enforce
-/// single-line *width* (`{wide_msg}`) but not content, so the caller owns this.
-fn sanitize(line: &str) -> String {
-    // Progress output overwrites its line with `\r`; keep only the final
-    // segment the terminal would have shown.
-    let visible = line.rsplit('\r').next().unwrap_or(line);
-    // Drop ANSI escape sequences, then any remaining control character (tabs
-    // become spaces so words don't fuse).
-    console::strip_ansi_codes(visible)
-        .chars()
-        .map(|c| if c == '\t' { ' ' } else { c })
-        .filter(|c| !c.is_control())
-        .collect()
-}
-
 /// The [`StepKey`] for target `label`'s command `idx` of `count`. A single
 /// command keys by the bare label (the row's identity is the worktree); a
 /// pipeline disambiguates each command by index. The plan builder and the
@@ -104,7 +85,9 @@ impl JobPresenter for RailExecPresenter {
 
     fn on_job_output(&self, name: &str, line: &str) {
         if let Some(key) = self.current(name) {
-            self.handle.push_row_output(&key, &sanitize(line));
+            // Raw child lines are sanitized for the live region at the
+            // `ThreadedJob::record` choke point (`output::live_line`, #751).
+            self.handle.push_row_output(&key, line);
         }
     }
 
@@ -199,21 +182,6 @@ mod tests {
         tl.commit_plan(plan);
         let presenter = RailExecPresenter::new(tl.handle(), rows);
         (tl, presenter, term)
-    }
-
-    #[test]
-    fn sanitize_strips_ansi_carriage_returns_and_controls() {
-        // A cargo/npm-style progress line: ANSI color + `\r` repaint. Only the
-        // final segment survives, control-free — nothing that could return the
-        // cursor or inject escapes into a rail row.
-        assert_eq!(
-            sanitize("\x1b[32mBuilding [==>  ] 40%\rBuilding [====] 100%\x1b[0m"),
-            "Building [====] 100%"
-        );
-        assert_eq!(sanitize("tab\there"), "tab here");
-        assert_eq!(sanitize("plain output"), "plain output");
-        // A bare carriage return leaves no residue.
-        assert_eq!(sanitize("gone\rkept"), "kept");
     }
 
     #[test]

--- a/src/output/hook_progress/interactive.rs
+++ b/src/output/hook_progress/interactive.rs
@@ -274,6 +274,10 @@ impl HookProgressRenderer {
                 return;
             };
 
+            // Buffer the raw child line: `finish_job` echoes it back to
+            // scrollback verbatim (color, emoji, alignment intact). Width
+            // normalization for the live tail bars (#751) happens at the
+            // rolling-window seam below, never at capture.
             state.output_buffer.push(line.to_string());
 
             // Nothing to display when quiet or tail_lines == 0.
@@ -342,7 +346,11 @@ impl HookProgressRenderer {
             for (i, tail_pb) in state.tail_lines.iter().enumerate() {
                 let buf_idx = start + i;
                 if buf_idx < buf_len {
-                    tail_pb.set_message(state.output_buffer[buf_idx].clone());
+                    // Live seam: sanitize on the way to the padded tail bar
+                    // (#751); the buffer keeps the raw copy for the echo.
+                    tail_pb.set_message(crate::output::live_line::sanitize(
+                        &state.output_buffer[buf_idx],
+                    ));
                 } else {
                     tail_pb.set_message(String::new());
                 }
@@ -610,6 +618,22 @@ impl HookProgressRenderer {
     #[cfg(test)]
     pub fn get_tail_line_count(&self, name: &str) -> usize {
         self.jobs.get(name).map(|s| s.tail_lines.len()).unwrap_or(0)
+    }
+
+    /// Test-only: the live tail bars' current messages, top to bottom. Distinct
+    /// from [`Self::get_buffered_output`] (the raw buffer) — these are the
+    /// sanitized live-region strings (#751).
+    #[cfg(test)]
+    pub fn get_tail_line_messages(&self, name: &str) -> Vec<String> {
+        self.jobs
+            .get(name)
+            .map(|s| {
+                s.tail_lines
+                    .iter()
+                    .map(|b| b.message().to_string())
+                    .collect()
+            })
+            .unwrap_or_default()
     }
 
     #[cfg(test)]

--- a/src/output/hook_progress/mod.rs
+++ b/src/output/hook_progress/mod.rs
@@ -258,6 +258,47 @@ mod tests {
     }
 
     #[test]
+    fn block_renderer_sanitizes_live_tail_but_keeps_raw_buffer() {
+        // #751: the block renderer's buffer feeds two audiences. The live tail
+        // bars are padded to terminal width, so they must be sanitized — VS16
+        // (`✔️`) to text presentation, ANSI/`\r` to the shown segment. The
+        // buffer itself stays raw: `finish_job` echoes it to permanent
+        // scrollback, where color and emoji must survive.
+        let config = HookOutputConfig {
+            tail_lines: 3,
+            ..Default::default()
+        };
+        let mut renderer = HookProgressRenderer::new_hidden(&config);
+        renderer.start_job("job", None);
+        renderer.update_job_output("job", "sync hooks: \u{2714}\u{FE0F} ok");
+        renderer.update_job_output("job", "\x1b[32m40%\x1b[0m\rdone");
+        // Raw buffer preserved for the scrollback echo.
+        assert_eq!(
+            renderer.get_buffered_output("job"),
+            &[
+                "sync hooks: \u{2714}\u{FE0F} ok".to_string(),
+                "\x1b[32m40%\x1b[0m\rdone".to_string(),
+            ]
+        );
+        // Live tail bars normalized: no VS16 reaches a padded row, and the
+        // `\r` rewrite resolves to its final segment.
+        let live = renderer.get_tail_line_messages("job");
+        assert!(
+            live.iter().all(|m| !m.contains('\u{FE0F}')),
+            "VS16 must not reach a live tail bar: {live:?}"
+        );
+        assert!(
+            live.iter().any(|m| m == "sync hooks: \u{2714} ok"),
+            "text presentation survives on the live bar: {live:?}"
+        );
+        assert!(
+            live.iter().any(|m| m == "done"),
+            "`\\r` rewrite resolves to the final segment: {live:?}"
+        );
+        renderer.finish_job_success("job", Duration::from_secs(1));
+    }
+
+    #[test]
     fn description_bar_is_tracked_for_removal() {
         // Regression guard (#651): the description bar must live in JobState
         // so remove_job_bars can mp.remove it. Untracked, its last handle

--- a/src/output/live_line.rs
+++ b/src/output/live_line.rs
@@ -1,0 +1,200 @@
+//! Width-normalization for child-process output shown in the live region.
+//!
+//! Every string a live-region `ProgressBar` displays must *render* exactly as
+//! wide as `unicode-width` *measures* it. indicatif pads each drawn row to
+//! exactly the terminal width (`draw_to_term`'s line filler) and computes rows
+//! to move up / clear from the same measurement — so there is zero slack in
+//! both directions. A glyph the terminal draws wider than measured wraps the
+//! physical row and leaks a ghost copy of the region's top row on every redraw
+//! tick; one drawn narrower under-fills the row, fuses the next line onto it,
+//! and makes the redraw climb into scrollback (#751). Truncation cannot help:
+//! the filler re-pads whatever space a clamp reserves. The only fix on daft's
+//! side is normalizing the *content* so every width notion agrees.
+//!
+//! [`sanitize`] is that normalization, and it is a *live-render* concern:
+//! applied at the seam where a buffered line becomes a bar `set_message`, never
+//! at capture. Each job's output buffer holds the raw line — the source of
+//! truth — and the live surfaces sanitize on the way to a bar: the rolling
+//! window (`ThreadedJob::roll_window`), the succinct annotation
+//! (`ThreadedJob::live_tail`), and the block hook renderer's rolling tail.
+//! Permanent surfaces that `println` whole lines — receipt logs, the deferred
+//! failure dump, the block renderer's scrollback echo — read the *raw* buffer
+//! and keep full fidelity
+//! (color, emoji, alignment); a `println`'d line wraps naturally and never
+//! drives move-up math, so it cannot ghost. Don't route child text into a bar
+//! around these seams; don't apply this to daft's own composed messages (they
+//! carry intentional ANSI styling).
+//!
+//! Residual, terminal-dependent and unfixable from here: a base glyph some
+//! terminals draw in emoji presentation by default even absent VS16 (e.g.
+//! U+2764), and East-Asian-Ambiguous glyphs on terminals configured
+//! `ambiguous = wide`, still measure narrower than they draw. There is no
+//! client-side width notion that captures either.
+
+use crate::output::format::strip_ansi;
+use console::measure_text_width;
+
+/// Normalize one captured child-output line for the live region.
+///
+/// - **ANSI escapes** are stripped (via [`strip_ansi`], whose scanner also
+///   swallows OSC-8 hyperlink payloads — `console::strip_ansi_codes` leaks
+///   them): a chatty command's color codes are merely unmeasured, but its
+///   cursor moves and erases would rewrite the region.
+/// - **`\r` rewrites** keep only the final segment — what the terminal would
+///   have shown after a progress line repainted itself.
+/// - **`\t` becomes one space** (the terminal advances to a tab stop the
+///   width math cannot see); remaining control characters drop.
+/// - **Variation selectors drop**: `✔\u{FE0F}` measures 1 column but VS16
+///   forces emoji presentation, drawn 2 cells — the exact lefthook glyph from
+///   the #751 field reports. Bare `✔` measures and draws 1 everywhere.
+/// - **ZWJ/skin-tone/keycap sequences reduce to their first scalar**: the
+///   parts measure individually (`👨‍👩‍👧` = 6) but modern terminals draw one
+///   glyph (2), under-filling the row. The first scalar alone agrees with
+///   both joining and non-joining terminals.
+pub(crate) fn sanitize(raw: &str) -> String {
+    let stripped = strip_ansi(raw.trim_end());
+    let seg = stripped.rsplit('\r').next().unwrap_or(&stripped);
+    let mut out = String::with_capacity(seg.len());
+    let mut chars = seg.chars();
+    while let Some(c) = chars.next() {
+        match c {
+            '\t' => out.push(' '),
+            // Variation selectors (VS1–VS16), skin-tone modifiers, keycap.
+            '\u{FE00}'..='\u{FE0F}' | '\u{1F3FB}'..='\u{1F3FF}' | '\u{20E3}' => {}
+            '\u{200D}' => {
+                // A ZWJ *between two wide (emoji) scalars* joins them into one
+                // drawn glyph — drop the joiner and the following scalar,
+                // keeping the first scalar's honest width. After a narrow
+                // scalar, or before one (complex-script shaping, `語\u{200D}A`),
+                // the joiner is invisible and width-neutral: drop it alone and
+                // keep the next character. (Known rare false positive: a ZWJ
+                // between two CJK ideographs elides the second — accept it;
+                // widening the gate re-opens the wide+ZWJ+text drop this
+                // guards against.)
+                let prev_wide = out.chars().next_back().is_some_and(is_wide);
+                let next_wide = chars.clone().next().is_some_and(is_wide);
+                if prev_wide && next_wide {
+                    chars.next();
+                }
+            }
+            c if c.is_control() => {}
+            c => out.push(c),
+        }
+    }
+    out.truncate(out.trim_end().len());
+    out
+}
+
+/// Whether `c` measures two columns — the emoji-join signal used to tell a
+/// composing ZWJ (between two wide scalars) from an invisible shaping joiner.
+fn is_wide(c: char) -> bool {
+    measure_text_width(c.encode_utf8(&mut [0u8; 4])) == 2
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_ascii_passes_unchanged() {
+        assert_eq!(sanitize("Compiling daft v1.23.0"), "Compiling daft v1.23.0");
+        assert_eq!(sanitize(""), "");
+    }
+
+    #[test]
+    fn vs16_emoji_presentation_drops_to_text_presentation() {
+        // The #751 field-report glyph: lefthook's `✔️` (U+2714 + VS16)
+        // measures 1 column but draws 2, wrapping a filler-padded row.
+        assert_eq!(
+            sanitize("sync hooks: \u{2714}\u{FE0F} (pre-push, pre-commit)"),
+            "sync hooks: \u{2714} (pre-push, pre-commit)"
+        );
+        assert_eq!(
+            sanitize("\u{2714}\u{FE0F} unit tests (related) (33.07 seconds)"),
+            "\u{2714} unit tests (related) (33.07 seconds)"
+        );
+        // VS15 (text presentation selector) is width-neutral; dropped for
+        // symmetry.
+        assert_eq!(sanitize("\u{2714}\u{FE0E} ok"), "\u{2714} ok");
+        // Bare `✔` measures what it draws.
+        assert_eq!(measure_text_width(&sanitize("\u{2714}\u{FE0F}")), 1);
+    }
+
+    #[test]
+    fn cr_rewrites_keep_the_final_segment() {
+        // A cargo/npm-style progress line: ANSI color + `\r` repaint. Only the
+        // final segment survives, control-free — nothing that could return
+        // the cursor or inject escapes into a rail row.
+        assert_eq!(
+            sanitize("\x1b[32mBuilding [==>  ] 40%\rBuilding [====] 100%\x1b[0m"),
+            "Building [====] 100%"
+        );
+        assert_eq!(sanitize("gone\rkept"), "kept");
+        // A trailing `\r` (or `\r\n` residue) is line termination, not a
+        // rewrite — it must not blank the line.
+        assert_eq!(sanitize("12%\r"), "12%");
+    }
+
+    #[test]
+    fn controls_scrub_and_tabs_become_spaces() {
+        assert_eq!(sanitize("tab\there"), "tab here");
+        assert_eq!(sanitize("a\u{7}b\u{8}c"), "abc");
+        // C1 controls are skipped by indicatif's width math but not by
+        // terminals.
+        assert_eq!(sanitize("a\u{85}b"), "ab");
+        assert_eq!(sanitize("done  "), "done");
+    }
+
+    #[test]
+    fn ansi_strips_including_osc_hyperlinks() {
+        assert_eq!(sanitize("\x1b[38;5;208mwarn\x1b[0m"), "warn");
+        assert_eq!(
+            sanitize("\x1b]8;;https://example.com\x1b\\link\x1b]8;;\x1b\\"),
+            "link"
+        );
+        assert_eq!(sanitize("\x1b[2K"), "");
+    }
+
+    #[test]
+    fn zwj_sequences_reduce_to_their_first_scalar() {
+        // Measured 2 (first scalar) == drawn 2, whether the terminal joins
+        // the sequence or not.
+        assert_eq!(
+            sanitize("\u{1F9D1}\u{200D}\u{1F4BB} tests"),
+            "\u{1F9D1} tests"
+        );
+        assert_eq!(
+            sanitize("\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}"),
+            "\u{1F468}"
+        );
+        // After a narrow scalar the joiner is shaping, not emoji composition:
+        // drop the invisible joiner alone, keep the text.
+        assert_eq!(sanitize("x\u{200D}y"), "xy");
+        // A wide scalar followed by a ZWJ + *narrow* text is shaping too, not
+        // an emoji join: the joiner drops but the text must survive. Keying the
+        // elision on the previous glyph's width alone would eat the "A".
+        assert_eq!(sanitize("\u{8A9E}\u{200D}A"), "\u{8A9E}A");
+        // A ZWJ trailing with nothing after it drops alone (no scalar to eat).
+        assert_eq!(sanitize("\u{1F468}\u{200D}"), "\u{1F468}");
+    }
+
+    #[test]
+    fn skin_tone_and_keycap_marks_drop() {
+        assert_eq!(
+            sanitize("\u{1F44D}\u{1F3FD} approved"),
+            "\u{1F44D} approved"
+        );
+        assert_eq!(sanitize("1\u{FE0F}\u{20E3} first"), "1 first");
+    }
+
+    #[test]
+    fn wide_and_rail_glyphs_pass_unchanged() {
+        // CJK measures 2 and draws 2 — already honest, untouched.
+        assert_eq!(sanitize("日本語のログ"), "日本語のログ");
+        // daft's own vocabulary must survive a round trip.
+        assert_eq!(
+            sanitize("\u{2713} \u{2502} \u{2514} \u{283c} \u{276f} \u{2726}"),
+            "\u{2713} \u{2502} \u{2514} \u{283c} \u{276f} \u{2726}"
+        );
+    }
+}

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -24,6 +24,7 @@ pub mod deferred_warn;
 pub mod emit;
 pub mod format;
 pub mod hook_progress;
+pub(crate) mod live_line;
 pub mod markdown;
 pub mod outline;
 pub mod pager;

--- a/src/output/timeline/mod.rs
+++ b/src/output/timeline/mod.rs
@@ -1329,6 +1329,32 @@ mod tests {
     }
 
     #[test]
+    fn terse_exec_annotation_sanitizes_vs16_emoji() {
+        // #751 report 2 shape: a short child line whose `✔️` (U+2714 + VS16)
+        // measures one column but draws two. The terse annotation must read
+        // the sanitized buffer back, never repaint the raw line.
+        let (mut tl, term) = captured("Running lefthook in 1 worktree");
+        tl.set_ordered_receipts(true);
+        tl.set_row_output(exec_row_output());
+        tl.commit_plan(PlanCommit::new(vec![exec_row("master")]));
+        let k = exec_key("master");
+        tl.on_stage(&k, StageEvent::Started);
+        tl.handle()
+            .push_row_output(&k, "\u{2714}\u{FE0F} unit tests (33.07 seconds)");
+        let live = term.contents();
+        assert!(
+            !live.contains('\u{FE0F}'),
+            "VS16 must not reach the live region: {live:?}"
+        );
+        assert!(
+            live.contains("\u{2714} unit tests"),
+            "text presentation survives on the annotation: {live:?}"
+        );
+        tl.on_stage(&k, StageEvent::Completed { annotation: None });
+        tl.finish("Done in 0.1s");
+    }
+
+    #[test]
     fn verbose_row_threads_its_log_grey_under_success() {
         let (mut tl, term) = captured("Running mise clean in 1 worktree");
         tl.set_ordered_receipts(true);

--- a/src/output/timeline/rail_hook.rs
+++ b/src/output/timeline/rail_hook.rs
@@ -261,8 +261,9 @@ impl RailHookRenderer {
             }
         } else {
             // Succinct's single line of liveness: the latest output line rides
-            // the annotation slot.
-            state.annotation = Some(line.trim_end().to_string());
+            // the annotation slot — sanitized on the way to the bar (#751), and
+            // skipping a control-only line so it never blanks the row.
+            state.annotation = state.thread.live_tail();
             self.refresh_bar(name);
         }
     }
@@ -846,6 +847,30 @@ mod tests {
         let live = r.jobs.get("db").unwrap().bar.message();
         assert!(live.contains("applying migration 3"), "got: {live:?}");
         assert!(!live.contains("Prepare the database"));
+    }
+
+    #[test]
+    fn succinct_annotation_sanitizes_vs16_emoji_output() {
+        // #751 report 1: lefthook's `✔️` (U+2714 + VS16) measures one column
+        // but draws two. Verbatim on a live bar, indicatif's full-width row
+        // filler makes the physical row overflow and leak a ghost copy every
+        // redraw tick. The annotation must carry the sanitized buffer line,
+        // never the raw child line.
+        let (mut r, _term, _h) = harness(None, false);
+        r.start_job("pnpm-install", None);
+        r.update_job_output(
+            "pnpm-install",
+            "lefthook postinstall: sync hooks: \u{2714}\u{FE0F} (pre-push, pre-commit)",
+        );
+        let msg = r.jobs.get("pnpm-install").unwrap().bar.message();
+        assert!(
+            !msg.contains('\u{FE0F}'),
+            "VS16 must not reach a live bar: {msg:?}"
+        );
+        assert!(
+            msg.contains("\u{2714} (pre-push"),
+            "text presentation survives: {msg:?}"
+        );
     }
 
     // ── verbose: the threaded log ─────────────────────────────────────────

--- a/src/output/timeline/region.rs
+++ b/src/output/timeline/region.rs
@@ -749,13 +749,12 @@ impl TimelineCore {
                 render::active_message(&label, annotation.as_deref(), label_width, inks, use_color)
             } else {
                 thread.job.close(&self.mp);
-                let latest = thread.job.output().last().map(|line| {
-                    render::paint(
-                        crate::output::palette::DARK_GREY,
-                        line.trim_end(),
-                        use_color,
-                    )
-                });
+                // Sanitized latest-with-visible-text (#751); an empty tail
+                // falls back to the row's own annotation.
+                let latest = thread
+                    .job
+                    .live_tail()
+                    .map(|line| render::paint(crate::output::palette::DARK_GREY, &line, use_color));
                 render::active_message(
                     &label,
                     latest.as_deref().or(annotation.as_deref()),
@@ -1259,13 +1258,15 @@ impl TimelineCore {
                 .job
                 .roll_window(&self.mp, &thread.styles, cfg.tail_lines, &bar);
         } else {
-            // Default density: the latest line rides the row's annotation, dim.
-            let dim = render::paint(
-                crate::output::palette::DARK_GREY,
-                line.trim_end(),
-                use_color,
-            );
-            let msg = render::active_message(&label, Some(&dim), label_width, inks, use_color);
+            // Default density: the latest line with visible text rides the
+            // row's annotation, dim — sanitized on the way to the bar (#751),
+            // never the raw input line. An all-empty tail passes `None`, not a
+            // color-wrapped blank.
+            let dim = thread
+                .job
+                .live_tail()
+                .map(|l| render::paint(crate::output::palette::DARK_GREY, &l, use_color));
+            let msg = render::active_message(&label, dim.as_deref(), label_width, inks, use_color);
             bar.set_message(msg);
         }
     }

--- a/src/output/timeline/thread_block.rs
+++ b/src/output/timeline/thread_block.rs
@@ -189,12 +189,20 @@ impl ThreadedJob {
         self.trailer = Some(pb);
     }
 
-    /// Buffer one output line into the receipt log, enforcing the byte cap.
-    /// The live view (annotation or rolling window) is repainted by the caller
-    /// / [`Self::roll_window`]; this only records.
+    /// Buffer one output line *raw* into the receipt log, enforcing the byte
+    /// cap. The live view (annotation or rolling window) is repainted by the
+    /// caller / [`Self::roll_window`]; this only records.
+    ///
+    /// The buffer is the source of truth and holds the unmodified child line,
+    /// so the permanent surfaces that read it back — [`Self::compose_log`] for
+    /// receipts and the caller's deferred failure dump — keep full fidelity
+    /// (color, emoji, alignment). Width normalization for the live region
+    /// ([`crate::output::live_line`], #751) happens only where a line becomes a
+    /// bar message: [`Self::roll_window`] and [`Self::live_tail`]. A live view
+    /// must be composed through one of those, never from a raw buffer line.
     pub(super) fn record(&mut self, line: &str) {
-        self.output.push(line.to_string());
         self.output_bytes += line.len() + 1;
+        self.output.push(line.to_string());
         if let Some(cap) = self.cap {
             let mut drop_to = 0;
             while self.output_bytes > cap && drop_to + 1 < self.output.len() {
@@ -238,9 +246,27 @@ impl ThreadedJob {
         }
         let start = self.output.len().saturating_sub(self.tail_bars.len());
         for (i, pb) in self.tail_bars.iter().enumerate() {
-            let text = self.output.get(start + i).map_or("", String::as_str);
-            pb.set_message(render::paint(GREY, text, styles.use_color));
+            // Live seam: each windowed line is sanitized (#751) so the padded
+            // bar row renders exactly as wide as indicatif measures it.
+            let text = self
+                .output
+                .get(start + i)
+                .map_or(String::new(), |l| crate::output::live_line::sanitize(l));
+            pb.set_message(render::paint(GREY, &text, styles.use_color));
         }
+    }
+
+    /// The most recent buffered line, sanitized for a single live annotation
+    /// slot (#751). Skips lines that sanitize away to nothing — a control-only
+    /// line (e.g. a bare erase) must not blank the row's liveness; the last
+    /// line that still carries visible text stays shown. `None` only when no
+    /// buffered line has visible content.
+    pub(super) fn live_tail(&self) -> Option<String> {
+        self.output
+            .iter()
+            .rev()
+            .map(|l| crate::output::live_line::sanitize(l))
+            .find(|s| !s.is_empty())
     }
 
     /// A ticking promoter: a job still silent past `delay` shows a dim elapsed
@@ -495,5 +521,71 @@ mod tests {
             job.record(&format!("line {i}"));
         }
         assert_eq!(job.output().len(), 100);
+    }
+
+    #[test]
+    fn record_keeps_raw_lines_the_live_seam_sanitizes() {
+        // #751: `record` buffers the child line unmodified — the buffer is the
+        // source of truth. VS16 (`✔️`), ANSI color, and `\r` rewrites all
+        // survive verbatim, so the permanent receipt / failure dump keep full
+        // fidelity.
+        let mut job = ThreadedJob::new(None, None);
+        job.record("sync hooks: \u{2714}\u{FE0F} (pre-push)");
+        job.record("\x1b[32m40%\x1b[0m\r\x1b[32m100%\x1b[0m");
+        assert_eq!(
+            job.output(),
+            &[
+                "sync hooks: \u{2714}\u{FE0F} (pre-push)".to_string(),
+                "\x1b[32m40%\x1b[0m\r\x1b[32m100%\x1b[0m".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn live_tail_sanitizes_and_skips_lines_that_sanitize_away() {
+        // The live annotation seam normalizes on the way to the bar: VS16 drops
+        // to text presentation, ANSI/`\r` resolve to the shown segment.
+        let mut job = ThreadedJob::new(None, None);
+        job.record("\u{2714}\u{FE0F} unit tests (33.07 seconds)");
+        assert_eq!(
+            job.live_tail().as_deref(),
+            Some("\u{2714} unit tests (33.07 seconds)")
+        );
+        // A trailing control-only line sanitizes to nothing; the annotation
+        // keeps the last line with visible text rather than blanking (#751).
+        job.record("\x1b[2K");
+        assert_eq!(
+            job.live_tail().as_deref(),
+            Some("\u{2714} unit tests (33.07 seconds)")
+        );
+        // No visible content anywhere → no annotation.
+        let mut blank = ThreadedJob::new(None, None);
+        blank.record("\x1b[2K");
+        assert_eq!(blank.live_tail(), None);
+    }
+
+    #[test]
+    fn roll_window_sanitizes_and_compose_log_keeps_raw() {
+        // The live window and the permanent receipt read the same raw buffer
+        // but diverge at the seam: the window sanitizes (no VS16 reaches a
+        // padded bar row), the receipt keeps the raw evidence under a failure.
+        let mp = MultiProgress::with_draw_target(indicatif::ProgressDrawTarget::hidden());
+        let row = mp.add(ProgressBar::new_spinner());
+        let styles = ThreadStyles::new(false, 0);
+        let mut job = ThreadedJob::new(None, None);
+        job.record("\u{2714}\u{FE0F} done");
+        job.open(&mp, &row, &styles);
+        job.roll_window(&mp, &styles, 4, &row);
+        assert!(
+            job.tail_messages().iter().all(|m| !m.contains('\u{FE0F}')),
+            "VS16 must not reach a live window bar: {:?}",
+            job.tail_messages()
+        );
+        assert!(
+            job.compose_log(&styles, true)
+                .iter()
+                .any(|l| l.contains('\u{FE0F}')),
+            "the failure receipt keeps the raw glyph as evidence"
+        );
     }
 }


### PR DESCRIPTION
## Problem

A hook or `daft exec` child line containing a VS16 emoji — lefthook's `✔️`
(U+2714 + U+FE0F) is the field example — measures one column narrower than
terminals draw it. indicatif pads every drawn row to exactly the terminal width
and derives its cursor move-up / clear math from that same `unicode-width`
measurement, so the padded physical row overflows by one column, wraps, and
every redraw tick leaves a ghost copy of the region's top row behind. On a 1.2s
hook job under a PTY this reproduced as **27 ghost rows** (frozen text,
advancing spinner glyph — matching both field reports).

### Correction to the ticket's root cause

The ticket blamed `{wide_msg}` padding. That's not it: a trailing wide element's
padding is `trim_end`-ed in indicatif's message expansion. The real zero-slack
culprit is the **draw loop** (`DrawState::draw_to_term`), which pads *every* row
— `{msg}` and `{wide_msg}` alike — to terminal width with a filler computed from
per-char `unicode-width` (VS16-blind). Consequences: clamping to `width - 1`
**cannot work** (the filler re-pads whatever a clamp reserves), the block
renderer ghosts on **short** lines too, and over-*wide* sequences (ZWJ emoji,
skin tones) desync in the opposite direction. The only sound daft-side fix is
normalizing child content so rendered width equals measured width.

## The fix — normalize at the live-render seam

- **`output::live_line::sanitize`** (new): strips ANSI (including OSC-8
  hyperlink payloads, which `console::strip_ansi_codes` leaks — a test caught
  it, so we use daft's own `format::strip_ansi`), keeps the final `\r` segment,
  scrubs controls (`\t` → one space), drops variation selectors (so `✔️` becomes
  text-presentation `✔`, honest at 1 column), and reduces a ZWJ *between two
  wide scalars* to its first scalar.
- **The output buffer keeps the raw child line** as the source of truth.
  `sanitize` runs only where a line becomes a bar message: the rolling window
  (`ThreadedJob::roll_window`), the succinct annotation
  (`ThreadedJob::live_tail`), and the block renderer's rolling tail.
- **Permanent surfaces keep full fidelity.** Receipt logs, the deferred failure
  dump, and the block renderer's scrollback echo `println` whole lines from the
  raw buffer — a `println`'d line wraps naturally and never drives move-up math,
  so it cannot ghost, and its color / emoji / alignment survive.
- `daft exec`'s presenter-local `sanitize` — the previous per-site patch of this
  exact class (from #533) — is **deleted** in favor of the shared normalizer.
- `live_tail` skips a line that sanitizes away to nothing, so a control-only
  child line never blanks the row's liveness.

## Review

Ran an `xhigh` `/code-review`. It caught a real regression in the first cut of
this PR: sanitizing at the **capture** seam (one choke point) also degraded the
**permanent** echoes — the block renderer's scrollback and the rail's failure
dump lost color and emoji. This revision resolves that by moving normalization
to the render seam and keeping the buffer raw (findings 1 + 3), fixes the ZWJ
gate so text after a wide scalar + joiner is not eaten (finding 4), and stops a
control-only line from blanking the annotation (finding 6). One finding is
deferred as out of scope and orthogonal to the ghost — `strip_ansi` /
`visible_width` over-consuming visible text after exotic escapes — filed as
#764. One is a documented terminal-dependent residual (a base glyph some
terminals draw in emoji presentation by default; East-Asian-Ambiguous width).

## Testing

- Regression tests pin the sanitizer and each live seam, and assert the
  permanent surfaces keep the raw bytes.
- End-to-end PTY reproduction (scratch repo + VS16-emitting hook, replayed
  through a terminal emulator modelling iTerm2-class emoji widening):
  **27 ghost rows before, 0 after — on both the succinct and verbose paths**.
- `mise run fmt`, `mise run clippy`, and the full unit suite (2965 tests) are
  green.

Fixes #751

🤖 Generated with [Claude Code](https://claude.com/claude-code)
