### PR TITLE
feat(hooks): abort on worktree-post-create failure by default

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -375,6 +375,14 @@ During `daft clone`, `post-clone` fires first (one-time repo bootstrap), then
 `worktree-post-create` (per-worktree setup) — so `post-clone` can install
 foundational tools the per-worktree hooks depend on.
 
+A failing `worktree-post-create` aborts the creation command by default: the
+command exits non-zero and skips its `-x`/`--exec` commands, but the new
+worktree stays on disk. Fix the cause, then
+`daft hooks run worktree-post-create` from inside that worktree to finish setup
+— do not treat the worktree as missing.
+`git config daft.hooks.worktreePostCreate.failMode warn` opts back into
+continue-on-failure.
+
 `pre-merge` aborts the merge on failure; `post-merge` warns but never rolls
 back. Both expose `DAFT_MERGE_*` env vars: `SOURCES`, `TARGET_BRANCH`,
 `TARGET_PATH`, `MODE` (`merge`/`ff`/`squash`/`octopus`), `STRATEGY`,

--- a/docs/hooks/lifecycle.md
+++ b/docs/hooks/lifecycle.md
@@ -120,19 +120,26 @@ layout transform, or adopt). They are available in all four move phases.
 Each hook type has a default fail mode that determines what happens when a hook
 exits with a non-zero status:
 
-| Hook                  | Default Fail Mode | Behavior                              |
-| --------------------- | ----------------- | ------------------------------------- |
-| `worktree-pre-create` | `abort`           | Operation is cancelled                |
-| All others            | `warn`            | Warning is shown, operation continues |
+| Hook                   | Default Fail Mode | Behavior                                                                                         |
+| ---------------------- | ----------------- | ------------------------------------------------------------------------------------------------ |
+| `worktree-pre-create`  | `abort`           | Operation is cancelled                                                                           |
+| `worktree-post-create` | `abort`           | Creation command exits non-zero and skips its `-x`/`--exec` commands; the worktree stays on disk |
+| `pre-merge`            | `abort`           | Merge is aborted                                                                                 |
+| All others             | `warn`            | Warning is shown, operation continues                                                            |
+
+A failed `worktree-post-create` aborts because the `-x`/`--exec` commands (and
+anything else scripted after the creation command) almost always depend on what
+the hook just set up — installed dependencies, a written `.env`, a build.
+Continuing would run them against a half-set-up worktree and exit `0`. The
+worktree itself is deliberately kept so you can inspect or repair it; the error
+names the path and how to re-run the hook.
 
 Override per-hook:
 
 ```bash
-# Make post-create hooks abort on failure
-git config daft.hooks.worktreePostCreate.failMode abort
-
-# Make pre-create hooks just warn
-git config daft.hooks.worktreePreCreate.failMode warn
+# Let creation commands continue past a failing post-create hook
+# (runs -x, warns, exits 0)
+git config daft.hooks.worktreePostCreate.failMode warn
 ```
 
 Hook failures during moves produce **warnings**, not errors. The move operation

--- a/docs/recipes/toolchain-bootstrap.md
+++ b/docs/recipes/toolchain-bootstrap.md
@@ -160,17 +160,22 @@ the thing daft hooks are meant to give you.
 
 ## Tuning the failure mode
 
-By default, `worktree-post-create` failures **warn**: the worktree is created
-even if install fails, leaving you with a half-set-up worktree to retry from. To
-make a failed install abort creation instead:
+By default, a `worktree-post-create` failure **aborts** the creation command: it
+exits non-zero and skips any `-x`/`--exec` commands, so nothing downstream runs
+against a worktree whose install failed. The worktree itself is still created
+and kept — after a flaky install (registry timeout, slow mirror), fix the cause
+and finish setup from inside it:
 
 ```bash
-git config daft.hooks.worktreePostCreate.failMode abort
+daft hooks run worktree-post-create
 ```
 
-The default is `warn` because flaky installs (registry timeouts, slow mirrors)
-are usually recoverable by re-running, and you'd rather have a worktree to retry
-from than no worktree at all.
+If you'd rather worktree creation always report success even when the install
+fails, opt into warn-and-continue:
+
+```bash
+git config daft.hooks.worktreePostCreate.failMode warn
+```
 
 ## Where to next
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -298,6 +298,9 @@ Hook names: `postClone`, `worktreePreCreate`, `worktreePostCreate`,
 Default fail modes:
 
 - `worktreePreCreate`: `abort` (setup must succeed before creating worktree)
+- `worktreePostCreate`: `abort` (a failed setup makes the creation command exit
+  non-zero and skip its `-x`/`--exec` commands; the worktree is kept on disk)
+- `preMerge`: `abort` (gates the merge)
 - All others: `warn` (don't block operations)
 
 ### Hook Output Settings
@@ -349,8 +352,8 @@ git config daft.update.args "--rebase"
 # Disable hooks globally
 git config --global daft.hooks.enabled false
 
-# Make post-create hooks abort on failure
-git config daft.hooks.worktreePostCreate.failMode abort
+# Let creation commands continue past a failing post-create hook
+git config daft.hooks.worktreePostCreate.failMode warn
 ```
 
 ## Environment Variables

--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -1969,23 +1969,39 @@ fn run_start_with_related(
 
     let original_dir = get_current_directory()?;
 
-    // 1) Current repo first — its failure aborts the whole fan-out.
+    // 1) Current repo first. A genuine *creation* failure aborts the whole
+    //    fan-out. A post-create *hook* failure does not (#765): the worktree
+    //    was created, so siblings still get the branch — matching the pre-#765
+    //    fan-out reach — and the command exits non-zero at the end instead.
     let git = GitCommand::new(args.quiet);
     let settings = DaftSettings::load_with(&git)?;
     let git = git.with_gitoxide(settings.use_gitoxide);
     let autocd = settings.autocd && !args.no_cd;
     let mut output = CliOutput::new(OutputConfig::with_autocd(args.quiet, args.verbose, autocd));
 
-    let current_result = match run_create_branch_core(&args, &settings, &git, &mut output) {
-        Ok(result) => result,
-        Err(e) => {
-            change_directory(&original_dir).ok();
-            return Err(e);
-        }
-    };
+    let (current_cd_target, current_post_create_failed) =
+        match run_create_branch_core(&args, &settings, &git, &mut output) {
+            Ok(result) => (result.cd_target, false),
+            Err(e) => match e.downcast::<crate::core::worktree::PostCreateHookFailed>() {
+                // Worktree created here — only the post-create hook failed.
+                // Surface its recovery hint, then carry on to the fan-out.
+                Ok(failed) => {
+                    output.error(&failed.to_string());
+                    (failed.worktree_path.clone(), true)
+                }
+                // Anything else means the branch was not created here: abort.
+                Err(e) => {
+                    change_directory(&original_dir).ok();
+                    return Err(e);
+                }
+            },
+        };
 
-    // 2) Every related repo, collecting failures instead of cascading.
-    let mut failures: Vec<(String, anyhow::Error)> = Vec::new();
+    // 2) Every related repo, distinguishing a post-create hook failure (branch
+    //    created there, only the hook broke) from a genuine creation failure —
+    //    the former must not be reported as "creation failed".
+    let mut creation_failures: Vec<(String, anyhow::Error)> = Vec::new();
+    let mut post_create_failures: Vec<String> = Vec::new();
     for relation in &resolved {
         let row = relation.repo.as_ref().expect("verified upfront");
         output.result(&format!(
@@ -1993,33 +2009,65 @@ fn run_start_with_related(
             args.branch_name, row.name
         ));
         if let Err(e) = create_branch_in_related_repo(row, &args, &mut output) {
-            failures.push((row.name.clone(), e));
+            match e.downcast::<crate::core::worktree::PostCreateHookFailed>() {
+                Ok(_) => post_create_failures.push(row.name.clone()),
+                Err(e) => creation_failures.push((row.name.clone(), e)),
+            }
         }
     }
 
     // 3) Settle in the current repo's new worktree.
-    change_directory(&current_result.cd_target)?;
+    change_directory(&current_cd_target)?;
     if let Some(src) = source_worktree
         && let Ok(git_dir) = get_git_common_dir()
     {
         let _ = previous::save(&git_dir, &src);
     }
 
-    // -x runs only in the current repo (documented).
-    let exec_result = crate::exec::run_exec_commands(&args.exec, &mut output);
-    output.cd_path(&current_result.cd_target);
-    maybe_show_shell_hint(&mut output)?;
-    exec_result?;
+    // -x runs only in the current repo (documented), and only if its
+    // post-create hook succeeded: #765 skips the -x tail on a failed hook and
+    // does not teleport the shell into the half-set-up worktree.
+    if current_post_create_failed {
+        maybe_show_shell_hint(&mut output)?;
+    } else {
+        let exec_result = crate::exec::run_exec_commands(&args.exec, &mut output);
+        output.cd_path(&current_cd_target);
+        maybe_show_shell_hint(&mut output)?;
+        exec_result?;
+    }
 
-    if !failures.is_empty() {
-        for (name, e) in &failures {
-            output.warning(&format!("'{name}': {e}"));
+    // Any post-create hook failure (here or in a sibling) or any genuine
+    // creation failure makes the command exit non-zero (#765).
+    if current_post_create_failed
+        || !post_create_failures.is_empty()
+        || !creation_failures.is_empty()
+    {
+        for (name, e) in &creation_failures {
+            output.warning(&format!("'{name}': creation failed: {e}"));
         }
-        anyhow::bail!(
-            "branch '{}' created here, but creation failed in {} related repo(s)",
-            args.branch_name,
-            failures.len()
-        );
+        for name in &post_create_failures {
+            output.warning(&format!(
+                "'{name}': branch created, but its worktree-post-create hook failed"
+            ));
+        }
+
+        let mut problems: Vec<String> = Vec::new();
+        if current_post_create_failed {
+            problems.push("its post-create hook failed here".to_string());
+        }
+        if !post_create_failures.is_empty() {
+            problems.push(format!(
+                "the post-create hook failed in {} related repo(s)",
+                post_create_failures.len()
+            ));
+        }
+        if !creation_failures.is_empty() {
+            problems.push(format!(
+                "creation failed in {} related repo(s)",
+                creation_failures.len()
+            ));
+        }
+        anyhow::bail!("branch '{}': {}", args.branch_name, problems.join("; "));
     }
     Ok(())
 }

--- a/src/core/settings.rs
+++ b/src/core/settings.rs
@@ -45,7 +45,7 @@
 //! | `daft.hooks.output.tailLines` | `6` | Rolling output tail lines per job (0 = none) |
 //! | `daft.hooks.output.verbose` | `false` | Show skipped jobs and their reasons |
 //! | `daft.hooks.<hookName>.enabled` | `true` | Enable/disable specific hook |
-//! | `daft.hooks.<hookName>.failMode` | varies | Behavior on hook failure (abort/warn) |
+//! | `daft.hooks.<hookName>.failMode` | varies | Behavior on hook failure (abort/warn). Defaults: `worktreePreCreate`, `worktreePostCreate`, `preMerge` abort; all others warn |
 //!
 //! # Example
 //!
@@ -59,8 +59,8 @@
 //! # Disable hooks globally
 //! git config --global daft.hooks.enabled false
 //!
-//! # Make post-create hooks abort on failure
-//! git config daft.hooks.postCreate.failMode abort
+//! # Let creation commands continue past a failing post-create hook
+//! git config daft.hooks.worktreePostCreate.failMode warn
 //! ```
 
 use crate::core::worktree::list::Stat;

--- a/src/core/worktree/checkout.rs
+++ b/src/core/worktree/checkout.rs
@@ -4,7 +4,7 @@
 
 use crate::core::layout::{Layout, auto_gitignore_if_needed};
 use crate::core::stage::{PlanCommit, Row, StageEvent, StageId, StepKey, StepSpec};
-use crate::core::{HookOutcome, HookRunner, ProgressSink};
+use crate::core::{HookRunner, ProgressSink};
 use crate::git::GitCommand;
 use crate::hooks::{HookContext, HookType};
 use crate::multi_remote::path::{
@@ -159,7 +159,6 @@ pub struct CheckoutResult {
     pub upstream_set: bool,
     pub upstream_skipped: bool,
     pub git_dir: PathBuf,
-    pub post_hook_outcome: HookOutcome,
 }
 
 /// Execute the checkout operation.
@@ -248,11 +247,6 @@ pub fn execute(
             upstream_set: false,
             upstream_skipped: true,
             git_dir,
-            post_hook_outcome: HookOutcome {
-                success: true,
-                skipped: true,
-                skip_reason: None,
-            },
         });
     }
 
@@ -280,11 +274,6 @@ pub fn execute(
             upstream_set: false,
             upstream_skipped: true,
             git_dir,
-            post_hook_outcome: HookOutcome {
-                success: true,
-                skipped: true,
-                skip_reason: None,
-            },
         });
     }
 
@@ -724,7 +713,13 @@ pub fn execute(
     )
     .with_new_branch(false);
 
-    let post_hook_outcome = sink.run_hook(&post_hook_ctx)?;
+    // A failed post-create aborts by default (#765): the Err propagates to
+    // the command layer, which returns before the `-x` tail and exits
+    // non-zero. Under `failMode=warn` the run returns Ok (success: false)
+    // and the command proceeds — that outcome is deliberately not captured;
+    // Err propagation is the single abort mechanism.
+    sink.run_hook(&post_hook_ctx)
+        .map_err(|e| super::post_create_failure_error(e, &worktree_path, &params.branch_name))?;
 
     Ok(CheckoutResult {
         branch_name: params.branch_name.clone(),
@@ -736,7 +731,6 @@ pub fn execute(
         upstream_set,
         upstream_skipped,
         git_dir,
-        post_hook_outcome,
     })
 }
 

--- a/src/core/worktree/checkout.rs
+++ b/src/core/worktree/checkout.rs
@@ -717,9 +717,11 @@ pub fn execute(
     // the command layer, which returns before the `-x` tail and exits
     // non-zero. Under `failMode=warn` the run returns Ok (success: false)
     // and the command proceeds — that outcome is deliberately not captured;
-    // Err propagation is the single abort mechanism.
-    sink.run_hook(&post_hook_ctx)
-        .map_err(|e| super::post_create_failure_error(e, &worktree_path, &params.branch_name))?;
+    // Err propagation is the single abort mechanism. `was_new_branch = false`:
+    // this branch pre-existed, so the recovery hint must not offer to delete it.
+    sink.run_hook(&post_hook_ctx).map_err(|e| {
+        super::post_create_failure_error(e, &worktree_path, &params.branch_name, false)
+    })?;
 
     Ok(CheckoutResult {
         branch_name: params.branch_name.clone(),

--- a/src/core/worktree/checkout_branch.rs
+++ b/src/core/worktree/checkout_branch.rs
@@ -369,8 +369,31 @@ pub fn execute(
     // non-zero. Under `failMode=warn` the run returns Ok (success: false)
     // and the command proceeds — that outcome is deliberately not captured;
     // Err propagation is the single abort mechanism.
-    sink.run_hook(&post_hook_ctx).map_err(|e| {
-        super::post_create_failure_error(e, &worktree_path, &params.new_branch_name)
+    let post_create_result = sink.run_hook(&post_hook_ctx);
+
+    // The upstream push ran before the hook, so on a post-create abort the
+    // remote state is already mutated — surface it now, because the abort
+    // error below becomes the command's failure and the deferred pre-push
+    // gate bail (#599) a few lines down is never reached (#765 review,
+    // findings 4 & 5).
+    if post_create_result.is_err() {
+        if let Some(message) = &push_gate_error {
+            sink.on_warning(&format!(
+                "the upstream push of '{}' was refused: {message}",
+                params.new_branch_name
+            ));
+        } else if push_set {
+            sink.on_warning(&format!(
+                "note: '{}' was already pushed to '{}' before the hook failed",
+                params.new_branch_name, params.remote_name
+            ));
+        }
+    }
+
+    // `was_new_branch = true`: this command created the branch, so `daft remove`
+    // is a safe cleanup suggestion.
+    post_create_result.map_err(|e| {
+        super::post_create_failure_error(e, &worktree_path, &params.new_branch_name, true)
     })?;
 
     // The worktree is fully set up — now surface a deferred pre-push gate

--- a/src/core/worktree/checkout_branch.rs
+++ b/src/core/worktree/checkout_branch.rs
@@ -10,7 +10,7 @@ use crate::core::worktree::ports::NoopStageRunner;
 use crate::core::worktree::push::{
     HookVerdict, PushAction, PushPayload, push_with_hooks, resolve_pre_push_plan,
 };
-use crate::core::{HookOutcome, HookRunner, ProgressSink};
+use crate::core::{HookRunner, ProgressSink};
 use crate::executor::presenter::JobPresenter;
 use crate::git::GitCommand;
 use crate::hooks::{HookContext, HookType};
@@ -72,7 +72,6 @@ pub struct CheckoutBranchResult {
     pub push_set: bool,
     pub push_skipped: bool,
     pub git_dir: PathBuf,
-    pub post_hook_outcome: HookOutcome,
 }
 
 /// Execute the checkout-branch operation.
@@ -365,7 +364,14 @@ pub fn execute(
     .with_new_branch(true)
     .with_base_branch(&base_branch);
 
-    let post_hook_outcome = sink.run_hook(&post_hook_ctx)?;
+    // A failed post-create aborts by default (#765): the Err propagates to
+    // the command layer, which returns before the `-x` tail and exits
+    // non-zero. Under `failMode=warn` the run returns Ok (success: false)
+    // and the command proceeds — that outcome is deliberately not captured;
+    // Err propagation is the single abort mechanism.
+    sink.run_hook(&post_hook_ctx).map_err(|e| {
+        super::post_create_failure_error(e, &worktree_path, &params.new_branch_name)
+    })?;
 
     // The worktree is fully set up — now surface a deferred pre-push gate
     // refusal as the command's failure (#599 acceptance: non-zero exit).
@@ -383,7 +389,6 @@ pub fn execute(
         push_set,
         push_skipped,
         git_dir,
-        post_hook_outcome,
     })
 }
 

--- a/src/core/worktree/mod.rs
+++ b/src/core/worktree/mod.rs
@@ -63,6 +63,31 @@ impl Default for WorktreeConfig {
 /// identically wherever the row appears.
 pub(crate) const FETCH_FAILED_REASON: &str = "failed \u{2014} continuing with local refs";
 
+/// Wrap a failed `worktree-post-create` run with the state the user is left
+/// in. Post-create failure aborts the creation command by default (#765):
+/// the `Err` built here propagates to the command layer, which returns
+/// before its `-x`/`--exec` tail and exits non-zero — but the worktree
+/// already exists and is deliberately kept on disk (a partially-populated
+/// `.env`/`node_modules` may be worth inspecting or repairing, and removal
+/// is one `remove` away). Shared by the two creation cores.
+pub(crate) fn post_create_failure_error(
+    err: anyhow::Error,
+    worktree_path: &std::path::Path,
+    branch_name: &str,
+) -> anyhow::Error {
+    anyhow::anyhow!(
+        "{err}\n  \
+         The worktree was created and kept at '{path}'; any -x/--exec commands were skipped.\n  \
+         tip: fix the hook and re-run it from that worktree with `{rerun}`, or remove the \
+         worktree with `{remove}`.\n  \
+         To continue past post-create failures instead: \
+         `git config daft.hooks.worktreePostCreate.failMode warn`",
+        path = worktree_path.display(),
+        rerun = crate::daft_cmd("hooks run worktree-post-create"),
+        remove = crate::daft_cmd(&format!("remove {branch_name}")),
+    )
+}
+
 /// Resolve the planned Carry row (#651): a clean tree resolves silently —
 /// the row vanishes — an applied stash completes, and a conflicted one
 /// fails with the recovery hint. Shared by the two creation cores, whose
@@ -89,5 +114,26 @@ pub(crate) fn resolve_carry_row(
                 detail: "stash conflicts \u{2014} run git stash pop".to_string(),
             },
         );
+    }
+}
+
+#[cfg(test)]
+mod post_create_failure_tests {
+    #[test]
+    fn message_names_state_and_recovery() {
+        let err = super::post_create_failure_error(
+            anyhow::anyhow!("worktree-post-create hook failed with exit code 1"),
+            std::path::Path::new("/tmp/wt/feat-x"),
+            "feat-x",
+        );
+        let msg = err.to_string();
+        // The original failure stays first…
+        assert!(msg.contains("worktree-post-create hook failed with exit code 1"));
+        // …followed by the state the user is left in and every recovery path.
+        assert!(msg.contains("created and kept at '/tmp/wt/feat-x'"));
+        assert!(msg.contains("-x/--exec commands were skipped"));
+        assert!(msg.contains("hooks run worktree-post-create"));
+        assert!(msg.contains("remove feat-x"));
+        assert!(msg.contains("daft.hooks.worktreePostCreate.failMode warn"));
     }
 }

--- a/src/core/worktree/mod.rs
+++ b/src/core/worktree/mod.rs
@@ -63,29 +63,100 @@ impl Default for WorktreeConfig {
 /// identically wherever the row appears.
 pub(crate) const FETCH_FAILED_REASON: &str = "failed \u{2014} continuing with local refs";
 
-/// Wrap a failed `worktree-post-create` run with the state the user is left
-/// in. Post-create failure aborts the creation command by default (#765):
-/// the `Err` built here propagates to the command layer, which returns
-/// before its `-x`/`--exec` tail and exits non-zero — but the worktree
-/// already exists and is deliberately kept on disk (a partially-populated
-/// `.env`/`node_modules` may be worth inspecting or repairing, and removal
-/// is one `remove` away). Shared by the two creation cores.
+/// A `worktree-post-create` hook that failed under the default abort fail
+/// mode (#765).
+///
+/// This is a *typed* error rather than a bare `anyhow!` on purpose. It carries
+/// two distinct meanings for its two kinds of caller:
+///
+///   - **Single-repo cores** propagate it with `?`. Its `Display` is the
+///     user-facing recovery message, and the `?` returns before the command's
+///     `-x`/`--exec` tail runs — fail-closed, so a forgotten check can never
+///     re-open the "`-x` ran after a failed hook" hole this change closed.
+///   - **The `--with-related` fan-out** `downcast`s it to tell "worktree
+///     created, hook failed" apart from "creation failed": siblings still get
+///     the branch (as before #765), each repo's outcome is reported
+///     accurately, and the command still exits non-zero.
+///
+/// The worktree already exists and is deliberately kept on disk (a
+/// partially-populated `.env`/`node_modules` may be worth inspecting or
+/// repairing).
+#[derive(Debug)]
+pub(crate) struct PostCreateHookFailed {
+    /// The original hook-failure error (exit code + stderr).
+    source: anyhow::Error,
+    /// The created-and-kept worktree.
+    pub worktree_path: std::path::PathBuf,
+    /// The branch the worktree is on.
+    pub branch_name: String,
+    /// Whether *this command* created `branch_name`. When false (an
+    /// existing-branch checkout), the branch pre-existed the command, so the
+    /// recovery hint must NOT suggest `daft remove <branch>` — that would
+    /// delete a branch the user already had (#765 review, finding 1).
+    was_new_branch: bool,
+}
+
+impl std::fmt::Display for PostCreateHookFailed {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // The original failure stays first, then the state the user is left in
+        // and every recovery path. (Display embeds the source rather than
+        // exposing it via `Error::source`, so anyhow prints this message once
+        // — it does not also walk and re-print the chained cause.)
+        write!(
+            f,
+            "{source}\n  \
+             The worktree was created and kept at '{path}'; any -x/--exec commands were skipped.\n  ",
+            source = self.source,
+            path = self.worktree_path.display(),
+        )?;
+        let rerun = crate::daft_cmd("hooks run worktree-post-create");
+        if self.was_new_branch {
+            let remove = crate::daft_cmd(&format!("remove {}", self.branch_name));
+            write!(
+                f,
+                "tip: fix the hook and re-run it from that worktree with `{rerun}`, or remove the \
+                 worktree with `{remove}`.\n  ",
+            )?;
+        } else {
+            // Existing branch: `daft remove` would delete the pre-existing
+            // branch (and its remote), not just the worktree, so point at
+            // git's worktree-only removal instead.
+            write!(
+                f,
+                "tip: fix the hook and re-run it from that worktree with `{rerun}`. The branch \
+                 '{branch}' already existed and is unchanged; to discard just this worktree run \
+                 `git worktree remove {path}`.\n  ",
+                branch = self.branch_name,
+                path = self.worktree_path.display(),
+            )?;
+        }
+        write!(
+            f,
+            "To continue past post-create failures instead: \
+             `git config daft.hooks.worktreePostCreate.failMode warn`",
+        )
+    }
+}
+
+impl std::error::Error for PostCreateHookFailed {}
+
+/// Wrap a failed `worktree-post-create` run as a [`PostCreateHookFailed`].
+/// `was_new_branch` distinguishes the branch-creating cores (`start` /
+/// `checkout -b`, which may safely suggest `daft remove`) from the
+/// existing-branch checkout, whose branch must not be offered for deletion.
+/// Shared by the two creation cores.
 pub(crate) fn post_create_failure_error(
     err: anyhow::Error,
     worktree_path: &std::path::Path,
     branch_name: &str,
+    was_new_branch: bool,
 ) -> anyhow::Error {
-    anyhow::anyhow!(
-        "{err}\n  \
-         The worktree was created and kept at '{path}'; any -x/--exec commands were skipped.\n  \
-         tip: fix the hook and re-run it from that worktree with `{rerun}`, or remove the \
-         worktree with `{remove}`.\n  \
-         To continue past post-create failures instead: \
-         `git config daft.hooks.worktreePostCreate.failMode warn`",
-        path = worktree_path.display(),
-        rerun = crate::daft_cmd("hooks run worktree-post-create"),
-        remove = crate::daft_cmd(&format!("remove {branch_name}")),
-    )
+    anyhow::Error::new(PostCreateHookFailed {
+        source: err,
+        worktree_path: worktree_path.to_path_buf(),
+        branch_name: branch_name.to_string(),
+        was_new_branch,
+    })
 }
 
 /// Resolve the planned Carry row (#651): a clean tree resolves silently —
@@ -120,11 +191,12 @@ pub(crate) fn resolve_carry_row(
 #[cfg(test)]
 mod post_create_failure_tests {
     #[test]
-    fn message_names_state_and_recovery() {
+    fn new_branch_message_names_state_and_recovery() {
         let err = super::post_create_failure_error(
             anyhow::anyhow!("worktree-post-create hook failed with exit code 1"),
             std::path::Path::new("/tmp/wt/feat-x"),
             "feat-x",
+            true,
         );
         let msg = err.to_string();
         // The original failure stays first…
@@ -133,7 +205,30 @@ mod post_create_failure_tests {
         assert!(msg.contains("created and kept at '/tmp/wt/feat-x'"));
         assert!(msg.contains("-x/--exec commands were skipped"));
         assert!(msg.contains("hooks run worktree-post-create"));
+        // The branch was just created, so offering to remove it is safe.
         assert!(msg.contains("remove feat-x"));
+        assert!(msg.contains("daft.hooks.worktreePostCreate.failMode warn"));
+    }
+
+    #[test]
+    fn existing_branch_message_does_not_offer_to_delete_the_branch() {
+        // finding 1: on the existing-branch checkout path the branch pre-existed
+        // the command, so the hint must not steer the user at `daft remove`
+        // (which deletes the branch), only at git's worktree-only removal.
+        let err = super::post_create_failure_error(
+            anyhow::anyhow!("worktree-post-create hook failed with exit code 1"),
+            std::path::Path::new("/tmp/wt/existing-feature"),
+            "existing-feature",
+            false,
+        );
+        let msg = err.to_string();
+        assert!(msg.contains("created and kept at '/tmp/wt/existing-feature'"));
+        assert!(msg.contains("hooks run worktree-post-create"));
+        // No `daft remove` steer — that would destroy the pre-existing branch.
+        assert!(!msg.contains("remove existing-feature"));
+        // Instead: reassure the branch is untouched, point at git worktree removal.
+        assert!(msg.contains("already existed and is unchanged"));
+        assert!(msg.contains("git worktree remove /tmp/wt/existing-feature"));
         assert!(msg.contains("daft.hooks.worktreePostCreate.failMode warn"));
     }
 }

--- a/src/hooks/executor.rs
+++ b/src/hooks/executor.rs
@@ -1159,6 +1159,67 @@ mod tests {
     }
 
     #[test]
+    fn post_create_failure_aborts_by_default() {
+        let temp_dir = tempdir().unwrap();
+        let worktree = temp_dir.path().join("main");
+        fs::create_dir_all(&worktree).unwrap();
+
+        create_test_hook(&worktree, "worktree-post-create", "#!/bin/bash\nexit 1");
+
+        let ctx = test_ctx_with_state(temp_dir.path(), &worktree, HookType::PostCreate, "main");
+
+        let mut trust_db = TrustDatabase::default();
+        trust_db.set_trust_level(&ctx.git_dir, TrustLevel::Allow);
+        let executor = HookExecutor::with_trust_db(HooksConfig::default(), trust_db);
+        let mut output = TestOutput::default();
+
+        // #765: a failed post-create aborts (Err) under the default config,
+        // so the creation command skips its `-x` tail and exits non-zero.
+        let err = executor
+            .execute(&ctx, &mut output, NullPresenter::arc())
+            .expect_err("post-create failure must abort by default");
+        assert!(
+            err.to_string().contains("worktree-post-create hook failed"),
+            "unexpected abort message: {err}"
+        );
+    }
+
+    #[test]
+    fn post_create_failure_warn_mode_continues() {
+        let temp_dir = tempdir().unwrap();
+        let worktree = temp_dir.path().join("main");
+        fs::create_dir_all(&worktree).unwrap();
+
+        create_test_hook(&worktree, "worktree-post-create", "#!/bin/bash\nexit 1");
+
+        let ctx = test_ctx_with_state(temp_dir.path(), &worktree, HookType::PostCreate, "main");
+
+        let mut config = HooksConfig::default();
+        config.worktree_post_create.fail_mode = FailMode::Warn;
+        let mut trust_db = TrustDatabase::default();
+        trust_db.set_trust_level(&ctx.git_dir, TrustLevel::Allow);
+        let executor = HookExecutor::with_trust_db(config, trust_db);
+        let mut output = TestOutput::default();
+
+        // `failMode=warn` is the #765 opt-out: the failure is reported but
+        // the run returns Ok so the creation command continues (runs `-x`,
+        // exits 0).
+        let result = executor
+            .execute(&ctx, &mut output, NullPresenter::arc())
+            .expect("warn mode must not abort");
+        assert!(!result.success);
+        assert!(!result.skipped);
+        assert!(
+            output
+                .warnings()
+                .iter()
+                .any(|w| w.contains("continuing anyway")),
+            "warn mode should announce it is continuing: {:?}",
+            output.warnings()
+        );
+    }
+
+    #[test]
     fn test_get_hook_source_worktree_post_remove_non_move_uses_source() {
         let ctx = HookContext::new(
             HookType::PostRemove,

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -209,6 +209,12 @@ impl HookType {
             // Pre-create and pre-merge hooks should abort by default
             // (setup / safety rails must succeed before the operation).
             HookType::PreCreate | HookType::PreMerge => FailMode::Abort,
+            // Post-create aborts by default too (#765): it gates the
+            // `-x`/`--exec` tail and the command's exit code. Continuing
+            // would run exec commands against a half-set-up worktree and
+            // exit 0 on a failed setup. `failMode=warn` opts back into
+            // continue-on-failure.
+            HookType::PostCreate => FailMode::Abort,
             // All other hooks warn by default (don't block operations)
             _ => FailMode::Warn,
         }
@@ -699,8 +705,11 @@ mod tests {
     #[test]
     fn test_hook_type_default_fail_mode() {
         assert_eq!(HookType::PreCreate.default_fail_mode(), FailMode::Abort);
-        assert_eq!(HookType::PostCreate.default_fail_mode(), FailMode::Warn);
+        // Post-create aborts by default (#765): it gates the `-x` tail and
+        // the creation command's exit code.
+        assert_eq!(HookType::PostCreate.default_fail_mode(), FailMode::Abort);
         assert_eq!(HookType::PreRemove.default_fail_mode(), FailMode::Warn);
+        assert_eq!(HookType::PostRemove.default_fail_mode(), FailMode::Warn);
     }
 
     #[test]
@@ -729,7 +738,7 @@ mod tests {
         assert!(config.worktree_pre_create.enabled);
         assert_eq!(config.worktree_pre_create.fail_mode, FailMode::Abort);
         assert!(config.worktree_post_create.enabled);
-        assert_eq!(config.worktree_post_create.fail_mode, FailMode::Warn);
+        assert_eq!(config.worktree_post_create.fail_mode, FailMode::Abort);
     }
 
     #[test]
@@ -765,6 +774,10 @@ mod tests {
 
         let config = HookConfig::new(HookType::PostCreate);
         assert!(config.enabled);
+        assert_eq!(config.fail_mode, FailMode::Abort);
+
+        let config = HookConfig::new(HookType::PostRemove);
+        assert!(config.enabled);
         assert_eq!(config.fail_mode, FailMode::Warn);
     }
 
@@ -777,6 +790,10 @@ mod tests {
         );
         assert_eq!(
             config.get_hook_config(HookType::PostCreate).fail_mode,
+            FailMode::Abort
+        );
+        assert_eq!(
+            config.get_hook_config(HookType::PostRemove).fail_mode,
             FailMode::Warn
         );
     }

--- a/tests/manual/scenarios/checkout-branch/start-with-related-current-post-create-abort.yml
+++ b/tests/manual/scenarios/checkout-branch/start-with-related-current-post-create-abort.yml
@@ -1,0 +1,76 @@
+name: Start --with-related fans out despite a current-repo post-create failure
+description:
+  "A failing worktree-post-create hook in the primary repo of a daft start
+  --with-related fan-out must NOT abort the fan-out (#765 review): the branch is
+  still created in every related repo, the primary worktree is kept, and the
+  command exits non-zero. Regression test — Err propagation from the creation
+  core previously short-circuited the sibling repos entirely."
+
+repos:
+  - name: test-rel-a
+    default_branch: main
+    branches:
+      - name: main
+        files:
+          - path: README.md
+            content: "# rel-a"
+        commits:
+          - message: "Initial commit"
+    daft_yml: |
+      hooks:
+        worktree-post-create:
+          jobs:
+            - name: setup
+              run: exit 1
+  - name: test-rel-b
+    default_branch: main
+    branches:
+      - name: main
+        files:
+          - path: README.md
+            content: "# rel-b"
+        commits:
+          - message: "Initial commit"
+
+steps:
+  - name: Clone both repos
+    run:
+      git-worktree-clone --layout contained $REMOTE_TEST_REL_A &&
+      git-worktree-clone --layout contained $REMOTE_TEST_REL_B
+    expect:
+      exit_code: 0
+
+  - name: Trust both repos
+    run:
+      'cd "$WORK_DIR/test-rel-a/main" && daft hooks trust --force && cd
+      "$WORK_DIR/test-rel-b/main" && daft hooks trust --force 2>&1'
+    expect:
+      exit_code: 0
+
+  - name: Declare a relation from A to B (keeping the committed failing hook)
+    run: |
+      printf 'relations:\n  - url: %s\n' "$REMOTE_TEST_REL_B" >> daft.yml
+    cwd: "$WORK_DIR/test-rel-a/main"
+    expect:
+      exit_code: 0
+
+  - name: Fan-out reaches the sibling even though the primary hook failed
+    run: daft start feat-sync --with-related 2>&1
+    cwd: "$WORK_DIR/test-rel-a/main"
+    expect:
+      exit_code: 1
+      output_contains:
+        - "worktree-post-create hook failed"
+        - "Creating 'feat-sync' in 'test-rel-b'"
+        - "its post-create hook failed here"
+      dirs_exist:
+        - "$WORK_DIR/test-rel-a/feat-sync"
+        - "$WORK_DIR/test-rel-b/feat-sync"
+
+  - name: The sibling branch reached its remote
+    run: "true"
+    expect:
+      exit_code: 0
+      branch_exists:
+        - repo: test-rel-b
+          branch: feat-sync

--- a/tests/manual/scenarios/checkout-branch/start-with-related-sibling-post-create-abort.yml
+++ b/tests/manual/scenarios/checkout-branch/start-with-related-sibling-post-create-abort.yml
@@ -1,0 +1,69 @@
+name: Start --with-related reports a related-repo post-create failure distinctly
+description:
+  "When a trusted related repo's worktree-post-create hook fails during a daft
+  start --with-related fan-out, the branch WAS created there — daft must report
+  'branch created, but its worktree-post-create hook failed', never 'creation
+  failed' (#765 review). The command still exits non-zero and both worktrees are
+  kept."
+
+repos:
+  - name: test-rel-a
+    default_branch: main
+    branches:
+      - name: main
+        files:
+          - path: README.md
+            content: "# rel-a"
+        commits:
+          - message: "Initial commit"
+  - name: test-rel-b
+    default_branch: main
+    branches:
+      - name: main
+        files:
+          - path: README.md
+            content: "# rel-b"
+        commits:
+          - message: "Initial commit"
+    daft_yml: |
+      hooks:
+        worktree-post-create:
+          jobs:
+            - name: setup
+              run: exit 1
+
+steps:
+  - name: Clone both repos
+    run:
+      git-worktree-clone --layout contained $REMOTE_TEST_REL_A &&
+      git-worktree-clone --layout contained $REMOTE_TEST_REL_B
+    expect:
+      exit_code: 0
+
+  - name: Trust the related repo so its post-create hook runs in the fan-out
+    run: daft hooks trust --force 2>&1
+    cwd: "$WORK_DIR/test-rel-b/main"
+    expect:
+      exit_code: 0
+
+  - name: Declare a relation from A to B
+    run: |
+      printf 'relations:\n  - url: %s\n' "$REMOTE_TEST_REL_B" > daft.yml
+    cwd: "$WORK_DIR/test-rel-a/main"
+    expect:
+      exit_code: 0
+
+  - name:
+      The sibling's hook failure is reported as such, not as creation failure
+    run: daft start feat-sync --with-related 2>&1
+    cwd: "$WORK_DIR/test-rel-a/main"
+    expect:
+      exit_code: 1
+      output_contains:
+        - "branch created, but its worktree-post-create hook failed"
+        - "the post-create hook failed in 1 related repo(s)"
+      output_not_contains:
+        - "creation failed"
+      dirs_exist:
+        - "$WORK_DIR/test-rel-a/feat-sync"
+        - "$WORK_DIR/test-rel-b/feat-sync"

--- a/tests/manual/scenarios/hooks/cross-worktree-retry.yml
+++ b/tests/manual/scenarios/hooks/cross-worktree-retry.yml
@@ -39,7 +39,9 @@ steps:
     run: env -u DAFT_TESTING git-worktree-checkout feature/target 2>&1
     cwd: "$WORK_DIR/test-cross-retry/main"
     expect:
-      exit_code: 0
+      # Post-create failure aborts the command by default (#765); the
+      # worktree is kept and the failed invocation is still recorded.
+      exit_code: 1
 
   - name: Retry from main worktree using --worktree flag
     run: daft hooks jobs retry --worktree feature/target 2>&1

--- a/tests/manual/scenarios/hooks/deleted-worktree-retry.yml
+++ b/tests/manual/scenarios/hooks/deleted-worktree-retry.yml
@@ -38,7 +38,9 @@ steps:
     run: env -u DAFT_TESTING git-worktree-checkout feature/ephemeral 2>&1
     cwd: "$WORK_DIR/test-deleted-retry/main"
     expect:
-      exit_code: 0
+      # Post-create failure aborts the command by default (#765); the
+      # worktree is kept and the failed invocation is still recorded.
+      exit_code: 1
 
   - name: Remove the worktree
     run: daft remove feature/ephemeral --force 2>&1

--- a/tests/manual/scenarios/hooks/listing-filters.yml
+++ b/tests/manual/scenarios/hooks/listing-filters.yml
@@ -40,7 +40,9 @@ steps:
     run: env -u DAFT_TESTING git-worktree-checkout feature/filters 2>&1
     cwd: "$WORK_DIR/test-listing-filters/main"
     expect:
-      exit_code: 0
+      # Post-create failure aborts the command by default (#765); the
+      # worktree is kept and the failed invocation is still recorded.
+      exit_code: 1
 
   - name: Filter by --status failed shows the invocation
     run: daft hooks jobs --status failed 2>&1

--- a/tests/manual/scenarios/hooks/post-create-abort.yml
+++ b/tests/manual/scenarios/hooks/post-create-abort.yml
@@ -1,0 +1,81 @@
+name: Post-create hook failure aborts by default, failMode=warn opts out
+description:
+  "A failing worktree-post-create hook makes the creation command skip its
+  -x/--exec tail and exit non-zero, while the worktree itself is kept on disk
+  (#765). Setting daft.hooks.worktreePostCreate.failMode=warn restores the old
+  continue-on-failure behavior: -x runs and the command exits 0."
+
+repos:
+  - name: test-pc-abort
+    default_branch: main
+    branches:
+      - name: main
+        files:
+          - path: README.md
+            content: "# Post-create abort test"
+        commits:
+          - message: "Initial commit"
+      - name: feat-abort
+        from: main
+      - name: feat-warn
+        from: main
+    daft_yml: |
+      hooks:
+        worktree-post-create:
+          jobs:
+            - name: setup
+              run: exit 1
+
+steps:
+  - name: Clone the repository
+    run: git-worktree-clone --layout contained $REMOTE_TEST_PC_ABORT
+    expect:
+      exit_code: 0
+
+  - name: Trust the repository
+    run: daft hooks trust --force 2>&1
+    cwd: "$WORK_DIR/test-pc-abort/main"
+    expect:
+      exit_code: 0
+
+  - name: Checkout with failing post-create skips -x and exits non-zero
+    run: git-worktree-checkout feat-abort -x 'touch exec-marker.txt' 2>&1
+    cwd: "$WORK_DIR/test-pc-abort/main"
+    expect:
+      exit_code: 1
+      output_contains:
+        - "worktree-post-create hook failed"
+        - "created and kept"
+      files_not_exist:
+        - "$WORK_DIR/test-pc-abort/feat-abort/exec-marker.txt"
+      dirs_exist:
+        - "$WORK_DIR/test-pc-abort/feat-abort"
+
+  - name: New-branch creation with failing post-create also aborts before -x
+    run: git-worktree-checkout -b feat-new -x 'touch exec-marker.txt' 2>&1
+    cwd: "$WORK_DIR/test-pc-abort/main"
+    expect:
+      exit_code: 1
+      output_contains:
+        - "worktree-post-create hook failed"
+        - "created and kept"
+      files_not_exist:
+        - "$WORK_DIR/test-pc-abort/feat-new/exec-marker.txt"
+      dirs_exist:
+        - "$WORK_DIR/test-pc-abort/feat-new"
+
+  - name: failMode=warn restores continue-on-failure
+    run: git config daft.hooks.worktreePostCreate.failMode warn
+    cwd: "$WORK_DIR/test-pc-abort/main"
+    expect:
+      exit_code: 0
+
+  - name: Checkout under warn runs -x and exits 0 despite the failing hook
+    run: git-worktree-checkout feat-warn -x 'touch exec-marker.txt' 2>&1
+    cwd: "$WORK_DIR/test-pc-abort/main"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "continuing anyway"
+      files_exist:
+        - "$WORK_DIR/test-pc-abort/feat-warn/exec-marker.txt"

--- a/tests/manual/scenarios/hooks/repo-identity-on-reclone.yml
+++ b/tests/manual/scenarios/hooks/repo-identity-on-reclone.yml
@@ -40,7 +40,9 @@ steps:
     run: env -u DAFT_TESTING git-worktree-checkout feature/rx 2>&1
     cwd: "$WORK_DIR/test-reclone-id/main"
     expect:
-      exit_code: 0
+      # Post-create failure aborts the command by default (#765); the
+      # worktree is kept and the failed invocation is still recorded.
+      exit_code: 1
 
   - name: List jobs — should show the failed invocation
     run: daft hooks jobs --all 2>&1

--- a/tests/manual/scenarios/hooks/retry-empty.yml
+++ b/tests/manual/scenarios/hooks/retry-empty.yml
@@ -54,7 +54,9 @@ steps:
     run: env -u DAFT_TESTING git-worktree-checkout feature/retry 2>&1
     cwd: "$WORK_DIR/test-retry-empty/main"
     expect:
-      exit_code: 0
+      # Post-create failure aborts the command by default (#765); the
+      # worktree is kept and the failed invocation is still recorded.
+      exit_code: 1
       output_contains:
         - "failing on purpose"
 

--- a/tests/manual/scenarios/hooks/retry-hook-name.yml
+++ b/tests/manual/scenarios/hooks/retry-hook-name.yml
@@ -38,7 +38,9 @@ steps:
     run: env -u DAFT_TESTING git-worktree-checkout feature/rh 2>&1
     cwd: "$WORK_DIR/test-retry-hook/main"
     expect:
-      exit_code: 0
+      # Post-create failure aborts the command by default (#765); the
+      # worktree is kept and the failed invocation is still recorded.
+      exit_code: 1
 
   - name: List jobs — should show one invocation with a failed job
     run: daft hooks jobs 2>&1

--- a/tests/manual/scenarios/hooks/retry-invocation-prefix.yml
+++ b/tests/manual/scenarios/hooks/retry-invocation-prefix.yml
@@ -38,7 +38,9 @@ steps:
     run: env -u DAFT_TESTING git-worktree-checkout feature/inv 2>&1
     cwd: "$WORK_DIR/test-retry-inv/main"
     expect:
-      exit_code: 0
+      # Post-create failure aborts the command by default (#765); the
+      # worktree is kept and the failed invocation is still recorded.
+      exit_code: 1
 
   - name: Retry using --inv flag with a short prefix from the listing
     run: |

--- a/tests/manual/scenarios/hooks/retry-job-name.yml
+++ b/tests/manual/scenarios/hooks/retry-job-name.yml
@@ -43,7 +43,9 @@ steps:
     run: env -u DAFT_TESTING git-worktree-checkout feature/rj 2>&1
     cwd: "$WORK_DIR/test-retry-job/main"
     expect:
-      exit_code: 0
+      # Post-create failure aborts the command by default (#765); the
+      # worktree is kept and the failed invocation is still recorded.
+      exit_code: 1
 
   - name: Retry the failed job by name
     run: daft hooks jobs retry fails-here 2>&1

--- a/tests/manual/scenarios/hooks/retry-mixed-fg-bg.yml
+++ b/tests/manual/scenarios/hooks/retry-mixed-fg-bg.yml
@@ -44,7 +44,9 @@ steps:
     run: env -u DAFT_TESTING git-worktree-checkout feature/mix 2>&1
     cwd: "$WORK_DIR/test-retry-mixed/main"
     expect:
-      exit_code: 0
+      # Post-create failure aborts the command by default (#765); the
+      # worktree is kept and the failed invocation is still recorded.
+      exit_code: 1
 
   - name: Wait for bg-fail to reach terminal state, then list
     # The old loop exited as soon as ANY job had status "failed", which

--- a/tests/manual/scenarios/hooks/retry-needs-pruning.yml
+++ b/tests/manual/scenarios/hooks/retry-needs-pruning.yml
@@ -53,7 +53,9 @@ steps:
     run: env -u DAFT_TESTING git-worktree-checkout feature/dag 2>&1
     cwd: "$WORK_DIR/test-retry-dag/main"
     expect:
-      exit_code: 0
+      # Post-create failure aborts the command by default (#765); the
+      # worktree is kept and the failed invocation is still recorded.
+      exit_code: 1
 
   - name: List jobs — a completed, b failed
     run: daft hooks jobs 2>&1


### PR DESCRIPTION
## What

Make a failing `worktree-post-create` hook **abort** the creation command by
default: it exits non-zero, skips any `-x`/`--exec` tail, and keeps the created
worktree on disk. The old warn-and-continue behavior stays available via the
existing `daft.hooks.worktreePostCreate.failMode warn` git-config — no new knob.

Before this change, a post-create failure only warned, ran the `-x` commands
anyway, and exited 0 — so downstream automation (e.g. a screenshot or test tail)
ran against a worktree whose setup had failed.

## How

- `default_fail_mode(PostCreate)` flips `Warn` → `Abort` (`src/hooks/mod.rs`).
- `Err` propagation is the single abort mechanism: the now-dead
  `post_hook_outcome` field is removed from `CheckoutResult` and
  `CheckoutBranchResult`; the hook error is wrapped by a shared
  `post_create_failure_error` helper (`src/core/worktree/mod.rs`) at both
  creation cores. The message names the kept worktree path, states that `-x`
  was skipped, and shows recovery: `daft hooks run worktree-post-create`,
  `daft remove <branch>`, and the `failMode warn` opt-out.
- Best-effort sites keep their behavior: multi-branch/TUI clone, merge's
  ephemeral-promotion, and move-setup hooks all still downgrade hook errors to
  warnings, so "moves never hard-fail" holds.

## Testing

- Executor unit tests: abort-by-default and `failMode=warn` opt-out.
- Message-content test on the shared helper.
- New scenario `hooks/post-create-abort.yml`: exit 1 + absent `-x` marker +
  kept worktree for both `checkout` and `checkout -b`; exit 0 + present marker
  under `failMode warn`.
- 10 retry-family scenarios updated from `exit_code: 0` → `1` (the failed
  invocation is still recorded before the abort and the worktree is kept, so
  retry machinery is unaffected).

All gates green: fmt, clippy, unit tests, full YAML manual suite,
`test_hooks.sh`, `man:verify`, docs build.

## Note

The issue's acceptance criteria referenced a per-hook `fail_mode:` key in
`daft.yml` as an existing alternative spelling. That key does **not** exist —
`HookDef` has no such field; git-config `daft.hooks.worktreePostCreate.failMode`
(local + global, deprecated `postCreate` fallback) is the only opt-out. Per the
issue's own no-new-knob principle, this PR does not invent it; a tracked-config
opt-out can be a follow-up if wanted.

Fixes #765

🤖 Generated with [Claude Code](https://claude.com/claude-code)
