### PR TITLE
feat: anonymous worktrees via go <commit-ish> and start --fork

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1041,17 +1041,17 @@ states instead (green/red/yellow, purple merged, dim closed). The cache
 refreshes in the background via `daft update`/`daft sync` and on listing with
 the column; prefer `--format json` (`pr_state`, `ci_status`, `pr_url` fields —
 present in the default schema even when the table hides the column) over parsing
-glyphs. Two modes — replace (`--columns branch,path,age`: exactly those, in
-order) and modifier (`--columns +size,-age`: adjust defaults; auto-detected when
-every entry starts with `+`/`-`). The `status` column is always pinned on
+glyphs. Two modes — replace (`--columns name,path,age`: exactly those, in order)
+and modifier (`--columns +size,-age`: adjust defaults; auto-detected when every
+entry starts with `+`/`-`). The `status` column is always pinned on
 `sync`/`prune`. Persistent defaults: `git config daft.<cmd>.columns`.
 
-**Sorting (`--sort`)** on `list`/`sync`/`prune`: columns `branch`, `path`,
-`size`, `age`, `owner`, `hash`, `activity`, `commit`; prefix `+` ascending
-(default) / `-` descending; comma-separate for multi-level
-(`--sort +owner,-size`). `activity` counts committed and uncommitted changes;
-`commit` (alias `last-commit`) only commit time. Sorting by hidden columns
-works. Persistent defaults: `git config daft.<cmd>.sort`.
+**Sorting (`--sort`)** on `list`/`sync`/`prune`: columns `name`, `path`, `size`,
+`age`, `owner`, `hash`, `activity`, `commit`; prefix `+` ascending (default) /
+`-` descending; comma-separate for multi-level (`--sort +owner,-size`).
+`activity` counts committed and uncommitted changes; `commit` (alias
+`last-commit`) only commit time. Sorting by hidden columns works. Persistent
+defaults: `git config daft.<cmd>.sort`.
 
 **Caches**: `daft list` writes content-addressed JSON caches under
 `<git-common-dir>/.daft/cache/` — safe to delete at any time; daft re-populates.

--- a/SKILL.md
+++ b/SKILL.md
@@ -339,9 +339,16 @@ Aftercare contract:
 - Remove with `daft remove <name>` (the printed path's basename) when done.
   Globs work: `daft remove main-fork-*`.
 - Commits made inside are safe while the worktree exists, but die with it:
-  removal refuses when HEAD moved off the pinned commit. To keep the work,
-  promote first — `daft start <new-branch>` from inside the sandbox bases the
-  new branch on the detached HEAD — then remove.
+  removal refuses when HEAD moved off the pinned commit. Two routes keep the
+  work. **Promote** when it deserves a branch: `daft start <new-branch>` from
+  inside the sandbox bases the new branch on the detached HEAD. **Merge back**
+  when adopting it into the branch you forked from: a fork's HEAD is a legal
+  merge source, spelled `worktrees/<dirname>/HEAD` — so
+  `daft merge worktrees/<dirname>/HEAD --into <branch>` adopts one fork, several
+  sources octopus-merge a fleet at once, and `git cherry-pick <sha>` adopts
+  single commits. After either route the commits are reachable elsewhere, so
+  `daft remove <dirname> -f` is safe — the `-f` acknowledges the moved pin,
+  which removal cannot verify on its own.
 - Sandboxes show in `daft list` under their directory name with a dim `○`;
   `prune` and `sync` skip them.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -213,7 +213,9 @@ root via `git rev-parse --git-common-dir`.
 | `daft go pr:<number>`                                                                                                                        | Check out a GitHub PR or GitLab MR (`mr:<number>`, or a pasted PR/MR URL) into a worktree on its source branch, configured to pull from the PR head. Fork-aware; resolves via the `gh`/`glab` CLI, which must be installed and authenticated (`daft doctor` reports). The platform is detected from the remote (`pr:`/`mr:` are aliases); `daft.forge.platform` overrides for ambiguous remotes. Works cross-repo from anywhere: `daft go <repo> pr:<number>` checks the PR out in that cataloged repo. |
 | `daft go -`                                                                                                                                  | Switch to the previous worktree (`cd -` style toggle)                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | `daft go -s <branch>`                                                                                                                        | Same, but auto-creates the branch if not found (also `daft.go.autoStart`)                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| `daft start <branch> [base]`                                                                                                                 | Create a new branch and worktree from the current or specified base; does not push by default (`daft.checkout.push`); `--local` skips remote even when push is enabled. A leading cataloged-repo name creates the branch in that repo instead — see the Repo Catalog table.                                                                                                                                                                                                                             |
+| `daft go <commit-ish>`                                                                                                                       | Open the canonical detached **sandbox** for a point in history — a tag, SHA, `HEAD~2`, `origin/master` — when the name is no branch and no repo. Idempotent (revisits land in the same worktree), hooks run, no branch exists. See Anonymous Worktrees below.                                                                                                                                                                                                                                           |
+| `daft start <branch> [base]`                                                                                                                 | Create a new branch and worktree from the current or specified base; does not push by default (`daft.checkout.push`); `--local` skips remote even when push is enabled. A leading cataloged-repo name creates the branch in that repo instead — see the Repo Catalog table. From a detached HEAD (inside a sandbox), the new branch bases on that commit — the promotion gesture.                                                                                                                       |
+| `daft start --fork [<base>] [-n N]`                                                                                                          | Mint N private anonymous worktrees pinned at `[<base>]` (default: current position) — detached, system-named, no branch, no push. **The created path(s) print bare on stdout, one per line** — capture them; narration is stderr. See Anonymous Worktrees below.                                                                                                                                                                                                                                        |
 | `daft remove <branch>`                                                                                                                       | Safely delete a branch: its worktree and local branch ref; the remote branch only when `daft.branchDelete.remote` is enabled; `--local` skips remote, `--remote` deletes only the remote branch                                                                                                                                                                                                                                                                                                         |
 | `daft remove -f <branch>`                                                                                                                    | Force-delete bypassing safety checks; for the default branch, removes the worktree only (preserves branch ref and remote)                                                                                                                                                                                                                                                                                                                                                                               |
 | `daft prune [-f] [-v\|-vv]`                                                                                                                  | Remove worktrees whose remote branches were deleted AND that are verified merged (ancestor or squash); gone-but-unmerged branches are kept unless forced. `-v` hook details, `-vv` full sequential                                                                                                                                                                                                                                                                                                      |
@@ -299,6 +301,54 @@ daft start my-feature -x claude
 Use `-x` for finite setup steps. To start a long-running process (a dev server,
 a compose stack, a watcher), define a task and run it on demand with `daft run`
 — see Tasks (`daft run`).
+
+## Anonymous Worktrees (sandboxes and forks)
+
+Worktrees decoupled from branches: detached-HEAD checkouts with hooks run and
+environment set up, living exactly as long as their directory. Two commands
+create them, and choosing between them is a decision rule, not a preference:
+
+- **Visit — `daft go <commit-ish>`** when you need to _look at_ a point in
+  history (build an old release, inspect a tag, reproduce a PR's "before" state)
+  and sharing is fine. Idempotent: the first visit materializes the canonical
+  sandbox for that commit, every later visit — by any spelling — lands in the
+  same worktree, environment warm.
+- **Mint — `daft start --fork [<base>]`** when you need a _private_ worktree to
+  run work in without colliding with anyone (or anything) else, or when you need
+  several. Always fresh: run it twice, get two. Never matched by `go`'s
+  resolution — a fork is reachable only by its printed name.
+
+The fork contract is built for agents: **stdout is the created path** (one per
+line under `-n`), narration is stderr, so capture is the whole integration:
+
+```bash
+wt=$(daft start --fork)                       # one private worktree at HEAD
+wt=$(daft start origin/master --fork)         # ...at master's current position
+daft start --fork -n 3 -x './rebuild.sh'      # three, each built, paths on stdout
+```
+
+Parallel agents each run their own `--fork` — names are claimed atomically, so
+concurrent invocations never collide and need no coordination. Do NOT share one
+worktree between parallel agents, and do NOT fall back to raw
+`git worktree add --detach`: it skips hooks and produces a half-configured
+checkout that cannot build.
+
+Aftercare contract:
+
+- These worktrees have **no branch and no upstream — never push from one.**
+- Remove with `daft remove <name>` (the printed path's basename) when done.
+  Globs work: `daft remove main-fork-*`.
+- Commits made inside are safe while the worktree exists, but die with it:
+  removal refuses when HEAD moved off the pinned commit. To keep the work,
+  promote first — `daft start <new-branch>` from inside the sandbox bases the
+  new branch on the detached HEAD — then remove.
+- Sandboxes show in `daft list` under their directory name with a dim `○`;
+  `prune` and `sync` skip them.
+
+Naming: forks follow `daft.start.forkNaming` — `derived` (default:
+`<source>-fork`, `-fork-2`, …) or `memorable` (`brave-otter`). Visit sandboxes
+name themselves after stable spellings (`v1.18.0`, `origin-master`) and after a
+commit-hex prefix for positional spellings like `HEAD~2`.
 
 ## Merging Across Worktrees (`daft merge`)
 
@@ -690,6 +740,11 @@ All hooks receive: `DAFT_HOOK`, `DAFT_COMMAND`, `DAFT_PROJECT_ROOT`,
 removal hooks `DAFT_REMOVAL_REASON` (`remote-deleted`, `manual`, `ejecting`);
 move hooks `DAFT_IS_MOVE`, `DAFT_OLD_WORKTREE_PATH`, `DAFT_OLD_BRANCH_NAME`.
 
+For anonymous sandbox worktrees `DAFT_BRANCH_NAME` is the empty string (the
+contract is "empty means no branch") and `DAFT_COMMIT` carries the pinned commit
+OID; the `{worktree_slug}` template variable works unchanged and is the right
+per-worktree handle for hooks serving both kinds.
+
 ## Tasks (`daft run`)
 
 Tasks are named, user-invoked job groups — the **serve on demand** half of the
@@ -924,6 +979,10 @@ Valid formats: `json`, `ndjson`, `tsv`, `csv`, `yaml`, `toon`, `markdown`.
 `--template '<tera-template>'` renders custom output (`{{ var }}`, `{% for %}`,
 `{% if %}`).
 
+`daft start --fork` has its own fixed stdout contract, no `--format` needed: the
+created worktree path(s), bare, one per line (everything else on stderr).
+`wt=$(daft start --fork)` captures it directly.
+
 **`daft list` output contract**: table columns show branch (`✦` marks the
 default branch), path (relative to cwd), base ahead/behind, file status (`!N`
 conflicted, `+N` staged, `-N` unstaged, `?N` untracked), remote status (`⇡N`
@@ -1020,7 +1079,8 @@ invocation.
 | `daft.checkoutBranch.carry`      | `true`                | Carry uncommitted changes on branch creation                                                                                                                                |
 | `daft.update.args`               | `"--ff-only"`         | Default pull arguments for update (same-branch mode)                                                                                                                        |
 | `daft.prune.cdTarget`            | `"root"`              | Where to cd after pruning (`root` or `default-branch`)                                                                                                                      |
-| `daft.go.autoStart`              | `false`               | Auto-create worktree when branch not found in `daft go`                                                                                                                     |
+| `daft.go.autoStart`              | `false`               | Auto-create worktree when branch not found in `daft go` (an existing tag/commit still wins: it opens a sandbox instead)                                                     |
+| `daft.start.forkNaming`          | `"derived"`           | How `daft start --fork` names sandboxes: `derived` (`<source>-fork`, `-fork-2`, …) or `memorable` (adjective-noun handles)                                                  |
 | `daft.forge.platform`            | (detected)            | Forge platform for `pr:`/`mr:` checkout (`github`, `gitlab`); unset detects from the remote URL                                                                             |
 | `daft.forge.githubCli`           | `"gh"`                | GitHub CLI binary used for PR resolution (Enterprise wrappers)                                                                                                              |
 | `daft.forge.gitlabCli`           | `"glab"`              | GitLab CLI binary used for MR resolution                                                                                                                                    |

--- a/SKILL.md
+++ b/SKILL.md
@@ -337,7 +337,9 @@ Aftercare contract:
 
 - These worktrees have **no branch and no upstream — never push from one.**
 - Remove with `daft remove <name>` (the printed path's basename) when done.
-  Globs work: `daft remove main-fork-*`.
+  Wildcards sweep a fleet: `daft remove 'main-fork*'` (quote the pattern — daft
+  expands it against sandbox names; it never matches branches, and a pattern
+  matching nothing errors).
 - Commits made inside are safe while the worktree exists, but die with it:
   removal refuses when HEAD moved off the pinned commit. Two routes keep the
   work. **Promote** when it deserves a branch: `daft start <new-branch>` from

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -259,6 +259,10 @@ export default defineConfig({
           },
           { text: "Merging across worktrees", link: "/worktrees/merging" },
           {
+            text: "Anonymous worktrees",
+            link: "/worktrees/anonymous-worktrees",
+          },
+          {
             text: "Checking out pull requests",
             link: "/worktrees/pull-requests",
           },

--- a/docs/cli/daft-go.md
+++ b/docs/cli/daft-go.md
@@ -27,6 +27,42 @@ With `--start` (or `-s`), if the branch does not exist locally or on the
 remote, a new branch and worktree are created automatically. This can also be
 enabled permanently with `git config daft.go.autoStart true`.
 
+### Points in history (detached sandboxes)
+
+`daft go` accepts any commit-ish, not just branches. A name that resolves to
+a commit but names no branch and no cataloged repo — a tag, a short or full
+SHA, a relative spelling like `HEAD~2`, a remote ref like `origin/master` —
+opens a *sandbox*: a fully set-up worktree pinned at that commit with a
+detached HEAD. Hooks run exactly as for a branch worktree, which is the
+entire point over `git worktree add --detach`: the checkout can actually
+build and serve.
+
+```bash
+daft go v1.18.0                              # inspect an old release
+daft go $(git merge-base HEAD origin/master) # a PR's "before" state
+daft go HEAD~2                               # two commits back, pinned
+```
+
+Visits are idempotent: the first one materializes the canonical sandbox for
+that commit, every later one navigates back to it — whatever the spelling
+(`daft go v1.18.0` and `daft go` with its SHA land in the same worktree).
+Stable spellings name the directory after themselves (`v1.18.0`,
+`origin-master`); position expressions like `HEAD~2` take a hex prefix of
+the commit they resolved to.
+
+Branches and cataloged repos always win the name: the sandbox reading only
+claims inputs that would otherwise be errors. Explicit `-b`/`--start`
+declare branch-creation intent and suppress it entirely, while the ambient
+`daft.go.autoStart` config loses to an existing tag — an existing entity
+beats auto-creation.
+
+Sandboxes appear in `daft list` under their directory name with a dim `○`,
+are skipped by `prune` and `sync`, and are removed with
+`daft remove <name>`. Work committed inside one is protected for as long as
+the worktree exists; promote it to a real branch with `daft start <name>`
+from inside the sandbox. For a private, always-fresh sandbox instead of the
+shared canonical one, see `daft start --fork`.
+
 ### Previous worktree (`-`)
 
 Use `-` as the branch name to switch to the previous worktree, similar to
@@ -82,6 +118,9 @@ daft go -
 # Check out a branch, auto-creating if it doesn't exist
 daft go -s feature/new-idea
 
+# Open a detached sandbox at a tag and build it
+daft go v1.18.0 -x 'npm install'
+
 # Check out and run a command after setup
 daft go feature/auth -x 'npm install'
 
@@ -103,6 +142,10 @@ daft go feature/auth --no-cd
    exist locally. In single-remote mode the `<remote>/` prefix is
    stripped for readability; in multi-remote mode the full
    `<remote>/<branch>` form is preserved.
+
+Sandbox worktrees are offered by directory name in the worktree group
+(annotated `sandbox @ <commit>`), and tags join the local group with a
+`tag` annotation — both are legitimate `go` destinations.
 
 In zsh and fish, each candidate is annotated with the relative time of
 its last commit (e.g. "3 days ago"). In zsh the three groups are

--- a/docs/cli/daft-list.md
+++ b/docs/cli/daft-list.md
@@ -22,7 +22,8 @@ and the remote tracking branch, branch age, and last commit details.
 Each worktree is shown with:
 
 - A `>` marker for the current worktree
-- Branch name, with `✦` for the default branch
+- Name — the branch name, or the directory name for detached sandboxes
+  (marked `○`) — with `✦` for the default branch
 - Relative path from the current directory
 - Ahead/behind counts vs. the base branch (e.g. +3 -1)
 - File status: !N conflicted, +N staged, -N unstaged, ?N untracked
@@ -123,8 +124,8 @@ section per repo. Both forms work from outside any repository.
 | `-r, --remotes` | Also show remote tracking branches | |
 | `-a, --all` | Show all branches (equivalent to `-b -r`) | |
 | `--stat <STAT>` | Statistics mode: `summary` or `lines` (default: from git config `daft.list.stat`, or `summary`) | |
-| `--columns <COLUMNS>` | Columns to display (comma-separated). Replace mode: `branch,path,age`. Modifier mode: `+col,-col` | |
-| `--sort <SORT>` | Sort order (comma-separated). `+col` ascending, `-col` descending. Sortable columns: `branch`, `path`, `size`, `age`, `owner`, `activity` (aliases: `commit`, `last-commit`). Default: `daft.list.sort` or `+branch`. | |
+| `--columns <COLUMNS>` | Columns to display (comma-separated). Replace mode: `name,path,age`. Modifier mode: `+col,-col` | |
+| `--sort <SORT>` | Sort order (comma-separated). `+col` ascending, `-col` descending. Sortable columns: `name`, `path`, `size`, `age`, `owner`, `activity` (aliases: `commit`, `last-commit`). Default: `daft.list.sort` or `+name`. | |
 
 ## Global Options
 
@@ -155,7 +156,7 @@ daft list --format json
 daft list --format json | jq '.[] | select(.unstaged > 0)'
 
 # Show only branch, path, and age columns (replace mode)
-daft list --columns branch,path,age
+daft list --columns name,path,age
 
 # Remove annotation and last-commit from defaults (modifier mode)
 daft list --columns -annotation,-last-commit
@@ -164,7 +165,7 @@ daft list --columns -annotation,-last-commit
 daft list --columns +owner
 
 # Show branch, path, and owner only
-daft list --columns branch,path,owner
+daft list --columns name,path,owner
 
 # List another cataloged repo's worktrees (sugar for --repo api)
 daft list api

--- a/docs/cli/daft-prune.md
+++ b/docs/cli/daft-prune.md
@@ -29,8 +29,8 @@ after branches have been merged and deleted on the remote.
 | `-v, --verbose` | Increase verbosity (`-v` for hook details, `-vv` for full sequential output) | |
 | `-f, --force` | Force removal of worktrees with uncommitted changes or untracked files | |
 | `--stat <STAT>` | Statistics mode: `summary` or `lines` (default: from git config `daft.prune.stat`, or `summary`) | |
-| `--columns <COLUMNS>` | Columns to display in the summary table (comma-separated). Replace mode: `branch,path,age`. Modifier mode: `+col,-col`. The status column is always shown. | |
-| `--sort <SORT>` | Sort order (comma-separated). `+col` ascending, `-col` descending. Sortable columns: `branch`, `path`, `size`, `age`, `owner`, `activity`. Default: `daft.prune.sort` or `+branch`. | |
+| `--columns <COLUMNS>` | Columns to display in the summary table (comma-separated). Replace mode: `name,path,age`. Modifier mode: `+col,-col`. The status column is always shown. | |
+| `--sort <SORT>` | Sort order (comma-separated). `+col` ascending, `-col` descending. Sortable columns: `name`, `path`, `size`, `age`, `owner`, `activity`. Default: `daft.prune.sort` or `+name`. | |
 
 ## Global Options
 

--- a/docs/cli/daft-remove.md
+++ b/docs/cli/daft-remove.md
@@ -33,7 +33,7 @@ name or path, exactly like branch worktrees:
 daft remove v1.18.0          # a tag sandbox, by name
 daft remove main-fork-2      # a fork, by name
 daft remove ../brave-otter   # by path
-daft remove main-fork-*      # shell globs expand against real directories
+daft remove 'main-fork*'     # a wildcard over sandbox names
 ```
 
 A branch sharing a sandbox's spelling always wins the name — the sandbox
@@ -46,6 +46,27 @@ removal — promote the work first with `daft start <new-branch>` from inside
 the sandbox, or pass `-f` to discard it. A detached worktree daft did not
 create (no identity record) keeps the historical refusal and is never
 treated as a sandbox.
+
+### Wildcards
+
+Sandbox names may be given as wildcard patterns: `*` matches any run of
+characters and `?` exactly one. `daft remove 'main-fork*'` sweeps every fork
+minted off main in one command — the natural cleanup after a
+`daft start --fork -n 3` fan-out. Each matched sandbox still passes the
+safety checks above, and one refusal aborts the whole run (fix it or pass
+`-f`).
+
+Patterns match sandbox names only. They never expand to branches — removing
+a branch also deletes its remote, and fleet-scale branch cleanup is
+[daft prune](./git-worktree-prune.md)'s job — and never to paths. A pattern
+that matches no live sandbox aborts the command rather than silently
+removing nothing; if branches did match the pattern, the error names them so
+you can spell them out deliberately.
+
+Quote the pattern (`'main-fork*'`) so your shell passes it through: zsh
+errors on globs that match nothing in the current directory, and an
+unquoted glob that does match local files would rewrite your arguments
+before daft sees them.
 
 When invoked outside any git repository, `daft remove` accepts absolute or
 relative worktree paths and discovers the owning repository from the path

--- a/docs/cli/daft-remove.md
+++ b/docs/cli/daft-remove.md
@@ -20,7 +20,32 @@ force-delete branches regardless of merge status (`git worktree-branch -D`).
 ## Description
 
 Deletes one or more local branches along with their associated worktrees in
-a single operation. Arguments can be branch names or worktree paths.
+a single operation. Arguments can be branch names, worktree paths, or
+sandbox names.
+
+### Sandboxes
+
+Anonymous detached worktrees created by daft — `daft go <commit-ish>`
+sandboxes and `daft start --fork` forks — are removed by their directory
+name or path, exactly like branch worktrees:
+
+```bash
+daft remove v1.18.0          # a tag sandbox, by name
+daft remove main-fork-2      # a fork, by name
+daft remove ../brave-otter   # by path
+daft remove main-fork-*      # shell globs expand against real directories
+```
+
+A branch sharing a sandbox's spelling always wins the name — the sandbox
+reading applies only when no such branch exists. There is no branch or
+remote to delete, so only the worktree goes; pre/post-remove hooks still
+run. Two safety checks replace the branch checks: the worktree must be
+clean, and its HEAD must still sit at the commit the sandbox was pinned at.
+Commits made on a detached HEAD exist nowhere else, so a moved HEAD refuses
+removal — promote the work first with `daft start <new-branch>` from inside
+the sandbox, or pass `-f` to discard it. A detached worktree daft did not
+create (no identity record) keeps the historical refusal and is never
+treated as a sandbox.
 
 When invoked outside any git repository, `daft remove` accepts absolute or
 relative worktree paths and discovers the owning repository from the path

--- a/docs/cli/daft-start.md
+++ b/docs/cli/daft-start.md
@@ -15,6 +15,7 @@ daft start [OPTIONS] <BRANCH_NAME> [BASE_OR_BRANCH] [BASE]
 daft start <branch> [<base>]                # local
 daft start <repo> <branch> [<base>]         # in another cataloged repo
 daft start --repo <repo> <branch> [<base>]  # explicit / script-safe
+daft start --fork [<base>] [-n N]           # anonymous throwaway worktree(s)
 ```
 
 The local form is equivalent to `git worktree-checkout -b`. All flags are the
@@ -88,6 +89,47 @@ Cross-repo semantics:
   target repo's new worktree; a relative `--at` resolves inside the target
   repo.
 
+## Anonymous forks (--fork)
+
+`daft start --fork` mints a *fork*: an anonymous throwaway worktree pinned
+at a position — detached HEAD, no branch, no tracking, no push, named by
+the system. With `--fork` the positionals reshape to just `[<base>]`
+(defaulting to the current position): the system owns the name, so there is
+no branch slot.
+
+```bash
+daft start --fork                      # fork the current position
+daft start --fork --carry              # ...including uncommitted changes
+daft start master --fork               # fork master's position
+daft start --fork -n 3                 # three private forks, one command
+daft start v1.18.0 --fork -x 'npm ci'  # fork a tag and set it up
+```
+
+Because the name is the system's, **the path is the result**: each created
+worktree's path prints bare on stdout, one per line, while all narration
+goes to stderr. `wt=$(daft start --fork)` is the whole scripting
+integration. A single fork cd's the shell into it; with `-n` greater than
+one there is no single destination and the shell stays put.
+
+Forks are *private*: unlike the canonical sandbox `daft go <commit-ish>`
+opens (shared, idempotent — revisits land in the same worktree), a fork is
+never matched by go's resolution and is reachable only by its printed name.
+That is what makes them safe for parallel agents: three concurrent
+`daft start --fork` invocations mint three distinct worktrees with zero
+coordination — names are claimed atomically by directory creation.
+
+Naming follows `daft.start.forkNaming`:
+
+- `derived` (default) — `<source>-fork`, `<source>-fork-2`, … Self-describing
+  provenance in `daft list`.
+- `memorable` — adjective-noun handles (`brave-otter`), collision-sparse and
+  easier to say and retype.
+
+Remove a fork with `daft remove <name>`. Commits made inside it are
+protected for as long as the worktree exists; removal refuses when HEAD
+moved off the pinned commit until you promote (`daft start <new-branch>`
+from inside the fork — the detached HEAD becomes the base) or force.
+
 ## Coordinated fan-out (--with-related)
 
 `daft start <branch> --with-related` also creates the branch in every repo the
@@ -111,6 +153,8 @@ repos *api's* manifest declares, and the shell lands in api's new worktree.
 |--------|-------------|---------|
 | `--repo <REPO>` | Create the branch in a repository from the catalog (for repo names shadowed by local branches) | |
 | `--with-related` | Also create the branch in every related repo (relations manifest), each based on its own default branch | |
+| `--fork` | Mint an anonymous throwaway worktree pinned at `[<base>]` (defaults to the current position): detached, system-named, no branch, no push; the created path prints on stdout | |
+| `-n, --count <N>` | Create N fork worktrees (requires `--fork`; one path per line on stdout; the shell stays where it is) | `1` |
 | `--local` | Skip all remote operations (no fetch, no push) for this invocation | |
 | `--skip-hooks <SELECTOR>` | Skip hooks this run (`all` \| a hook name like `worktree-post-create` \| `tag:<tag>` \| `<job>`); repeatable/comma-separated | |
 | `-c, --carry` | Apply uncommitted changes from the current worktree to the new one | |

--- a/docs/cli/daft-start.md
+++ b/docs/cli/daft-start.md
@@ -118,6 +118,10 @@ That is what makes them safe for parallel agents: three concurrent
 `daft start --fork` invocations mint three distinct worktrees with zero
 coordination — names are claimed atomically by directory creation.
 
+The full loop — fork a branch's position several times, commit in each, then
+merge the keepers back with `daft merge worktrees/<dirname>/HEAD` — is walked
+through in [Anonymous worktrees](/worktrees/anonymous-worktrees).
+
 Naming follows `daft.start.forkNaming`:
 
 - `derived` (default) — `<source>-fork`, `<source>-fork-2`, … Self-describing

--- a/docs/cli/daft-sync.md
+++ b/docs/cli/daft-sync.md
@@ -91,8 +91,8 @@ daft sync --rebase main --push --include feature/shared-work
 | `--force-with-lease` | Use `--force-with-lease` when pushing (requires `--push`) | |
 | `--include <VALUE>` | Include additional branches in rebase/push: `unowned`, an email address, or a branch name. Repeatable. | |
 | `--stat <STAT>` | Statistics mode: `summary` or `lines` (default: from git config `daft.sync.stat`, or `summary`) | |
-| `--columns <COLUMNS>` | Columns to display in the summary table (comma-separated). Replace mode: `branch,path,age`. Modifier mode: `+col,-col`. The status column is always shown. | |
-| `--sort <SORT>` | Sort order (comma-separated). `+col` ascending, `-col` descending. Sortable columns: `branch`, `path`, `size`, `age`, `owner`, `activity`. Default: `daft.sync.sort` or `+branch`. | |
+| `--columns <COLUMNS>` | Columns to display in the summary table (comma-separated). Replace mode: `name,path,age`. Modifier mode: `+col,-col`. The status column is always shown. | |
+| `--sort <SORT>` | Sort order (comma-separated). `+col` ascending, `-col` descending. Sortable columns: `name`, `path`, `size`, `age`, `owner`, `activity`. Default: `daft.sync.sort` or `+name`. | |
 
 ::: info
 The `--force` flag is a deprecated alias for `--prune-dirty` and will be removed

--- a/docs/cli/git-worktree-clone.md
+++ b/docs/cli/git-worktree-clone.md
@@ -53,7 +53,7 @@ git worktree-clone [OPTIONS] <REPOSITORY_URL>
 | `-r, --remote <REMOTE>` | Organize worktree under this remote folder (enables multi-remote mode) |  |
 | `--no-cd` | Do not change directory to the new worktree |  |
 | `--layout <LAYOUT>` | Worktree layout to use for this repository |  |
-| `--columns <COLUMNS>` | Columns to display (comma-separated). Replace: branch,base,age. Modify defaults: +col,-col. Available: branch, path, size, base, changes, remote, age, annotation, owner, hash, last-commit |  |
+| `--columns <COLUMNS>` | Columns to display (comma-separated). Replace: name,base,age. Modify defaults: +col,-col. Available: name, path, size, base, changes, remote, age, annotation, owner, hash, last-commit |  |
 | `-x, --exec <EXEC>` | Run a command in the worktree after setup completes (repeatable) |  |
 | `--install` | Run `daft install` in the new worktree(s) after a successful clone (implies --trust-hooks) |  |
 | `--git-exclude` | With --install: add /daft.yml to .git/info/exclude without prompting |  |

--- a/docs/cli/git-worktree-list.md
+++ b/docs/cli/git-worktree-list.md
@@ -63,7 +63,7 @@ Supported formats: json, ndjson, tsv, csv, yaml, toon, markdown. Use
 for details.
 
 Use --columns to select which columns are shown and in what order.
-  Replace mode:  --columns branch,path,age (exact set and order)
+  Replace mode:  --columns name,path,age (exact set and order)
   Modifier mode: --columns -annotation,-last-commit (remove from defaults)
   Add optional:  --columns +size (add disk size column after path)
 Defaults can be set in git config with daft.list.columns.
@@ -92,11 +92,11 @@ with `git config -- daft.list.columns -pr`.
 
 Use --sort to control the sort order. Prefix with + for ascending (default) or
 - for descending. Multiple columns can be comma-separated for multi-level sort.
-  Sort by branch descending:  --sort -branch
+  Sort by name descending:    --sort -name
   Sort by owner then size:    --sort +owner,-size
   Most recent activity first: --sort -activity
 
-Sortable columns: branch, path, size, age, owner, hash, activity, commit (alias:
+Sortable columns: name, path, size, age, owner, hash, activity, commit (alias:
 last-commit). activity considers both commits and uncommitted file changes;
 commit sorts by last commit time only. You can sort by columns not shown in
 the output (e.g. --sort -size without --columns +size). Defaults can be set
@@ -127,8 +127,8 @@ git worktree-list [OPTIONS] [REPO]
 | `-a, --all` | Show all branches (equivalent to -b -r) |  |
 | `--merging` | Only show worktrees with an in-progress merge |  |
 | `--stat <STAT>` | Statistics mode: summary or lines (default: from git config daft.list.stat, or summary) |  |
-| `--columns <COLUMNS>` | Columns to display (comma-separated). Replace: branch,path,age. Modify defaults: +col,-col. Available: branch, path, size, base, changes, remote, pr, age, annotation, status, owner, hash, last-commit |  |
-| `--sort <SORT>` | Sort order (comma-separated). +col ascending, -col descending. Columns: branch, path, size, base, changes, remote, age, owner, hash, activity, commit |  |
+| `--columns <COLUMNS>` | Columns to display (comma-separated). Replace: name,path,age. Modify defaults: +col,-col. Available: name, path, size, base, changes, remote, pr, age, annotation, status, owner, hash, last-commit |  |
+| `--sort <SORT>` | Sort order (comma-separated). +col ascending, -col descending. Columns: name, path, size, base, changes, remote, age, owner, hash, activity, commit |  |
 | `--repo <REPO>` | List another cataloged repository's worktrees |  |
 | `--all-repos` | List every cataloged repository's worktrees |  |
 

--- a/docs/cli/git-worktree-prune.md
+++ b/docs/cli/git-worktree-prune.md
@@ -62,8 +62,8 @@ git worktree-prune [OPTIONS]
 | `-v, --verbose` | Increase verbosity (-v for hook details, -vv for full sequential output) |  |
 | `-f, --force` | Force removal of worktrees with uncommitted changes or untracked files |  |
 | `--stat <STAT>` | Statistics mode: summary or lines (default: from git config daft.prune.stat, or summary) |  |
-| `--columns <COLUMNS>` | Columns to display (comma-separated). Replace: branch,path,age. Modify defaults: +col,-col. Available: branch, path, size, base, changes, remote, pr, age, annotation, owner, hash, last-commit |  |
-| `--sort <SORT>` | Sort order (comma-separated). +col ascending, -col descending. Columns: branch, path, size, base, changes, remote, age, owner, hash, activity, commit |  |
+| `--columns <COLUMNS>` | Columns to display (comma-separated). Replace: name,path,age. Modify defaults: +col,-col. Available: name, path, size, base, changes, remote, pr, age, annotation, owner, hash, last-commit |  |
+| `--sort <SORT>` | Sort order (comma-separated). +col ascending, -col descending. Columns: name, path, size, base, changes, remote, age, owner, hash, activity, commit |  |
 | `--repo <REPO>` | Prune another cataloged repository |  |
 | `--all-repos` | Prune every cataloged repository (current repo last) |  |
 

--- a/docs/cli/git-worktree-sync.md
+++ b/docs/cli/git-worktree-sync.md
@@ -71,8 +71,8 @@ git worktree-sync [OPTIONS]
 | `--no-verify` | Skip the repo's pre-push hook when pushing (requires --push) |  |
 | `--include <INCLUDE>` | Include additional branches in rebase/push (email, branch name, or 'unowned') |  |
 | `--stat <STAT>` | Statistics mode: summary or lines (default: from git config daft.sync.stat, or summary) |  |
-| `--columns <COLUMNS>` | Columns to display (comma-separated). Replace: branch,path,age. Modify defaults: +col,-col. Available: branch, path, size, base, changes, remote, pr, age, annotation, owner, hash, last-commit |  |
-| `--sort <SORT>` | Sort order (comma-separated). +col ascending, -col descending. Columns: branch, path, size, base, changes, remote, age, owner, hash, activity, commit |  |
+| `--columns <COLUMNS>` | Columns to display (comma-separated). Replace: name,path,age. Modify defaults: +col,-col. Available: name, path, size, base, changes, remote, pr, age, annotation, owner, hash, last-commit |  |
+| `--sort <SORT>` | Sort order (comma-separated). +col ascending, -col descending. Columns: name, path, size, base, changes, remote, age, owner, hash, activity, commit |  |
 | `--jobs <N>` | Cap concurrent pushes when a pre-push hook is present (requires --push; default: from daft.governor.jobs, or max(2, cores/4)) |  |
 | `--no-throttle` | Disable the push resource governor for this run (requires --push) |  |
 

--- a/docs/hooks/lifecycle.md
+++ b/docs/hooks/lifecycle.md
@@ -57,10 +57,11 @@ YAML jobs and shell script hooks.
 
 ### Worktree (creation and removal hooks)
 
-| Variable             | Description                         |
-| -------------------- | ----------------------------------- |
-| `DAFT_WORKTREE_PATH` | Path to the target worktree         |
-| `DAFT_BRANCH_NAME`   | Branch name for the target worktree |
+| Variable             | Description                                                                     |
+| -------------------- | ------------------------------------------------------------------------------- |
+| `DAFT_WORKTREE_PATH` | Path to the target worktree                                                     |
+| `DAFT_BRANCH_NAME`   | Branch name for the target worktree — the empty string for an anonymous sandbox |
+| `DAFT_COMMIT`        | Pinned commit OID (anonymous sandbox worktrees only)                            |
 
 ### Creation (create hooks only)
 

--- a/docs/hooks/yaml-reference.md
+++ b/docs/hooks/yaml-reference.md
@@ -252,6 +252,7 @@ lifecycle hooks and `daft run` tasks):
 | `{remote}`          | Remote name (usually `"origin"`)                        |
 | `{job_name}`        | Name of the current job                                 |
 | `{base_branch}`     | Base branch name (for `checkout -b` commands)           |
+| `{commit}`          | Pinned commit OID (anonymous sandbox worktrees only)    |
 | `{repository_url}`  | Repository URL (for `post-clone`)                       |
 | `{default_branch}`  | Default branch name (for `post-clone`)                  |
 
@@ -262,6 +263,13 @@ DNS-label limit. Because it is keyed off the worktree rather than the branch, it
 is unique per worktree and stable even when the worktree is not on a branch —
 use it to keep per-worktree names collision-free, e.g.
 `COMPOSE_PROJECT_NAME: "api-{worktree_slug}"`.
+
+For anonymous sandbox worktrees (`daft go <commit-ish>`, `daft start --fork`)
+the branch variables substitute to the empty string — the contract is "empty
+means no branch" — and `{commit}` (env: `DAFT_COMMIT`) carries the commit the
+sandbox is pinned at. `{worktree_slug}` works unchanged, which makes it the
+right handle for per-worktree resources in hooks that must serve both branch and
+sandbox worktrees.
 
 **Move hooks only** (available when `DAFT_IS_MOVE` is `true`):
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -145,7 +145,7 @@ Run `daft doctor` to check whether `gh`/`glab` are installed and authenticated.
 | --------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `daft.list.stat`            | `"summary"` | Default statistics mode for list command (`summary` or `lines`)                                                                                                                                              |
 | `daft.list.columns`         |             | Default column selection for list command (e.g., `branch,path,age` or `+size,-annotation`)                                                                                                                   |
-| `daft.list.sort`            |             | Default sort order for list command (e.g., `+branch`, `-activity`, `+owner,-size`). Sortable: branch, path, size, age, owner, activity                                                                       |
+| `daft.list.sort`            |             | Default sort order for list command (e.g., `+name`, `-activity`, `+owner,-size`). Sortable: name, path, size, age, owner, activity                                                                           |
 | `daft.list.sizeConcurrency` |             | Max concurrent directory-size walks for `--columns +size` on both `daft list` and `daft repo list`. Default: CPU count. Lower on slow/network filesystems. The `DAFT_SIZE_WALK_JOBS` env var overrides this. |
 
 ## Prune Settings
@@ -155,7 +155,7 @@ Run `daft doctor` to check whether `gh`/`glab` are installed and authenticated.
 | `daft.prune.cdTarget` | `"root"`    | Where to cd after pruning the current worktree. Values: `root` (project root) or `default-branch` (default branch worktree) |
 | `daft.prune.stat`     | `"summary"` | Default statistics mode for prune command (`summary` or `lines`)                                                            |
 | `daft.prune.columns`  |             | Default column selection for prune command                                                                                  |
-| `daft.prune.sort`     |             | Default sort order for prune command (e.g., `+branch`, `-activity`)                                                         |
+| `daft.prune.sort`     |             | Default sort order for prune command (e.g., `+name`, `-activity`)                                                           |
 
 ## Sync Settings
 
@@ -163,7 +163,7 @@ Run `daft doctor` to check whether `gh`/`glab` are installed and authenticated.
 | ---------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `daft.sync.stat`             | `"summary"`    | Default statistics mode for sync command (`summary` or `lines`)                                                                                                                                               |
 | `daft.sync.columns`          |                | Default column selection for sync command                                                                                                                                                                     |
-| `daft.sync.sort`             |                | Default sort order for sync command (e.g., `+branch`, `-activity`)                                                                                                                                            |
+| `daft.sync.sort`             |                | Default sort order for sync command (e.g., `+name`, `-activity`)                                                                                                                                              |
 | `daft.sync.pushTimeout`      | `"30m"`        | Wall-clock budget per push unit (git + pre-push hook). A hung hook is torn down and the push fails with a hint; `off` (or `0`) disables                                                                       |
 | `daft.sync.pushHookStrategy` | `"per-branch"` | Pre-push hook cadence for `sync --push`: `per-branch` runs the hook once per branch; `batched` pushes every branch in one `git push` so the hook fires once with all refs (one refusal fails the whole batch) |
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -21,13 +21,14 @@ git config --global daft.autocd false
 
 ## General Settings
 
-| Key                 | Default    | Description                                                                               |
-| ------------------- | ---------- | ----------------------------------------------------------------------------------------- |
-| `daft.autocd`       | `true`     | CD into new worktrees when using shell wrappers                                           |
-| `daft.remote`       | `"origin"` | Default remote name for all operations                                                    |
-| `daft.updateCheck`  | `true`     | Show notifications when a new daft version is available                                   |
-| `daft.gitoxide`     | `true`     | Use gitoxide for supported Git operations; `false` opts out to the git-subprocess backend |
-| `daft.go.autoStart` | `false`    | Auto-create worktree when branch not found in `daft go`                                   |
+| Key                     | Default    | Description                                                                                                                    |
+| ----------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `daft.autocd`           | `true`     | CD into new worktrees when using shell wrappers                                                                                |
+| `daft.remote`           | `"origin"` | Default remote name for all operations                                                                                         |
+| `daft.updateCheck`      | `true`     | Show notifications when a new daft version is available                                                                        |
+| `daft.gitoxide`         | `true`     | Use gitoxide for supported Git operations; `false` opts out to the git-subprocess backend                                      |
+| `daft.go.autoStart`     | `false`    | Auto-create worktree when branch not found in `daft go`                                                                        |
+| `daft.start.forkNaming` | `derived`  | How `daft start --fork` names its sandboxes: `derived` (`<source>-fork`, `-fork-2`, …) or `memorable` (adjective-noun handles) |
 
 ## Layout Settings
 

--- a/docs/worktrees/anonymous-worktrees.md
+++ b/docs/worktrees/anonymous-worktrees.md
@@ -1,0 +1,125 @@
+---
+title: Anonymous Worktrees
+description:
+  Detached-HEAD sandboxes and forks — visit points in history, fan out private
+  worktrees for parallel work, and merge the results back.
+---
+
+# Anonymous Worktrees
+
+Not every worktree needs a branch. An anonymous worktree is a detached-HEAD
+checkout with the full daft treatment — hooks run, environment set up, visible
+in `daft list` — that lives exactly as long as its directory. No branch, no
+tracking, no push.
+
+Two commands create them, split by intent: **`go` visits anything that exists;
+`start` mints anything new.**
+
+## Quick examples
+
+```bash
+daft go v1.18.0                              # visit a tag — sandbox created, hooks run, cd in
+daft go $(git merge-base HEAD origin/master) # inspect a PR's "before" state
+wt=$(daft start --fork)                      # mint a private fork of the current position
+daft start --fork -n 3 -x './rebuild.sh'     # three forks, each built, paths on stdout
+```
+
+## Visit or mint?
+
+- **Visit — `daft go <commit-ish>`** when you need to _look at_ a point in
+  history and sharing is fine. Idempotent: the first visit materializes the
+  canonical sandbox for that commit; every later visit — by any spelling that
+  resolves to the same commit — lands in the same worktree, environment warm.
+- **Mint — `daft start --fork [<base>]`** when you need a _private_ worktree
+  that nothing else will collide with, or several at once. Always fresh: run it
+  twice, get two. A fork is never matched by `go`'s resolution — it is reachable
+  only by its printed name, which is what makes it safe for parallel agents.
+
+The created path prints bare on stdout (one per line under `-n`), narration goes
+to stderr — `wt=$(daft start --fork)` is the whole scripting integration. See
+[`daft go`](/reference/cli/daft-go) and
+[`daft start`](/reference/cli/daft-start) for the full surface.
+
+## Fan out, then merge back
+
+The loop that motivates forks: split a branch's current position into several
+private worktrees, work in each, then adopt the results. From a worktree on
+`feature-x`:
+
+```bash
+daft start --fork -n 3        # three forks of feature-x's HEAD; paths on stdout
+```
+
+Make commits in each fork as usual. Every worktree's HEAD is a git reachability
+root, so the commits are protected for as long as the fork exists — no branch
+required.
+
+To merge work back, name a fork's HEAD from the target worktree. Git spells
+another worktree's HEAD as `worktrees/<dirname>/HEAD`, and `daft merge` accepts
+any commit-ish as a source:
+
+```bash
+# from the feature-x worktree
+daft merge worktrees/feature-x-fork/HEAD          # adopt one fork
+
+# adopt two at once — octopus, one merge commit
+daft merge worktrees/feature-x-fork/HEAD worktrees/feature-x-fork-2/HEAD
+
+# adopt a single commit out of a fork instead of the whole thing
+git cherry-pick <sha>
+```
+
+Merge hooks fire as on any other merge, with `DAFT_MERGE_SOURCE_SHAS` naming the
+resolved fork positions — see [Merging across worktrees](/worktrees/merging).
+
+## Keeping work: promotion
+
+When a fork's work deserves a branch of its own — a PR, a push, a longer life —
+promote it instead of merging: from inside the fork,
+
+```bash
+daft start real-branch-name   # new branch based on the fork's detached HEAD
+```
+
+mints a real branch at the fork's position, and from there it is ordinary branch
+machinery.
+
+## Cleanup and the pin guard
+
+Remove anonymous worktrees by their directory name (globs work):
+
+```bash
+daft remove feature-x-fork-3        # untouched fork: removes cleanly
+daft remove feature-x-fork -f       # fork with new commits: -f required
+```
+
+Every anonymous worktree records the commit it was created at — its _pin_.
+`daft remove` compares the worktree's HEAD to the pin:
+
+| Fork state                     | Removal behavior                        |
+| ------------------------------ | --------------------------------------- |
+| HEAD still on the pin          | Removes without ceremony                |
+| HEAD moved (commits were made) | Refuses — the commits die with the fork |
+| HEAD moved, `-f` passed        | Removes; you have confirmed the loss    |
+
+The guard is a plain HEAD-vs-pin comparison — it does not know whether the
+commits were merged elsewhere. After a successful merge back, the target branch
+reaches the fork's commits, so `-f` is the informed confirmation that nothing is
+actually lost.
+
+::: warning Never push from an anonymous worktree
+
+There is no branch and no upstream. To publish work made in a fork, promote it
+to a branch first or merge it into one.
+
+:::
+
+## Where to next
+
+- **Merging:** [Merging across worktrees](/worktrees/merging) — styles,
+  conflicts, hook gates
+- **CLI reference:** [`daft go`](/reference/cli/daft-go),
+  [`daft start`](/reference/cli/daft-start),
+  [`daft remove`](/reference/cli/daft-remove)
+- **Configuration:** `daft.start.forkNaming` in
+  [Configuration](/reference/configuration)

--- a/docs/worktrees/anonymous-worktrees.md
+++ b/docs/worktrees/anonymous-worktrees.md
@@ -86,12 +86,18 @@ machinery.
 
 ## Cleanup and the pin guard
 
-Remove anonymous worktrees by their directory name (globs work):
+Remove anonymous worktrees by their directory name, one at a time or with a
+wildcard pattern over the whole fleet:
 
 ```bash
 daft remove feature-x-fork-3        # untouched fork: removes cleanly
 daft remove feature-x-fork -f       # fork with new commits: -f required
+daft remove 'feature-x-fork*'       # every fork in one sweep
 ```
+
+Patterns (`*` and `?`) are expanded by daft against sandbox names — they never
+match branches, and a pattern that matches nothing aborts. Quote the pattern so
+your shell passes it through untouched.
 
 Every anonymous worktree records the commit it was created at — its _pin_.
 `daft remove` compares the worktree's HEAD to the pin:

--- a/docs/worktrees/index.md
+++ b/docs/worktrees/index.md
@@ -272,6 +272,9 @@ root and place new worktrees according to the active layout.
   [Running commands across worktrees](/worktrees/running-commands) — `daft exec`
 - **Merge across worktrees:** [Merging across worktrees](/worktrees/merging) —
   `daft merge` from anywhere, octopus, ephemeral targets, PR-style hook gates
+- **Worktrees without branches:**
+  [Anonymous worktrees](/worktrees/anonymous-worktrees) — visit points in
+  history, fan out private forks, merge the results back
 - **Faster typing:** [Shortcuts](/worktrees/shortcuts) — `gwt*` symlink aliases
 - **Recipes:** [Recipes for Worktrees](/recipes/?pillar=worktrees)
 - **Next pillar:** [Hooks](/hooks/) — automate the env-setup-per-worktree

--- a/docs/worktrees/merging.md
+++ b/docs/worktrees/merging.md
@@ -82,6 +82,18 @@ daft merge feature/hotfix --into release/1.2 --adopt-target
 On success the ephemeral worktree is promoted to a permanent worktree at the
 configured layout. On conflict it stays put so you can resolve in place.
 
+## Fork worktrees as sources
+
+Sources are any commit-ish, not just branches — so anonymous fork worktrees
+merge back by naming their HEAD:
+
+```bash
+daft merge worktrees/feature-x-fork/HEAD --into feature-x
+```
+
+See [Anonymous worktrees](/worktrees/anonymous-worktrees) for the full
+fan-out-and-merge-back workflow.
+
 ## Hook gates
 
 `pre-merge` and `post-merge` hooks fire around the operation, with

--- a/man/daft-clone.1
+++ b/man/daft-clone.1
@@ -55,7 +55,7 @@ Worktree layout to use for this repository.
 Built\-in layouts: contained, sibling, nested, centralized. Can also be a custom layout name from ~/.config/daft/config.toml or an inline template string.
 .TP
 \fB\-\-columns\fR \fI<COLUMNS>\fR
-Columns to display (comma\-separated). Replace: branch,base,age. Modify defaults: +col,\-col. Available: branch, path, size, base, changes, remote, age, annotation, owner, hash, last\-commit
+Columns to display (comma\-separated). Replace: name,base,age. Modify defaults: +col,\-col. Available: name, path, size, base, changes, remote, age, annotation, owner, hash, last\-commit
 .TP
 \fB\-x\fR, \fB\-\-exec\fR \fI<EXEC>\fR
 Run a command in the worktree after setup completes (repeatable)

--- a/man/daft-go.1
+++ b/man/daft-go.1
@@ -2,7 +2,7 @@
 .el .ds Aq '
 .TH "daft go" 1  "daft go 1.23.0" 
 .SH NAME
-daft go \- Open a worktree for an existing branch, or create one with \-b
+daft go \- Open a worktree for a branch or commit; create a new branch with \-b
 .SH SYNOPSIS
 \fBdaft go\fR [\fB\-\-repo\fR] [\fB\-b\fR|\fB\-\-create\-branch\fR] [\fB\-s\fR|\fB\-\-start\fR] [\fB\-c\fR|\fB\-\-carry\fR] [\fB\-\-no\-carry\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-\-no\-cd\fR] [\fB\-x\fR|\fB\-\-exec\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-@\fR|\fB\-\-at\fR] [\fB\-\-local\fR] [\fB\-\-no\-verify\fR] [\fB\-\-skip\-hooks\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fIBRANCH_NAME\fR] [\fISECOND\fR] 
 .SH DESCRIPTION
@@ -102,7 +102,7 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 Print version
 .TP
 [\fIBRANCH_NAME\fR]
-Branch (or catalog repo) to open; use \*(Aq\-\*(Aq for previous worktree
+Branch, commit\-ish, or catalog repo to open; use \*(Aq\-\*(Aq for previous worktree
 .TP
 [\fISECOND\fR]
 Branch inside <repo> when two arguments are given; base branch with \-b

--- a/man/daft-go.1
+++ b/man/daft-go.1
@@ -4,7 +4,7 @@
 .SH NAME
 daft go \- Open a worktree for a branch or commit; create a new branch with \-b
 .SH SYNOPSIS
-\fBdaft go\fR [\fB\-\-repo\fR] [\fB\-b\fR|\fB\-\-create\-branch\fR] [\fB\-s\fR|\fB\-\-start\fR] [\fB\-c\fR|\fB\-\-carry\fR] [\fB\-\-no\-carry\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-\-no\-cd\fR] [\fB\-x\fR|\fB\-\-exec\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-@\fR|\fB\-\-at\fR] [\fB\-\-local\fR] [\fB\-\-no\-verify\fR] [\fB\-\-skip\-hooks\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fIBRANCH_NAME\fR] [\fISECOND\fR] 
+\fBdaft go\fR [\fB\-\-repo\fR] [\fB\-b\fR|\fB\-\-create\-branch\fR] [\fB\-s\fR|\fB\-\-start\fR] [\fB\-c\fR|\fB\-\-carry\fR] [\fB\-\-no\-carry\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-\-no\-cd\fR] [\fB\-x\fR|\fB\-\-exec\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-@\fR|\fB\-\-at\fR] [\fB\-\-local\fR] [\fB\-\-no\-verify\fR] [\fB\-\-skip\-hooks\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fIBRANCH|COMMIT\-ISH\fR] [\fIBRANCH_OR_BASE\fR] 
 .SH DESCRIPTION
 .PP
 Opens a worktree for an existing local or remote branch. The worktree is
@@ -31,7 +31,8 @@ resolves purely against the catalog. Anything resolvable in the current
 repository always wins over a catalog match.
 .PP
 With \-b, creates a new branch and worktree in a single operation. The new
-branch is based on the current branch, or on `<base\-branch>` if specified. It
+branch is based on the current branch, or on `<base>` (a branch or any
+commit\-ish) if specified. It
 is pushed to the remote and upstream tracking is configured; the pre\-push hook
 runs only when that push introduces new commits, skipping ref\-only pushes
 (configurable via daft.checkout.pushVerify, which defaults to the base
@@ -101,10 +102,10 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 \fB\-V\fR, \fB\-\-version\fR
 Print version
 .TP
-[\fIBRANCH_NAME\fR]
+[\fIBRANCH|COMMIT\-ISH\fR]
 Branch, commit\-ish, or catalog repo to open; use \*(Aq\-\*(Aq for previous worktree
 .TP
-[\fISECOND\fR]
-Branch inside <repo> when two arguments are given; base branch with \-b
+[\fIBRANCH_OR_BASE\fR]
+Branch inside <repo> when two arguments are given; base branch or commit\-ish with \-b
 .SH VERSION
 v1.23.0

--- a/man/daft-go.1
+++ b/man/daft-go.1
@@ -42,6 +42,13 @@ With \-s (\-\-start), if the specified branch does not exist locally or on the
 remote, a new branch and worktree are created automatically. This can also
 be enabled permanently with the daft.go.autoStart git config option.
 .PP
+A name that resolves to a commit but names no branch and no cataloged repo —
+a tag, a SHA, a spelling like `HEAD~2` — opens a detached sandbox worktree
+pinned at that commit: hooks run, no branch is created, and revisits land in
+the same worktree. Explicit \-b/\-\-start suppress this reading; remove a
+sandbox with `daft remove <name>`, and promote work committed inside it by
+running `daft start <new\-branch>` from within.
+.PP
 Lifecycle hooks from .daft/hooks/ are executed if the repository is trusted.
 See daft\-hooks(1) for hook management.
 .SH OPTIONS

--- a/man/daft-list.1
+++ b/man/daft-list.1
@@ -57,7 +57,7 @@ Supported formats: json, ndjson, tsv, csv, yaml, toon, markdown. Use
 for details.
 .PP
 Use \-\-columns to select which columns are shown and in what order.
-  Replace mode:  \-\-columns branch,path,age (exact set and order)
+  Replace mode:  \-\-columns name,path,age (exact set and order)
   Modifier mode: \-\-columns \-annotation,\-last\-commit (remove from defaults)
   Add optional:  \-\-columns +size (add disk size column after path)
 Defaults can be set in git config with daft.list.columns.
@@ -86,11 +86,11 @@ with `git config \-\- daft.list.columns \-pr`.
 .PP
 Use \-\-sort to control the sort order. Prefix with + for ascending (default) or
 \- for descending. Multiple columns can be comma\-separated for multi\-level sort.
-  Sort by branch descending:  \-\-sort \-branch
+  Sort by name descending:    \-\-sort \-name
   Sort by owner then size:    \-\-sort +owner,\-size
   Most recent activity first: \-\-sort \-activity
 .PP
-Sortable columns: branch, path, size, age, owner, hash, activity, commit (alias:
+Sortable columns: name, path, size, age, owner, hash, activity, commit (alias:
 last\-commit). activity considers both commits and uncommitted file changes;
 commit sorts by last commit time only. You can sort by columns not shown in
 the output (e.g. \-\-sort \-size without \-\-columns +size). Defaults can be set
@@ -155,10 +155,10 @@ lines: Line\-level counts: insertions/deletions for all columns
 .RE
 .TP
 \fB\-\-columns\fR \fI<COLUMNS>\fR
-Columns to display (comma\-separated). Replace: branch,path,age. Modify defaults: +col,\-col. Available: branch, path, size, base, changes, remote, pr, age, annotation, status, owner, hash, last\-commit
+Columns to display (comma\-separated). Replace: name,path,age. Modify defaults: +col,\-col. Available: name, path, size, base, changes, remote, pr, age, annotation, status, owner, hash, last\-commit
 .TP
 \fB\-\-sort\fR \fI<SORT>\fR
-Sort order (comma\-separated). +col ascending, \-col descending. Columns: branch, path, size, base, changes, remote, age, owner, hash, activity, commit
+Sort order (comma\-separated). +col ascending, \-col descending. Columns: name, path, size, base, changes, remote, age, owner, hash, activity, commit
 .TP
 \fB\-\-repo\fR \fI<REPO>\fR
 List another cataloged repository\*(Aqs worktrees

--- a/man/daft-prune.1
+++ b/man/daft-prune.1
@@ -64,10 +64,10 @@ lines: Line\-level counts: insertions/deletions for all columns
 .RE
 .TP
 \fB\-\-columns\fR \fI<COLUMNS>\fR
-Columns to display (comma\-separated). Replace: branch,path,age. Modify defaults: +col,\-col. Available: branch, path, size, base, changes, remote, pr, age, annotation, owner, hash, last\-commit
+Columns to display (comma\-separated). Replace: name,path,age. Modify defaults: +col,\-col. Available: name, path, size, base, changes, remote, pr, age, annotation, owner, hash, last\-commit
 .TP
 \fB\-\-sort\fR \fI<SORT>\fR
-Sort order (comma\-separated). +col ascending, \-col descending. Columns: branch, path, size, base, changes, remote, age, owner, hash, activity, commit
+Sort order (comma\-separated). +col ascending, \-col descending. Columns: name, path, size, base, changes, remote, age, owner, hash, activity, commit
 .TP
 \fB\-\-repo\fR \fI<REPO>\fR
 Prune another cataloged repository

--- a/man/daft-remove.1
+++ b/man/daft-remove.1
@@ -14,10 +14,18 @@ remote tracking branches in a single operation. This is the inverse of
 By default, performs a safe delete that checks whether each branch has been
 merged. Use \-f (\-\-force) to force\-delete branches regardless of merge status.
 .PP
-Arguments can be branch names or worktree paths. When a path is given
-(absolute, relative, or "."), the branch checked out in that worktree is
-resolved automatically. This is convenient when you are inside a worktree
-and want to delete it without remembering the branch name.
+Arguments can be branch names, worktree paths, or sandbox names. When a path
+is given (absolute, relative, or "."), the branch checked out in that
+worktree is resolved automatically. This is convenient when you are inside a
+worktree and want to delete it without remembering the branch name.
+.PP
+An anonymous sandbox worktree (`daft go <commit\-ish>` / `daft start \-\-fork`)
+is addressed by its directory name or path; a branch sharing the spelling
+always wins the name. There is no branch to delete, so only the worktree
+goes — after two checks: the worktree is clean, and its HEAD still sits at
+the pinned commit (commits made on a detached HEAD exist nowhere else, so a
+moved HEAD refuses removal until promoted or forced). Detached worktrees
+daft has no record of are refused as before.
 .PP
 Use \-\-repo <name> to remove branches in another cataloged repository without
 leaving your current directory: `daft remove \-\-repo api feature\-x` deletes

--- a/man/daft-remove.1
+++ b/man/daft-remove.1
@@ -27,6 +27,14 @@ the pinned commit (commits made on a detached HEAD exist nowhere else, so a
 moved HEAD refuses removal until promoted or forced). Detached worktrees
 daft has no record of are refused as before.
 .PP
+Sandbox names may be given as wildcard patterns: `*` matches any run of
+characters and `?` exactly one, so `daft remove \*(Aqmain\-fork*\*(Aq` sweeps every
+fork minted off main in one command. Patterns match sandbox names only —
+never branches (removing a branch also deletes its remote; for fleet\-scale
+branch cleanup use `daft prune`) and never paths. A pattern that matches no
+live sandbox aborts the command. Quote the pattern so your shell does not
+expand or reject it before daft sees it (zsh errors on unmatched globs).
+.PP
 Use \-\-repo <name> to remove branches in another cataloged repository without
 leaving your current directory: `daft remove \-\-repo api feature\-x` deletes
 `feature\-x` in the `api` repo. \-\-repo is a flag rather than a positional
@@ -99,6 +107,6 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 Print version
 .TP
 <\fIBRANCHES\fR>
-Branches, worktree paths, or sandbox names to delete
+Branches, worktree paths, or sandbox names to delete; sandbox names may use wildcards (*, ?)
 .SH VERSION
 v1.23.0

--- a/man/daft-remove.1
+++ b/man/daft-remove.1
@@ -91,6 +91,6 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 Print version
 .TP
 <\fIBRANCHES\fR>
-Branches or worktree paths to delete
+Branches, worktree paths, or sandbox names to delete
 .SH VERSION
 v1.23.0

--- a/man/daft-start.1
+++ b/man/daft-start.1
@@ -34,6 +34,17 @@ target repo\*(Aqs hooks run only if it is trusted, and the shell lands in the ne
 worktree there. Carry (`\-c`) cannot cross repositories; `\-x` runs in the
 target worktree.
 .PP
+With \-\-fork, the positionals become just the optional base and daft mints an
+anonymous throwaway worktree pinned at that position instead — detached
+HEAD, no branch, no tracking, no push, named by the system (see
+daft.start.forkNaming: derived or memorable). The created worktree\*(Aqs path
+prints bare on stdout, one per line with `\-n <count>`, while narration goes
+to stderr — `wt=$(daft start \-\-fork)` captures it. A single fork cd\*(Aqs the
+shell into it; with several there is no one destination and the shell stays
+put. Remove a fork with `daft remove <name>`; promote work committed inside
+it by running `daft start <new\-branch>` from within (a detached HEAD bases
+the new branch on its commit).
+.PP
 With \-\-with\-related, the same branch is also created in every repo the
 primary repo\*(Aqs daft.yml `relations:` manifest points at — the entry point
 for a coordinated cross\-repo change (pair with `daft exec \-\-related`). The

--- a/man/daft-start.1
+++ b/man/daft-start.1
@@ -4,15 +4,16 @@
 .SH NAME
 daft start \- Create a new branch and worktree, or a throwaway fork with \-\-fork
 .SH SYNOPSIS
-\fBdaft start\fR [\fB\-\-repo\fR] [\fB\-\-with\-related\fR] [\fB\-\-fork\fR] [\fB\-n\fR|\fB\-\-count\fR] [\fB\-c\fR|\fB\-\-carry\fR] [\fB\-\-no\-carry\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-\-no\-cd\fR] [\fB\-x\fR|\fB\-\-exec\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-@\fR|\fB\-\-at\fR] [\fB\-\-local\fR] [\fB\-\-no\-verify\fR] [\fB\-\-skip\-hooks\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fIBRANCH_NAME\fR] [\fIBASE_OR_BRANCH\fR] [\fIBASE\fR] 
+\fBdaft start\fR [\fB\-\-repo\fR] [\fB\-\-with\-related\fR] [\fB\-\-fork\fR] [\fB\-n\fR|\fB\-\-count\fR] [\fB\-c\fR|\fB\-\-carry\fR] [\fB\-\-no\-carry\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-\-no\-cd\fR] [\fB\-x\fR|\fB\-\-exec\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-@\fR|\fB\-\-at\fR] [\fB\-\-local\fR] [\fB\-\-no\-verify\fR] [\fB\-\-skip\-hooks\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fIBRANCH|COMMIT\-ISH\fR] [\fIBASE_OR_BRANCH\fR] [\fIBASE\fR] 
 .SH DESCRIPTION
 .PP
 Creates a new branch and a corresponding worktree in a single operation. The
 worktree is placed at the project root level as a sibling to other worktrees,
 using the branch name as the directory name.
 .PP
-The new branch is based on the current branch, or on `<base\-branch>` if
-specified. After creating the branch locally, it is pushed to the remote and
+The new branch is based on the current branch, or on `<base>` if specified —
+a branch, or any commit\-ish (a tag, a SHA, a spelling like `HEAD~2`).
+After creating the branch locally, it is pushed to the remote and
 upstream tracking is configured (unless disabled via daft.checkout.push). The
 repo\*(Aqs pre\-push hook runs only when that push introduces new commits; a
 ref\-only push of already\-pushed commits skips it (configurable via
@@ -113,13 +114,13 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 \fB\-V\fR, \fB\-\-version\fR
 Print version
 .TP
-[\fIBRANCH_NAME\fR]
-Name for the new branch; or a cataloged repo to create it in, with `daft start <repo> <branch> [base]`; with \-\-fork, the base position instead
+[\fIBRANCH|COMMIT\-ISH\fR]
+Name for the new branch; or a cataloged repo to create it in, with `daft start <repo> <branch> [base]`; with \-\-fork, the commit\-ish to fork from instead (defaults to HEAD)
 .TP
 [\fIBASE_OR_BRANCH\fR]
-Base branch (defaults to the current branch); or, when it names no ref here, the new branch inside `<repo>`
+Base branch or commit\-ish (defaults to the current branch); or, when it resolves to nothing here, the new branch inside `<repo>`; not used with \-\-fork
 .TP
 [\fIBASE\fR]
-Base branch inside `<repo>` (three\-name form); must exist there
+Base branch or commit\-ish inside `<repo>` (three\-name form); must resolve there; not used with \-\-fork
 .SH VERSION
 v1.23.0

--- a/man/daft-start.1
+++ b/man/daft-start.1
@@ -2,7 +2,7 @@
 .el .ds Aq '
 .TH "daft start" 1  "daft start 1.23.0" 
 .SH NAME
-daft start \- Create a new branch and worktree
+daft start \- Create a new branch and worktree, or a throwaway fork with \-\-fork
 .SH SYNOPSIS
 \fBdaft start\fR [\fB\-\-repo\fR] [\fB\-\-with\-related\fR] [\fB\-\-fork\fR] [\fB\-n\fR|\fB\-\-count\fR] [\fB\-c\fR|\fB\-\-carry\fR] [\fB\-\-no\-carry\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-\-no\-cd\fR] [\fB\-x\fR|\fB\-\-exec\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-@\fR|\fB\-\-at\fR] [\fB\-\-local\fR] [\fB\-\-no\-verify\fR] [\fB\-\-skip\-hooks\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fIBRANCH_NAME\fR] [\fIBASE_OR_BRANCH\fR] [\fIBASE\fR] 
 .SH DESCRIPTION

--- a/man/daft-start.1
+++ b/man/daft-start.1
@@ -4,7 +4,7 @@
 .SH NAME
 daft start \- Create a new branch and worktree
 .SH SYNOPSIS
-\fBdaft start\fR [\fB\-\-repo\fR] [\fB\-\-with\-related\fR] [\fB\-c\fR|\fB\-\-carry\fR] [\fB\-\-no\-carry\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-\-no\-cd\fR] [\fB\-x\fR|\fB\-\-exec\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-@\fR|\fB\-\-at\fR] [\fB\-\-local\fR] [\fB\-\-no\-verify\fR] [\fB\-\-skip\-hooks\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIBRANCH_NAME\fR> [\fIBASE_OR_BRANCH\fR] [\fIBASE\fR] 
+\fBdaft start\fR [\fB\-\-repo\fR] [\fB\-\-with\-related\fR] [\fB\-\-fork\fR] [\fB\-n\fR|\fB\-\-count\fR] [\fB\-c\fR|\fB\-\-carry\fR] [\fB\-\-no\-carry\fR] [\fB\-r\fR|\fB\-\-remote\fR] [\fB\-\-no\-cd\fR] [\fB\-x\fR|\fB\-\-exec\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-@\fR|\fB\-\-at\fR] [\fB\-\-local\fR] [\fB\-\-no\-verify\fR] [\fB\-\-skip\-hooks\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fIBRANCH_NAME\fR] [\fIBASE_OR_BRANCH\fR] [\fIBASE\fR] 
 .SH DESCRIPTION
 .PP
 Creates a new branch and a corresponding worktree in a single operation. The
@@ -57,6 +57,12 @@ Create the branch in a repository from the catalog (for repo names shadowed by l
 \fB\-\-with\-related\fR
 Also create the branch in every related repo (relations manifest), each based on its own default branch
 .TP
+\fB\-\-fork\fR
+Mint an anonymous throwaway worktree pinned at [<base>] (defaults to HEAD): detached, system\-named, no branch, no push; the created path is printed on stdout
+.TP
+\fB\-n\fR, \fB\-\-count\fR \fI<N>\fR
+Create N fork worktrees (one path per line on stdout; the shell stays where it is)
+.TP
 \fB\-c\fR, \fB\-\-carry\fR
 Apply uncommitted changes from the current worktree to the new one
 .TP
@@ -96,8 +102,8 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 \fB\-V\fR, \fB\-\-version\fR
 Print version
 .TP
-<\fIBRANCH_NAME\fR>
-Name for the new branch; or a cataloged repo to create it in, with `daft start <repo> <branch> [base]`
+[\fIBRANCH_NAME\fR]
+Name for the new branch; or a cataloged repo to create it in, with `daft start <repo> <branch> [base]`; with \-\-fork, the base position instead
 .TP
 [\fIBASE_OR_BRANCH\fR]
 Base branch (defaults to the current branch); or, when it names no ref here, the new branch inside `<repo>`

--- a/man/daft-sync.1
+++ b/man/daft-sync.1
@@ -84,10 +84,10 @@ lines: Line\-level counts: insertions/deletions for all columns
 .RE
 .TP
 \fB\-\-columns\fR \fI<COLUMNS>\fR
-Columns to display (comma\-separated). Replace: branch,path,age. Modify defaults: +col,\-col. Available: branch, path, size, base, changes, remote, pr, age, annotation, owner, hash, last\-commit
+Columns to display (comma\-separated). Replace: name,path,age. Modify defaults: +col,\-col. Available: name, path, size, base, changes, remote, pr, age, annotation, owner, hash, last\-commit
 .TP
 \fB\-\-sort\fR \fI<SORT>\fR
-Sort order (comma\-separated). +col ascending, \-col descending. Columns: branch, path, size, base, changes, remote, age, owner, hash, activity, commit
+Sort order (comma\-separated). +col ascending, \-col descending. Columns: name, path, size, base, changes, remote, age, owner, hash, activity, commit
 .TP
 \fB\-\-jobs\fR \fI<N>\fR
 Cap concurrent pushes when a pre\-push hook is present (requires \-\-push; default: from daft.governor.jobs, or max(2, cores/4))

--- a/man/daft.1
+++ b/man/daft.1
@@ -74,10 +74,10 @@ daft\-adopt(1)
 Convert a traditional repository to worktree\-based layout
 .TP
 daft\-go(1)
-Open a worktree for an existing branch, or create one with \-b
+Open a worktree for a branch or commit; create a new branch with \-b
 .TP
 daft\-start(1)
-Create a new branch and worktree
+Create a new branch and worktree, or a throwaway fork with \-\-fork
 .TP
 daft\-carry(1)
 Transfer uncommitted changes to other worktrees

--- a/man/git-worktree-clone.1
+++ b/man/git-worktree-clone.1
@@ -55,7 +55,7 @@ Worktree layout to use for this repository.
 Built\-in layouts: contained, sibling, nested, centralized. Can also be a custom layout name from ~/.config/daft/config.toml or an inline template string.
 .TP
 \fB\-\-columns\fR \fI<COLUMNS>\fR
-Columns to display (comma\-separated). Replace: branch,base,age. Modify defaults: +col,\-col. Available: branch, path, size, base, changes, remote, age, annotation, owner, hash, last\-commit
+Columns to display (comma\-separated). Replace: name,base,age. Modify defaults: +col,\-col. Available: name, path, size, base, changes, remote, age, annotation, owner, hash, last\-commit
 .TP
 \fB\-x\fR, \fB\-\-exec\fR \fI<EXEC>\fR
 Run a command in the worktree after setup completes (repeatable)

--- a/man/git-worktree-list.1
+++ b/man/git-worktree-list.1
@@ -57,7 +57,7 @@ Supported formats: json, ndjson, tsv, csv, yaml, toon, markdown. Use
 for details.
 .PP
 Use \-\-columns to select which columns are shown and in what order.
-  Replace mode:  \-\-columns branch,path,age (exact set and order)
+  Replace mode:  \-\-columns name,path,age (exact set and order)
   Modifier mode: \-\-columns \-annotation,\-last\-commit (remove from defaults)
   Add optional:  \-\-columns +size (add disk size column after path)
 Defaults can be set in git config with daft.list.columns.
@@ -86,11 +86,11 @@ with `git config \-\- daft.list.columns \-pr`.
 .PP
 Use \-\-sort to control the sort order. Prefix with + for ascending (default) or
 \- for descending. Multiple columns can be comma\-separated for multi\-level sort.
-  Sort by branch descending:  \-\-sort \-branch
+  Sort by name descending:    \-\-sort \-name
   Sort by owner then size:    \-\-sort +owner,\-size
   Most recent activity first: \-\-sort \-activity
 .PP
-Sortable columns: branch, path, size, age, owner, hash, activity, commit (alias:
+Sortable columns: name, path, size, age, owner, hash, activity, commit (alias:
 last\-commit). activity considers both commits and uncommitted file changes;
 commit sorts by last commit time only. You can sort by columns not shown in
 the output (e.g. \-\-sort \-size without \-\-columns +size). Defaults can be set
@@ -155,10 +155,10 @@ lines: Line\-level counts: insertions/deletions for all columns
 .RE
 .TP
 \fB\-\-columns\fR \fI<COLUMNS>\fR
-Columns to display (comma\-separated). Replace: branch,path,age. Modify defaults: +col,\-col. Available: branch, path, size, base, changes, remote, pr, age, annotation, status, owner, hash, last\-commit
+Columns to display (comma\-separated). Replace: name,path,age. Modify defaults: +col,\-col. Available: name, path, size, base, changes, remote, pr, age, annotation, status, owner, hash, last\-commit
 .TP
 \fB\-\-sort\fR \fI<SORT>\fR
-Sort order (comma\-separated). +col ascending, \-col descending. Columns: branch, path, size, base, changes, remote, age, owner, hash, activity, commit
+Sort order (comma\-separated). +col ascending, \-col descending. Columns: name, path, size, base, changes, remote, age, owner, hash, activity, commit
 .TP
 \fB\-\-repo\fR \fI<REPO>\fR
 List another cataloged repository\*(Aqs worktrees

--- a/man/git-worktree-prune.1
+++ b/man/git-worktree-prune.1
@@ -64,10 +64,10 @@ lines: Line\-level counts: insertions/deletions for all columns
 .RE
 .TP
 \fB\-\-columns\fR \fI<COLUMNS>\fR
-Columns to display (comma\-separated). Replace: branch,path,age. Modify defaults: +col,\-col. Available: branch, path, size, base, changes, remote, pr, age, annotation, owner, hash, last\-commit
+Columns to display (comma\-separated). Replace: name,path,age. Modify defaults: +col,\-col. Available: name, path, size, base, changes, remote, pr, age, annotation, owner, hash, last\-commit
 .TP
 \fB\-\-sort\fR \fI<SORT>\fR
-Sort order (comma\-separated). +col ascending, \-col descending. Columns: branch, path, size, base, changes, remote, age, owner, hash, activity, commit
+Sort order (comma\-separated). +col ascending, \-col descending. Columns: name, path, size, base, changes, remote, age, owner, hash, activity, commit
 .TP
 \fB\-\-repo\fR \fI<REPO>\fR
 Prune another cataloged repository

--- a/man/git-worktree-sync.1
+++ b/man/git-worktree-sync.1
@@ -84,10 +84,10 @@ lines: Line\-level counts: insertions/deletions for all columns
 .RE
 .TP
 \fB\-\-columns\fR \fI<COLUMNS>\fR
-Columns to display (comma\-separated). Replace: branch,path,age. Modify defaults: +col,\-col. Available: branch, path, size, base, changes, remote, pr, age, annotation, owner, hash, last\-commit
+Columns to display (comma\-separated). Replace: name,path,age. Modify defaults: +col,\-col. Available: name, path, size, base, changes, remote, pr, age, annotation, owner, hash, last\-commit
 .TP
 \fB\-\-sort\fR \fI<SORT>\fR
-Sort order (comma\-separated). +col ascending, \-col descending. Columns: branch, path, size, base, changes, remote, age, owner, hash, activity, commit
+Sort order (comma\-separated). +col ascending, \-col descending. Columns: name, path, size, base, changes, remote, age, owner, hash, activity, commit
 .TP
 \fB\-\-jobs\fR \fI<N>\fR
 Cap concurrent pushes when a pre\-push hook is present (requires \-\-push; default: from daft.governor.jobs, or max(2, cores/4))

--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -199,6 +199,13 @@ With -s (--start), if the specified branch does not exist locally or on the
 remote, a new branch and worktree are created automatically. This can also
 be enabled permanently with the daft.go.autoStart git config option.
 
+A name that resolves to a commit but names no branch and no cataloged repo —
+a tag, a SHA, a spelling like `HEAD~2` — opens a detached sandbox worktree
+pinned at that commit: hooks run, no branch is created, and revisits land in
+the same worktree. Explicit -b/--start suppress this reading; remove a
+sandbox with `daft remove <name>`, and promote work committed inside it by
+running `daft start <new-branch>` from within.
+
 Lifecycle hooks from .daft/hooks/ are executed if the repository is trusted.
 See daft-hooks(1) for hook management.
 "#)]
@@ -325,6 +332,17 @@ without a base the branch is based on the target repo's default branch, the
 target repo's hooks run only if it is trusted, and the shell lands in the new
 worktree there. Carry (`-c`) cannot cross repositories; `-x` runs in the
 target worktree.
+
+With --fork, the positionals become just the optional base and daft mints an
+anonymous throwaway worktree pinned at that position instead — detached
+HEAD, no branch, no tracking, no push, named by the system (see
+daft.start.forkNaming: derived or memorable). The created worktree's path
+prints bare on stdout, one per line with `-n <count>`, while narration goes
+to stderr — `wt=$(daft start --fork)` captures it. A single fork cd's the
+shell into it; with several there is no one destination and the shell stays
+put. Remove a fork with `daft remove <name>`; promote work committed inside
+it by running `daft start <new-branch>` from within (a detached HEAD bases
+the new branch on its commit).
 
 With --with-related, the same branch is also created in every repo the
 primary repo's daft.yml `relations:` manifest points at — the entry point

--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -25,7 +25,7 @@ use crate::{
 use anyhow::Result;
 use clap::Parser;
 use std::io::IsTerminal;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 #[derive(Parser, Clone)]
@@ -345,9 +345,10 @@ See daft-hooks(1) for hook management.
 pub struct StartArgs {
     #[arg(
         value_name = "BRANCH_NAME",
-        help = "Name for the new branch; or a cataloged repo to create it in, with `daft start <repo> <branch> [base]`"
+        required_unless_present = "fork",
+        help = "Name for the new branch; or a cataloged repo to create it in, with `daft start <repo> <branch> [base]`; with --fork, the base position instead"
     )]
-    first: String,
+    first: Option<String>,
 
     #[arg(
         value_name = "BASE_OR_BRANCH",
@@ -373,6 +374,23 @@ pub struct StartArgs {
         help = "Also create the branch in every related repo (relations manifest), each based on its own default branch"
     )]
     with_related: bool,
+
+    #[arg(
+        long = "fork",
+        conflicts_with_all = ["repo", "with_related"],
+        help = "Mint an anonymous throwaway worktree pinned at [<base>] (defaults to HEAD): detached, system-named, no branch, no push; the created path is printed on stdout"
+    )]
+    fork: bool,
+
+    #[arg(
+        short = 'n',
+        long = "count",
+        value_name = "N",
+        requires = "fork",
+        conflicts_with = "at",
+        help = "Create N fork worktrees (one path per line on stdout; the shell stays where it is)"
+    )]
+    count: Option<u32>,
 
     #[arg(
         short = 'c',
@@ -613,8 +631,21 @@ pub fn run_start() -> Result<()> {
     raw[0] = "daft start".to_string();
     let start_args = StartArgs::parse_from(raw);
 
+    // With --fork the positional grammar reshapes to just [<base>] — the
+    // system owns the name, so there is no branch slot (#53). Handled before
+    // the branch grammar so `daft start fork` (a legal branch name) keeps
+    // meaning the branch.
+    if start_args.fork {
+        let (base, count) = decode_fork_grammar(&start_args)?;
+        return run_start_fork(start_args, base, count);
+    }
+
+    let first = start_args
+        .first
+        .clone()
+        .expect("clap enforces the first positional unless --fork");
     let routing = decode_start_grammar(
-        start_args.first.clone(),
+        first,
         start_args.second.clone(),
         start_args.third.clone(),
         start_args.repo.clone(),
@@ -659,6 +690,300 @@ pub fn run_start() -> Result<()> {
             guessed,
         } => run_start_cross(start_args, repo, branch, base, guessed),
     }
+}
+
+/// Decode the `--fork` reshape of `daft start`'s positionals: exactly
+/// `[<base>]`, plus the count. The clap-level rules (`-n` requires `--fork`
+/// and conflicts with `--at`; `--fork` conflicts with `--repo` /
+/// `--with-related`) have already run by the time this is called.
+fn decode_fork_grammar(args: &StartArgs) -> Result<(Option<String>, u32)> {
+    if args.second.is_some() || args.third.is_some() {
+        anyhow::bail!(
+            "--fork takes at most one <base> (usage: `{}`)",
+            crate::daft_cmd("start --fork [<base>] [-n N]")
+        );
+    }
+    if args.first.as_deref() == Some("-") {
+        anyhow::bail!("'-' is not a base for --fork");
+    }
+    let count = args.count.unwrap_or(1);
+    if count == 0 {
+        anyhow::bail!("-n/--count must be at least 1");
+    }
+    if args.carry && count > 1 {
+        anyhow::bail!(
+            "--carry cannot fan out across -n {count} forks: a stash is consumed by the \
+             first pop (fork once with --carry, or drop --carry)"
+        );
+    }
+    Ok((args.first.clone(), count))
+}
+
+/// The `daft start --fork` engine (#53): mint `count` anonymous detached
+/// worktrees at a position. Always fresh — never reuses, never touches refs.
+///
+/// Output contract: each created worktree's path prints bare on stdout — the
+/// system chose the name, so the path IS the result — and narration goes to
+/// stderr. With `count == 1` the shell cd's into the fork; with more there is
+/// no one "there" and the shell stays put. Partial failure is best-effort:
+/// successes keep their printed paths, failures are named on stderr, and the
+/// exit is nonzero.
+fn run_start_fork(args: StartArgs, base: Option<String>, count: u32) -> Result<()> {
+    use crate::core::worktree::{fork_names, sandbox};
+
+    init_logging(args.verbose);
+    if !is_git_repository()? {
+        anyhow::bail!("Not inside a Git repository");
+    }
+    crate::catalog::touch_current_repo();
+    let original_dir = get_current_directory()?;
+    let source_worktree = get_current_worktree_path().ok();
+
+    let git = GitCommand::new(args.quiet);
+    let settings = DaftSettings::load_with(&git)?;
+    let git = git.with_gitoxide(settings.use_gitoxide);
+
+    // Bulk minting has no single destination — autocd only for one fork.
+    let autocd = settings.autocd && !args.no_cd && count == 1;
+    let config = OutputConfig::with_autocd(args.quiet, args.verbose, autocd);
+    let mut output = CliOutput::new(config);
+
+    let spelling = base.unwrap_or_else(|| "HEAD".to_string());
+    let Some(commit) = resolve_commitish(&spelling) else {
+        anyhow::bail!("'{spelling}' does not resolve to a commit here");
+    };
+    if !output.is_quiet() {
+        output.notice(&format!(
+            "Forking {spelling} @ {}",
+            sandbox::short_oid(&commit)
+        ));
+    }
+
+    let project_root = get_project_root()?;
+    let (resolved_layout, source) = resolve_checkout_layout(&git, &mut output);
+    let (layout, should_persist) =
+        interactive_layout_resolution(&resolved_layout, source, &mut output)?;
+    if should_persist && let Ok(git_dir) = get_git_common_dir() {
+        let _ = TrustDatabase::update(|db| {
+            db.set_layout(&git_dir, layout.name.clone());
+            Ok(())
+        });
+    }
+
+    let hooks_config = crate::core::settings::load_hooks_config_with(&git)?;
+    let hook_output_config = hooks_config.output.with_cli_verbose(output.is_verbose());
+
+    // The candidate stream the claim loop draws from.
+    let mut candidates: Box<dyn Iterator<Item = String>> = match settings.start_fork_naming {
+        crate::settings::ForkNaming::Derived => {
+            let stem = fork_stem(&spelling, &commit, &git);
+            Box::new((0u32..).map(move |i| match i {
+                0 => format!("{stem}-fork"),
+                _ => format!("{stem}-fork-{}", i + 1),
+            }))
+        }
+        crate::settings::ForkNaming::Memorable => {
+            Box::new(fork_names::candidates(fork_name_seed()))
+        }
+    };
+
+    let mut completed: Vec<sandbox::SandboxResult> = Vec::new();
+    let mut failures: Vec<(String, anyhow::Error)> = Vec::new();
+
+    for _ in 0..count {
+        // Each fork resolves and creates from where the user stood — the
+        // previous iteration left the cwd inside its fork.
+        change_directory(&original_dir)?;
+
+        let (dirname, claimed_path) = claim_fork_dir(
+            candidates.as_mut(),
+            args.at.as_deref(),
+            &layout,
+            &project_root,
+        )?;
+
+        let params = sandbox::SandboxParams {
+            spelling: spelling.clone(),
+            commit: commit.clone(),
+            dirname: dirname.clone(),
+            kind: crate::store::models::WorktreeKind::Fork,
+            path_preclaimed: true,
+            carry: args.carry,
+            // Ambient carry cannot fan out (a stash is consumed by the first
+            // pop); the explicit --carry × -n combination bailed at decode.
+            no_carry: args.no_carry || count > 1,
+            checkout_carry: settings.checkout_carry,
+            remote: args.remote.clone(),
+            remote_name: settings.remote.clone(),
+            multi_remote_enabled: settings.multi_remote_enabled,
+            multi_remote_default: settings.multi_remote_default.clone(),
+            layout: Some(layout.clone()),
+            at_path: args.at.clone(),
+        };
+
+        let executor = HookExecutor::new(hooks_config.clone())?.with_job_filter(
+            crate::hooks::yaml_executor::JobFilter::skipping(&args.skip_hooks),
+        );
+        let mut timeline = Timeline::new(
+            TimelineMode::auto(output.is_quiet()),
+            output.is_verbose(),
+            format!("Forking {dirname}"),
+        );
+        timeline.set_verbose_density(hook_output_config.verbose);
+        timeline.open_planning("Pinning commit");
+        let create_result = {
+            let mut bridge = TimelineBridge::new(
+                &mut output,
+                &mut timeline,
+                executor,
+                hook_output_config.clone(),
+            );
+            sandbox::execute_create(&params, &git, &project_root, &mut bridge)
+        };
+        timeline.abandon_planning();
+        match create_result {
+            Ok(result) => {
+                if timeline.region_live() {
+                    timeline.finish(&format!("Ready in {}", timeline.elapsed_display()));
+                }
+                // The path is the record: bare on stdout, exactly once, in
+                // every mode (rail, plain, quiet, redirected).
+                output.raw(&format!("{}\n", result.worktree_path.display()));
+                // Per-fork exec, inside the fork (core chdir'd there). A
+                // failed command marks this fork failed; the worktree stays.
+                if !args.exec.is_empty()
+                    && let Err(e) = crate::exec::run_exec_commands(&args.exec, &mut output)
+                {
+                    failures.push((dirname.clone(), e));
+                }
+                completed.push(result);
+            }
+            Err(e) => {
+                timeline.abort(&format!("Failed after {}", timeline.elapsed_display()));
+                // A failed create can leave the claimed (still empty)
+                // directory behind; release the name.
+                let _ = std::fs::remove_dir(&claimed_path);
+                failures.push((dirname, e));
+            }
+        }
+    }
+
+    if count == 1
+        && failures.is_empty()
+        && let Some(result) = completed.last()
+    {
+        // Stay inside the fork (the cwd already is) and honor the wrapper's
+        // cd contract.
+        output.cd_path(&result.cd_target);
+        maybe_show_shell_hint(&mut output)?;
+        if let Some(src) = source_worktree
+            && let Ok(git_dir) = get_git_common_dir()
+        {
+            let _ = previous::save(&git_dir, &src);
+        }
+    } else {
+        change_directory(&original_dir)?;
+    }
+
+    for (name, e) in &failures {
+        output.warning(&format!("fork '{name}': {e:#}"));
+    }
+    if !failures.is_empty() {
+        anyhow::bail!("{} of {count} fork(s) failed", failures.len());
+    }
+    Ok(())
+}
+
+/// The derived-scheme stem: what a fork is named after. An explicit base
+/// keeps its own (nameable) spelling; a bare `--fork` forks "here" and is
+/// named after the current branch — or the commit, when detached.
+fn fork_stem(spelling: &str, commit: &str, git: &GitCommand) -> String {
+    use crate::core::worktree::sandbox;
+    if spelling == "HEAD" {
+        git.symbolic_ref_short_head()
+            .ok()
+            .map(|b| b.replace('/', "-"))
+            .unwrap_or_else(|| sandbox::derived_dirname(commit))
+    } else {
+        sandbox::sandbox_dirname(spelling).unwrap_or_else(|| sandbox::derived_dirname(commit))
+    }
+}
+
+/// Entropy for memorable fork names: time × pid, no new dependency.
+/// Uniqueness is enforced by the mkdir claim, never by this seed.
+fn fork_name_seed() -> u64 {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.subsec_nanos() as u64)
+        .unwrap_or(0);
+    nanos ^ ((std::process::id() as u64) << 17)
+}
+
+/// Claim a directory for a fork by creating it — mkdir is the atomic lock
+/// that lets parallel invocations mint names with zero coordination. `--at`
+/// claims exactly the given path (no suffixing a user-chosen name); the
+/// naming scheme's candidate stream is consulted otherwise.
+fn claim_fork_dir(
+    candidates: &mut dyn Iterator<Item = String>,
+    at: Option<&Path>,
+    layout: &crate::core::layout::Layout,
+    project_root: &Path,
+) -> Result<(String, PathBuf)> {
+    if let Some(at) = at {
+        let dirname = at
+            .file_name()
+            .ok_or_else(|| anyhow::anyhow!("--at path has no directory name"))?
+            .to_string_lossy()
+            .into_owned();
+        if let Some(parent) = at.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            std::fs::create_dir_all(parent)?;
+        }
+        return match std::fs::create_dir(at) {
+            Ok(()) => Ok((dirname, at.to_path_buf())),
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                anyhow::bail!("directory '{}' already exists", at.display())
+            }
+            Err(e) => anyhow::bail!("could not create '{}': {e}", at.display()),
+        };
+    }
+
+    for _ in 0..100 {
+        let Some(dirname) = candidates.next() else {
+            break;
+        };
+        let path = fork_path_for(&dirname, layout, project_root)?;
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        match std::fs::create_dir(&path) {
+            Ok(()) => return Ok((dirname, path)),
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(e) => anyhow::bail!("could not create '{}': {e}", path.display()),
+        }
+    }
+    anyhow::bail!("could not find a free fork name after 100 attempts")
+}
+
+/// The layout path a fork named `dirname` will occupy — the same computation
+/// the sandbox core performs, so the claimed directory and the created
+/// worktree always agree.
+fn fork_path_for(
+    dirname: &str,
+    layout: &crate::core::layout::Layout,
+    project_root: &Path,
+) -> Result<PathBuf> {
+    let effective_root = if layout.needs_wrapper() {
+        project_root
+            .parent()
+            .map(|p| p.to_path_buf())
+            .unwrap_or_else(|| project_root.to_path_buf())
+    } else {
+        project_root.to_path_buf()
+    };
+    let ctx = crate::multi_remote::path::build_template_context(&effective_root, dirname);
+    layout.worktree_path(&ctx)
 }
 
 /// How a `daft start` invocation routes after grammar decode.
@@ -2515,7 +2840,8 @@ mod start_grammar_tests {
         full.extend_from_slice(argv);
         let a = StartArgs::try_parse_from(full).expect("argv should parse");
         decode_start_grammar(
-            a.first,
+            a.first
+                .expect("grammar tests always pass a first positional"),
             a.second,
             a.third,
             a.repo,
@@ -2837,6 +3163,100 @@ mod start_grammar_tests {
                 also_live_repo: false
             }
         );
+    }
+}
+
+#[cfg(test)]
+mod fork_grammar_tests {
+    use super::*;
+
+    fn parse(argv: &[&str]) -> StartArgs {
+        let mut full = vec!["daft start"];
+        full.extend_from_slice(argv);
+        StartArgs::try_parse_from(full).expect("argv should parse")
+    }
+
+    fn parse_err(argv: &[&str]) -> String {
+        let mut full = vec!["daft start"];
+        full.extend_from_slice(argv);
+        match StartArgs::try_parse_from(full) {
+            Ok(_) => panic!("argv {argv:?} should be rejected by clap"),
+            Err(e) => e.to_string(),
+        }
+    }
+
+    #[test]
+    fn bare_fork_defaults_to_head_and_one() {
+        let args = parse(&["--fork"]);
+        let (base, count) = decode_fork_grammar(&args).unwrap();
+        assert_eq!(base, None);
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn the_first_positional_becomes_the_base() {
+        let args = parse(&["--fork", "v1.2"]);
+        let (base, count) = decode_fork_grammar(&args).unwrap();
+        assert_eq!(base.as_deref(), Some("v1.2"));
+        assert_eq!(count, 1);
+        // Flag order does not matter.
+        let args = parse(&["master", "--fork", "-n", "3"]);
+        let (base, count) = decode_fork_grammar(&args).unwrap();
+        assert_eq!(base.as_deref(), Some("master"));
+        assert_eq!(count, 3);
+    }
+
+    #[test]
+    fn two_positionals_are_rejected() {
+        let args = parse(&["--fork", "a", "b"]);
+        let err = decode_fork_grammar(&args).unwrap_err().to_string();
+        assert!(err.contains("at most one <base>"), "{err}");
+    }
+
+    #[test]
+    fn dash_is_not_a_base() {
+        let args = parse(&["--fork", "--", "-"]);
+        assert!(decode_fork_grammar(&args).is_err());
+    }
+
+    #[test]
+    fn zero_count_is_rejected() {
+        let args = parse(&["--fork", "-n", "0"]);
+        let err = decode_fork_grammar(&args).unwrap_err().to_string();
+        assert!(err.contains("at least 1"), "{err}");
+    }
+
+    #[test]
+    fn explicit_carry_cannot_fan_out() {
+        let args = parse(&["--fork", "-c", "-n", "2"]);
+        let err = decode_fork_grammar(&args).unwrap_err().to_string();
+        assert!(err.contains("--carry cannot fan out"), "{err}");
+        // A single fork carries fine.
+        let args = parse(&["--fork", "-c"]);
+        assert!(decode_fork_grammar(&args).is_ok());
+    }
+
+    #[test]
+    fn clap_level_conflicts_hold() {
+        // -n requires --fork.
+        assert!(parse_err(&["feat-x", "-n", "2"]).contains("--fork"));
+        // -n conflicts with --at (one path cannot hold N worktrees).
+        assert!(!parse_err(&["--fork", "-n", "2", "--at", "p"]).is_empty());
+        // --fork conflicts with the cross-repo and fan-out forms.
+        assert!(!parse_err(&["--fork", "--repo", "api"]).is_empty());
+        assert!(!parse_err(&["--fork", "--with-related"]).is_empty());
+        // A branch name is still required without --fork.
+        assert!(!parse_err(&[]).is_empty());
+    }
+
+    /// The non-fork grammar is byte-identical: the positional Option-ization
+    /// must not loosen anything.
+    #[test]
+    fn plain_start_still_requires_the_branch_positional() {
+        let args = parse(&["feat-x", "main"]);
+        assert_eq!(args.first.as_deref(), Some("feat-x"));
+        assert_eq!(args.second.as_deref(), Some("main"));
+        assert!(!args.fork);
     }
 }
 

--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -188,7 +188,8 @@ resolves purely against the catalog. Anything resolvable in the current
 repository always wins over a catalog match.
 
 With -b, creates a new branch and worktree in a single operation. The new
-branch is based on the current branch, or on `<base-branch>` if specified. It
+branch is based on the current branch, or on `<base>` (a branch or any
+commit-ish) if specified. It
 is pushed to the remote and upstream tracking is configured; the pre-push hook
 runs only when that push introduces new commits, skipping ref-only pushes
 (configurable via daft.checkout.pushVerify, which defaults to the base
@@ -211,13 +212,17 @@ See daft-hooks(1) for hook management.
 "#)]
 pub struct GoArgs {
     #[arg(
+        value_name = "BRANCH|COMMIT-ISH",
         help = "Branch, commit-ish, or catalog repo to open; use '-' for previous worktree",
         allow_hyphen_values = true,
         required_unless_present = "repo"
     )]
     branch_name: Option<String>,
 
-    #[arg(help = "Branch inside <repo> when two arguments are given; base branch with -b")]
+    #[arg(
+        value_name = "BRANCH_OR_BASE",
+        help = "Branch inside <repo> when two arguments are given; base branch or commit-ish with -b"
+    )]
     second: Option<String>,
 
     #[arg(
@@ -310,8 +315,9 @@ Creates a new branch and a corresponding worktree in a single operation. The
 worktree is placed at the project root level as a sibling to other worktrees,
 using the branch name as the directory name.
 
-The new branch is based on the current branch, or on `<base-branch>` if
-specified. After creating the branch locally, it is pushed to the remote and
+The new branch is based on the current branch, or on `<base>` if specified —
+a branch, or any commit-ish (a tag, a SHA, a spelling like `HEAD~2`).
+After creating the branch locally, it is pushed to the remote and
 upstream tracking is configured (unless disabled via daft.checkout.push). The
 repo's pre-push hook runs only when that push introduces new commits; a
 ref-only push of already-pushed commits skips it (configurable via
@@ -362,21 +368,21 @@ See daft-hooks(1) for hook management.
 "#)]
 pub struct StartArgs {
     #[arg(
-        value_name = "BRANCH_NAME",
+        value_name = "BRANCH|COMMIT-ISH",
         required_unless_present = "fork",
-        help = "Name for the new branch; or a cataloged repo to create it in, with `daft start <repo> <branch> [base]`; with --fork, the base position instead"
+        help = "Name for the new branch; or a cataloged repo to create it in, with `daft start <repo> <branch> [base]`; with --fork, the commit-ish to fork from instead (defaults to HEAD)"
     )]
     first: Option<String>,
 
     #[arg(
         value_name = "BASE_OR_BRANCH",
-        help = "Base branch (defaults to the current branch); or, when it names no ref here, the new branch inside `<repo>`"
+        help = "Base branch or commit-ish (defaults to the current branch); or, when it resolves to nothing here, the new branch inside `<repo>`; not used with --fork"
     )]
     second: Option<String>,
 
     #[arg(
         value_name = "BASE",
-        help = "Base branch inside `<repo>` (three-name form); must exist there"
+        help = "Base branch or commit-ish inside `<repo>` (three-name form); must resolve there; not used with --fork"
     )]
     third: Option<String>,
 

--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -860,6 +860,57 @@ pub(crate) fn local_base_ref_exists(name: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Silent probe: does `refs/remotes/<remote>/<name>` exist in the repository
+/// the cwd sits in? The sibling of [`local_branch_exists`], for the sandbox
+/// rung's precedence guard — a remote branch must keep beating a commit-ish
+/// reading even when its spelling fails branch-name validation.
+pub(crate) fn remote_branch_exists(name: &str, remote: &str) -> bool {
+    let Ok(cwd) = get_current_directory() else {
+        return false;
+    };
+    git_command_at(&cwd)
+        .args([
+            "show-ref",
+            "--verify",
+            "--quiet",
+            &format!("refs/remotes/{remote}/{name}"),
+        ])
+        .output()
+        .map(|out| out.status.success())
+        .unwrap_or(false)
+}
+
+/// Resolve `name` to a full commit OID iff it is commit-ish in the
+/// repository the cwd sits in — the probe behind the `daft go <commit-ish>`
+/// sandbox rung. Accepts what `rev-parse <name>^{commit}` accepts: tags,
+/// SHAs, remote-tracking refs, derived spellings like `HEAD~2`.
+///
+/// Dash-guarded: go's positional allows hyphen values, so arbitrary `-…`
+/// strings reach this probe and must never be handed to rev-parse in option
+/// position (`--end-of-options` is belt and braces on top of the guard).
+/// `None` outside any repository.
+pub(crate) fn resolve_commitish(name: &str) -> Option<String> {
+    if name.starts_with('-') {
+        return None;
+    }
+    let cwd = get_current_directory().ok()?;
+    let out = git_command_at(&cwd)
+        .args([
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            "--end-of-options",
+            &format!("{name}^{{commit}}"),
+        ])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let oid = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    (!oid.is_empty()).then_some(oid)
+}
+
 /// The canonical git common dir of the repository the cwd sits in — the
 /// identity the catalog keys on. `None` outside any repository.
 fn current_repo_git_common_dir() -> Option<String> {
@@ -1223,7 +1274,44 @@ fn run_in_repo(
     let config = OutputConfig::with_autocd(args.quiet, args.verbose, autocd);
     let mut output = CliOutput::new(config);
 
-    let result = if args.create_branch {
+    // The sandbox rung's early half (#53): spellings like `HEAD~2` or
+    // `@{-1}` can never be branches — `validate_branch_name` rejects them
+    // inside core before any probe could raise BranchNotFound — but they can
+    // resolve to a commit here. Gates mirror the handler arms below: bare
+    // `daft go <name>` only, suppressed by declared branch-creation intent,
+    // and every prior rung probed first. The branch probes are load-bearing
+    // even for "impossible" names: validation rejects anything *containing*
+    // `HEAD`, so a real branch `feature/HEADER-fix` fails it yet must keep
+    // today's validation error rather than become a sandbox pinned at its
+    // own tip.
+    let sandbox_early = if catalog_fallback
+        && !args.create_branch
+        && !args.start
+        && validate_branch_name(&args.branch_name).is_err()
+        && !local_branch_exists(&args.branch_name)
+        && !remote_branch_exists(&args.branch_name, &settings.remote)
+        && lookup_live_repo(&args.branch_name).is_none()
+    {
+        resolve_commitish(&args.branch_name)
+    } else {
+        None
+    };
+
+    let result = if let Some(commit) = sandbox_early {
+        output.result(&format!(
+            "'{}' is not a branch; opening a detached sandbox at {}",
+            args.branch_name,
+            crate::core::worktree::sandbox::short_oid(&commit)
+        ));
+        sandbox_entry(
+            &args,
+            &args.branch_name.clone(),
+            commit,
+            &settings,
+            &git,
+            &mut output,
+        )
+    } else if args.create_branch {
         run_create_branch(&args, &settings, &git, &mut output)
     } else {
         match run_checkout(&args, &settings, &git, &mut output) {
@@ -1246,10 +1334,26 @@ fn run_in_repo(
                 ref remote,
                 fetch_failed,
             }) => {
+                // A daft-created sandbox answers to its directory name —
+                // local-first, like everything in the ladder, so an
+                // established sandbox keeps beating a later-cataloged repo
+                // of the same name. (Sandboxes at their layout-default path
+                // never reach this handler: core's on-disk fallback
+                // navigates first. This arm covers --at-placed ones.)
+                if catalog_fallback
+                    && !args.start
+                    && let Some((dirname, sandbox_path)) = lookup_sandbox_by_name(branch)
+                {
+                    change_directory(&sandbox_path)?;
+                    output.result(&format!("Switched to sandbox '{dirname}'"));
+                    output.cd_path(&sandbox_path);
+                    maybe_show_shell_hint(&mut output)?;
+                    Ok(())
+                }
                 // A live catalog repo beats creating a branch: `daft go api`
                 // means "open the api repo" when no branch `api` exists.
                 // `--start` forces branch creation instead.
-                if catalog_fallback
+                else if catalog_fallback
                     && !args.start
                     && let Some(row) = lookup_live_repo(branch)
                     && std::path::Path::new(&row.path).is_dir()
@@ -1261,25 +1365,46 @@ fn run_in_repo(
                     ));
                     return go_to_repo(&row, None, args.clone(), original_dir, source_worktree);
                 }
-
-                let auto_start = args.start || settings.go_auto_start;
-                if auto_start {
+                // A commit-ish that names no branch and no repo opens a
+                // detached sandbox (#53). After the catalog on purpose: a
+                // repo named `v2` keeps winning over a tag `v2`, because
+                // that input was never an error. Before autoStart on
+                // purpose too: an existing entity beats ambient
+                // auto-creation config (the catalog arm's own precedent) —
+                // without this, `daft go v1.18.0` under autoStart would
+                // create a *branch* named v1.18.0. Explicit --start still
+                // forces the branch reading.
+                else if catalog_fallback
+                    && !args.start
+                    && let Some(commit) = resolve_commitish(branch)
+                {
                     change_directory(&original_dir).ok();
                     output.result(&format!(
-                        "Branch '{branch}' not found, creating new worktree..."
+                        "Branch '{branch}' not found; opening a detached sandbox at {} \
+                         (use --start to create a branch named '{branch}')",
+                        crate::core::worktree::sandbox::short_oid(&commit)
                     ));
-                    run_create_branch(&args, &settings, &git, &mut output)
+                    sandbox_entry(&args, &branch.clone(), commit, &settings, &git, &mut output)
                 } else {
-                    change_directory(&original_dir).ok();
-                    // --at with a non-existent branch requires --start or autoStart
-                    if args.at.is_some() {
-                        anyhow::bail!(
-                            "--at requires --start (or daft.go.autoStart=true) \
+                    let auto_start = args.start || settings.go_auto_start;
+                    if auto_start {
+                        change_directory(&original_dir).ok();
+                        output.result(&format!(
+                            "Branch '{branch}' not found, creating new worktree..."
+                        ));
+                        run_create_branch(&args, &settings, &git, &mut output)
+                    } else {
+                        change_directory(&original_dir).ok();
+                        // --at with a non-existent branch requires --start or autoStart
+                        if args.at.is_some() {
+                            anyhow::bail!(
+                                "--at requires --start (or daft.go.autoStart=true) \
                              when branch '{branch}' does not exist"
-                        );
+                            );
+                        }
+                        render_branch_not_found_error(branch, remote, fetch_failed, &settings);
+                        std::process::exit(1);
                     }
-                    render_branch_not_found_error(branch, remote, fetch_failed, &settings);
-                    std::process::exit(1);
                 }
             }
             Err(checkout::CheckoutError::Other(e)) => Err(e),
@@ -1744,6 +1869,147 @@ fn run_checkout(
     exec_result?;
 
     Ok(result.already_existed)
+}
+
+/// Shared shell for both sandbox-rung entrances (#53): run the visit, then
+/// apply the same --at-navigation guard the branch path applies.
+fn sandbox_entry(
+    args: &Args,
+    spelling: &str,
+    commit: String,
+    settings: &DaftSettings,
+    git: &GitCommand,
+    output: &mut dyn Output,
+) -> Result<()> {
+    let already_existed = run_sandbox_visit(args, spelling, commit, settings, git, output)?;
+    if args.at.is_some() && already_existed {
+        anyhow::bail!(
+            "--at cannot be used: sandbox already exists for '{spelling}'. \
+             Use `{}` without --at to navigate to it.",
+            crate::daft_cmd(&format!("go {spelling}"))
+        );
+    }
+    Ok(())
+}
+
+/// The `daft go <commit-ish>` engine's command-layer shell: the sandbox
+/// sibling of [`run_checkout`]. Returns whether an existing sandbox was
+/// navigated to.
+fn run_sandbox_visit(
+    args: &Args,
+    spelling: &str,
+    commit: String,
+    settings: &DaftSettings,
+    git: &GitCommand,
+    output: &mut dyn Output,
+) -> Result<bool> {
+    use crate::core::worktree::sandbox;
+
+    let project_root = get_project_root()?;
+
+    let (resolved_layout, source) = resolve_checkout_layout(git, output);
+    let (layout, should_persist) = interactive_layout_resolution(&resolved_layout, source, output)?;
+    if should_persist && let Ok(git_dir) = get_git_common_dir() {
+        let _ = TrustDatabase::update(|db| {
+            db.set_layout(&git_dir, layout.name.clone());
+            Ok(())
+        });
+    }
+
+    let dirname =
+        sandbox::sandbox_dirname(spelling).unwrap_or_else(|| sandbox::derived_dirname(&commit));
+    let params = sandbox::SandboxParams {
+        spelling: spelling.to_string(),
+        commit,
+        dirname,
+        kind: crate::store::models::WorktreeKind::Canonical,
+        path_preclaimed: false,
+        carry: args.carry,
+        no_carry: args.no_carry,
+        checkout_carry: settings.checkout_carry,
+        remote: args.remote.clone(),
+        remote_name: settings.remote.clone(),
+        multi_remote_enabled: settings.multi_remote_enabled,
+        multi_remote_default: settings.multi_remote_default.clone(),
+        layout: Some(layout),
+        at_path: args.at.clone(),
+    };
+
+    let hooks_config = crate::core::settings::load_hooks_config_with(git)?;
+    let hook_output_config = hooks_config.output.with_cli_verbose(output.is_verbose());
+    let executor = HookExecutor::new(hooks_config)?.with_job_filter(
+        crate::hooks::yaml_executor::JobFilter::skipping(&args.skip_hooks),
+    );
+
+    let mut timeline = Timeline::new(
+        TimelineMode::auto(output.is_quiet()),
+        output.is_verbose(),
+        format!("Opening {spelling}"),
+    );
+    timeline.set_verbose_density(hook_output_config.verbose);
+
+    timeline.open_planning("Resolving commit");
+    let visit_result = {
+        let mut bridge = TimelineBridge::new(output, &mut timeline, executor, hook_output_config);
+        sandbox::execute_visit(&params, git, &project_root, &mut bridge)
+    };
+    timeline.abandon_planning();
+    let result = match visit_result {
+        Ok(result) => result,
+        Err(e) => {
+            timeline.abort(&format!("Failed after {}", timeline.elapsed_display()));
+            return Err(e);
+        }
+    };
+
+    if timeline.region_live() {
+        timeline.finish(&format!("Ready in {}", timeline.elapsed_display()));
+    }
+    if !timeline.replaces_stdout_record() || result.already_existed {
+        render_sandbox_result(&result, output);
+    }
+
+    // Run exec commands (after hooks, before cd_path)
+    let exec_result = crate::exec::run_exec_commands(&args.exec, output);
+
+    output.cd_path(&result.cd_target);
+    maybe_show_shell_hint(output)?;
+
+    exec_result?;
+
+    Ok(result.already_existed)
+}
+
+/// A daft-created sandbox whose recorded name is `name`, with its live
+/// worktree path. The dirname-addressing tier of go's ladder, for sandboxes
+/// placed off the layout-default path (`--at`); default-placed ones are
+/// navigated by core's on-disk fallback before the ladder ever misses.
+fn lookup_sandbox_by_name(name: &str) -> Option<(String, PathBuf)> {
+    let git_dir = get_git_common_dir().ok()?;
+    let records = crate::core::worktree::identity_store::read_identities(&git_dir);
+    let row = records
+        .values()
+        .find(|r| r.kind.is_sandbox() && r.branch == name)?;
+    let path = PathBuf::from(&row.worktree_path);
+    (path.join(".git").is_file()).then(|| (row.branch.clone(), path))
+}
+
+fn render_sandbox_result(
+    result: &crate::core::worktree::sandbox::SandboxResult,
+    output: &mut dyn Output,
+) {
+    let short = crate::core::worktree::sandbox::short_oid(&result.commit);
+    if result.already_existed {
+        output.result(&format!(
+            "Switched to sandbox '{}' (detached @ {short})",
+            result.dirname
+        ));
+    } else {
+        output.result(&format!(
+            "Prepared sandbox '{}' (detached @ {short})",
+            result.dirname
+        ));
+    }
 }
 
 fn run_create_branch(

--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -162,7 +162,7 @@ pub struct Args {
 #[derive(Parser)]
 #[command(name = "daft go")]
 #[command(version = crate::VERSION)]
-#[command(about = "Open a worktree for an existing branch, or create one with -b")]
+#[command(about = "Open a worktree for a branch or commit; create a new branch with -b")]
 #[command(long_about = r#"
 Opens a worktree for an existing local or remote branch. The worktree is
 placed at the project root level as a sibling to other worktrees, using the
@@ -211,7 +211,7 @@ See daft-hooks(1) for hook management.
 "#)]
 pub struct GoArgs {
     #[arg(
-        help = "Branch (or catalog repo) to open; use '-' for previous worktree",
+        help = "Branch, commit-ish, or catalog repo to open; use '-' for previous worktree",
         allow_hyphen_values = true,
         required_unless_present = "repo"
     )]
@@ -304,7 +304,7 @@ pub struct GoArgs {
 #[derive(Parser)]
 #[command(name = "daft start")]
 #[command(version = crate::VERSION)]
-#[command(about = "Create a new branch and worktree")]
+#[command(about = "Create a new branch and worktree, or a throwaway fork with --fork")]
 #[command(long_about = r#"
 Creates a new branch and a corresponding worktree in a single operation. The
 worktree is placed at the project root level as a sibling to other worktrees,

--- a/src/commands/clone.rs
+++ b/src/commands/clone.rs
@@ -143,7 +143,7 @@ pub struct Args {
 
     #[arg(
         long,
-        help = "Columns to display (comma-separated). Replace: branch,base,age. Modify defaults: +col,-col. Available: branch, path, size, base, changes, remote, age, annotation, owner, hash, last-commit"
+        help = "Columns to display (comma-separated). Replace: name,base,age. Modify defaults: +col,-col. Available: name, path, size, base, changes, remote, age, annotation, owner, hash, last-commit"
     )]
     columns: Option<String>,
 

--- a/src/commands/complete.rs
+++ b/src/commands/complete.rs
@@ -482,7 +482,16 @@ fn collect_worktrees(repo: &gix::Repository) -> Vec<(String, std::path::PathBuf)
 }
 
 /// Collect `(branch, RefInfo)` pairs for a given ref prefix via gitoxide.
-fn collect_refs_with_info(repo: &gix::Repository, prefix: &str) -> Vec<(String, RefInfo)> {
+/// `keep` gates by short name BEFORE the commit metadata is peeled —
+/// `ref_commit_info` costs object-DB reads per ref, so callers that only
+/// want a completion-prefix's worth of refs must not pay for the whole
+/// namespace (a repo with thousands of tags would otherwise peel them all
+/// on every Tab keypress).
+fn collect_refs_with_info(
+    repo: &gix::Repository,
+    prefix: &str,
+    keep: impl Fn(&str) -> bool,
+) -> Vec<(String, RefInfo)> {
     let platform = match repo.references() {
         Ok(p) => p,
         Err(_) => return Vec::new(),
@@ -499,6 +508,9 @@ fn collect_refs_with_info(repo: &gix::Repository, prefix: &str) -> Vec<(String, 
             Err(_) => continue,
         };
         let short_name = reference.name().shorten().to_string();
+        if !keep(&short_name) {
+            continue;
+        }
         let info = ref_commit_info(&mut reference);
         result.push((short_name, info));
     }
@@ -507,7 +519,7 @@ fn collect_refs_with_info(repo: &gix::Repository, prefix: &str) -> Vec<(String, 
 
 /// Collect `(branch, RefInfo)` pairs for every local branch.
 fn collect_local_branches(repo: &gix::Repository) -> Vec<(String, RefInfo)> {
-    collect_refs_with_info(repo, "refs/heads/")
+    collect_refs_with_info(repo, "refs/heads/", |_| true)
 }
 
 /// Sandbox worktrees (#53) as completion entries: detached, so invisible to
@@ -541,7 +553,7 @@ fn sandbox_entries(repo: &gix::Repository, prefix: &str) -> Vec<CompletionEntry>
 /// Collect `(branch, RefInfo)` pairs for every remote-tracking
 /// branch across all remotes.
 fn collect_remote_branches(repo: &gix::Repository) -> Vec<(String, RefInfo)> {
-    collect_refs_with_info(repo, "refs/remotes/")
+    collect_refs_with_info(repo, "refs/remotes/", |_| true)
 }
 
 /// Collect the current worktree's branch, if any — used to exclude it
@@ -643,16 +655,16 @@ pub(crate) fn complete_daft_go(prefix: &str, fetch_on_miss: bool) -> Result<Vec<
         // matching tag must suppress the fetch.
         let claimed: std::collections::HashSet<&str> =
             entries.iter().map(|e| e.name.as_str()).collect();
-        let mut tags: Vec<CompletionEntry> = collect_refs_with_info(repo, "refs/tags/")
-            .into_iter()
-            .filter(|(name, _)| name.starts_with(prefix))
-            .filter(|(name, _)| !claimed.contains(name.as_str()))
-            .map(|(name, info)| CompletionEntry {
-                name,
-                group: CompletionGroup::Local,
-                description: format!("tag \u{b7} {} \u{b7} {}", info.age, info.author),
-            })
-            .collect();
+        let mut tags: Vec<CompletionEntry> = collect_refs_with_info(repo, "refs/tags/", |name| {
+            name.starts_with(prefix) && !claimed.contains(name)
+        })
+        .into_iter()
+        .map(|(name, info)| CompletionEntry {
+            name,
+            group: CompletionGroup::Local,
+            description: format!("tag \u{b7} {} \u{b7} {}", info.age, info.author),
+        })
+        .collect();
         tags.sort_by(|a, b| a.name.cmp(&b.name));
         entries.extend(tags);
         let d_build = t.elapsed();

--- a/src/commands/complete.rs
+++ b/src/commands/complete.rs
@@ -188,10 +188,12 @@ fn complete(
         ("daft-remove", _) => {
             let repo_flag = std::env::var("DAFT_COMPLETE_REPO_FLAG").unwrap_or_default();
             if repo_flag.is_empty() {
-                Ok(format_entries_as_strings(&complete_rich_branches(
-                    word,
-                    &CONFIG_REMOVE,
-                )?))
+                let mut entries = complete_rich_branches(word, &CONFIG_REMOVE)?;
+                // Sandboxes are removal targets addressed by dirname (#53).
+                if let Ok(repo) = discover_repo() {
+                    entries.extend(sandbox_entries(&repo, word));
+                }
+                Ok(format_entries_as_strings(&entries))
             } else {
                 Ok(format_entries_as_strings(&cross_repo_branches(
                     &repo_flag, word,
@@ -508,6 +510,34 @@ fn collect_local_branches(repo: &gix::Repository) -> Vec<(String, RefInfo)> {
     collect_refs_with_info(repo, "refs/heads/")
 }
 
+/// Sandbox worktrees (#53) as completion entries: detached, so invisible to
+/// every branch collection, yet immediate navigation/removal targets by
+/// directory name. Read from the identity records; a record whose worktree
+/// is gone is skipped.
+fn sandbox_entries(repo: &gix::Repository, prefix: &str) -> Vec<CompletionEntry> {
+    let records = crate::core::worktree::identity_store::read_identities(repo.common_dir());
+    let mut entries: Vec<CompletionEntry> = records
+        .values()
+        .filter(|r| r.kind.is_sandbox())
+        .filter(|r| r.branch.starts_with(prefix))
+        .filter(|r| {
+            std::path::Path::new(&r.worktree_path)
+                .join(".git")
+                .is_file()
+        })
+        .map(|r| CompletionEntry {
+            name: r.branch.clone(),
+            group: CompletionGroup::Worktree,
+            description: match r.pinned_commit.as_deref() {
+                Some(pin) => format!("sandbox @ {}", &pin[..pin.len().min(7)]),
+                None => "sandbox".to_string(),
+            },
+        })
+        .collect();
+    entries.sort_by(|a, b| a.name.cmp(&b.name));
+    entries
+}
+
 /// Collect `(branch, RefInfo)` pairs for every remote-tracking
 /// branch across all remotes.
 fn collect_remote_branches(repo: &gix::Repository) -> Vec<(String, RefInfo)> {
@@ -591,7 +621,7 @@ pub(crate) fn complete_daft_go(prefix: &str, fetch_on_miss: bool) -> Result<Vec<
         let d_current = t.elapsed();
 
         let t = Instant::now();
-        let entries = build_rich_completions(
+        let mut entries = build_rich_completions(
             &worktrees,
             &local,
             &remote,
@@ -603,6 +633,28 @@ pub(crate) fn complete_daft_go(prefix: &str, fetch_on_miss: bool) -> Result<Vec<
             &columns,
             &statuses,
         );
+        // Sandbox worktrees (#53): detached, so invisible to every branch
+        // collection above, yet immediate navigation targets by dirname.
+        entries.extend(sandbox_entries(repo, prefix));
+        // Tags: `daft go <tag>` opens the tag's sandbox, so tags are
+        // legitimate destinations. They ride the `local` group — a local
+        // ref without a worktree — with a description that says what they
+        // are. Counted before the fetch-on-miss decision on purpose: a
+        // matching tag must suppress the fetch.
+        let claimed: std::collections::HashSet<&str> =
+            entries.iter().map(|e| e.name.as_str()).collect();
+        let mut tags: Vec<CompletionEntry> = collect_refs_with_info(repo, "refs/tags/")
+            .into_iter()
+            .filter(|(name, _)| name.starts_with(prefix))
+            .filter(|(name, _)| !claimed.contains(name.as_str()))
+            .map(|(name, info)| CompletionEntry {
+                name,
+                group: CompletionGroup::Local,
+                description: format!("tag \u{b7} {} \u{b7} {}", info.age, info.author),
+            })
+            .collect();
+        tags.sort_by(|a, b| a.name.cmp(&b.name));
+        entries.extend(tags);
         let d_build = t.elapsed();
 
         if timings {

--- a/src/commands/completions/bash.rs
+++ b/src/commands/completions/bash.rs
@@ -96,9 +96,9 @@ pub(super) fn generate_bash_completion_string(command_name: &str) -> Result<Stri
         // `status` is list-only: sync/prune pin their own operation-progress
         // Status column and reject the token.
         let columns = if command_name == "git-worktree-list" {
-            "annotation status branch path size base changes remote pr age owner hash last-commit"
+            "annotation status name path size base changes remote pr age owner hash last-commit"
         } else {
-            "annotation branch path size base changes remote pr age owner hash last-commit"
+            "annotation name path size base changes remote pr age owner hash last-commit"
         };
         output.push_str(&format!("        local columns=\"{columns}\"\n"));
         output.push_str("        local prefixed=\"\"\n");
@@ -109,7 +109,7 @@ pub(super) fn generate_bash_completion_string(command_name: &str) -> Result<Stri
         output.push('\n');
         output.push_str("    # Sort column completion for --sort\n");
         output.push_str("    if [[ \"$prev\" == \"--sort\" ]]; then\n");
-        output.push_str("        local cols=\"branch path size base changes remote age owner hash activity commit\"\n");
+        output.push_str("        local cols=\"name path size base changes remote age owner hash activity commit\"\n");
         output.push_str("        local prefixed=\"\"\n");
         output.push_str("        for c in $cols; do prefixed=\"$prefixed $c +$c -$c\"; done\n");
         output.push_str("        COMPREPLY=( $(compgen -W \"$prefixed\" -- \"$cur\") )\n");

--- a/src/commands/completions/fig.rs
+++ b/src/commands/completions/fig.rs
@@ -248,7 +248,7 @@ pub(super) fn generate_fig_completion_string(command_name: &str) -> Result<Strin
                     ("annotation", "Annotation markers"),
                     // list-only; filtered out below for sync/prune.
                     ("status", "Paused operation and conflicts"),
-                    ("branch", "Branch name"),
+                    ("name", "Branch or sandbox name"),
                     ("path", "Worktree path"),
                     ("size", "Disk size of worktree"),
                     ("base", "Ahead/behind base branch"),
@@ -284,7 +284,7 @@ pub(super) fn generate_fig_completion_string(command_name: &str) -> Result<Strin
                 })
             } else if has_columns && long == "--sort" {
                 let sort_defs = [
-                    ("branch", "Sort by branch name"),
+                    ("name", "Sort by name"),
                     ("path", "Sort by worktree path"),
                     ("size", "Sort by disk size"),
                     ("base", "Sort by total base divergence"),

--- a/src/commands/completions/fish.rs
+++ b/src/commands/completions/fish.rs
@@ -142,7 +142,7 @@ pub(super) fn generate_fish_completion_string(command_name: &str) -> Result<Stri
             ("annotation", "Annotation markers"),
             // list-only; filtered out below for sync/prune.
             ("status", "Paused operation and conflicts"),
-            ("branch", "Branch name"),
+            ("name", "Branch or sandbox name"),
             ("path", "Worktree path"),
             ("size", "Disk size of worktree"),
             ("base", "Ahead/behind base branch"),
@@ -166,7 +166,7 @@ pub(super) fn generate_fish_completion_string(command_name: &str) -> Result<Stri
 
         output.push_str("\n# Sort column completions for --sort\n");
         let sort_columns = [
-            ("branch", "Sort by branch name"),
+            ("name", "Sort by name"),
             ("path", "Sort by worktree path"),
             ("size", "Sort by disk size"),
             ("base", "Sort by total base divergence"),

--- a/src/commands/completions/zsh.rs
+++ b/src/commands/completions/zsh.rs
@@ -113,7 +113,7 @@ pub(super) fn generate_zsh_completion_string(command_name: &str) -> Result<Strin
         if command_name == "git-worktree-list" {
             output.push_str("            'status:Paused operation and conflicts'\n");
         }
-        output.push_str("            'branch:Branch name'\n");
+        output.push_str("            'name:Branch or sandbox name'\n");
         output.push_str("            'path:Worktree path'\n");
         output.push_str("            'size:Disk size of worktree'\n");
         output.push_str("            'base:Ahead/behind base branch'\n");
@@ -128,7 +128,7 @@ pub(super) fn generate_zsh_completion_string(command_name: &str) -> Result<Strin
         if command_name == "git-worktree-list" {
             output.push_str("            '+status:Add operation status'\n");
         }
-        output.push_str("            '+branch:Add branch name'\n");
+        output.push_str("            '+name:Add branch or sandbox name'\n");
         output.push_str("            '+path:Add worktree path'\n");
         output.push_str("            '+size:Add disk size of worktree'\n");
         output.push_str("            '+base:Add ahead/behind base branch'\n");
@@ -143,7 +143,7 @@ pub(super) fn generate_zsh_completion_string(command_name: &str) -> Result<Strin
         if command_name == "git-worktree-list" {
             output.push_str("            '-status:Remove operation status'\n");
         }
-        output.push_str("            '-branch:Remove branch name'\n");
+        output.push_str("            '-name:Remove branch or sandbox name'\n");
         output.push_str("            '-path:Remove worktree path'\n");
         output.push_str("            '-size:Remove disk size of worktree'\n");
         output.push_str("            '-base:Remove ahead/behind base branch'\n");
@@ -163,7 +163,7 @@ pub(super) fn generate_zsh_completion_string(command_name: &str) -> Result<Strin
         output.push_str("    if [[ \"$prev_word\" == \"--sort\" ]]; then\n");
         output.push_str("        local -a sort_values\n");
         output.push_str("        sort_values=(\n");
-        output.push_str("            'branch:Sort by branch name'\n");
+        output.push_str("            'name:Sort by name'\n");
         output.push_str("            'path:Sort by worktree path'\n");
         output.push_str("            'size:Sort by disk size'\n");
         output.push_str("            'base:Sort by total base divergence'\n");
@@ -175,7 +175,7 @@ pub(super) fn generate_zsh_completion_string(command_name: &str) -> Result<Strin
         output
             .push_str("            'activity:Sort by overall activity (commits + uncommitted)'\n");
         output.push_str("            'commit:Sort by last commit time only'\n");
-        output.push_str("            '+branch:Sort by branch name ascending'\n");
+        output.push_str("            '+name:Sort by name ascending'\n");
         output.push_str("            '+path:Sort by worktree path ascending'\n");
         output.push_str("            '+size:Sort by disk size ascending'\n");
         output.push_str("            '+base:Sort by total base divergence ascending'\n");
@@ -186,7 +186,7 @@ pub(super) fn generate_zsh_completion_string(command_name: &str) -> Result<Strin
         output.push_str("            '+hash:Sort by commit hash ascending'\n");
         output.push_str("            '+activity:Sort by overall activity ascending'\n");
         output.push_str("            '+commit:Sort by last commit time ascending'\n");
-        output.push_str("            '-branch:Sort by branch name descending'\n");
+        output.push_str("            '-name:Sort by name descending'\n");
         output.push_str("            '-path:Sort by worktree path descending'\n");
         output.push_str("            '-size:Sort by disk size descending'\n");
         output.push_str("            '-base:Sort by total base divergence descending'\n");

--- a/src/commands/hooks/jobs.rs
+++ b/src/commands/hooks/jobs.rs
@@ -1599,8 +1599,14 @@ fn cancel_matching(
 
     match CoordinatorClient::connect(&repo_hash)? {
         Some(mut client) => {
-            let names =
-                client.cancel_matching(hook, worktree, tag, invocation_prefix, older_than_secs)?;
+            let names = client.cancel_matching(
+                hook,
+                worktree,
+                tag,
+                invocation_prefix,
+                older_than_secs,
+                false,
+            )?;
             if names.is_empty() {
                 output.info("No active jobs matched the filter.");
             } else {

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -583,11 +583,11 @@ fn run_blocking(args: Args) -> Result<()> {
         && let Ok(repo_hash) =
             crate::core::repo_identity::compute_repo_id_from_common_dir(&git_common_dir)
     {
+        // Sandboxes cache like branches: their dirnames are unique worktree
+        // names since #53, and the seed's path-guard covers the
+        // branch∪sandbox slug-shadowing case.
         let fresh = infos
             .iter()
-            // Sandboxes all report name "(detached)" and would collide on the
-            // (repo_hash, branch_slug) cache key — don't cache them (review).
-            .filter(|info| !info.is_sandbox)
             .filter_map(|info| Some((info.name.clone(), info.path.clone()?, info.size_bytes?)));
         crate::commands::size_cache::persist_worktree_sizes(&repo_hash, fresh);
     }
@@ -1865,6 +1865,7 @@ mod tests {
             size_bytes: None,
             working_tree_mtime: None,
             is_sandbox: false,
+            branchless: false,
             op: None,
             identity_source: None,
             drifted: false,
@@ -1928,6 +1929,7 @@ mod tests {
             size_bytes: Some(1024),
             working_tree_mtime: None,
             is_sandbox: false,
+            branchless: false,
             op: None,
             identity_source: None,
             drifted: false,

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -90,7 +90,7 @@ Supported formats: json, ndjson, tsv, csv, yaml, toon, markdown. Use
 for details.
 
 Use --columns to select which columns are shown and in what order.
-  Replace mode:  --columns branch,path,age (exact set and order)
+  Replace mode:  --columns name,path,age (exact set and order)
   Modifier mode: --columns -annotation,-last-commit (remove from defaults)
   Add optional:  --columns +size (add disk size column after path)
 Defaults can be set in git config with daft.list.columns.
@@ -119,11 +119,11 @@ with `git config -- daft.list.columns -pr`.
 
 Use --sort to control the sort order. Prefix with + for ascending (default) or
 - for descending. Multiple columns can be comma-separated for multi-level sort.
-  Sort by branch descending:  --sort -branch
+  Sort by name descending:    --sort -name
   Sort by owner then size:    --sort +owner,-size
   Most recent activity first: --sort -activity
 
-Sortable columns: branch, path, size, age, owner, hash, activity, commit (alias:
+Sortable columns: name, path, size, age, owner, hash, activity, commit (alias:
 last-commit). activity considers both commits and uncommitted file changes;
 commit sorts by last commit time only. You can sort by columns not shown in
 the output (e.g. --sort -size without --columns +size). Defaults can be set
@@ -185,13 +185,13 @@ pub struct Args {
 
     #[arg(
         long,
-        help = "Columns to display (comma-separated). Replace: branch,path,age. Modify defaults: +col,-col. Available: branch, path, size, base, changes, remote, pr, age, annotation, status, owner, hash, last-commit"
+        help = "Columns to display (comma-separated). Replace: name,path,age. Modify defaults: +col,-col. Available: name, path, size, base, changes, remote, pr, age, annotation, status, owner, hash, last-commit"
     )]
     pub(crate) columns: Option<String>,
 
     #[arg(
         long,
-        help = "Sort order (comma-separated). +col ascending, -col descending. Columns: branch, path, size, base, changes, remote, age, owner, hash, activity, commit"
+        help = "Sort order (comma-separated). +col ascending, -col descending. Columns: name, path, size, base, changes, remote, age, owner, hash, activity, commit"
     )]
     pub(crate) sort: Option<String>,
 
@@ -724,7 +724,7 @@ fn run_blocking(args: Args) -> Result<()> {
 
 /// Determine which logical column groups are active for emit output.
 struct EmitColumns {
-    branch: bool,
+    name: bool,
     annotation: bool,
     status: bool,
     path: bool,
@@ -747,7 +747,7 @@ impl EmitColumns {
         let has = |col: ListColumn| is_default || selected.contains(&col);
         let has_lines = stat == Stat::Lines;
         Self {
-            branch: has(ListColumn::Branch),
+            name: has(ListColumn::Name),
             annotation: has(ListColumn::Annotation),
             // Opt-in like size/hash (explicit selection only, never in
             // defaults): the composed text is presentation, but a selection
@@ -773,7 +773,7 @@ impl EmitColumns {
 
     fn headers(&self) -> Vec<String> {
         let mut h = Vec::new();
-        if self.branch {
+        if self.name {
             h.push("kind".into());
             h.push("name".into());
         }
@@ -864,7 +864,7 @@ fn build_emit_table(
     for info in infos {
         let mut row: Vec<Cell> = Vec::new();
 
-        if cols.branch {
+        if cols.name {
             let kind_str = match info.kind {
                 EntryKind::Worktree => "worktree",
                 EntryKind::LocalBranch => "branch",
@@ -1439,7 +1439,7 @@ fn print_table(
         .map(|c| {
             let label = match c {
                 ListColumn::Status => "Status",
-                ListColumn::Branch => "Branch",
+                ListColumn::Name => "Name",
                 ListColumn::Path => "Path",
                 ListColumn::Size => "Size",
                 ListColumn::Base => "Base",
@@ -1502,7 +1502,7 @@ fn print_table(
             .iter()
             .map(|(_, c)| match c {
                 ListColumn::Status => row.status.as_str(),
-                ListColumn::Branch => row.name.as_str(),
+                ListColumn::Name => row.name.as_str(),
                 ListColumn::Path => row.path.as_str(),
                 ListColumn::Size => row.size.as_str(),
                 ListColumn::Base => row.base.as_str(),
@@ -1697,7 +1697,7 @@ mod tests {
         // Removing it, or naming other columns, is not asking for it.
         assert!(!pr_explicitly_selected("-pr"));
         assert!(!pr_explicitly_selected("+size"));
-        assert!(!pr_explicitly_selected("branch,path"));
+        assert!(!pr_explicitly_selected("name,path"));
         // Token match, not substring match.
         assert!(!pr_explicitly_selected("prune"));
     }
@@ -1749,7 +1749,7 @@ mod tests {
             std::path::Path::new("/tmp/proj"),
             std::path::Path::new("/tmp/proj"),
             Stat::Summary,
-            &[ListColumn::Branch, ListColumn::Status],
+            &[ListColumn::Name, ListColumn::Status],
             0,
             None,
         );
@@ -1933,7 +1933,7 @@ mod tests {
             drifted: false,
             forge_ref: None,
         };
-        let selected = &[ListColumn::Branch, ListColumn::Path, ListColumn::Size];
+        let selected = &[ListColumn::Name, ListColumn::Path, ListColumn::Size];
         let table = build_emit_table(
             &[info],
             std::path::Path::new("/tmp/proj"),
@@ -1964,7 +1964,7 @@ mod tests {
         // is computed against the post-filter column list, then offset by 1
         // when the annotation column is shown.
         let cols = &[
-            ListColumn::Branch,
+            ListColumn::Name,
             ListColumn::Path,
             ListColumn::Size,
             ListColumn::Age,
@@ -1975,7 +1975,7 @@ mod tests {
 
     #[test]
     fn size_column_index_is_none_when_size_unselected() {
-        let cols = &[ListColumn::Branch, ListColumn::Path];
+        let cols = &[ListColumn::Name, ListColumn::Path];
         assert_eq!(size_column_index(cols, false), None);
         assert_eq!(size_column_index(cols, true), None);
     }
@@ -1985,7 +1985,7 @@ mod tests {
         // Annotation in selected_columns is filtered out before col_headers
         // is built, so the visible position of Size shifts down by one when
         // Annotation appears earlier in the list.
-        let cols = &[ListColumn::Annotation, ListColumn::Branch, ListColumn::Size];
+        let cols = &[ListColumn::Annotation, ListColumn::Name, ListColumn::Size];
         // show_annotations=false: annotation column not shown, Size is at 1.
         assert_eq!(size_column_index(cols, false), Some(1));
         // show_annotations=true: leading annotation column adds 1.

--- a/src/commands/list_live.rs
+++ b/src/commands/list_live.rs
@@ -524,7 +524,7 @@ fn collector_fields(columns: &[ListColumn], sort_spec: Option<&SortSpec>, stat: 
     for column in columns {
         fields |= match column {
             // Populated by the porcelain seed, never streamed.
-            ListColumn::Annotation | ListColumn::Branch | ListColumn::Path => FieldSet::EMPTY,
+            ListColumn::Annotation | ListColumn::Name | ListColumn::Path => FieldSet::EMPTY,
             ListColumn::Size => FieldSet::SIZE,
             ListColumn::Base => FieldSet::BASE_AHEAD_BEHIND,
             ListColumn::Changes => FieldSet::CHANGES,
@@ -607,12 +607,12 @@ mod collector_fields_tests {
 
     /// The status column's op-less Persisted arm renders `detached @ <sha>`
     /// from `last_commit_hash`, which streams only under LAST_COMMIT. With a
-    /// narrow selection (`--columns status,branch`) the live cell otherwise
+    /// narrow selection (`--columns status,name`) the live cell otherwise
     /// sticks at a bare `detached` forever while the piped path shows the
     /// sha.
     #[test]
     fn status_column_collects_changes_and_last_commit() {
-        let resolved = ColumnSelection::parse("status,branch", CommandKind::List).unwrap();
+        let resolved = ColumnSelection::parse("status,name", CommandKind::List).unwrap();
         let fields = collector_fields(&resolved.columns, None, Stat::Summary);
         assert!(fields.contains(FieldSet::CHANGES | FieldSet::LAST_COMMIT));
     }
@@ -684,7 +684,7 @@ mod collector_fields_tests {
         // base_lines_* even though no base column is rendered.
         let spec = sort("-base", Stat::Lines);
         let fields = collector_fields(
-            &[ListColumn::Branch, ListColumn::Path],
+            &[ListColumn::Name, ListColumn::Path],
             Some(&spec),
             Stat::Lines,
         );
@@ -693,7 +693,7 @@ mod collector_fields_tests {
 
     #[test]
     fn seed_only_view_collects_nothing() {
-        let fields = collector_fields(&[ListColumn::Branch, ListColumn::Path], None, Stat::Summary);
+        let fields = collector_fields(&[ListColumn::Name, ListColumn::Path], None, Stat::Summary);
         assert!(fields.is_empty());
     }
 }

--- a/src/commands/list_live.rs
+++ b/src/commands/list_live.rs
@@ -115,15 +115,14 @@ pub fn run_live(args: Args) -> Result<()> {
         info.is_default_branch = is_default_branch;
         apply_identity(&mut info, &identity);
         info.kind = EntryKind::Worktree;
+        let branchless = info.branchless;
         worktree_infos.push(info);
 
         targets.push(list_stream::CollectorTarget {
             branch_name: branch_display.clone(),
             path: Some(entry.path.clone()),
             kind: EntryKind::Worktree,
-            // "has no branch to query", not "HEAD is detached" — a recovered
-            // worktree has a real ref, so its branch-keyed cells must stream.
-            is_detached: identity.branch.is_none(),
+            is_detached: branchless,
         });
 
         // Recovered branches join the dedup set too, or `--branches` would
@@ -461,8 +460,6 @@ pub fn run_live(args: Args) -> Result<()> {
             .filter(|(idx, row)| {
                 final_state.live.received_patches[*idx].contains(FieldSet::SIZE)
                     && row.info.size_bytes.is_some()
-                    // Sandboxes collide on one slug — don't cache them (review).
-                    && !row.info.is_sandbox
             })
             .filter_map(|(_, row)| {
                 Some((
@@ -511,6 +508,11 @@ fn apply_identity(
     info.op = identity.op;
     info.identity_source = Some(identity.source);
     info.drifted = identity.drifted;
+    // "Has no branch to query", not "HEAD is detached" — a recovered
+    // worktree has a real ref, so its branch-keyed cells must stream. The
+    // same bit drives the collector's per-target skip and the live table's
+    // settle-as-blank seeding of the BRANCH_KEYED cells.
+    info.branchless = identity.branch.is_none();
 }
 
 /// Fields the streaming collector must populate for this view: what the
@@ -603,6 +605,22 @@ mod collector_fields_tests {
             Some(crate::core::worktree::identity::IdentitySource::Attached)
         );
         assert!(info.drifted, "drifted must survive the seed copy");
+        assert!(!info.branchless, "a real ref is not branchless");
+
+        // The branchless bit is what settles a sandbox's branch-keyed cells
+        // as blank at seed — a missed copy revives the phantom shimmer.
+        let sandbox = crate::core::worktree::identity::WorktreeIdentity {
+            name: "main-fork".to_string(),
+            branch: None,
+            source: crate::core::worktree::identity::IdentitySource::Sandbox,
+            op: None,
+            is_sandbox: true,
+            drifted: false,
+        };
+        let mut info = crate::core::worktree::list::WorktreeInfo::empty("main-fork");
+        apply_identity(&mut info, &sandbox);
+        assert!(info.branchless, "no branch to query must survive the copy");
+        assert!(info.is_sandbox);
     }
 
     /// The status column's op-less Persisted arm renders `detached @ <sha>`

--- a/src/commands/prune.rs
+++ b/src/commands/prune.rs
@@ -95,13 +95,13 @@ pub struct Args {
 
     #[arg(
         long,
-        help = "Columns to display (comma-separated). Replace: branch,path,age. Modify defaults: +col,-col. Available: branch, path, size, base, changes, remote, pr, age, annotation, owner, hash, last-commit"
+        help = "Columns to display (comma-separated). Replace: name,path,age. Modify defaults: +col,-col. Available: name, path, size, base, changes, remote, pr, age, annotation, owner, hash, last-commit"
     )]
     columns: Option<String>,
 
     #[arg(
         long,
-        help = "Sort order (comma-separated). +col ascending, -col descending. Columns: branch, path, size, base, changes, remote, age, owner, hash, activity, commit"
+        help = "Sort order (comma-separated). +col ascending, -col descending. Columns: name, path, size, base, changes, remote, age, owner, hash, activity, commit"
     )]
     sort: Option<String>,
 

--- a/src/commands/size_cache.rs
+++ b/src/commands/size_cache.rs
@@ -73,10 +73,13 @@ fn read_inner(repo_hash: &str) -> Option<HashMap<String, (PathBuf, u64)>> {
 
 /// Seed each worktree's Size cell from `cached` (the caller renders it stale),
 /// but only when the cached row's stored path still matches the worktree's
-/// current path. Skips sandboxes (never cached) and any slug now checked out at
-/// a different path — so a reused branch name can't surface the previous
-/// worktree's size. Split out from the command glue so the path-guard is
-/// unit-testable.
+/// current path — so a reused slug (a pruned-then-recreated branch, or a
+/// branch shadowing a like-named sandbox) can't surface a different
+/// worktree's size. Sandboxes seed like any other row: their dirnames are
+/// unique among worktrees, and the path-guard covers the branch∪sandbox
+/// shadowing case (the shared slug degrades to a cache miss for whichever
+/// side wrote second — never a wrong value). Split out from the command glue
+/// so the path-guard is unit-testable.
 pub(crate) fn seed_worktree_sizes(
     infos: &mut [crate::core::worktree::list::WorktreeInfo],
     cached: &HashMap<String, (PathBuf, u64)>,
@@ -85,9 +88,6 @@ pub(crate) fn seed_worktree_sizes(
         let Some(path) = info.path.as_deref() else {
             continue; // local-branch stubs etc. have no worktree to size
         };
-        if info.is_sandbox {
-            continue; // detached sandboxes collide on one slug — never cached
-        }
         if let Some((cached_path, bytes)) = cached.get(&info.name)
             && path == cached_path.as_path()
         {
@@ -243,10 +243,11 @@ mod tests {
     }
 
     /// The seed's path-guard: a cached size is applied only when its stored
-    /// path matches the worktree's current path, and sandboxes are never
-    /// seeded. Pure (no store), so no `IsolatedStateDir`/`serial` needed.
+    /// path matches the worktree's current path — sandboxes included (they
+    /// carry unique dirnames since #53). Pure (no store), so no
+    /// `IsolatedStateDir`/`serial` needed.
     #[test]
-    fn seed_path_guards_reused_slug_and_skips_sandbox() {
+    fn seed_path_guards_reused_slug_and_covers_sandboxes() {
         use crate::core::worktree::list::WorktreeInfo;
 
         let mut infos = vec![
@@ -261,9 +262,17 @@ mod tests {
                 i
             },
             {
-                let mut i = WorktreeInfo::empty("(detached)");
-                i.path = Some(PathBuf::from("/repo/sandbox"));
+                let mut i = WorktreeInfo::empty("main-fork");
+                i.path = Some(PathBuf::from("/repo/main-fork"));
                 i.is_sandbox = true;
+                i.branchless = true;
+                i
+            },
+            {
+                // A branch shadowing a like-named sandbox: the shared slug's
+                // stored path points at the sandbox, so the branch misses.
+                let mut i = WorktreeInfo::empty("shadowed");
+                i.path = Some(PathBuf::from("/repo/shadowed-branch"));
                 i
             },
         ];
@@ -276,10 +285,15 @@ mod tests {
             "feat/stable".to_string(),
             (PathBuf::from("/repo/stable"), 42),
         );
-        // A stale detached row — a sandbox must never be seeded.
+        // A sandbox whose stored path matches — seeds like any branch row.
         cached.insert(
-            "(detached)".to_string(),
-            (PathBuf::from("/repo/sandbox"), 999),
+            "main-fork".to_string(),
+            (PathBuf::from("/repo/main-fork"), 999),
+        );
+        // The shadowed slug's cache row belongs to the sandbox side.
+        cached.insert(
+            "shadowed".to_string(),
+            (PathBuf::from("/repo/shadowed-sandbox"), 7),
         );
 
         seed_worktree_sizes(&mut infos, &cached);
@@ -293,6 +307,14 @@ mod tests {
             Some(42),
             "a matching stored path seeds the cached size"
         );
-        assert_eq!(infos[2].size_bytes, None, "sandboxes are never seeded");
+        assert_eq!(
+            infos[2].size_bytes,
+            Some(999),
+            "a sandbox with a matching stored path seeds"
+        );
+        assert_eq!(
+            infos[3].size_bytes, None,
+            "slug shadowing degrades to a miss, never a wrong value"
+        );
     }
 }

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -196,13 +196,13 @@ pub struct Args {
 
     #[arg(
         long,
-        help = "Columns to display (comma-separated). Replace: branch,path,age. Modify defaults: +col,-col. Available: branch, path, size, base, changes, remote, pr, age, annotation, owner, hash, last-commit"
+        help = "Columns to display (comma-separated). Replace: name,path,age. Modify defaults: +col,-col. Available: name, path, size, base, changes, remote, pr, age, annotation, owner, hash, last-commit"
     )]
     columns: Option<String>,
 
     #[arg(
         long,
-        help = "Sort order (comma-separated). +col ascending, -col descending. Columns: branch, path, size, base, changes, remote, age, owner, hash, activity, commit"
+        help = "Sort order (comma-separated). +col ascending, -col descending. Columns: name, path, size, base, changes, remote, age, owner, hash, activity, commit"
     )]
     sort: Option<String>,
 

--- a/src/commands/worktree_branch.rs
+++ b/src/commands/worktree_branch.rs
@@ -211,7 +211,10 @@ daft.checkout.pushVerify overrides it for that push alone. Pass --no-verify
 to skip it unconditionally.
 "#)]
 pub struct RemoveArgs {
-    #[arg(required = true, help = "Branches or worktree paths to delete")]
+    #[arg(
+        required = true,
+        help = "Branches, worktree paths, or sandbox names to delete"
+    )]
     branches: Vec<String>,
 
     #[arg(

--- a/src/commands/worktree_branch.rs
+++ b/src/commands/worktree_branch.rs
@@ -162,10 +162,18 @@ remote tracking branches in a single operation. This is the inverse of
 By default, performs a safe delete that checks whether each branch has been
 merged. Use -f (--force) to force-delete branches regardless of merge status.
 
-Arguments can be branch names or worktree paths. When a path is given
-(absolute, relative, or "."), the branch checked out in that worktree is
-resolved automatically. This is convenient when you are inside a worktree
-and want to delete it without remembering the branch name.
+Arguments can be branch names, worktree paths, or sandbox names. When a path
+is given (absolute, relative, or "."), the branch checked out in that
+worktree is resolved automatically. This is convenient when you are inside a
+worktree and want to delete it without remembering the branch name.
+
+An anonymous sandbox worktree (`daft go <commit-ish>` / `daft start --fork`)
+is addressed by its directory name or path; a branch sharing the spelling
+always wins the name. There is no branch to delete, so only the worktree
+goes — after two checks: the worktree is clean, and its HEAD still sits at
+the pinned commit (commits made on a detached HEAD exist nowhere else, so a
+moved HEAD refuses removal until promoted or forced). Detached worktrees
+daft has no record of are refused as before.
 
 Use --repo <name> to remove branches in another cataloged repository without
 leaving your current directory: `daft remove --repo api feature-x` deletes

--- a/src/commands/worktree_branch.rs
+++ b/src/commands/worktree_branch.rs
@@ -175,6 +175,14 @@ the pinned commit (commits made on a detached HEAD exist nowhere else, so a
 moved HEAD refuses removal until promoted or forced). Detached worktrees
 daft has no record of are refused as before.
 
+Sandbox names may be given as wildcard patterns: `*` matches any run of
+characters and `?` exactly one, so `daft remove 'main-fork*'` sweeps every
+fork minted off main in one command. Patterns match sandbox names only —
+never branches (removing a branch also deletes its remote; for fleet-scale
+branch cleanup use `daft prune`) and never paths. A pattern that matches no
+live sandbox aborts the command. Quote the pattern so your shell does not
+expand or reject it before daft sees it (zsh errors on unmatched globs).
+
 Use --repo <name> to remove branches in another cataloged repository without
 leaving your current directory: `daft remove --repo api feature-x` deletes
 `feature-x` in the `api` repo. --repo is a flag rather than a positional
@@ -221,7 +229,8 @@ to skip it unconditionally.
 pub struct RemoveArgs {
     #[arg(
         required = true,
-        help = "Branches, worktree paths, or sandbox names to delete"
+        help = "Branches, worktree paths, or sandbox names to delete; \
+                sandbox names may use wildcards (*, ?)"
     )]
     branches: Vec<String>,
 

--- a/src/coordinator/client.rs
+++ b/src/coordinator/client.rs
@@ -64,6 +64,7 @@ impl CoordinatorClient {
         _tag: Option<&str>,
         _invocation_prefix: Option<&str>,
         _older_than_secs: Option<u64>,
+        _kill: bool,
     ) -> Result<Vec<String>> {
         match self.0 {}
     }

--- a/src/coordinator/client.rs
+++ b/src/coordinator/client.rs
@@ -212,7 +212,8 @@ impl CoordinatorClient {
     }
 
     /// Cancel every active job matching the predicate set. Returns the
-    /// names of the jobs that were signaled.
+    /// names of the jobs that were signaled. `kill` escalates SIGTERM to
+    /// SIGKILL for jobs that survived a polite cancel.
     pub fn cancel_matching(
         &mut self,
         hook: Option<&str>,
@@ -220,6 +221,7 @@ impl CoordinatorClient {
         tag: Option<&str>,
         invocation_prefix: Option<&str>,
         older_than_secs: Option<u64>,
+        kill: bool,
     ) -> Result<Vec<String>> {
         let req = CoordinatorRequest::CancelMatching {
             hook: hook.map(str::to_string),
@@ -227,6 +229,7 @@ impl CoordinatorClient {
             tag: tag.map(str::to_string),
             invocation_prefix: invocation_prefix.map(str::to_string),
             older_than_secs,
+            kill,
         };
         match self.send(&req)? {
             CoordinatorResponse::Cancelled { names, .. } => Ok(names),
@@ -354,7 +357,7 @@ mod tests {
         let stream = UnixStream::connect(&socket_path).unwrap();
         let mut client = CoordinatorClient::from_stream(stream);
         let names = client
-            .cancel_matching(Some("h"), None, None, None, None)
+            .cancel_matching(Some("h"), None, None, None, None, false)
             .unwrap();
         assert_eq!(names, vec!["a", "b"]);
 

--- a/src/coordinator/mod.rs
+++ b/src/coordinator/mod.rs
@@ -64,6 +64,11 @@ pub enum CoordinatorRequest {
         tag: Option<String>,
         invocation_prefix: Option<String>,
         older_than_secs: Option<u64>,
+        /// Escalate to SIGKILL instead of SIGTERM. `serde(default)` keeps
+        /// the wire compatible in both directions: an old daemon ignores
+        /// the field (polite SIGTERM), an old client omits it (false).
+        #[serde(default)]
+        kill: bool,
     },
     /// Streaming tail of a job's structured log file. Server emits one
     /// `StreamFrame` envelope per `LogRecord` then a single `StreamEnd`

--- a/src/coordinator/process.rs
+++ b/src/coordinator/process.rs
@@ -54,15 +54,30 @@ fn reconcile_active_jobs(_store: &SqliteJobsStore, _repo_hash: &str) -> Result<(
     Ok(())
 }
 
-/// Shared state for tracking running child processes.
-/// Maps job name to the child process PID, allowing cancellation.
-type ChildPidMap = Arc<Mutex<HashMap<String, u32>>>;
+/// Runtime identity of one background job: `(invocation_id, job_name)`.
+///
+/// The display name alone is NOT unique — three worktrees minted together
+/// each run a warmup named `mise dev`, and a name-keyed map made
+/// `CancelMatching` SIGTERM whichever same-named job registered last (the
+/// field failure: removing fork 1 killed fork 3's build while fork 1's
+/// kept writing, so `git worktree remove` died on "Directory not empty").
+/// A job name is unique *within* an invocation (`create_job_dir` keys log
+/// dirs the same way), so the pair pins exactly one process group.
+type JobKey = (String, String);
 
-/// Shared set of job names that have been cancelled individually
+fn job_key(invocation_id: &str, name: &str) -> JobKey {
+    (invocation_id.to_string(), name.to_string())
+}
+
+/// Shared state for tracking running child processes.
+/// Maps [`JobKey`] to the child process PID, allowing cancellation.
+type ChildPidMap = Arc<Mutex<HashMap<JobKey, u32>>>;
+
+/// Shared set of [`JobKey`]s that have been cancelled individually
 /// (as opposed to a global `cancel_all`). Consulted by the post-run
 /// status classifier so per-job cancel records `JobStatus::Cancelled`
 /// instead of `JobStatus::Failed`.
-type CancelledJobs = Arc<Mutex<HashSet<String>>>;
+type CancelledJobs = Arc<Mutex<HashSet<JobKey>>>;
 
 /// State for a coordinator process managing background jobs.
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
@@ -591,14 +606,14 @@ fn run_single_background_job(
     // 5. Set up a one-shot PID channel; register the spawned child's PID
     //    in `child_pids` so the socket listener can SIGTERM it on cancel.
     let (pid_tx, pid_rx) = std::sync::mpsc::channel::<u32>();
-    let job_name_for_register = job.name.clone();
+    let key_for_register = job_key(ctx.invocation_id, &job.name);
     let child_pids_for_register = child_pids.clone();
     let registrar = std::thread::spawn(move || {
         if let Ok(pid) = pid_rx.recv() {
             child_pids_for_register
                 .lock()
                 .unwrap()
-                .insert(job_name_for_register, pid);
+                .insert(key_for_register, pid);
         }
     });
 
@@ -624,7 +639,8 @@ fn run_single_background_job(
     // so the terminal JobRow write can record it. `process_group(0)` makes
     // pid == pgid for every spawned hook job, so the same value is also
     // the PGID that `killpg` would target.
-    let child_pid = child_pids.lock().unwrap().remove(&job.name);
+    let key = job_key(ctx.invocation_id, &job.name);
+    let child_pid = child_pids.lock().unwrap().remove(&key);
 
     // Wait for the log writer thread to finish; recover the next seq for
     // the terminal Status record.
@@ -636,12 +652,12 @@ fn run_single_background_job(
     //    cancellation. Either signal routes the job to Cancelled rather
     //    than Failed.
     let was_cancelled_globally = cancel_all.load(Ordering::Relaxed);
-    let was_cancelled_per_job = cancelled_jobs.lock().unwrap().contains(&job.name);
+    let was_cancelled_per_job = cancelled_jobs.lock().unwrap().contains(&key);
     let was_cancelled = was_cancelled_globally || was_cancelled_per_job;
 
     // Clear the per-job cancellation entry (if any) so a re-invocation of
     // the same job name does not inherit a stale `Cancelled` flag.
-    cancelled_jobs.lock().unwrap().remove(&job.name);
+    cancelled_jobs.lock().unwrap().remove(&key);
 
     let (status, node_status, exit_code) = if was_cancelled {
         (JobStatus::Cancelled, NodeStatus::Skipped, None)
@@ -899,15 +915,10 @@ fn handle_client_connection(
         }
         CoordinatorRequest::CancelAll => {
             cancel_all.store(true, Ordering::Relaxed);
-            let pids: Vec<(String, u32)> = child_pids
-                .lock()
-                .unwrap()
-                .iter()
-                .map(|(k, v)| (k.clone(), *v))
-                .collect();
+            let pids: Vec<u32> = child_pids.lock().unwrap().values().copied().collect();
 
             let mut count = 0;
-            for (name, pid) in &pids {
+            for pid in &pids {
                 // Bg children are process-group leaders (PID == PGID via
                 // setpgid). killpg reaches every descendant — e.g. a `sleep`
                 // grandchild of the wrapping `sh`.
@@ -916,7 +927,6 @@ fn handle_client_connection(
                     nix::sys::signal::Signal::SIGTERM,
                 );
                 count += 1;
-                let _ = name; // used for counting
             }
 
             CoordinatorResponse::Ack {
@@ -946,6 +956,7 @@ fn handle_client_connection(
             tag,
             invocation_prefix,
             older_than_secs,
+            kill,
         } => cancel_matching(
             CancelMatchingArgs {
                 hook: hook.as_deref(),
@@ -954,6 +965,7 @@ fn handle_client_connection(
                 invocation_prefix: invocation_prefix.as_deref(),
                 older_than_secs,
             },
+            kill,
             child_pids,
             cancelled_jobs,
             job_store,
@@ -1016,23 +1028,34 @@ fn cancel_single_job(
     cancelled_jobs: &CancelledJobs,
     _store: &LogStore,
 ) -> CoordinatorResponse {
-    let pids = child_pids.lock().unwrap();
-    if let Some(&pid) = pids.get(name) {
-        cancelled_jobs.lock().unwrap().insert(name.to_string());
+    // The user addresses jobs by display name; the map is keyed by
+    // (invocation, name). Cancel every invocation's instance of the name —
+    // with concurrent same-named jobs there is no principled way to pick
+    // one, and "stop the job called X" plainly means all of them.
+    let matches: Vec<(JobKey, u32)> = child_pids
+        .lock()
+        .unwrap()
+        .iter()
+        .filter(|((_, n), _)| n == name)
+        .map(|(k, v)| (k.clone(), *v))
+        .collect();
+    if matches.is_empty() {
+        return CoordinatorResponse::Error {
+            code: ErrorCode::JobNotFound,
+            message: format!("Job not found or not running: {name}"),
+        };
+    }
+    for (key, pid) in matches {
+        cancelled_jobs.lock().unwrap().insert(key);
         // The bg child is a process-group leader (PID == PGID via setpgid),
         // so killpg reaches every descendant.
         let _ = nix::sys::signal::killpg(
             nix::unistd::Pid::from_raw(pid as i32),
             nix::sys::signal::Signal::SIGTERM,
         );
-        CoordinatorResponse::Ack {
-            message: format!("Cancelled job: {name}"),
-        }
-    } else {
-        CoordinatorResponse::Error {
-            code: ErrorCode::JobNotFound,
-            message: format!("Job not found or not running: {name}"),
-        }
+    }
+    CoordinatorResponse::Ack {
+        message: format!("Cancelled job: {name}"),
     }
 }
 
@@ -1072,9 +1095,34 @@ fn filter_matching_jobs(
         .collect()
 }
 
+/// Resolve matched job rows to the process groups this coordinator owns.
+///
+/// Pure so the name-collision case is unit-testable: each row resolves
+/// through its own `(invocation_id, name)` key, so two concurrent jobs
+/// that share a display name (three forks' `mise dev`) each land on their
+/// OWN pid — the field failure this replaces looked up by name alone and
+/// signalled whichever same-named job registered last.
+fn resolve_cancel_targets(
+    matched: &[JobRow],
+    pids_snapshot: &HashMap<JobKey, u32>,
+) -> Vec<(JobKey, u32)> {
+    matched
+        .iter()
+        .filter_map(|row| {
+            let key = job_key(&row.invocation_id, &row.name);
+            let pid = *pids_snapshot.get(&key)?;
+            Some((key, pid))
+        })
+        .collect()
+}
+
 /// Cancel every active job whose SQLite `JobRow` matches *all* supplied
 /// predicates (AND, missing-is-wildcard). Looks up the runtime PID via
 /// `child_pids` so we signal exactly the process group that's still alive.
+///
+/// `kill` escalates SIGTERM to SIGKILL — the worktree-removal path sends
+/// it for jobs that outlived the polite cancel and are about to have the
+/// directory deleted from under them.
 ///
 /// Rows the coordinator never wrote (e.g. legacy pre-store invocations)
 /// can't be filtered by the SQL schema, so they fall through unmatched —
@@ -1082,6 +1130,7 @@ fn filter_matching_jobs(
 #[cfg(unix)]
 fn cancel_matching(
     args: CancelMatchingArgs<'_>,
+    kill: bool,
     child_pids: &ChildPidMap,
     cancelled_jobs: &CancelledJobs,
     job_store: Option<&SqliteJobsStore>,
@@ -1115,16 +1164,20 @@ fn cancel_matching(
         let g = child_pids.lock().unwrap();
         g.clone()
     };
+    let signal = if kill {
+        nix::sys::signal::Signal::SIGKILL
+    } else {
+        nix::sys::signal::Signal::SIGTERM
+    };
     let mut names: Vec<String> = Vec::new();
-    for row in &matched {
-        if let Some(&pid) = pids_snapshot.get(&row.name) {
-            cancelled_jobs.lock().unwrap().insert(row.name.clone());
-            let _ = nix::sys::signal::killpg(
-                nix::unistd::Pid::from_raw(pid as i32),
-                nix::sys::signal::Signal::SIGTERM,
-            );
-            names.push(row.name.clone());
-        }
+    for (key, pid) in resolve_cancel_targets(&matched, &pids_snapshot) {
+        names.push(key.1.clone());
+        cancelled_jobs.lock().unwrap().insert(key);
+        let pgid = nix::unistd::Pid::from_raw(pid as i32);
+        let _ = nix::sys::signal::killpg(pgid, signal);
+        // A governor-frozen (SIGSTOP'd) group holds the termination signal
+        // pending until it resumes — thaw it so the signal can land.
+        let _ = nix::sys::signal::killpg(pgid, nix::sys::signal::Signal::SIGCONT);
     }
 
     CoordinatorResponse::Cancelled {
@@ -1817,6 +1870,58 @@ mod tests {
     // `other_repos_are_left_alone`). The thin wrapper in this module is
     // exercised end-to-end via the YAML integration scenarios.
 
+    /// The field failure this pins: three worktrees each running a warmup
+    /// named `mise dev`. A name-keyed PID map made every cancel land on
+    /// whichever same-named job registered last; the composite
+    /// `(invocation, name)` key must route each matched row to its OWN
+    /// process group.
+    #[test]
+    fn resolve_cancel_targets_distinguishes_same_named_jobs() {
+        fn row(name: &str, wt: &str, inv: &str) -> JobRow {
+            JobRow {
+                repo_hash: "rh".into(),
+                invocation_id: inv.into(),
+                name: name.into(),
+                hook_type: "worktree-post-create".into(),
+                worktree: wt.into(),
+                command: "x".into(),
+                working_dir: "/tmp".into(),
+                env: HashMap::new(),
+                started_at: chrono::Utc::now(),
+                finished_at: None,
+                status: JobStatus::Running.as_status_str().to_string(),
+                exit_code: None,
+                pid: Some(1),
+                pgid: Some(1),
+                background: true,
+                needs: vec![],
+                tags: vec![],
+                retention_seconds: None,
+                max_log_size_bytes: None,
+            }
+        }
+
+        let pids = HashMap::from([
+            (job_key("inv-fork-1", "mise dev"), 101),
+            (job_key("inv-fork-2", "mise dev"), 102),
+            (job_key("inv-fork-3", "mise dev"), 103),
+        ]);
+
+        // Cancelling fork-1's job must signal PID 101 — not whichever
+        // same-named registration happened to be last.
+        let matched = vec![row("mise dev", "master-fork", "inv-fork-1")];
+        let targets = resolve_cancel_targets(&matched, &pids);
+        assert_eq!(
+            targets,
+            vec![(job_key("inv-fork-1", "mise dev"), 101)],
+            "each row resolves through its own invocation"
+        );
+
+        // A row this coordinator never registered resolves to nothing.
+        let foreign = vec![row("mise dev", "elsewhere", "inv-unknown")];
+        assert!(resolve_cancel_targets(&foreign, &pids).is_empty());
+    }
+
     /// Filter predicates AND together; missing predicates wildcard. Tag
     /// matching is "contains" against the JobRow's `tags` vector.
     #[test]
@@ -2211,7 +2316,10 @@ mod tests {
             let deadline = std::time::Instant::now() + std::time::Duration::from_millis(600);
             loop {
                 let snap = pids_probe.lock().unwrap().clone();
-                if snap.contains_key("sleep-job") {
+                if snap.contains_key(&job_key(
+                    "00000000-0000-0000-0000-000000000001",
+                    "sleep-job",
+                )) {
                     return snap;
                 }
                 if std::time::Instant::now() >= deadline {
@@ -2224,12 +2332,10 @@ mod tests {
         let _ = run_single_background_job(&job, &ctx, &store);
 
         let mid = probe.join().unwrap();
+        let key = job_key("00000000-0000-0000-0000-000000000001", "sleep-job");
+        assert!(mid.contains_key(&key), "PID should be registered mid-run");
         assert!(
-            mid.contains_key("sleep-job"),
-            "PID should be registered mid-run"
-        );
-        assert!(
-            !child_pids.lock().unwrap().contains_key("sleep-job"),
+            !child_pids.lock().unwrap().contains_key(&key),
             "PID should be deregistered after completion"
         );
     }
@@ -2267,7 +2373,8 @@ mod tests {
                 // cancel_single_job would no-op because the map was still
                 // empty.
                 let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
-                while !pids.lock().unwrap().contains_key("long-job") {
+                let key = job_key("00000000-0000-0000-0000-000000000002", "long-job");
+                while !pids.lock().unwrap().contains_key(&key) {
                     if std::time::Instant::now() >= deadline {
                         break;
                     }
@@ -2401,10 +2508,10 @@ mod tests {
         // Pre-insert into cancelled_jobs BEFORE running. The cmd will succeed
         // (exit 0), but the classifier will see was_cancelled_per_job and route
         // status to Cancelled. The log must survive.
-        cancelled_jobs
-            .lock()
-            .unwrap()
-            .insert("pre-cancelled".to_string());
+        cancelled_jobs.lock().unwrap().insert(job_key(
+            "00000000-0000-0000-0000-000000000006",
+            "pre-cancelled",
+        ));
 
         let job = JobSpec {
             name: "pre-cancelled".to_string(),
@@ -2614,7 +2721,7 @@ mod tests {
             // we try to cancel. A fixed 200ms sleep raced fork-exec
             // scheduling under heavy parallel-test load.
             let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
-            while !pids.lock().unwrap().contains_key("long") {
+            while !pids.lock().unwrap().keys().any(|(_, n)| n == "long") {
                 if std::time::Instant::now() >= deadline {
                     break;
                 }

--- a/src/core/columns.rs
+++ b/src/core/columns.rs
@@ -21,7 +21,7 @@ trait SelectableColumn: Copy + Eq + Hash + FromStr<Err = String> {
 }
 
 /// Family-specific wording for the mixed-mode error — flags say
-/// `--columns branch,path`, config values say `age,path`.
+/// `--columns name,path`, config values say `age,path`.
 struct ModeExamples {
     replace: &'static str,
     modifier: &'static str,
@@ -145,8 +145,9 @@ pub enum ListColumn {
     /// Paused git operation and conflict state, spelled out. Opt-in — the
     /// annotation column carries the same state as glyphs by default.
     Status,
-    /// Branch name.
-    Branch,
+    /// Worktree name: the branch name for branch worktrees, the directory
+    /// name for detached sandboxes.
+    Name,
     /// Worktree path.
     Path,
     /// Disk size of the worktree folder.
@@ -175,7 +176,7 @@ impl ListColumn {
         &[
             ListColumn::Annotation,
             ListColumn::Status,
-            ListColumn::Branch,
+            ListColumn::Name,
             ListColumn::Path,
             ListColumn::Size,
             ListColumn::Base,
@@ -198,7 +199,7 @@ impl ListColumn {
     pub fn list_defaults() -> &'static [ListColumn] {
         &[
             ListColumn::Annotation,
-            ListColumn::Branch,
+            ListColumn::Name,
             ListColumn::Path,
             ListColumn::Base,
             ListColumn::Changes,
@@ -220,7 +221,7 @@ impl ListColumn {
     pub fn tui_defaults() -> &'static [ListColumn] {
         &[
             ListColumn::Annotation,
-            ListColumn::Branch,
+            ListColumn::Name,
             ListColumn::Path,
             ListColumn::Base,
             ListColumn::Changes,
@@ -234,7 +235,7 @@ impl ListColumn {
 
     pub fn clone_defaults() -> &'static [ListColumn] {
         &[
-            ListColumn::Branch,
+            ListColumn::Name,
             ListColumn::Path,
             ListColumn::Base,
             ListColumn::Age,
@@ -249,7 +250,7 @@ impl ListColumn {
             // Before Branch: state reads first, identity second — the same
             // order the annotation glyphs already sit in.
             Self::Status => 2,
-            Self::Branch => 3,
+            Self::Name => 3,
             Self::Path => 4,
             Self::Size => 5,
             Self::Base => 6,
@@ -268,7 +269,7 @@ impl ListColumn {
         match self {
             Self::Annotation => "annotation",
             Self::Status => "status",
-            Self::Branch => "branch",
+            Self::Name => "name",
             Self::Path => "path",
             Self::Size => "size",
             Self::Base => "base",
@@ -305,7 +306,7 @@ impl FromStr for ListColumn {
         match s.trim().to_lowercase().as_str() {
             "annotation" => Ok(Self::Annotation),
             "status" => Ok(Self::Status),
-            "branch" => Ok(Self::Branch),
+            "name" => Ok(Self::Name),
             "path" => Ok(Self::Path),
             "size" => Ok(Self::Size),
             "base" => Ok(Self::Base),
@@ -377,7 +378,7 @@ impl ColumnSelection {
             input,
             defaults,
             ModeExamples {
-                replace: "--columns branch,path,age",
+                replace: "--columns name,path,age",
                 modifier: "--columns -annotation,-remote",
             },
             |name| Self::check_unsupported_token(name, command),
@@ -715,7 +716,7 @@ mod tests {
             "annotation".parse::<ListColumn>().unwrap(),
             ListColumn::Annotation
         );
-        assert_eq!("branch".parse::<ListColumn>().unwrap(), ListColumn::Branch);
+        assert_eq!("name".parse::<ListColumn>().unwrap(), ListColumn::Name);
         assert_eq!("path".parse::<ListColumn>().unwrap(), ListColumn::Path);
         assert_eq!("size".parse::<ListColumn>().unwrap(), ListColumn::Size);
         assert_eq!("base".parse::<ListColumn>().unwrap(), ListColumn::Base);
@@ -758,20 +759,20 @@ mod tests {
 
     #[test]
     fn test_replace_mode() {
-        let resolved = ColumnSelection::parse("branch,path,age", CommandKind::List).unwrap();
+        let resolved = ColumnSelection::parse("name,path,age", CommandKind::List).unwrap();
         assert_eq!(
             resolved.columns,
-            vec![ListColumn::Branch, ListColumn::Path, ListColumn::Age]
+            vec![ListColumn::Name, ListColumn::Path, ListColumn::Age]
         );
         assert!(resolved.explicit);
     }
 
     #[test]
     fn test_replace_mode_custom_order() {
-        let resolved = ColumnSelection::parse("age,branch,path", CommandKind::List).unwrap();
+        let resolved = ColumnSelection::parse("age,name,path", CommandKind::List).unwrap();
         assert_eq!(
             resolved.columns,
-            vec![ListColumn::Age, ListColumn::Branch, ListColumn::Path]
+            vec![ListColumn::Age, ListColumn::Name, ListColumn::Path]
         );
         assert!(resolved.explicit);
     }
@@ -838,7 +839,7 @@ mod tests {
 
     #[test]
     fn test_modifier_add_idempotent() {
-        let resolved = ColumnSelection::parse("+branch,+path", CommandKind::List).unwrap();
+        let resolved = ColumnSelection::parse("+name,+path", CommandKind::List).unwrap();
         assert_eq!(resolved.columns, ListColumn::list_defaults().to_vec());
     }
 
@@ -850,7 +851,7 @@ mod tests {
 
     #[test]
     fn test_mixed_mode_error() {
-        let err = ColumnSelection::parse("branch,+age", CommandKind::List).unwrap_err();
+        let err = ColumnSelection::parse("name,+age", CommandKind::List).unwrap_err();
         assert!(err.contains("cannot mix"), "Got: {err}");
     }
 
@@ -867,34 +868,34 @@ mod tests {
 
     #[test]
     fn test_unknown_column_error() {
-        let err = ColumnSelection::parse("branch,foo", CommandKind::List).unwrap_err();
+        let err = ColumnSelection::parse("name,foo", CommandKind::List).unwrap_err();
         assert!(err.contains("unknown column 'foo'"), "Got: {err}");
     }
 
     #[test]
     fn test_duplicate_replace_error() {
-        let err = ColumnSelection::parse("branch,path,branch", CommandKind::List).unwrap_err();
+        let err = ColumnSelection::parse("name,path,name", CommandKind::List).unwrap_err();
         assert!(err.contains("duplicate"), "Got: {err}");
     }
 
     #[test]
     fn test_duplicate_modifier_idempotent() {
-        let resolved = ColumnSelection::parse("+branch,+branch", CommandKind::List).unwrap();
+        let resolved = ColumnSelection::parse("+name,+name", CommandKind::List).unwrap();
         assert_eq!(resolved.columns, ListColumn::list_defaults().to_vec());
     }
 
     #[test]
     fn test_whitespace_trimmed() {
-        let resolved = ColumnSelection::parse("branch , path , age", CommandKind::List).unwrap();
+        let resolved = ColumnSelection::parse("name , path , age", CommandKind::List).unwrap();
         assert_eq!(
             resolved.columns,
-            vec![ListColumn::Branch, ListColumn::Path, ListColumn::Age]
+            vec![ListColumn::Name, ListColumn::Path, ListColumn::Age]
         );
     }
 
     #[test]
     fn test_status_on_sync_errors() {
-        let err = ColumnSelection::parse("status,branch", CommandKind::Sync).unwrap_err();
+        let err = ColumnSelection::parse("status,name", CommandKind::Sync).unwrap_err();
         assert!(err.contains("cannot be controlled"), "Got: {err}");
     }
 
@@ -909,14 +910,11 @@ mod tests {
     /// column, so the token stays rejected for them.
     #[test]
     fn test_status_selectable_on_list_only() {
-        let resolved = ColumnSelection::parse("status,branch", CommandKind::List).unwrap();
-        assert_eq!(
-            resolved.columns,
-            vec![ListColumn::Status, ListColumn::Branch]
-        );
+        let resolved = ColumnSelection::parse("status,name", CommandKind::List).unwrap();
+        assert_eq!(resolved.columns, vec![ListColumn::Status, ListColumn::Name]);
 
         for command in [CommandKind::Sync, CommandKind::Prune, CommandKind::Clone] {
-            let err = ColumnSelection::parse("status,branch", command).unwrap_err();
+            let err = ColumnSelection::parse("status,name", command).unwrap_err();
             assert!(err.contains("cannot be controlled"), "Got: {err}");
             assert!(
                 err.contains("daft list"),
@@ -935,14 +933,14 @@ mod tests {
             .iter()
             .position(|c| *c == ListColumn::Status)
             .expect("status column added");
-        let branch = resolved
+        let name = resolved
             .columns
             .iter()
-            .position(|c| *c == ListColumn::Branch)
-            .expect("branch column present");
+            .position(|c| *c == ListColumn::Name)
+            .expect("name column present");
         assert!(
-            status < branch,
-            "status must precede branch, got {:?}",
+            status < name,
+            "status must precede name, got {:?}",
             resolved.columns
         );
         // And it is opt-in: absent from the defaults.
@@ -956,7 +954,7 @@ mod tests {
         assert!(ListColumn::tui_defaults().contains(&ListColumn::Pr));
         let sync = ColumnSelection::parse("+pr", CommandKind::Sync).unwrap();
         assert!(sync.columns.contains(&ListColumn::Pr));
-        let prune = ColumnSelection::parse("pr,branch", CommandKind::Prune).unwrap();
+        let prune = ColumnSelection::parse("pr,name", CommandKind::Prune).unwrap();
         assert!(prune.columns.contains(&ListColumn::Pr));
         // Removing it works the same as on list.
         let removed = ColumnSelection::parse("-pr", CommandKind::Sync).unwrap();

--- a/src/core/progress.rs
+++ b/src/core/progress.rs
@@ -457,12 +457,17 @@ impl HookRunner for TimelineBridge<'_> {
         use crate::core::stage::StageId;
 
         // Embedded path: the region is live and the plan has a row for this
-        // hook phase (scoped by the context's branch when the plan is
-        // multi-branch). The presenter is lazy — the row expands into the
-        // hook block only if the executor actually starts the phase.
+        // hook phase (scoped by the target's display name when the plan is
+        // multi-branch). Resolution must use `worktree_label()`, not
+        // `branch_name`: sandbox targets run hooks under the branchless
+        // contract (`branch_name` is `""`) while their plan rows are scoped
+        // by dirname — an empty scope can never claim such a row, leaving
+        // the hook to run invisibly and the row to drop as unresolved. The
+        // presenter is lazy — the row expands into the hook block only if
+        // the executor actually starts the phase.
         let embed_key = StageId::for_hook_type(ctx.hook_type)
             .filter(|_| self.timeline.region_live())
-            .and_then(|id| self.timeline.resolve_key(id, Some(&ctx.branch_name)));
+            .and_then(|id| self.timeline.resolve_key(id, Some(ctx.worktree_label())));
 
         if let Some(key) = embed_key {
             let presenter: Arc<dyn JobPresenter> =
@@ -683,6 +688,86 @@ mod tests {
             output.entries()
         );
         timeline.finish("Removed in 0.1s");
+    }
+
+    /// Regression test (#53): `daft remove` scopes its per-target hook rows
+    /// by the target's display name — for sandboxes the dirname — while the
+    /// hook context carries `branch_name = ""` (the branchless contract).
+    /// Resolving the embed row by `branch_name` could never claim a
+    /// dirname-scoped row: the hook ran invisibly through the no-row
+    /// fallback and the planned row stayed unresolved — silently dropped on
+    /// success, a false `(not run)` receipt on abort. Resolution must go
+    /// through `worktree_label()`.
+    #[test]
+    fn sandbox_hook_row_is_claimed_despite_branchless_context() {
+        use crate::core::stage::{PlanCommit, Row, StageId, StepKey, StepSpec};
+        use crate::output::OutputConfig;
+        use crate::output::timeline::{Timeline, TimelineMode};
+
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let worktree = tmp.path().join("master-fork");
+        std::fs::create_dir_all(&worktree).expect("create worktree dir");
+        std::fs::write(
+            worktree.join("daft.yml"),
+            "hooks:\n  worktree-pre-remove:\n    jobs:\n      - name: ok\n        run: \"true\"\n",
+        )
+        .expect("write daft.yml");
+
+        let hooks_config = HooksConfig {
+            user_directory: tmp.path().join("user-hooks"),
+            ..HooksConfig::default()
+        };
+        let executor = HookExecutor::new(hooks_config)
+            .expect("create executor")
+            .with_bypass_trust(true);
+
+        let mut output = TestOutput::with_config(OutputConfig::new(false, false));
+        let mut timeline = Timeline::new(
+            TimelineMode::Interactive { color: false },
+            false,
+            "Removing master-fork",
+        );
+        let term = indicatif::InMemoryTerm::new(60, 100);
+        timeline.set_test_draw_target(indicatif::ProgressDrawTarget::term_like(Box::new(
+            term.clone(),
+        )));
+        // The plan scopes the hook row by the sandbox dirname, exactly as
+        // `branch_delete::build_plan` does for every target.
+        timeline.commit_plan(PlanCommit::new(vec![Row::Step(StepSpec::new(
+            StepKey::scoped(StageId::PreRemoveHooks, "master-fork"),
+        ))]));
+        assert!(timeline.region_live());
+
+        let ctx = HookContext::new(
+            HookType::PreRemove,
+            "test-remove",
+            tmp.path().to_path_buf(),
+            // A real directory: the invocation record hashes this path.
+            tmp.path().to_path_buf(),
+            "origin",
+            tmp.path().join("master"),
+            worktree,
+            // Branchless: sandbox targets carry no branch name.
+            "",
+        )
+        .with_state_dir(tmp.path());
+        let outcome = {
+            let mut bridge = TimelineBridge::new(
+                &mut output,
+                &mut timeline,
+                executor,
+                HookOutputConfig::default(),
+            );
+            bridge.run_hook(&ctx).expect("run_hook")
+        };
+        assert!(!outcome.skipped, "the daft.yml hook must run");
+        timeline.finish("Removed in 0.1s");
+        let contents = term.contents();
+        assert!(
+            contents.contains("pre-remove hooks"),
+            "the dirname-scoped row must be claimed by the branchless hook \
+             context, not dropped as unresolved:\n{contents}"
+        );
     }
 
     /// The consolidation prompts fire during validation, under the live

--- a/src/core/settings.rs
+++ b/src/core/settings.rs
@@ -123,6 +123,28 @@ impl PushVerify {
     }
 }
 
+/// How `daft start --fork` names the sandboxes it mints (#53).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ForkNaming {
+    /// `<source>-fork`, `<source>-fork-2`, … — self-describing provenance in
+    /// `daft list`. The default.
+    Derived,
+    /// Docker-style adjective-noun names (`brave-otter`) — collision-sparse
+    /// and better *handles* when several sandboxes are alive at once.
+    Memorable,
+}
+
+impl ForkNaming {
+    /// Parse a string value into a ForkNaming.
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.to_lowercase().as_str() {
+            "derived" => Some(Self::Derived),
+            "memorable" => Some(Self::Memorable),
+            _ => None,
+        }
+    }
+}
+
 /// How `daft sync --push` runs the repo's pre-push hook across branches
 /// (#678). Batched trades per-branch hook semantics for an N→1 resource
 /// cost: one `git push` carries every branch, so the hook runs once with
@@ -282,7 +304,8 @@ pub fn parse_push_timeout(value: &str) -> Option<Option<std::time::Duration>> {
 /// Default values for settings.
 pub mod defaults {
     use super::{
-        GovernorJobs, GovernorMode, MemoryReserve, PruneCdTarget, PushHookStrategy, PushVerify,
+        ForkNaming, GovernorJobs, GovernorMode, MemoryReserve, PruneCdTarget, PushHookStrategy,
+        PushVerify,
     };
     use crate::core::worktree::list::Stat;
 
@@ -323,6 +346,9 @@ pub mod defaults {
     /// Default value for checkout.pushVerify setting (follows the base
     /// `daft.pushVerify` when unset).
     pub const CHECKOUT_PUSH_VERIFY: PushVerify = PushVerify::Auto;
+
+    /// Default value for start.forkNaming setting (#53).
+    pub const START_FORK_NAMING: ForkNaming = ForkNaming::Derived;
 
     /// Default value for remote setting.
     pub const REMOTE: &str = "origin";
@@ -469,6 +495,9 @@ pub mod keys {
 
     /// Config key for go.autoStart setting.
     pub const GO_AUTO_START: &str = "daft.go.autoStart";
+
+    /// Config key for start.forkNaming setting (#53).
+    pub const START_FORK_NAMING: &str = "daft.start.forkNaming";
 
     /// Config key for go.fetchOnMiss setting.
     pub const GO_FETCH_ON_MISS: &str = "daft.go.fetchOnMiss";
@@ -680,6 +709,9 @@ pub struct DaftSettings {
     /// Automatically create worktree when branch not found in go command.
     pub go_auto_start: bool,
 
+    /// How `daft start --fork` names its sandboxes (#53).
+    pub start_fork_naming: ForkNaming,
+
     /// Whether `daft go` completion should run `git fetch` when the typed
     /// prefix has no local matches. Controlled by `daft.go.fetchOnMiss`.
     pub go_fetch_on_miss: bool,
@@ -812,6 +844,7 @@ impl Default for DaftSettings {
             multi_remote_default: defaults::MULTI_REMOTE_DEFAULT_REMOTE.to_string(),
             use_gitoxide: defaults::USE_GITOXIDE,
             go_auto_start: defaults::GO_AUTO_START,
+            start_fork_naming: defaults::START_FORK_NAMING,
             go_fetch_on_miss: defaults::GO_FETCH_ON_MISS,
             list_stat: defaults::LIST_STAT,
             sync_stat: defaults::SYNC_STAT,
@@ -937,6 +970,12 @@ impl DaftSettings {
 
         if let Some(value) = git.config_get(keys::GO_AUTO_START)? {
             settings.go_auto_start = parse_bool(&value, defaults::GO_AUTO_START);
+        }
+
+        if let Some(value) = git.config_get(keys::START_FORK_NAMING)?
+            && let Some(naming) = ForkNaming::parse(&value)
+        {
+            settings.start_fork_naming = naming;
         }
 
         if let Some(value) = git.config_get(keys::GO_FETCH_ON_MISS)? {
@@ -1191,6 +1230,12 @@ impl DaftSettings {
 
         if let Some(value) = git.config_get_global(keys::GO_AUTO_START)? {
             settings.go_auto_start = parse_bool(&value, defaults::GO_AUTO_START);
+        }
+
+        if let Some(value) = git.config_get_global(keys::START_FORK_NAMING)?
+            && let Some(naming) = ForkNaming::parse(&value)
+        {
+            settings.start_fork_naming = naming;
         }
 
         if let Some(value) = git.config_get_global(keys::GO_FETCH_ON_MISS)? {

--- a/src/core/sort.rs
+++ b/src/core/sort.rs
@@ -12,8 +12,8 @@ use std::cmp::Ordering;
 /// A column that can be used in a `--sort` specification.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SortColumn {
-    /// Sort by branch name (case-insensitive).
-    Branch,
+    /// Sort by worktree name (case-insensitive).
+    Name,
     /// Sort by worktree path.
     Path,
     /// Sort by disk size.
@@ -42,7 +42,7 @@ pub enum SortColumn {
 impl SortColumn {
     /// All valid CLI sort column names, for use in error messages.
     pub fn valid_names() -> &'static str {
-        "branch, path, size, base, changes, remote, age, owner, hash, activity, commit (alias: last-commit)"
+        "name, path, size, base, changes, remote, age, owner, hash, activity, commit (alias: last-commit)"
     }
 
     /// Map this sort column to the corresponding display column, if any.
@@ -51,7 +51,7 @@ impl SortColumn {
     /// working tree mtime) that doesn't correspond to a single display column.
     pub fn to_list_column(self) -> Option<ListColumn> {
         match self {
-            Self::Branch => Some(ListColumn::Branch),
+            Self::Name => Some(ListColumn::Name),
             Self::Path => Some(ListColumn::Path),
             Self::Size => Some(ListColumn::Size),
             Self::Age => Some(ListColumn::Age),
@@ -68,7 +68,7 @@ impl SortColumn {
     /// Human-readable display name for this sort column.
     pub fn display_name(self) -> &'static str {
         match self {
-            Self::Branch => "Branch",
+            Self::Name => "Name",
             Self::Path => "Path",
             Self::Size => "Size",
             Self::Base => "Base",
@@ -85,7 +85,7 @@ impl SortColumn {
     /// Parse a sort column name (case-insensitive).
     fn parse(name: &str) -> Result<Self, String> {
         match name.trim().to_lowercase().as_str() {
-            "branch" => Ok(Self::Branch),
+            "name" => Ok(Self::Name),
             "path" => Ok(Self::Path),
             "size" => Ok(Self::Size),
             "age" => Ok(Self::Age),
@@ -125,7 +125,7 @@ impl SortKey {
     /// `None` values always sort last, regardless of sort direction.
     fn compare(&self, a: &WorktreeInfo, b: &WorktreeInfo, stat: Stat) -> Ordering {
         match self.column {
-            SortColumn::Branch => {
+            SortColumn::Name => {
                 // Branch name is always present, just apply direction directly.
                 let ord = a.name.to_lowercase().cmp(&b.name.to_lowercase());
                 self.apply_direction(ord)
@@ -285,11 +285,11 @@ pub struct SortSpec {
 }
 
 impl SortSpec {
-    /// The default sort: branch name ascending, summary stat mode.
+    /// The default sort: name ascending, summary stat mode.
     pub fn default_sort() -> Self {
         Self {
             keys: vec![SortKey {
-                column: SortColumn::Branch,
+                column: SortColumn::Name,
                 direction: SortDirection::Ascending,
             }],
             stat: Stat::Summary,
@@ -304,8 +304,8 @@ impl SortSpec {
     /// # Examples
     ///
     /// ```text
-    /// "branch"            → branch ascending
-    /// "+branch,-size"     → branch ascending, then size descending
+    /// "name"              → name ascending
+    /// "+name,-size"       → name ascending, then size descending
     /// "-activity"         → last commit timestamp descending (most recent first)
     /// "commit"            → alias for activity ascending
     /// ```
@@ -455,7 +455,7 @@ impl SortSpec {
         let mut acc = FieldSet::EMPTY;
         for key in &self.keys {
             acc |= match key.column {
-                SortColumn::Branch => FieldSet::EMPTY,
+                SortColumn::Name => FieldSet::EMPTY,
                 SortColumn::Path => FieldSet::EMPTY,
                 SortColumn::Size => FieldSet::SIZE,
                 SortColumn::Age => FieldSet::BRANCH_AGE,
@@ -530,21 +530,21 @@ mod tests {
 
     #[test]
     fn test_parse_single_column_no_prefix() {
-        let spec = SortSpec::parse("branch").unwrap();
+        let spec = SortSpec::parse("name").unwrap();
         assert_eq!(spec.keys.len(), 1);
-        assert_eq!(spec.keys[0].column, SortColumn::Branch);
+        assert_eq!(spec.keys[0].column, SortColumn::Name);
         assert_eq!(spec.keys[0].direction, SortDirection::Ascending);
     }
 
     #[test]
     fn test_parse_ascending_prefix() {
-        let spec = SortSpec::parse("+branch").unwrap();
+        let spec = SortSpec::parse("+name").unwrap();
         assert_eq!(spec.keys[0].direction, SortDirection::Ascending);
     }
 
     #[test]
     fn test_parse_descending_prefix() {
-        let spec = SortSpec::parse("-branch").unwrap();
+        let spec = SortSpec::parse("-name").unwrap();
         assert_eq!(spec.keys[0].direction, SortDirection::Descending);
     }
 
@@ -583,17 +583,17 @@ mod tests {
 
     #[test]
     fn test_parse_case_insensitive() {
-        let spec = SortSpec::parse("Branch").unwrap();
-        assert_eq!(spec.keys[0].column, SortColumn::Branch);
+        let spec = SortSpec::parse("Name").unwrap();
+        assert_eq!(spec.keys[0].column, SortColumn::Name);
         let spec = SortSpec::parse("SIZE").unwrap();
         assert_eq!(spec.keys[0].column, SortColumn::Size);
     }
 
     #[test]
     fn test_parse_whitespace_trimmed() {
-        let spec = SortSpec::parse(" branch , -size ").unwrap();
+        let spec = SortSpec::parse(" name , -size ").unwrap();
         assert_eq!(spec.keys.len(), 2);
-        assert_eq!(spec.keys[0].column, SortColumn::Branch);
+        assert_eq!(spec.keys[0].column, SortColumn::Name);
         assert_eq!(spec.keys[1].column, SortColumn::Size);
     }
 
@@ -647,7 +647,7 @@ mod tests {
 
     #[test]
     fn test_parse_duplicate_column_error() {
-        let err = SortSpec::parse("branch,-branch").unwrap_err();
+        let err = SortSpec::parse("name,-name").unwrap_err();
         assert!(err.contains("duplicate"), "Got: {err}");
     }
 
@@ -678,7 +678,7 @@ mod tests {
     fn test_default_sort() {
         let spec = SortSpec::default_sort();
         assert_eq!(spec.keys.len(), 1);
-        assert_eq!(spec.keys[0].column, SortColumn::Branch);
+        assert_eq!(spec.keys[0].column, SortColumn::Name);
         assert_eq!(spec.keys[0].direction, SortDirection::Ascending);
     }
 
@@ -687,24 +687,24 @@ mod tests {
     #[test]
     fn test_needs_size_true() {
         assert!(SortSpec::parse("size").unwrap().needs_size());
-        assert!(SortSpec::parse("branch,-size").unwrap().needs_size());
+        assert!(SortSpec::parse("name,-size").unwrap().needs_size());
     }
 
     #[test]
     fn test_needs_size_false() {
-        assert!(!SortSpec::parse("branch").unwrap().needs_size());
+        assert!(!SortSpec::parse("name").unwrap().needs_size());
         assert!(!SortSpec::parse("activity").unwrap().needs_size());
     }
 
     #[test]
     fn test_needs_mtime_true() {
         assert!(SortSpec::parse("activity").unwrap().needs_mtime());
-        assert!(SortSpec::parse("branch,activity").unwrap().needs_mtime());
+        assert!(SortSpec::parse("name,activity").unwrap().needs_mtime());
     }
 
     #[test]
     fn test_needs_mtime_false() {
-        assert!(!SortSpec::parse("branch").unwrap().needs_mtime());
+        assert!(!SortSpec::parse("name").unwrap().needs_mtime());
         assert!(!SortSpec::parse("commit").unwrap().needs_mtime());
         assert!(!SortSpec::parse("last-commit").unwrap().needs_mtime());
     }
@@ -712,8 +712,8 @@ mod tests {
     // ── Sorting tests ──────────────────────────────────────────────────
 
     #[test]
-    fn test_sort_by_branch_ascending() {
-        let spec = SortSpec::parse("branch").unwrap();
+    fn test_sort_by_name_ascending() {
+        let spec = SortSpec::parse("name").unwrap();
         let mut infos = vec![info("charlie"), info("alpha"), info("bravo")];
         spec.sort(&mut infos);
         let names: Vec<&str> = infos.iter().map(|i| i.name.as_str()).collect();
@@ -721,8 +721,8 @@ mod tests {
     }
 
     #[test]
-    fn test_sort_by_branch_descending() {
-        let spec = SortSpec::parse("-branch").unwrap();
+    fn test_sort_by_name_descending() {
+        let spec = SortSpec::parse("-name").unwrap();
         let mut infos = vec![info("charlie"), info("alpha"), info("bravo")];
         spec.sort(&mut infos);
         let names: Vec<&str> = infos.iter().map(|i| i.name.as_str()).collect();
@@ -731,7 +731,7 @@ mod tests {
 
     #[test]
     fn test_sort_by_branch_case_insensitive() {
-        let spec = SortSpec::parse("branch").unwrap();
+        let spec = SortSpec::parse("name").unwrap();
         let mut infos = vec![info("Charlie"), info("alpha"), info("Bravo")];
         spec.sort(&mut infos);
         let names: Vec<&str> = infos.iter().map(|i| i.name.as_str()).collect();
@@ -966,7 +966,7 @@ mod tests {
 
     #[test]
     fn test_compare_method() {
-        let spec = SortSpec::parse("-branch").unwrap();
+        let spec = SortSpec::parse("-name").unwrap();
         let a = info("alpha");
         let b = info("bravo");
         assert_eq!(spec.compare(&a, &b), Ordering::Greater);
@@ -987,7 +987,7 @@ mod required_fields_tests {
     #[test]
     fn branch_path_hash_require_no_dynamic_fields() {
         // These sort by data already present from porcelain.
-        assert_eq!(fields_for("branch"), FieldSet::EMPTY);
+        assert_eq!(fields_for("name"), FieldSet::EMPTY);
         assert_eq!(fields_for("path"), FieldSet::EMPTY);
         assert_eq!(fields_for("hash"), FieldSet::LAST_COMMIT);
     }

--- a/src/core/worktree/branch_delete.rs
+++ b/src/core/worktree/branch_delete.rs
@@ -17,7 +17,7 @@ use crate::remote::get_default_branch_local;
 use crate::settings::{PruneCdTarget, PushVerify};
 use crate::{get_git_common_dir, get_project_root};
 use anyhow::{Context, Result};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -508,8 +508,27 @@ fn resolve_branch_args(
     sink: &mut dyn ProgressSink,
 ) -> Result<Vec<ResolvedTarget>> {
     let mut resolved = Vec::with_capacity(args.len());
+    // Sandbox dirnames already targeted by an earlier arg or pattern — a
+    // worktree can only be removed once, so overlaps collapse to one target
+    // instead of a doomed second delete.
+    let mut claimed: HashSet<String> = HashSet::new();
 
     for arg in args {
+        // Wildcard tier: `*`/`?` are illegal in git refnames and absent from
+        // sandbox dirnames, so a metachar can only mean a pattern — the
+        // branch-precedence question the dirname tier wrestles with cannot
+        // arise here.
+        if is_wildcard_pattern(arg) {
+            expand_sandbox_pattern(
+                arg,
+                identities,
+                worktree_entries,
+                &mut claimed,
+                &mut resolved,
+                sink,
+            )?;
+            continue;
+        }
         match resolve_single_arg(arg, worktree_entries, project_root) {
             ResolveResult::Branch(name) => {
                 sink.on_step(&format!("Resolved path '{}' to branch '{}'", arg, name));
@@ -527,6 +546,12 @@ fn resolve_branch_args(
                     .then(|| sandbox_target_by_name(arg, identities, worktree_entries))
                     .flatten()
                 {
+                    Some(target) if !claimed.insert(target.dirname.clone()) => {
+                        sink.on_step(&format!(
+                            "Sandbox '{}' already targeted; skipping duplicate",
+                            target.dirname
+                        ));
+                    }
                     Some(target) => {
                         sink.on_step(&format!("Resolved '{arg}' to sandbox worktree"));
                         resolved.push(ResolvedTarget::Sandbox(target));
@@ -536,6 +561,12 @@ fn resolve_branch_args(
             }
             ResolveResult::DetachedHead(path) => {
                 match sandbox_target_by_path(&path, identities) {
+                    Some(target) if !claimed.insert(target.dirname.clone()) => {
+                        sink.on_step(&format!(
+                            "Sandbox '{}' already targeted; skipping duplicate",
+                            target.dirname
+                        ));
+                    }
                     Some(target) => {
                         sink.on_step(&format!(
                             "Resolved path '{arg}' to sandbox '{}'",
@@ -594,6 +625,113 @@ fn sandbox_target_by_name(
         path: recorded,
         pinned_commit: row.pinned_commit.clone(),
     })
+}
+
+/// True when `arg` is a wildcard pattern over sandbox names. Git refuses
+/// `*` and `?` in refnames and the sandbox naming charset excludes them, so
+/// a metachar cannot belong to a branch or sandbox name.
+fn is_wildcard_pattern(arg: &str) -> bool {
+    arg.contains(['*', '?'])
+}
+
+/// Glob-style match over a whole name: `*` matches any run of characters
+/// (including none), `?` matches exactly one, everything else is literal.
+fn wildcard_match(pattern: &str, text: &str) -> bool {
+    let p: Vec<char> = pattern.chars().collect();
+    let t: Vec<char> = text.chars().collect();
+    let (mut pi, mut ti) = (0, 0);
+    let mut backtrack: Option<(usize, usize)> = None;
+    while ti < t.len() {
+        if pi < p.len() && (p[pi] == '?' || p[pi] == t[ti]) {
+            pi += 1;
+            ti += 1;
+        } else if pi < p.len() && p[pi] == '*' {
+            backtrack = Some((pi, ti));
+            pi += 1;
+        } else if let Some((star, mark)) = backtrack {
+            // The literal run after the last `*` failed — let the star
+            // swallow one more character and retry.
+            backtrack = Some((star, mark + 1));
+            pi = star + 1;
+            ti = mark + 1;
+        } else {
+            return false;
+        }
+    }
+    p[pi..].iter().all(|c| *c == '*')
+}
+
+/// Expand a wildcard argument over the recorded sandbox names into removal
+/// targets.
+///
+/// Patterns deliberately never match branches: removing a branch also
+/// deletes its remote, and fleet-scale branch cleanup is `daft prune`'s
+/// job. A pattern matching no live sandbox fails the whole command — a glob
+/// silently expanding to nothing would turn "remove these" into "remove
+/// nothing".
+fn expand_sandbox_pattern(
+    pattern: &str,
+    identities: &HashMap<String, crate::store::models::WorktreeIdentityRow>,
+    worktree_entries: &[WorktreeListEntry],
+    claimed: &mut HashSet<String>,
+    resolved: &mut Vec<ResolvedTarget>,
+    sink: &mut dyn ProgressSink,
+) -> Result<()> {
+    let mut names: Vec<&str> = identities
+        .values()
+        .filter(|row| row.kind.is_sandbox() && wildcard_match(pattern, &row.branch))
+        .map(|row| row.branch.as_str())
+        .collect();
+    names.sort_unstable();
+    names.dedup();
+
+    let mut live = 0usize;
+    for name in names {
+        // Stale records (worktree already gone) are not matches.
+        let Some(target) = sandbox_target_by_name(name, identities, worktree_entries) else {
+            continue;
+        };
+        live += 1;
+        if !claimed.insert(target.dirname.clone()) {
+            sink.on_step(&format!(
+                "Sandbox '{name}' already targeted; skipping duplicate"
+            ));
+            continue;
+        }
+        sink.on_step(&format!("Pattern '{pattern}' matched sandbox '{name}'"));
+        resolved.push(ResolvedTarget::Sandbox(target));
+    }
+
+    if live == 0 {
+        let mut branches: Vec<&str> = worktree_entries
+            .iter()
+            .filter_map(|e| e.branch.as_deref())
+            .filter(|b| wildcard_match(pattern, b))
+            .collect();
+        branches.sort_unstable();
+        branches.dedup();
+        if branches.is_empty() {
+            anyhow::bail!(
+                "pattern '{pattern}' matches no sandbox worktrees \
+                 (wildcards match sandbox names, not paths or branches)"
+            );
+        }
+        let noun = if branches.len() == 1 {
+            "branch"
+        } else {
+            "branches"
+        };
+        let list = branches
+            .iter()
+            .map(|b| format!("'{b}'"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        anyhow::bail!(
+            "pattern '{pattern}' matches no sandbox worktrees; it does match {noun} {list} — \
+             wildcards never target branches, name them explicitly"
+        );
+    }
+    Ok(())
 }
 
 /// Try to resolve a single argument as a worktree path.
@@ -822,6 +960,161 @@ mod sandbox_target_tests {
         let wt = tmp.path().join("foreign");
         std::fs::create_dir_all(&wt).unwrap();
         assert!(sandbox_target_by_path(&wt, &HashMap::new()).is_none());
+    }
+
+    #[test]
+    fn wildcard_match_covers_star_question_literals_and_backtracking() {
+        assert!(wildcard_match("main-fork*", "main-fork"));
+        assert!(wildcard_match("main-fork*", "main-fork-2"));
+        assert!(!wildcard_match("main-fork*", "main"));
+        assert!(wildcard_match("*", "anything"));
+        assert!(wildcard_match("*-fork-?", "main-fork-2"));
+        assert!(!wildcard_match("*-fork-?", "main-fork-22"));
+        assert!(wildcard_match("*a*b", "xaycb"));
+        assert!(!wildcard_match("*a*b", "xayc"));
+        assert!(wildcard_match("abc", "abc"));
+        assert!(!wildcard_match("abc", "abd"));
+        assert!(wildcard_match("", ""));
+        assert!(!wildcard_match("", "x"));
+        assert!(!wildcard_match("?", ""));
+        assert!(wildcard_match("**", "x"));
+    }
+
+    fn resolved_names(resolved: &[ResolvedTarget]) -> Vec<&str> {
+        resolved
+            .iter()
+            .map(|t| match t {
+                ResolvedTarget::Branch(name) => name.as_str(),
+                ResolvedTarget::Sandbox(s) => s.dirname.as_str(),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn a_pattern_expands_to_every_live_matching_sandbox() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut identities = HashMap::new();
+        let mut entries = Vec::new();
+        for name in ["main-fork", "main-fork-2", "v1.0"] {
+            let wt = tmp.path().join(name);
+            std::fs::create_dir_all(&wt).unwrap();
+            let (id, mut row) = sandbox_row(&format!("wt-{name}"), name, &wt);
+            if name.starts_with("main-fork") {
+                row.kind = WorktreeKind::Fork;
+            }
+            identities.insert(id, row);
+            entries.push(detached_entry(&wt));
+        }
+
+        let mut claimed = HashSet::new();
+        let mut resolved = Vec::new();
+        expand_sandbox_pattern(
+            "main-fork*",
+            &identities,
+            &entries,
+            &mut claimed,
+            &mut resolved,
+            &mut crate::core::NullSink,
+        )
+        .expect("pattern with matches expands");
+        assert_eq!(resolved_names(&resolved), ["main-fork", "main-fork-2"]);
+    }
+
+    /// A pattern that matches nothing must abort the command, not quietly
+    /// contribute zero targets.
+    #[test]
+    fn a_pattern_matching_no_sandbox_fails_closed() {
+        let err = expand_sandbox_pattern(
+            "nosuch*",
+            &HashMap::new(),
+            &[],
+            &mut HashSet::new(),
+            &mut Vec::new(),
+            &mut crate::core::NullSink,
+        )
+        .expect_err("no matches must fail");
+        assert!(err.to_string().contains("matches no sandbox worktrees"));
+    }
+
+    /// A record whose worktree is gone is not a match — a pattern over only
+    /// stale records fails closed like any other zero-match pattern.
+    #[test]
+    fn a_pattern_over_only_stale_records_fails_closed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wt = tmp.path().join("main-fork");
+        std::fs::create_dir_all(&wt).unwrap();
+        let identities = HashMap::from([sandbox_row("wt-a", "main-fork", &wt)]);
+
+        // No live worktree entries: the record is stale.
+        let err = expand_sandbox_pattern(
+            "main-fork*",
+            &identities,
+            &[],
+            &mut HashSet::new(),
+            &mut Vec::new(),
+            &mut crate::core::NullSink,
+        )
+        .expect_err("stale-only matches must fail");
+        assert!(err.to_string().contains("matches no sandbox worktrees"));
+    }
+
+    /// Branches a pattern would textually match are named in the error so
+    /// the refusal explains itself — but they are never targeted.
+    #[test]
+    fn a_pattern_matching_only_branches_names_them_in_the_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wt = tmp.path().join("main-forky");
+        std::fs::create_dir_all(&wt).unwrap();
+        let attached = WorktreeListEntry {
+            path: wt,
+            branch: Some("main-forky".into()),
+            is_bare: false,
+            is_detached: false,
+        };
+
+        let mut resolved = Vec::new();
+        let err = expand_sandbox_pattern(
+            "main-fork*",
+            &HashMap::new(),
+            &[attached],
+            &mut HashSet::new(),
+            &mut resolved,
+            &mut crate::core::NullSink,
+        )
+        .expect_err("branch-only matches must fail");
+        let msg = err.to_string();
+        assert!(msg.contains("branch 'main-forky'"));
+        assert!(msg.contains("never target branches"));
+        assert!(resolved.is_empty());
+    }
+
+    /// Overlapping patterns (or a pattern over an explicitly named sandbox)
+    /// collapse to one target instead of a doomed second delete.
+    #[test]
+    fn a_pattern_skips_sandboxes_already_targeted() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut identities = HashMap::new();
+        let mut entries = Vec::new();
+        for name in ["main-fork", "main-fork-2"] {
+            let wt = tmp.path().join(name);
+            std::fs::create_dir_all(&wt).unwrap();
+            let (id, row) = sandbox_row(&format!("wt-{name}"), name, &wt);
+            identities.insert(id, row);
+            entries.push(detached_entry(&wt));
+        }
+
+        let mut claimed = HashSet::from(["main-fork".to_string()]);
+        let mut resolved = Vec::new();
+        expand_sandbox_pattern(
+            "main-fork*",
+            &identities,
+            &entries,
+            &mut claimed,
+            &mut resolved,
+            &mut crate::core::NullSink,
+        )
+        .expect("live matches expand even when some are claimed");
+        assert_eq!(resolved_names(&resolved), ["main-fork-2"]);
     }
 }
 

--- a/src/core/worktree/branch_delete.rs
+++ b/src/core/worktree/branch_delete.rs
@@ -703,7 +703,7 @@ fn validate_sandbox_target(
     // branch protects.
     if !params.force
         && let Some(pin) = sandbox.pinned_commit.as_deref()
-        && let Some(head) = worktree_head(&sandbox.path)
+        && let Some(head) = super::sandbox::worktree_head(&sandbox.path)
         && head != pin
     {
         return Err(ValidationError {
@@ -823,21 +823,6 @@ mod sandbox_target_tests {
         std::fs::create_dir_all(&wt).unwrap();
         assert!(sandbox_target_by_path(&wt, &HashMap::new()).is_none());
     }
-}
-
-/// `HEAD` of the worktree at `path`, as a full OID. `None` when unreadable —
-/// the pinned check then stays silent rather than blocking removal of a
-/// broken worktree.
-fn worktree_head(path: &Path) -> Option<String> {
-    let out = crate::utils::git_command_at(path)
-        .args(["rev-parse", "HEAD"])
-        .output()
-        .ok()?;
-    if !out.status.success() {
-        return None;
-    }
-    let oid = String::from_utf8_lossy(&out.stdout).trim().to_string();
-    (!oid.is_empty()).then_some(oid)
 }
 
 /// Validate all requested branches. Returns a tuple of (validated, errors).

--- a/src/core/worktree/branch_delete.rs
+++ b/src/core/worktree/branch_delete.rs
@@ -1979,7 +1979,7 @@ fn delete_single_branch(
         } else if wt_path.exists() {
             sink.on_step(&format!("Removing worktree at {}...", wt_path.display()));
             sink.on_stage(&stage_key(StageId::RemoveWorktree), StageEvent::Started);
-            match ctx.git.worktree_remove(wt_path, force) {
+            match remove_worktree_completing_orphans(ctx.git, wt_path, force, sink) {
                 Ok(()) => {
                     result.worktree_removed = true;
                     sink.on_step(&format!("Removed worktree '{}'", branch.name));
@@ -2161,6 +2161,51 @@ fn run_removal_hook(
 fn parse_worktree_list(git: &GitCommand) -> Result<Vec<WorktreeListEntry>> {
     let porcelain_output = git.worktree_list_porcelain()?;
     Ok(parse_worktree_list_porcelain(&porcelain_output))
+}
+
+/// Remove a worktree via git, completing the delete by hand when git
+/// unregisters it but fails to clear the directory.
+///
+/// `git worktree remove` clears the working tree and its admin entry as
+/// separate steps: when something wins a file-create race mid-delete
+/// (observed: a warmup build still writing while its fork was removed),
+/// git reports "Directory not empty" — with the worktree already
+/// unregistered. Left there, the directory is invisible to git and daft
+/// alike, so a retry has nothing to act on. Once git has disowned the
+/// path, finishing the delete ourselves is the only way to complete the
+/// removal the target was already validated for. If the registration
+/// state can't be read, or git still lists the worktree, the original
+/// error stands untouched.
+fn remove_worktree_completing_orphans(
+    git: &GitCommand,
+    wt_path: &Path,
+    force: bool,
+    sink: &mut dyn ProgressSink,
+) -> Result<()> {
+    let orig = match git.worktree_remove(wt_path, force) {
+        Ok(()) => return Ok(()),
+        Err(e) => e,
+    };
+    let target = std::fs::canonicalize(wt_path).unwrap_or_else(|_| wt_path.to_path_buf());
+    let still_registered = parse_worktree_list(git)
+        .map(|entries| {
+            entries.iter().any(|e| {
+                std::fs::canonicalize(&e.path).unwrap_or_else(|_| e.path.clone()) == target
+            })
+        })
+        // Can't tell → assume registered and keep the original error.
+        .unwrap_or(true);
+    if still_registered || !wt_path.exists() {
+        return Err(orig);
+    }
+    sink.on_step(&format!(
+        "git unregistered the worktree but left '{}'; completing the delete",
+        wt_path.display()
+    ));
+    match std::fs::remove_dir_all(wt_path) {
+        Ok(()) => Ok(()),
+        Err(e) => Err(orig.context(format!("the direct delete of the leftover failed too: {e}"))),
+    }
 }
 
 /// Resolve where to cd after deleting the user's current worktree.
@@ -2590,6 +2635,54 @@ mod tests {
                 branch,
             ],
         );
+    }
+
+    /// The half-removed state `remove_worktree_completing_orphans` exists
+    /// for: git has unregistered the worktree (admin entry gone) but the
+    /// directory remains — observed when a dying background build won a
+    /// file-create race during `git worktree remove`. The helper must
+    /// finish the delete instead of erroring against a directory git no
+    /// longer owns.
+    #[test]
+    #[serial]
+    fn an_unregistered_leftover_worktree_dir_is_deleted_directly() {
+        let _cwd = CwdGuard::new();
+        let tmp = tempfile::tempdir().unwrap();
+        init_repo(tmp.path());
+        let wt = tmp.path().join("fork");
+        setup_worktree(tmp.path(), "fork-branch", &wt);
+        std::env::set_current_dir(tmp.path()).unwrap();
+
+        // Simulate git's mid-delete unregister: admin entry gone, dir kept.
+        std::fs::remove_dir_all(tmp.path().join(".git/worktrees/fork")).unwrap();
+        assert!(wt.exists());
+
+        let git = GitCommand::new(true);
+        remove_worktree_completing_orphans(&git, &wt, false, &mut crate::core::NullSink)
+            .expect("a disowned directory must still get deleted");
+        assert!(!wt.exists(), "the leftover directory must be gone");
+    }
+
+    /// A still-registered worktree whose removal fails keeps the original
+    /// git error — the direct delete fires only once git has disowned the
+    /// path, never as a way around git's own refusals.
+    #[test]
+    #[serial]
+    fn a_registered_worktree_failure_keeps_the_git_error() {
+        let _cwd = CwdGuard::new();
+        let tmp = tempfile::tempdir().unwrap();
+        init_repo(tmp.path());
+        let wt = tmp.path().join("dirty");
+        setup_worktree(tmp.path(), "dirty-branch", &wt);
+        std::env::set_current_dir(tmp.path()).unwrap();
+        // Untracked file: a non-force `git worktree remove` refuses.
+        std::fs::write(wt.join("junk.txt"), "x").unwrap();
+
+        let git = GitCommand::new(true);
+        let err = remove_worktree_completing_orphans(&git, &wt, false, &mut crate::core::NullSink)
+            .expect_err("a registered dirty worktree must keep refusing");
+        assert!(err.to_string().contains("Git worktree remove failed"));
+        assert!(wt.exists(), "the worktree must be untouched");
     }
 
     #[test]

--- a/src/core/worktree/branch_delete.rs
+++ b/src/core/worktree/branch_delete.rs
@@ -160,6 +160,14 @@ struct ValidatedBranch {
     merged_via: Option<crate::core::worktree::forge_ref::ForgeBranchRef>,
     /// What to do with the worktree's untracked daft files before removal.
     daft_files: DaftFilePlan,
+    /// A daft-created sandbox (#53): `name` is the directory name, there is
+    /// no branch to delete (`worktree_only` is also set), hooks get the
+    /// branchless context, and identity cleanup goes through the sandbox
+    /// forget path.
+    is_sandbox: bool,
+    /// The sandbox's pinned commit, threaded through for the removal hooks'
+    /// `DAFT_COMMIT`. `None` for branch targets.
+    pinned_commit: Option<String>,
 }
 
 /// Resolved-at-validation decision for the worktree's untracked daft files.
@@ -185,6 +193,25 @@ enum ResolveResult {
     PassThrough,
     /// Argument matched a worktree but it has no branch (detached HEAD).
     DetachedHead(PathBuf),
+}
+
+/// One removal target after argument resolution: a branch, or a daft-created
+/// sandbox (#53). Foreign detached worktrees resolve to neither — they keep
+/// the historical refusal.
+enum ResolvedTarget {
+    Branch(String),
+    Sandbox(SandboxTarget),
+}
+
+/// A sandbox removal target: identified by its directory name, with the
+/// provenance the safety checks need.
+struct SandboxTarget {
+    dirname: String,
+    path: PathBuf,
+    /// The commit the sandbox was pinned at when created. `None` when the
+    /// record predates the pin or was written without one — the moved-HEAD
+    /// check then has nothing to compare and stays silent.
+    pinned_commit: Option<String>,
 }
 
 // ── Public API ─────────────────────────────────────────────────────────────
@@ -228,9 +255,18 @@ pub fn execute(
         }
     }
 
-    // Resolve arguments: each arg can be a branch name or a worktree path.
-    let resolved =
-        resolve_branch_args(&params.branches, &worktree_entries, &ctx.project_root, sink)?;
+    // Resolve arguments: each arg can be a branch name, a worktree path, or
+    // a sandbox name. The identity records are what tell a daft-created
+    // sandbox apart from a foreign detached worktree.
+    let identities = crate::core::worktree::identity_store::read_identities(&ctx.git_dir);
+    let resolved = resolve_branch_args(
+        &params.branches,
+        &worktree_entries,
+        &ctx.project_root,
+        &identities,
+        &git,
+        sink,
+    )?;
 
     // Detect current worktree context for is_current_worktree flagging.
     let current_wt_path = git.get_current_worktree_path().ok();
@@ -413,7 +449,9 @@ fn build_plan(
         let remote_in_scope = params.delete_remote || params.remote_only;
         if !params.keep_local_branch {
             if branch.worktree_only {
-                let text = if remote_in_scope {
+                let text = if branch.is_sandbox {
+                    "sandbox \u{2014} no branch to delete"
+                } else if remote_in_scope {
                     "branch and remote kept (default branch)"
                 } else {
                     "branch kept (default branch)"
@@ -453,38 +491,109 @@ pub(crate) fn display_path(path: &Path) -> String {
 
 // ── Argument resolution ────────────────────────────────────────────────────
 
-/// Resolve each argument to a branch name.
+/// Resolve each argument to a removal target.
 ///
 /// Arguments can be:
 ///   - A branch name (passed through as-is if no worktree path matches)
 ///   - A worktree path (absolute or relative to cwd, including ".")
+///   - A sandbox's directory name or path (#53), recognized through the
+///     identity records — a foreign detached worktree matches none of these
+///     and keeps the historical refusal.
 fn resolve_branch_args(
     args: &[String],
     worktree_entries: &[WorktreeListEntry],
     project_root: &Path,
+    identities: &HashMap<String, crate::store::models::WorktreeIdentityRow>,
+    git: &GitCommand,
     sink: &mut dyn ProgressSink,
-) -> Result<Vec<String>> {
+) -> Result<Vec<ResolvedTarget>> {
     let mut resolved = Vec::with_capacity(args.len());
 
     for arg in args {
         match resolve_single_arg(arg, worktree_entries, project_root) {
             ResolveResult::Branch(name) => {
                 sink.on_step(&format!("Resolved path '{}' to branch '{}'", arg, name));
-                resolved.push(name);
+                resolved.push(ResolvedTarget::Branch(name));
             }
             ResolveResult::PassThrough => {
-                resolved.push(arg.clone());
+                // Dirname tier: a name that is not a branch but is a recorded
+                // sandbox targets the sandbox. Branch precedence is
+                // load-bearing — a branch sharing a sandbox's spelling must
+                // keep meaning the branch.
+                let is_branch = git
+                    .show_ref_exists(&format!("refs/heads/{arg}"))
+                    .unwrap_or(false);
+                match (!is_branch)
+                    .then(|| sandbox_target_by_name(arg, identities, worktree_entries))
+                    .flatten()
+                {
+                    Some(target) => {
+                        sink.on_step(&format!("Resolved '{arg}' to sandbox worktree"));
+                        resolved.push(ResolvedTarget::Sandbox(target));
+                    }
+                    None => resolved.push(ResolvedTarget::Branch(arg.clone())),
+                }
             }
             ResolveResult::DetachedHead(path) => {
-                anyhow::bail!(
-                    "worktree at '{}' has a detached HEAD; specify a branch name instead",
-                    path.display()
-                );
+                match sandbox_target_by_path(&path, identities) {
+                    Some(target) => {
+                        sink.on_step(&format!(
+                            "Resolved path '{arg}' to sandbox '{}'",
+                            target.dirname
+                        ));
+                        resolved.push(ResolvedTarget::Sandbox(target));
+                    }
+                    // Not a daft sandbox: keep the historical protection for
+                    // detached worktrees daft has no record of.
+                    None => anyhow::bail!(
+                        "worktree at '{}' has a detached HEAD; specify a branch name instead",
+                        path.display()
+                    ),
+                }
             }
         }
     }
 
     Ok(resolved)
+}
+
+/// The sandbox target for a detached worktree at `path`, if the identity
+/// records say daft created it as one.
+fn sandbox_target_by_path(
+    path: &Path,
+    identities: &HashMap<String, crate::store::models::WorktreeIdentityRow>,
+) -> Option<SandboxTarget> {
+    let id = crate::core::worktree::identity_store::worktree_id_for(path)?;
+    let row = identities.get(&id).filter(|row| row.kind.is_sandbox())?;
+    Some(SandboxTarget {
+        dirname: row.branch.clone(),
+        path: path.to_path_buf(),
+        pinned_commit: row.pinned_commit.clone(),
+    })
+}
+
+/// The sandbox target recorded under `name`, if its worktree is still a live
+/// detached entry.
+fn sandbox_target_by_name(
+    name: &str,
+    identities: &HashMap<String, crate::store::models::WorktreeIdentityRow>,
+    worktree_entries: &[WorktreeListEntry],
+) -> Option<SandboxTarget> {
+    let row = identities
+        .values()
+        .find(|row| row.kind.is_sandbox() && row.branch == name)?;
+    let recorded = PathBuf::from(&row.worktree_path);
+    let canonical = std::fs::canonicalize(&recorded).ok()?;
+    let live = worktree_entries.iter().any(|e| {
+        e.branch.is_none()
+            && !e.is_bare
+            && std::fs::canonicalize(&e.path).is_ok_and(|p| p == canonical)
+    });
+    live.then(|| SandboxTarget {
+        dirname: row.branch.clone(),
+        path: recorded,
+        pinned_commit: row.pinned_commit.clone(),
+    })
 }
 
 /// Try to resolve a single argument as a worktree path.
@@ -558,6 +667,179 @@ fn try_resolve_relative_to_root(
 
 // ── Validation ─────────────────────────────────────────────────────────────
 
+/// Validate a sandbox removal target: it must be clean (unless forced) and
+/// still sitting at its pinned commit (unless forced) — commits made on a
+/// detached HEAD die with the worktree, so a moved HEAD refuses with the
+/// promotion hint rather than silently unreaching someone's work.
+fn validate_sandbox_target(
+    ctx: &BranchDeleteContext,
+    sandbox: &SandboxTarget,
+    params: &BranchDeleteParams,
+    current_wt_path: Option<&PathBuf>,
+    sink: &mut dyn ProgressSink,
+) -> Result<ValidatedBranch, ValidationError> {
+    // Clean: the same protection branch worktrees get from Check 3.
+    if !params.force {
+        match ctx.git.has_uncommitted_changes_in(&sandbox.path) {
+            Ok(true) => {
+                return Err(ValidationError {
+                    branch: sandbox.dirname.clone(),
+                    message: "has uncommitted changes in worktree (use -D to force)".to_string(),
+                });
+            }
+            Ok(false) => {}
+            Err(e) => {
+                return Err(ValidationError {
+                    branch: sandbox.dirname.clone(),
+                    message: format!(
+                        "failed to check for uncommitted changes: {e} (use -D to force)"
+                    ),
+                });
+            }
+        }
+    }
+
+    // Pinned: a sandbox that moved off its creation commit holds work no
+    // branch protects.
+    if !params.force
+        && let Some(pin) = sandbox.pinned_commit.as_deref()
+        && let Some(head) = worktree_head(&sandbox.path)
+        && head != pin
+    {
+        return Err(ValidationError {
+            branch: sandbox.dirname.clone(),
+            message: format!(
+                "has moved off its pinned commit ({} \u{2192} {}); commits made inside it \
+                 may become unreachable after removal — promote them with `{}` from inside \
+                 the sandbox first, or use {} to remove anyway",
+                &pin[..pin.len().min(7)],
+                &head[..head.len().min(7)],
+                crate::daft_cmd("start <new-branch>"),
+                params.force_flag_label
+            ),
+        });
+    }
+
+    // Path comparison only: `current_branch` is meaningless on a detached
+    // HEAD, and a like-named branch elsewhere must not mark this row current.
+    let is_current = current_wt_path.is_some_and(|current| {
+        &sandbox.path == current
+            || std::fs::canonicalize(&sandbox.path).ok() == std::fs::canonicalize(current).ok()
+    });
+
+    sink.on_step(&format!("Sandbox '{}' passed validation", sandbox.dirname));
+
+    Ok(ValidatedBranch {
+        name: sandbox.dirname.clone(),
+        worktree_path: Some(sandbox.path.clone()),
+        remote_name: None,
+        remote_branch_name: None,
+        is_current_worktree: is_current,
+        // No branch to delete: reuse the worktree-only skips of the remote
+        // and local-branch steps.
+        worktree_only: true,
+        merged_into: None,
+        merged_via: None,
+        daft_files: DaftFilePlan::Nothing,
+        is_sandbox: true,
+        pinned_commit: sandbox.pinned_commit.clone(),
+    })
+}
+
+#[cfg(test)]
+mod sandbox_target_tests {
+    use super::*;
+    use crate::store::models::{WorktreeIdentityRow, WorktreeKind};
+
+    fn sandbox_row(id: &str, dirname: &str, path: &Path) -> (String, WorktreeIdentityRow) {
+        (
+            id.to_string(),
+            WorktreeIdentityRow {
+                repo_hash: "repo".into(),
+                worktree_id: id.into(),
+                branch: dirname.into(),
+                worktree_path: path.display().to_string(),
+                updated_at: chrono::Utc::now(),
+                kind: WorktreeKind::Canonical,
+                source_spelling: Some(dirname.into()),
+                pinned_commit: Some("a".repeat(40)),
+            },
+        )
+    }
+
+    fn detached_entry(path: &Path) -> WorktreeListEntry {
+        WorktreeListEntry {
+            path: path.to_path_buf(),
+            branch: None,
+            is_bare: false,
+            is_detached: true,
+        }
+    }
+
+    #[test]
+    fn a_recorded_sandbox_with_a_live_detached_entry_resolves() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wt = tmp.path().join("v1");
+        std::fs::create_dir_all(&wt).unwrap();
+        let identities = HashMap::from([sandbox_row("wt-a", "v1", &wt)]);
+
+        let target = sandbox_target_by_name("v1", &identities, &[detached_entry(&wt)])
+            .expect("resolves to the sandbox");
+        assert_eq!(target.dirname, "v1");
+        assert_eq!(
+            target.pinned_commit.as_deref(),
+            Some("a".repeat(40).as_str())
+        );
+    }
+
+    /// A record whose worktree is gone (or was never detached) must not
+    /// resolve — the arg falls through to the branch path and its
+    /// "branch not found" error.
+    #[test]
+    fn a_stale_or_attached_record_does_not_resolve() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wt = tmp.path().join("v1");
+        std::fs::create_dir_all(&wt).unwrap();
+        let identities = HashMap::from([sandbox_row("wt-a", "v1", &wt)]);
+
+        // No live entry at all.
+        assert!(sandbox_target_by_name("v1", &identities, &[]).is_none());
+        // The entry at that path is attached to a branch.
+        let attached = WorktreeListEntry {
+            path: wt.clone(),
+            branch: Some("v1".into()),
+            is_bare: false,
+            is_detached: false,
+        };
+        assert!(sandbox_target_by_name("v1", &identities, &[attached]).is_none());
+    }
+
+    /// A detached worktree daft has no record of is foreign: by path it must
+    /// resolve to nothing so the historical refusal fires.
+    #[test]
+    fn a_foreign_detached_worktree_has_no_sandbox_target() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wt = tmp.path().join("foreign");
+        std::fs::create_dir_all(&wt).unwrap();
+        assert!(sandbox_target_by_path(&wt, &HashMap::new()).is_none());
+    }
+}
+
+/// `HEAD` of the worktree at `path`, as a full OID. `None` when unreadable —
+/// the pinned check then stays silent rather than blocking removal of a
+/// broken worktree.
+fn worktree_head(path: &Path) -> Option<String> {
+    let out = crate::utils::git_command_at(path)
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let oid = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    (!oid.is_empty()).then_some(oid)
+}
+
 /// Validate all requested branches. Returns a tuple of (validated, errors).
 ///
 /// Each branch goes through up to 5 checks:
@@ -570,7 +852,7 @@ fn try_resolve_relative_to_root(
 #[allow(clippy::too_many_arguments)]
 fn validate_branches(
     ctx: &BranchDeleteContext,
-    branches: &[String],
+    targets: &[ResolvedTarget],
     params: &BranchDeleteParams,
     worktree_map: &HashMap<String, PathBuf>,
     current_wt_path: Option<&PathBuf>,
@@ -589,7 +871,20 @@ fn validate_branches(
     let mut validated = Vec::new();
     let mut errors = Vec::new();
 
-    'branches: for branch in branches {
+    'branches: for target in targets {
+        // Sandboxes run their own three checks (registered, clean, pinned);
+        // everything branch-shaped continues into the 6-check body below.
+        let branch = match target {
+            ResolvedTarget::Branch(name) => name,
+            ResolvedTarget::Sandbox(sandbox) => {
+                sink.on_step(&format!("Validating sandbox '{}'...", sandbox.dirname));
+                match validate_sandbox_target(ctx, sandbox, params, current_wt_path, sink) {
+                    Ok(v) => validated.push(v),
+                    Err(err) => errors.push(err),
+                }
+                continue;
+            }
+        };
         sink.on_step(&format!("Validating branch '{branch}'..."));
 
         // Remote-only mode: skip local branch checks entirely.
@@ -624,6 +919,8 @@ fn validate_branches(
                 merged_into: None,
                 merged_via: None,
                 daft_files: DaftFilePlan::Nothing,
+                is_sandbox: false,
+                pinned_commit: None,
             });
             continue;
         }
@@ -700,6 +997,8 @@ fn validate_branches(
                     merged_into: None,
                     merged_via: None,
                     daft_files: DaftFilePlan::Nothing,
+                    is_sandbox: false,
+                    pinned_commit: None,
                 });
                 continue;
             }
@@ -887,6 +1186,8 @@ fn validate_branches(
             merged_into,
             merged_via,
             daft_files,
+            is_sandbox: false,
+            pinned_commit: None,
         });
     }
 
@@ -1235,7 +1536,7 @@ fn delete_single_branch(
             HookType::PreRemove,
             ctx,
             wt_path,
-            &branch.name,
+            branch,
             command_label,
             sink,
         );
@@ -1497,7 +1798,7 @@ fn delete_single_branch(
             HookType::PostRemove,
             ctx,
             wt_path,
-            &branch.name,
+            branch,
             command_label,
             sink,
         );
@@ -1514,7 +1815,14 @@ fn delete_single_branch(
         && let Some(store) =
             crate::core::worktree::identity_store::IdentityStore::open(&ctx.git_dir)
     {
-        store.forget(identity_id.as_deref(), &branch.name);
+        // Sandboxes go through the sandbox forget path: its by-name fallback
+        // sweeps only sandbox rows, so a branch sharing the spelling keeps
+        // its record (and vice versa on the branch path).
+        if branch.is_sandbox {
+            store.forget_sandbox(identity_id.as_deref(), &branch.name);
+        } else {
+            store.forget(identity_id.as_deref(), &branch.name);
+        }
     }
 
     result
@@ -1523,15 +1831,20 @@ fn delete_single_branch(
 // ── Hook execution ─────────────────────────────────────────────────────────
 
 /// Run a lifecycle hook (pre-remove or post-remove) for a worktree.
+///
+/// Sandbox targets get the branchless contract: `DAFT_BRANCH_NAME` is the
+/// empty string and `DAFT_COMMIT` carries the pinned OID — the dirname is
+/// not a branch and must not masquerade as one in hook environments.
 fn run_removal_hook(
     hook_type: HookType,
     ctx: &BranchDeleteContext,
     worktree_path: &Path,
-    branch_name: &str,
+    branch: &ValidatedBranch,
     command_label: &str,
     sink: &mut (impl ProgressSink + HookRunner),
 ) {
-    let hook_ctx = HookContext::new(
+    let branch_name = if branch.is_sandbox { "" } else { &branch.name };
+    let mut hook_ctx = HookContext::new(
         hook_type,
         command_label,
         &ctx.project_root,
@@ -1542,15 +1855,19 @@ fn run_removal_hook(
         branch_name,
     )
     .with_removal_reason(RemovalReason::Manual);
+    if let Some(pin) = branch.pinned_commit.as_deref() {
+        hook_ctx = hook_ctx.with_commit(pin);
+    }
 
     if let Err(e) = sink.run_hook(&hook_ctx) {
         sink.on_warning(&format!(
-            "{} hook failed for {branch_name}: {e}",
+            "{} hook failed for {}: {e}",
             match hook_type {
                 HookType::PreRemove => "Pre-remove",
                 HookType::PostRemove => "Post-remove",
                 _ => "Hook",
-            }
+            },
+            branch.name
         ));
     }
 }
@@ -1653,6 +1970,8 @@ mod tests {
             merged_into: None,
             merged_via: None,
             daft_files: DaftFilePlan::Nothing,
+            is_sandbox: false,
+            pinned_commit: None,
         };
         let params = BranchDeleteParams {
             branches: vec![".".to_string()],
@@ -1693,6 +2012,8 @@ mod tests {
             merged_into: None,
             merged_via: None,
             daft_files: DaftFilePlan::Nothing,
+            is_sandbox: false,
+            pinned_commit: None,
         };
         let params = |delete_remote: bool| BranchDeleteParams {
             branches: vec!["feat-x".to_string()],
@@ -1760,6 +2081,8 @@ mod tests {
             merged_into: None,
             merged_via: None,
             daft_files: DaftFilePlan::Nothing,
+            is_sandbox: false,
+            pinned_commit: None,
         };
         assert_eq!(vb.name, "feature/test");
         assert!(vb.worktree_path.is_some());
@@ -1779,6 +2102,8 @@ mod tests {
             merged_into: None,
             merged_via: None,
             daft_files: DaftFilePlan::Nothing,
+            is_sandbox: false,
+            pinned_commit: None,
         };
         assert!(vb.worktree_path.is_none());
         assert!(vb.remote_name.is_none());
@@ -1797,6 +2122,8 @@ mod tests {
             merged_into: None,
             merged_via: None,
             daft_files: DaftFilePlan::Nothing,
+            is_sandbox: false,
+            pinned_commit: None,
         };
         assert!(vb.worktree_only);
         assert!(vb.worktree_path.is_some());
@@ -2200,6 +2527,8 @@ mod tests {
             merged_into: None,
             merged_via: None,
             daft_files: DaftFilePlan::Nothing,
+            is_sandbox: false,
+            pinned_commit: None,
         };
         let params = BranchDeleteParams {
             branches: vec!["feat-x".to_string()],

--- a/src/core/worktree/checkout.rs
+++ b/src/core/worktree/checkout.rs
@@ -253,15 +253,28 @@ pub fn execute(
     // Fallback: check if the worktree directory already exists on disk.
     // This handles cases where the branch association is missing from
     // `git worktree list` (e.g., detached HEAD from an interrupted rebase).
+    // It is also how a revisit reaches a deliberate sandbox sitting at its
+    // layout-default path (`daft go v1.18.0` the second time): the identity
+    // record distinguishes the routine case from the alarming one.
     if worktree_path.exists() && worktree_path.join(".git").is_file() {
         sink.on_step(&format!(
             "Worktree directory '{}' already exists, switching to it",
             worktree_path.display()
         ));
-        sink.on_warning(
-            "Worktree may be in detached HEAD state (e.g., from an interrupted rebase). \
-             Run 'git status' to check, and 'git rebase --abort' or 'git checkout <branch>' to recover.",
-        );
+        match sandbox_record_for(&git_dir, &worktree_path) {
+            Some(row) => {
+                let pin = row
+                    .pinned_commit
+                    .as_deref()
+                    .map(|oid| format!(" (detached @ {})", super::sandbox::short_oid(oid)))
+                    .unwrap_or_default();
+                sink.on_step(&format!("'{}' is a daft sandbox{pin}", row.branch));
+            }
+            None => sink.on_warning(
+                "Worktree may be in detached HEAD state (e.g., from an interrupted rebase). \
+                 Run 'git status' to check, and 'git rebase --abort' or 'git checkout <branch>' to recover.",
+            ),
+        }
         change_directory(&worktree_path)?;
 
         return Ok(CheckoutResult {
@@ -738,6 +751,21 @@ pub fn execute(
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────
+
+/// The sandbox identity record for the worktree at `path`, if daft created
+/// it as one. Best-effort: store trouble reads as "not a sandbox", which
+/// only costs the friendlier message.
+fn sandbox_record_for(
+    git_dir: &Path,
+    path: &Path,
+) -> Option<crate::store::models::WorktreeIdentityRow> {
+    let records = super::identity_store::read_identities(git_dir);
+    let id = super::identity_store::worktree_id_for(path)?;
+    records
+        .get(&id)
+        .filter(|row| row.kind.is_sandbox())
+        .cloned()
+}
 
 /// Check if a worktree already exists for the given branch name.
 fn find_existing_worktree_for_branch(

--- a/src/core/worktree/checkout_branch.rs
+++ b/src/core/worktree/checkout_branch.rs
@@ -610,7 +610,7 @@ fn select_checkout_base(
         Ok(format!("{remote_name}/{base_branch}"))
     } else {
         sink.on_step(&format!(
-            "Neither local nor remote branch found for '{base_branch}', using as-is"
+            "No local or remote branch named '{base_branch}'; using it as a commit-ish base"
         ));
         Ok(base_branch.to_string())
     }

--- a/src/core/worktree/checkout_branch.rs
+++ b/src/core/worktree/checkout_branch.rs
@@ -433,9 +433,24 @@ fn resolve_base_branch(
         }
         None => {
             sink.on_step("Base branch not specified, using current branch...");
-            let current = git.symbolic_ref_short_head()?;
-            sink.on_step(&format!("Using current branch as base: '{current}'"));
-            Ok(current)
+            match git.symbolic_ref_short_head() {
+                Ok(current) => {
+                    sink.on_step(&format!("Using current branch as base: '{current}'"));
+                    Ok(current)
+                }
+                // A detached HEAD has no current branch — base on the commit
+                // instead. This is the promotion gesture for sandboxes (#53):
+                // `daft start <name>` from inside one mints a branch carrying
+                // everything committed there.
+                Err(_) => {
+                    let oid = git.rev_parse("HEAD")?;
+                    sink.on_step(&format!(
+                        "Detached HEAD; using commit {} as base",
+                        &oid[..oid.len().min(12)]
+                    ));
+                    Ok(oid)
+                }
+            }
         }
     }
 }

--- a/src/core/worktree/fork_names.rs
+++ b/src/core/worktree/fork_names.rs
@@ -1,0 +1,116 @@
+//! Memorable names for fork sandboxes (`daft.start.forkNaming = memorable`).
+//!
+//! Docker-style adjective-noun pairs: collision-sparse by construction and
+//! better *handles* than `master-fork-3` when several sandboxes are alive —
+//! `daft go brave-otter` reads back the way it was said. The words are
+//! embedded so name generation needs no I/O and no new dependency; the
+//! caller supplies entropy (time/pid derived) and claims directories
+//! atomically, so this module only has to produce a well-spread, eventually
+//! terminating candidate stream.
+
+const ADJECTIVES: &[&str] = &[
+    "amber",
+    "bold",
+    "brave",
+    "bright",
+    "brisk",
+    "calm",
+    "clever",
+    "cosmic",
+    "crisp",
+    "curious",
+    "deft",
+    "eager",
+    "fable",
+    "fleet",
+    "gentle",
+    "glad",
+    "golden",
+    "keen",
+    "kind",
+    "lively",
+    "lucid",
+    "lunar",
+    "mellow",
+    "merry",
+    "misty",
+    "nimble",
+    "noble",
+    "quiet",
+    "rapid",
+    "rustic",
+    "silent",
+    "solar",
+    "spry",
+    "steady",
+    "sunny",
+    "swift",
+    "tidy",
+    "vivid",
+    "wandering",
+    "witty",
+];
+
+const NOUNS: &[&str] = &[
+    "aspen", "badger", "beacon", "birch", "brook", "cedar", "comet", "coral", "crane", "delta",
+    "dune", "falcon", "fjord", "gecko", "glade", "grove", "harbor", "heron", "ibis", "inlet",
+    "lagoon", "lark", "lynx", "maple", "marmot", "meadow", "otter", "owl", "pine", "plover",
+    "prairie", "quill", "reef", "ridge", "sparrow", "summit", "tarn", "thicket", "walrus", "wren",
+];
+
+/// After this many pure adjective-noun draws, candidates gain a numeric
+/// suffix so the stream terminates against any set of claimed directories.
+const PURE_DRAWS: u64 = 16;
+
+/// An endless, well-spread candidate stream seeded by the caller.
+///
+/// Consecutive draws step both word indices by odd multipliers, so no two
+/// draws in a run collide on both words; past [`PURE_DRAWS`] a numeric
+/// suffix guarantees eventual uniqueness even in a directory full of
+/// claimed names.
+pub fn candidates(seed: u64) -> impl Iterator<Item = String> {
+    (0u64..).map(move |i| {
+        let a = ADJECTIVES[(seed.wrapping_mul(31).wrapping_add(i.wrapping_mul(7))
+            % ADJECTIVES.len() as u64) as usize];
+        let n = NOUNS[(seed.wrapping_mul(17).wrapping_add(i.wrapping_mul(13)) % NOUNS.len() as u64)
+            as usize];
+        if i < PURE_DRAWS {
+            format!("{a}-{n}")
+        } else {
+            format!("{a}-{n}-{}", i - PURE_DRAWS + 2)
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn draws_are_distinct_within_a_run() {
+        let names: Vec<String> = candidates(42).take(PURE_DRAWS as usize).collect();
+        let unique: std::collections::HashSet<&String> = names.iter().collect();
+        assert_eq!(unique.len(), names.len(), "no early duplicates: {names:?}");
+    }
+
+    #[test]
+    fn suffixed_candidates_terminate_any_collision_run() {
+        let far: Vec<String> = candidates(7).skip(PURE_DRAWS as usize).take(3).collect();
+        assert!(
+            far.iter()
+                .all(|n| n.chars().last().unwrap().is_ascii_digit())
+        );
+        let unique: std::collections::HashSet<&String> = far.iter().collect();
+        assert_eq!(unique.len(), far.len());
+    }
+
+    #[test]
+    fn names_are_valid_sandbox_dirnames() {
+        for name in candidates(123).take(50) {
+            assert!(
+                super::super::sandbox::sandbox_dirname(&name).is_some(),
+                "'{name}' must survive the sandbox naming rules"
+            );
+        }
+    }
+}

--- a/src/core/worktree/identity.rs
+++ b/src/core/worktree/identity.rs
@@ -15,14 +15,16 @@
 //! 1. **Attached** — the porcelain names a branch. Always wins.
 //! 2. **Recovered** — HEAD is detached, but an in-progress operation records
 //!    the branch it is replaying ([`crate::git::op_state`]).
-//! 3. **None** — nothing names a branch: a genuine detached checkout.
+//! 3. **Persisted / Sandbox** — daft recorded what the worktree is for: the
+//!    branch it was created for, or (for an anonymous sandbox) its directory
+//!    name. The one tier that can be out of date, which is why it ranks
+//!    below everything live.
+//! 4. **None** — nothing names a branch: a genuine detached checkout.
 //!
 //! The ordering is the whole design. Live git state cannot be stale, so it
 //! outranks anything remembered; and every attached worktree claims its name
 //! before any recovery is attempted, so a recovered name can never displace a
-//! real checkout. (A persisted tier lands between 2 and 3 in a later commit;
-//! it is the only one that can be out of date, which is exactly why it ranks
-//! last.)
+//! real checkout.
 //!
 //! An operation also *explains* a detachment even when it records no branch —
 //! `git am` writes no `head-name`. Such a worktree keeps `(detached)` as its
@@ -44,9 +46,14 @@ pub enum IdentitySource {
     /// HEAD is detached; an in-progress operation records the branch.
     Recovered,
     /// HEAD is detached with nothing to explain it, but daft recorded what
-    /// this worktree is for. The only tier that can be out of date, which is
-    /// why it ranks last.
+    /// this worktree is for. Can be out of date, which is why it ranks
+    /// below everything live.
     Persisted,
+    /// HEAD is detached because daft created this worktree as an anonymous
+    /// sandbox (`daft go <commit-ish>` / `daft start --fork`); the record
+    /// names it after its directory. Same rank as [`Self::Persisted`] —
+    /// the two are one tier carrying two kinds of record.
+    Sandbox,
     /// Nothing names a branch.
     None,
 }
@@ -58,6 +65,7 @@ impl IdentitySource {
             Self::Attached => "attached",
             Self::Recovered => "recovered",
             Self::Persisted => "persisted",
+            Self::Sandbox => "sandbox",
             Self::None => "none",
         }
     }
@@ -151,8 +159,8 @@ pub fn resolve_identities_with(
             if let Some(branch) = &entry.branch {
                 // Cross-check, never an override: a record that disagrees
                 // with a live checkout is the thing that is wrong.
-                let drifted = recorded_branch(records, &entry.path)
-                    .is_some_and(|recorded| recorded != *branch);
+                let drifted =
+                    recorded_row(records, &entry.path).is_some_and(|row| row.branch != *branch);
                 return Some(WorktreeIdentity {
                     name: branch.clone(),
                     branch: Some(branch.clone()),
@@ -168,13 +176,36 @@ pub fn resolve_identities_with(
             let Some(state) = probe_op_state(&entry.path) else {
                 // Nothing live explains this detachment. Fall back to what
                 // daft recorded the worktree was for — the row keeps its
-                // name and its branch-keyed cells, and stays a sandbox,
-                // because being *named* and being *explained* are different
-                // things.
-                return Some(match recorded_branch(records, &entry.path) {
-                    Some(branch) if !claimed.contains(branch.as_str()) => WorktreeIdentity {
-                        name: branch.clone(),
-                        branch: Some(branch),
+                // name and stays a sandbox, because being *named* and being
+                // *explained* are different things.
+                return Some(match recorded_row(records, &entry.path) {
+                    // A deliberate sandbox: the record names it after its
+                    // directory. The name is not a ref, so `branch` stays
+                    // `None` — nothing branch-keyed (ahead/behind, upstream,
+                    // PR linkage) may query it.
+                    Some(row) if row.kind.is_sandbox() => {
+                        if claimed.contains(row.branch.as_str()) {
+                            // An attached checkout owns this name (a branch
+                            // named like the sandbox's directory). Two rows
+                            // must never claim one name.
+                            WorktreeIdentity {
+                                drifted: true,
+                                ..WorktreeIdentity::unnamed(None)
+                            }
+                        } else {
+                            WorktreeIdentity {
+                                name: row.branch.clone(),
+                                branch: None,
+                                source: IdentitySource::Sandbox,
+                                op: None,
+                                is_sandbox: true,
+                                drifted: false,
+                            }
+                        }
+                    }
+                    Some(row) if !claimed.contains(row.branch.as_str()) => WorktreeIdentity {
+                        name: row.branch.clone(),
+                        branch: Some(row.branch.clone()),
                         source: IdentitySource::Persisted,
                         op: None,
                         is_sandbox: true,
@@ -209,16 +240,16 @@ pub fn resolve_identities_with(
         .collect()
 }
 
-/// The branch daft recorded for the worktree at `path`, if any.
-fn recorded_branch(
-    records: &HashMap<String, WorktreeIdentityRow>,
+/// The identity daft recorded for the worktree at `path`, if any.
+fn recorded_row<'a>(
+    records: &'a HashMap<String, WorktreeIdentityRow>,
     path: &std::path::Path,
-) -> Option<String> {
+) -> Option<&'a WorktreeIdentityRow> {
     if records.is_empty() {
         return None;
     }
     let id = super::identity_store::worktree_id_for(path)?;
-    records.get(&id).map(|row| row.branch.clone())
+    records.get(&id)
 }
 
 #[cfg(test)]
@@ -398,8 +429,23 @@ mod tests {
                 branch: branch.into(),
                 worktree_path: String::from("/tmp/") + id,
                 updated_at: chrono::Utc::now(),
+                kind: crate::store::models::WorktreeKind::Branch,
+                source_spelling: None,
+                pinned_commit: None,
             },
         )
+    }
+
+    fn sandbox_record(
+        id: &str,
+        dirname: &str,
+        kind: crate::store::models::WorktreeKind,
+    ) -> (String, WorktreeIdentityRow) {
+        let (key, mut row) = record(id, dirname);
+        row.kind = kind;
+        row.source_spelling = Some("v1.18.0".into());
+        row.pinned_commit = Some("a".repeat(40));
+        (key, row)
     }
 
     /// A linked worktree, so it has a private-gitdir id records can key on.
@@ -510,6 +556,73 @@ mod tests {
 
         assert_eq!(ids[1].as_ref().unwrap().name, "feat/x");
         assert!(!ids[1].as_ref().unwrap().drifted);
+    }
+
+    /// A daft-created sandbox shows its directory name instead of the
+    /// anonymous `(detached)` label — but exposes no branch, because the
+    /// dirname is not a ref and nothing branch-keyed may query it.
+    #[test]
+    fn a_sandbox_record_names_the_row_after_its_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wt = linked(tmp.path(), "wt-a");
+        let records = HashMap::from([sandbox_record(
+            "wt-a",
+            "v1.18.0",
+            crate::store::models::WorktreeKind::Canonical,
+        )]);
+
+        let id = resolve_identities_with(&[entry(&wt, None)], &records)
+            .remove(0)
+            .unwrap();
+        assert_eq!(id.name, "v1.18.0");
+        assert_eq!(id.branch, None, "a sandbox name is not a ref");
+        assert_eq!(id.source, IdentitySource::Sandbox);
+        assert!(id.is_sandbox);
+        assert!(!id.drifted);
+    }
+
+    /// Forks are the same display tier as canonical sandboxes — the kind
+    /// matters to resolution and removal, not to naming.
+    #[test]
+    fn a_fork_record_names_the_row_the_same_way() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wt = linked(tmp.path(), "wt-a");
+        let records = HashMap::from([sandbox_record(
+            "wt-a",
+            "master-fork-2",
+            crate::store::models::WorktreeKind::Fork,
+        )]);
+
+        let id = resolve_identities_with(&[entry(&wt, None)], &records)
+            .remove(0)
+            .unwrap();
+        assert_eq!(id.name, "master-fork-2");
+        assert_eq!(id.source, IdentitySource::Sandbox);
+        assert!(id.is_sandbox);
+    }
+
+    /// A branch attached elsewhere owns its name outright — a sandbox whose
+    /// directory shares the spelling degrades rather than duplicating it.
+    #[test]
+    fn a_sandbox_name_never_duplicates_an_attached_branch() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sandbox = linked(tmp.path(), "wt-a");
+        let attached = linked(tmp.path(), "wt-b");
+        let records = HashMap::from([sandbox_record(
+            "wt-a",
+            "v1.18.0",
+            crate::store::models::WorktreeKind::Canonical,
+        )]);
+
+        let ids = resolve_identities_with(
+            &[entry(&sandbox, None), entry(&attached, Some("v1.18.0"))],
+            &records,
+        );
+
+        let degraded = ids[0].as_ref().unwrap();
+        assert_eq!(degraded.name, DETACHED_LABEL);
+        assert!(degraded.drifted, "the collision is worth surfacing");
+        assert_eq!(ids[1].as_ref().unwrap().name, "v1.18.0");
     }
 
     #[test]

--- a/src/core/worktree/identity_store.rs
+++ b/src/core/worktree/identity_store.rs
@@ -16,7 +16,7 @@
 //! build degrades to "no record" rather than failing a command. Reads never
 //! create the store; only writes do.
 
-use crate::store::models::WorktreeIdentityRow;
+use crate::store::models::{WorktreeIdentityRow, WorktreeKind};
 use crate::store::repos::{WorktreeIdentitiesRepo, with_write_txn};
 use crate::store::{Pool, paths};
 use std::collections::HashMap;
@@ -89,9 +89,46 @@ impl IdentityStore {
             branch: branch.to_string(),
             worktree_path: worktree_path.display().to_string(),
             updated_at: chrono::Utc::now(),
+            kind: WorktreeKind::Branch,
+            source_spelling: None,
+            pinned_commit: None,
         };
         if let Err(e) = self.write(|conn| WorktreeIdentitiesRepo::upsert(conn, &row)) {
             crate::log_debug!("could not record worktree identity: {e}");
+        }
+    }
+
+    /// Record that `worktree_path` is an anonymous sandbox named `dirname`,
+    /// created from `source_spelling` and pinned at `pinned_commit`.
+    ///
+    /// The sandbox counterpart of [`Self::record`]: the directory name goes
+    /// where a branch identity would, and `kind` says which meaning the row
+    /// carries. `Canonical` rows are what `daft go <commit-ish>` matches on a
+    /// revisit; `Fork` rows are never matched by resolution — a fork is
+    /// reachable only by its name.
+    pub fn record_sandbox(
+        &self,
+        worktree_path: &Path,
+        dirname: &str,
+        kind: WorktreeKind,
+        source_spelling: &str,
+        pinned_commit: &str,
+    ) {
+        let Some(worktree_id) = worktree_id_for(worktree_path) else {
+            return;
+        };
+        let row = WorktreeIdentityRow {
+            repo_hash: self.repo_hash.clone(),
+            worktree_id,
+            branch: dirname.to_string(),
+            worktree_path: worktree_path.display().to_string(),
+            updated_at: chrono::Utc::now(),
+            kind,
+            source_spelling: Some(source_spelling.to_string()),
+            pinned_commit: Some(pinned_commit.to_string()),
+        };
+        if let Err(e) = self.write(|conn| WorktreeIdentitiesRepo::upsert(conn, &row)) {
+            crate::log_debug!("could not record sandbox identity: {e}");
         }
     }
 
@@ -114,6 +151,12 @@ impl IdentityStore {
                     branch: branch.to_string(),
                     worktree_path: path.display().to_string(),
                     updated_at: now,
+                    // Observations are of *attached* worktrees, so a fill-in
+                    // is a branch identity; on an existing row the repo layer
+                    // refreshes only path/timestamp, never the kind.
+                    kind: WorktreeKind::Branch,
+                    source_spelling: None,
+                    pinned_commit: None,
                 })
             })
             .collect();
@@ -156,10 +199,38 @@ impl IdentityStore {
     /// that could no longer read the private-gitdir id (the directory was
     /// already gone). Over-broad (two records naming one branch both go) and
     /// blind to drifted rows (the record names the intent, not the checkout),
-    /// which is why [`Self::forget`] prefers the id.
+    /// which is why [`Self::forget`] prefers the id. Branch rows only: a
+    /// sandbox sharing the name is a different worktree.
     pub fn forget_branch(&self, branch: &str) {
         if let Err(e) = self.write(|conn| {
             WorktreeIdentitiesRepo::delete_for_branch(conn, &self.repo_hash, branch).map(|_| ())
+        }) {
+            crate::log_debug!("could not forget worktree identity: {e}");
+        }
+    }
+
+    /// Forget a removed sandbox's record: by captured private-gitdir id when
+    /// one was read before the removal, else by directory name (sandbox rows
+    /// only — the mirror of [`Self::forget`]'s branch fallback).
+    pub fn forget_sandbox(&self, captured_id: Option<&str>, dirname: &str) {
+        if let Some(id) = captured_id {
+            self.forget_id(id);
+            return;
+        }
+        if let Err(e) = self.write(|conn| {
+            WorktreeIdentitiesRepo::delete_sandbox_by_name(conn, &self.repo_hash, dirname)
+                .map(|_| ())
+        }) {
+            crate::log_debug!("could not forget sandbox identity: {e}");
+        }
+    }
+
+    /// Forget the record keyed on `worktree_id`, whatever it names. For
+    /// callers that discover a stale row themselves (a recorded sandbox whose
+    /// worktree is gone) and have no branch or dirname to sweep by.
+    pub fn forget_id(&self, worktree_id: &str) {
+        if let Err(e) = self.write(|conn| {
+            WorktreeIdentitiesRepo::delete(conn, &self.repo_hash, worktree_id).map(|_| ())
         }) {
             crate::log_debug!("could not forget worktree identity: {e}");
         }
@@ -408,6 +479,69 @@ mod tests {
 
         store.forget(None, "feat/x");
         assert!(read_identities(&common).is_empty());
+    }
+
+    #[test]
+    #[serial]
+    fn sandbox_records_round_trip_with_kind_and_pin() {
+        let _guard = crate::store::paths::IsolatedStateDir::new();
+        let (_tmp, common, worktree) = linked_worktree("wt-s");
+        let store = IdentityStore::open(&common).expect("store opens");
+
+        store.record_sandbox(
+            &worktree,
+            "v1.18.0",
+            WorktreeKind::Canonical,
+            "v1.18.0",
+            "abc123def4567890abc123def4567890abc123de",
+        );
+
+        let found = read_identities(&common);
+        let row = &found["wt-s"];
+        assert_eq!(row.branch, "v1.18.0", "the dirname is the identity");
+        assert_eq!(row.kind, WorktreeKind::Canonical);
+        assert_eq!(row.source_spelling.as_deref(), Some("v1.18.0"));
+        assert_eq!(
+            row.pinned_commit.as_deref(),
+            Some("abc123def4567890abc123def4567890abc123de")
+        );
+    }
+
+    /// Sandbox removal sweeps by dirname when no id was captured — and only
+    /// sandbox rows, so a branch sharing the spelling survives.
+    #[test]
+    #[serial]
+    fn forget_sandbox_by_name_spares_the_same_named_branch_record() {
+        let _guard = crate::store::paths::IsolatedStateDir::new();
+        let (tmp, common, wt_branch) = linked_worktree("wt-a");
+        let private_s = common.join("worktrees/wt-s");
+        std::fs::create_dir_all(&private_s).unwrap();
+        let wt_s = tmp.path().join("wt-s");
+        std::fs::create_dir_all(&wt_s).unwrap();
+        std::fs::write(
+            wt_s.join(".git"),
+            String::from("gitdir: ") + private_s.to_str().unwrap() + "\n",
+        )
+        .unwrap();
+        let store = IdentityStore::open(&common).unwrap();
+
+        store.record(&wt_branch, "scratch");
+        store.record_sandbox(
+            &wt_s,
+            "scratch",
+            WorktreeKind::Fork,
+            "HEAD",
+            &"a".repeat(40),
+        );
+
+        store.forget_sandbox(None, "scratch");
+
+        let found = read_identities(&common);
+        assert!(!found.contains_key("wt-s"), "the sandbox record is gone");
+        assert_eq!(
+            found["wt-a"].branch, "scratch",
+            "the like-named branch record survives"
+        );
     }
 
     /// Paths with no private-gitdir id are silently skipped, not errors —

--- a/src/core/worktree/info_field.rs
+++ b/src/core/worktree/info_field.rs
@@ -28,6 +28,22 @@ impl FieldSet {
     /// Fields whose values can change after a `git fetch`.
     pub const REMOTE_DERIVED: Self = Self(Self::REMOTE_AHEAD_BEHIND.0 | Self::REMOTE_LINES.0);
 
+    /// Fields keyed by a branch name. A branchless target (a sandbox, or any
+    /// worktree with no branch to query) has no value for these: the
+    /// streaming collector masks them out of its request, and the live table
+    /// pre-marks them received at seed so the cells read as blank instead of
+    /// shimmering until the whole collection completes. One constant serves
+    /// both sides so the skip-list and the settle-list cannot drift.
+    pub const BRANCH_KEYED: Self = Self(
+        Self::BASE_AHEAD_BEHIND.0
+            | Self::REMOTE_AHEAD_BEHIND.0
+            | Self::BRANCH_AGE.0
+            | Self::OWNER.0
+            | Self::BASE_LINES.0
+            | Self::REMOTE_LINES.0
+            | Self::FORGE_REF.0,
+    );
+
     /// Fields whose values can change after any per-branch task
     /// (Update / Rebase / Push). Used by the orchestrator for post-task
     /// re-runs.
@@ -146,6 +162,34 @@ mod tests {
         let requested = FieldSet::CHANGES | FieldSet::OWNER;
         assert_eq!(requested | !requested, FieldSet::ALL);
         assert_eq!(!FieldSet::EMPTY, FieldSet::ALL);
+    }
+
+    #[test]
+    fn branch_keyed_covers_exactly_the_branchless_skips() {
+        // The collector computes these from a branch name — a branchless
+        // target can't stream them, so they must all be in the mask...
+        for member in [
+            FieldSet::BASE_AHEAD_BEHIND,
+            FieldSet::REMOTE_AHEAD_BEHIND,
+            FieldSet::BRANCH_AGE,
+            FieldSet::OWNER,
+            FieldSet::BASE_LINES,
+            FieldSet::REMOTE_LINES,
+            FieldSet::FORGE_REF,
+        ] {
+            assert!(FieldSet::BRANCH_KEYED.contains(member));
+        }
+        // ...while path-derived fields stream for every worktree, branch or
+        // not, and must never be masked.
+        for member in [
+            FieldSet::CHANGES,
+            FieldSet::LAST_COMMIT,
+            FieldSet::CHANGES_LINES,
+            FieldSet::SIZE,
+            FieldSet::MTIME,
+        ] {
+            assert!(!FieldSet::BRANCH_KEYED.contains(member));
+        }
     }
 
     #[test]

--- a/src/core/worktree/list.rs
+++ b/src/core/worktree/list.rs
@@ -125,6 +125,14 @@ pub struct WorktreeInfo {
     /// Narrower than "HEAD is detached": a worktree paused mid-operation is
     /// not a sandbox. See [`super::identity`].
     pub is_sandbox: bool,
+    /// This row has no branch to query: a daft sandbox, or a foreign
+    /// detached worktree. Wider than `is_sandbox`, narrower than "HEAD is
+    /// detached" (a recovered worktree has a real ref and stays `false`).
+    /// The live table settles the `FieldSet::BRANCH_KEYED` cells of a
+    /// branchless row as blank at seed — the collector will never stream
+    /// them, and without the settle they shimmer until the whole collection
+    /// completes.
+    pub branchless: bool,
     /// The git operation paused in this worktree, if any. Present for
     /// attached worktrees too — a merge never detaches HEAD.
     pub op: Option<crate::git::op_state::OpKind>,
@@ -172,6 +180,7 @@ impl WorktreeInfo {
             size_bytes: None,
             working_tree_mtime: None,
             is_sandbox: false,
+            branchless: false,
             op: None,
             identity_source: None,
             drifted: false,
@@ -211,6 +220,7 @@ impl WorktreeInfo {
             size_bytes: None,
             working_tree_mtime: None,
             is_sandbox: false,
+            branchless: false,
             op: None,
             identity_source: None,
             drifted: false,
@@ -986,6 +996,7 @@ pub fn collect_worktree_info(
             size_bytes: None,
             working_tree_mtime,
             is_sandbox: identity.is_sandbox,
+            branchless: branch.is_none(),
             op: identity.op,
             identity_source: Some(identity.source),
             drifted: identity.drifted,
@@ -1133,6 +1144,7 @@ pub fn collect_branch_info(
                 size_bytes: None,
                 working_tree_mtime: None,
                 is_sandbox: false,
+                branchless: false,
                 op: None,
                 identity_source: None,
                 drifted: false,
@@ -1223,6 +1235,7 @@ pub fn collect_branch_info(
                 size_bytes: None,
                 working_tree_mtime: None,
                 is_sandbox: false,
+                branchless: false,
                 op: None,
                 identity_source: None,
                 drifted: false,

--- a/src/core/worktree/list_stream.rs
+++ b/src/core/worktree/list_stream.rs
@@ -223,11 +223,20 @@ fn run_worker(
 
     let path = target.path.as_deref();
 
-    // 1. BASE_AHEAD_BEHIND (skip detached) — content-addressed cache by
-    //    (base_sha, head_sha). Falls through to compute on key-resolution
-    //    failure; the wrapper itself skips writing on a None compute result.
+    // A branchless target streams only its path-derived fields. Masking here
+    // (rather than gating each cluster) keeps the skip-list identical to the
+    // BRANCH_KEYED bits the live table settles as blank at seed — the two
+    // sides can't drift apart.
+    let fields = if target.is_detached {
+        fields & !FieldSet::BRANCH_KEYED
+    } else {
+        fields
+    };
+
+    // 1. BASE_AHEAD_BEHIND — content-addressed cache by (base_sha, head_sha).
+    //    Falls through to compute on key-resolution failure; the wrapper
+    //    itself skips writing on a None compute result.
     if fields.contains(FieldSet::BASE_AHEAD_BEHIND)
-        && !target.is_detached
         && let Some(p) = path
     {
         let base_sha = crate::core::worktree::cell_cache::resolve_ref_sha(p, &ctx.base_branch);
@@ -277,18 +286,16 @@ fn run_worker(
         });
     }
 
-    // 4. BRANCH_AGE (skip detached)
+    // 4. BRANCH_AGE
     if fields.contains(FieldSet::BRANCH_AGE)
-        && !target.is_detached
         && let Some(p) = path
     {
         let v = get_branch_creation_timestamp(&target.branch_name, p);
         emit!(P::BranchAge(v));
     }
 
-    // 5. OWNER (skip detached)
+    // 5. OWNER
     if fields.contains(FieldSet::OWNER)
-        && !target.is_detached
         && let Some(p) = path
     {
         let owner = ownership::resolve_owner_with_fallbacks(
@@ -302,19 +309,17 @@ fn run_worker(
         emit!(P::Owner(owner));
     }
 
-    // 5b. FORGE_REF (skip detached) — a cheap local `branch.<name>.merge` read.
+    // 5b. FORGE_REF — a cheap local `branch.<name>.merge` read.
     if fields.contains(FieldSet::FORGE_REF)
-        && !target.is_detached
         && let Some(p) = path
     {
         emit!(P::ForgeRef(get_forge_branch_ref(&target.branch_name, p)));
     }
 
-    // 6. REMOTE_AHEAD_BEHIND (skip detached) — content-addressed cache by
+    // 6. REMOTE_AHEAD_BEHIND — content-addressed cache by
     //    (head_sha, upstream_sha). The upstream refspec uses the
     //    `<branch>@{upstream}` form so git resolves the configured upstream.
     if fields.contains(FieldSet::REMOTE_AHEAD_BEHIND)
-        && !target.is_detached
         && let Some(p) = path
     {
         let head_sha = crate::core::worktree::cell_cache::resolve_ref_sha(p, "HEAD");
@@ -338,7 +343,6 @@ fn run_worker(
     if matches!(stat, Stat::Lines) {
         // BASE_LINES — content-addressed cache by (base_sha, head_sha).
         if fields.contains(FieldSet::BASE_LINES)
-            && !target.is_detached
             && let Some(p) = path
         {
             let base_sha = crate::core::worktree::cell_cache::resolve_ref_sha(p, &ctx.base_branch);
@@ -365,7 +369,6 @@ fn run_worker(
         }
         // REMOTE_LINES — content-addressed cache by (head_sha, upstream_sha).
         if fields.contains(FieldSet::REMOTE_LINES)
-            && !target.is_detached
             && let Some(p) = path
         {
             let head_sha = crate::core::worktree::cell_cache::resolve_ref_sha(p, "HEAD");

--- a/src/core/worktree/mod.rs
+++ b/src/core/worktree/mod.rs
@@ -21,6 +21,7 @@ pub mod fetch;
 pub mod flow_adopt;
 pub mod flow_eject;
 pub mod forge_ref;
+pub mod fork_names;
 pub mod identity;
 pub mod identity_store;
 pub mod info_field;

--- a/src/core/worktree/mod.rs
+++ b/src/core/worktree/mod.rs
@@ -39,6 +39,7 @@ pub mod push;
 pub mod rebase;
 pub mod remove_repo;
 pub mod rename;
+pub mod sandbox;
 pub mod sync_dag;
 pub mod temp_worktree;
 

--- a/src/core/worktree/prune.rs
+++ b/src/core/worktree/prune.rs
@@ -1048,15 +1048,59 @@ fn delete_branch(git: &GitCommand, branch_name: &str, sink: &mut dyn ProgressSin
 /// `JobInfo.worktree` carries the branch slug (e.g. "feat/x") set from
 /// `ctx.branch_name` at job-launch time, NOT the filesystem path. Comparing
 /// against a path here would never match.
-/// Cancel any running background jobs for a specific worktree.
+/// How long the polite (SIGTERM) phase of a worktree-removal cancel waits
+/// before escalating to SIGKILL, and how long the SIGKILL phase waits
+/// before giving up. Killing must finish before the caller starts deleting
+/// the directory under the job — a build that outlives the cancel keeps
+/// writing files mid-delete and `git worktree remove` dies on
+/// "Directory not empty" (the field failure that motivated the wait).
+const CANCEL_TERM_GRACE: std::time::Duration = std::time::Duration::from_secs(5);
+const CANCEL_KILL_GRACE: std::time::Duration = std::time::Duration::from_secs(2);
+const CANCEL_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(150);
+
+/// The next move for the cancel wait-loop, decided from elapsed time alone.
+/// Pure so the escalation ladder is unit-testable without a coordinator.
+#[derive(Debug, PartialEq, Eq)]
+enum CancelWaitAction {
+    /// Keep polling — inside the SIGTERM grace window.
+    Wait,
+    /// SIGTERM grace expired: send the SIGKILL escalation.
+    Escalate,
+    /// Both grace windows expired: warn and let the caller proceed.
+    GiveUp,
+}
+
+fn next_cancel_wait_action(elapsed: std::time::Duration, escalated: bool) -> CancelWaitAction {
+    if elapsed < CANCEL_TERM_GRACE {
+        CancelWaitAction::Wait
+    } else if !escalated {
+        CancelWaitAction::Escalate
+    } else if elapsed < CANCEL_TERM_GRACE + CANCEL_KILL_GRACE {
+        CancelWaitAction::Wait
+    } else {
+        CancelWaitAction::GiveUp
+    }
+}
+
+/// Cancel any running background jobs for a specific worktree and wait for
+/// them to actually die.
 ///
 /// Best-effort: if no coordinator is running or unreachable, errors are
 /// silently dropped so the worktree-removal flow proceeds. Implemented as
 /// a single `CancelMatching { worktree: ... }` IPC call so the coordinator
 /// filters its SQLite-recorded active jobs in one round trip rather than the
 /// previous list-then-cancel-per-name dance.
+///
+/// The wait matters as much as the signal: the caller is about to delete
+/// the worktree directory, and a job that is merely *signalled* keeps
+/// writing until it exits — `git worktree remove` then races the dying
+/// build and fails with "Directory not empty". So when the cancel matched
+/// anything, this polls the coordinator until those jobs leave `Running`,
+/// escalating SIGTERM → SIGKILL after a grace period and giving up (with a
+/// warning) only after the kill grace also expires.
 pub(crate) fn cancel_background_jobs_for_worktree(branch_slug: &str, sink: &mut dyn ProgressSink) {
     use crate::coordinator::client::CoordinatorClient;
+    use crate::coordinator::log_store::JobStatus;
 
     let repo_hash = match crate::core::repo_identity::compute_repo_id() {
         Ok(id) => id,
@@ -1068,16 +1112,55 @@ pub(crate) fn cancel_background_jobs_for_worktree(branch_slug: &str, sink: &mut 
         _ => return,
     };
 
-    match client.cancel_matching(None, Some(branch_slug), None, None, None) {
-        Ok(names) if names.is_empty() => {}
-        Ok(names) => {
-            for name in names {
-                sink.on_step(&format!("Stopped background job '{name}'"));
+    let names = match client.cancel_matching(None, Some(branch_slug), None, None, None, false) {
+        Ok(names) if names.is_empty() => return,
+        Ok(names) => names,
+        Err(e) => {
+            sink.on_warning(&format!(
+                "Failed to cancel background jobs for '{branch_slug}': {e}"
+            ));
+            return;
+        }
+    };
+    for name in &names {
+        sink.on_step(&format!("Stopped background job '{name}'"));
+    }
+
+    // Wait for the signalled jobs to leave `Running` before returning to
+    // the deletion path. Poll failures end the wait rather than block the
+    // removal — the cancel itself stays best-effort.
+    let start = std::time::Instant::now();
+    let mut escalated = false;
+    loop {
+        let still_running = match client.list_jobs() {
+            Ok(jobs) => jobs.into_iter().any(|j| {
+                j.worktree == branch_slug
+                    && matches!(j.status, JobStatus::Running)
+                    && names.contains(&j.name)
+            }),
+            Err(_) => return,
+        };
+        if !still_running {
+            return;
+        }
+        match next_cancel_wait_action(start.elapsed(), escalated) {
+            CancelWaitAction::Wait => std::thread::sleep(CANCEL_POLL_INTERVAL),
+            CancelWaitAction::Escalate => {
+                escalated = true;
+                let _ = client.cancel_matching(None, Some(branch_slug), None, None, None, true);
+                sink.on_step(&format!(
+                    "Background jobs for '{branch_slug}' outlived the polite cancel; killing"
+                ));
+            }
+            CancelWaitAction::GiveUp => {
+                sink.on_warning(&format!(
+                    "Background jobs for '{branch_slug}' are still running; the worktree \
+                     removal may fail — inspect them with `{}`",
+                    crate::daft_cmd("hooks jobs")
+                ));
+                return;
             }
         }
-        Err(e) => sink.on_warning(&format!(
-            "Failed to cancel background jobs for '{branch_slug}': {e}"
-        )),
     }
 }
 
@@ -1156,3 +1239,38 @@ fn cleanup_empty_parent_dirs(
 // not the filesystem path — lives in
 // `coordinator::process::filter_matching_jobs` and is covered by tests
 // in that module (`filter_matching_jobs_combines_predicates_and`).
+
+#[cfg(test)]
+mod cancel_wait_tests {
+    use super::*;
+    use std::time::Duration;
+
+    /// The escalation ladder that keeps `git worktree remove` from racing
+    /// a signalled-but-alive background build: polite wait → SIGKILL →
+    /// bounded give-up (the removal must never hang on an unkillable job).
+    #[test]
+    fn cancel_wait_ladder_escalates_then_gives_up() {
+        assert_eq!(
+            next_cancel_wait_action(Duration::from_secs(1), false),
+            CancelWaitAction::Wait
+        );
+        assert_eq!(
+            next_cancel_wait_action(CANCEL_TERM_GRACE, false),
+            CancelWaitAction::Escalate
+        );
+        assert_eq!(
+            next_cancel_wait_action(CANCEL_TERM_GRACE + Duration::from_millis(1), true),
+            CancelWaitAction::Wait
+        );
+        assert_eq!(
+            next_cancel_wait_action(CANCEL_TERM_GRACE + CANCEL_KILL_GRACE, true),
+            CancelWaitAction::GiveUp
+        );
+        // An early `escalated` flag with a short clock still just waits —
+        // the ladder is driven by elapsed time, never by call order.
+        assert_eq!(
+            next_cancel_wait_action(Duration::ZERO, true),
+            CancelWaitAction::Wait
+        );
+    }
+}

--- a/src/core/worktree/sandbox.rs
+++ b/src/core/worktree/sandbox.rs
@@ -90,6 +90,21 @@ pub fn short_oid(oid: &str) -> &str {
     &oid[..oid.len().min(7)]
 }
 
+/// `HEAD` of the worktree at `path`, as a full OID. `None` when unreadable —
+/// callers degrade (report the requested commit, skip a guard) rather than
+/// erroring on a broken worktree.
+pub(crate) fn worktree_head(path: &Path) -> Option<String> {
+    let out = crate::utils::git_command_at(path)
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let oid = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    (!oid.is_empty()).then_some(oid)
+}
+
 /// Directory name for a spelling that cannot name itself: a hex prefix of
 /// the resolved commit.
 pub fn derived_dirname(commit: &str) -> String {
@@ -165,7 +180,14 @@ pub fn execute_visit(
     {
         let kind = record_for(&records, &entry.path).map(|r| r.kind);
         if kind != Some(WorktreeKind::Fork) {
-            return navigate(&dir, &entry.path.clone(), &params.commit, &git_dir, sink);
+            return navigate(
+                &dir,
+                &entry.path.clone(),
+                &params.commit,
+                &params.spelling,
+                &git_dir,
+                sink,
+            );
         }
     }
 
@@ -190,6 +212,7 @@ pub fn execute_visit(
                     &row.branch,
                     &entry.path.clone(),
                     &params.commit,
+                    &params.spelling,
                     &git_dir,
                     sink,
                 );
@@ -281,6 +304,7 @@ fn create_sandbox(
                 &params.dirname,
                 &worktree_path,
                 &params.commit,
+                &params.spelling,
                 git_dir,
                 sink,
             );
@@ -478,6 +502,7 @@ fn navigate(
     dirname: &str,
     worktree_path: &Path,
     commit: &str,
+    spelling: &str,
     git_dir: &Path,
     sink: &mut impl ProgressSink,
 ) -> Result<SandboxResult> {
@@ -485,11 +510,27 @@ fn navigate(
         "Sandbox '{dirname}' already exists at '{}', switching to it",
         worktree_path.display()
     ));
+    // Report the worktree's real position, not the caller's freshly-resolved
+    // commit: the two diverge when the spelling is a moving ref
+    // (`origin/master` after a fetch) or when commits were made inside the
+    // sandbox. Landing the shell at X while announcing Y is the lie to avoid;
+    // the sandbox itself deliberately keeps its position (never mutated on
+    // revisit — it may hold uncommitted or committed work).
+    let head = worktree_head(worktree_path);
+    let actual = head.as_deref().unwrap_or(commit);
+    if actual != commit {
+        sink.on_warning(&format!(
+            "Sandbox '{dirname}' sits at {}, but '{spelling}' now resolves to {} — \
+             it keeps its position; remove the sandbox and revisit to take the new one",
+            short_oid(actual),
+            short_oid(commit)
+        ));
+    }
     change_directory(worktree_path)?;
     Ok(SandboxResult {
         dirname: dirname.to_string(),
         worktree_path: worktree_path.to_path_buf(),
-        commit: commit.to_string(),
+        commit: actual.to_string(),
         already_existed: true,
         cd_target: get_current_directory()?,
         git_dir: git_dir.to_path_buf(),
@@ -855,6 +896,76 @@ mod tests {
         .expect("the visit creates its own sandbox");
         assert!(!result.already_existed, "the fork was not matched");
         assert_ne!(result.worktree_path, fork_wt);
+    }
+
+    /// A revisit reports the sandbox's real position, not the freshly
+    /// resolved commit: when the spelling moves (a fetch advancing
+    /// `origin/master`, a re-tagged release), the shell lands in the
+    /// existing worktree — the result must say where that is, and the
+    /// divergence must be called out.
+    #[test]
+    #[serial]
+    fn a_revisit_after_the_spelling_moved_reports_the_sandbox_position() {
+        struct WarningSink {
+            warnings: Vec<String>,
+        }
+        impl ProgressSink for WarningSink {
+            fn on_step(&mut self, _msg: &str) {}
+            fn on_warning(&mut self, msg: &str) {
+                self.warnings.push(msg.to_string());
+            }
+            fn on_debug(&mut self, _msg: &str) {}
+        }
+        impl HookRunner for WarningSink {
+            fn run_hook(&mut self, _ctx: &HookContext) -> Result<HookOutcome> {
+                Ok(HookOutcome {
+                    success: true,
+                    skipped: true,
+                    skip_reason: None,
+                })
+            }
+        }
+
+        let _state = crate::store::paths::IsolatedStateDir::new();
+        let _cwd = CwdGuard::new();
+        let (tmp, repo, oid) = repo_with_tag();
+        std::env::set_current_dir(&repo).unwrap();
+
+        let wt = tmp.path().join("v1");
+        execute_visit(
+            &params("v1", &oid, WorktreeKind::Canonical, wt.clone()),
+            &GitCommand::new(true),
+            &repo,
+            &mut NullBridge,
+        )
+        .expect("first visit materializes");
+        std::env::set_current_dir(&repo).unwrap();
+
+        // The spelling moves: model a fetch/re-tag by resolving it to main's
+        // tip on the second visit.
+        let moved = git_out(&repo, &["rev-parse", "HEAD"]);
+        assert_ne!(moved, oid);
+
+        let mut sink = WarningSink {
+            warnings: Vec::new(),
+        };
+        let result = execute_visit(
+            &params("v1", &moved, WorktreeKind::Canonical, wt.clone()),
+            &GitCommand::new(true),
+            &repo,
+            &mut sink,
+        )
+        .expect("revisit navigates");
+
+        assert!(result.already_existed);
+        assert_eq!(result.commit, oid, "reports the worktree's real position");
+        assert!(
+            sink.warnings
+                .iter()
+                .any(|w| w.contains(short_oid(&oid)) && w.contains(short_oid(&moved))),
+            "the divergence is called out: {:?}",
+            sink.warnings
+        );
     }
 
     /// The hook context on the sandbox path is branchless: an empty branch

--- a/src/core/worktree/sandbox.rs
+++ b/src/core/worktree/sandbox.rs
@@ -1,0 +1,932 @@
+//! Core logic for anonymous (detached-HEAD) sandbox worktrees (#53).
+//!
+//! A sandbox is a worktree pinned at a commit with no branch attached: no
+//! tracking, no push, a lifetime exactly as long as its directory. Two
+//! entrances create them, along the verb taxonomy — go visits, start mints:
+//!
+//! - [`execute_visit`] — `daft go <commit-ish>`. Idempotent: the first visit
+//!   materializes the *canonical* sandbox for a commit, every later visit
+//!   navigates back to it (by directory name for stable spellings, by pinned
+//!   commit for derived ones like `HEAD~2`, so every spelling of one commit
+//!   converges on one sandbox).
+//! - [`execute_create`] — `daft start --fork`. Always fresh: no idempotence,
+//!   the caller has already claimed a directory, and the resulting *fork* is
+//!   never matched by go's resolution — it is reachable only by name.
+//!
+//! Deliberately a lean sibling of [`super::checkout::execute`] rather than a
+//! parameterization of it: a sandbox has no fetch, no upstream, no forge and
+//! no branch, which is most of what `CheckoutParams` exists to carry. What it
+//! shares — hooks, carry, shared-file links, visitor propagation, the cd
+//! contract — it shares by calling the same helpers in the same order.
+
+use crate::core::layout::{Layout, auto_gitignore_if_needed};
+use crate::core::stage::{PlanCommit, Row, StageEvent, StageId, StepKey, StepSpec};
+use crate::core::{HookOutcome, HookRunner, ProgressSink};
+use crate::git::GitCommand;
+use crate::hooks::{HookContext, HookType};
+use crate::multi_remote::path::{build_template_context, calculate_worktree_path};
+use crate::store::models::{WorktreeIdentityRow, WorktreeKind};
+use crate::utils::*;
+use anyhow::Result;
+use std::path::{Path, PathBuf};
+
+/// Hex length used for directory names derived from a commit (`HEAD~2`, raw
+/// SHAs — spellings that would lie tomorrow or are unwieldy as names). Longer
+/// than git's usual display abbreviation on purpose: a directory name never
+/// re-resolves, so it only has to dodge sibling-directory collisions.
+const DERIVED_DIRNAME_HEX: usize = 12;
+
+/// Input parameters shared by both sandbox entrances.
+pub struct SandboxParams {
+    /// What the user typed (`v1.18.0`, `origin/master`, `HEAD~2`; `HEAD` for
+    /// a bare `--fork`). Recorded as provenance, shown in announcements.
+    pub spelling: String,
+    /// The spelling resolved to a full commit OID, by the command layer.
+    pub commit: String,
+    /// Final directory name. The worktree's identity everywhere (list,
+    /// `daft go <name>`, `daft remove <name>`).
+    pub dirname: String,
+    /// `Canonical` for a visit, `Fork` for a mint. Decides whether go's
+    /// resolution may ever match the worktree again.
+    pub kind: WorktreeKind,
+    /// The fork claim loop already created the (empty) directory; skip the
+    /// exists handling.
+    pub path_preclaimed: bool,
+    /// Carry flags, as on checkout: explicit request, explicit refusal, and
+    /// the `daft.checkout.carry` default.
+    pub carry: bool,
+    pub no_carry: bool,
+    pub checkout_carry: bool,
+    /// Remote override for worktree organization (multi-remote mode).
+    pub remote: Option<String>,
+    /// Remote name from settings (hook context only — nothing is fetched).
+    pub remote_name: String,
+    pub multi_remote_enabled: bool,
+    pub multi_remote_default: String,
+    /// Layout for computing the worktree path, as on checkout.
+    pub layout: Option<Layout>,
+    /// Explicit placement override (`--at`).
+    pub at_path: Option<PathBuf>,
+}
+
+/// Result of a sandbox visit or creation.
+pub struct SandboxResult {
+    pub dirname: String,
+    pub worktree_path: PathBuf,
+    /// Full OID the sandbox is pinned at.
+    pub commit: String,
+    /// True when an existing sandbox was found and navigated into.
+    pub already_existed: bool,
+    /// Directory to cd into after the operation.
+    pub cd_target: PathBuf,
+    pub git_dir: PathBuf,
+    pub stash_applied: bool,
+    pub stash_conflict: bool,
+    pub post_hook_outcome: HookOutcome,
+}
+
+/// Short display form of a full OID.
+pub fn short_oid(oid: &str) -> &str {
+    &oid[..oid.len().min(7)]
+}
+
+/// Directory name for a spelling that cannot name itself: a hex prefix of
+/// the resolved commit.
+pub fn derived_dirname(commit: &str) -> String {
+    commit[..commit.len().min(DERIVED_DIRNAME_HEX)].to_string()
+}
+
+/// The directory name a spelling earns, or `None` when the name must be
+/// derived from the resolved commit instead.
+///
+/// A spelling is *nameable* when it reads as a stable human name: only
+/// `[A-Za-z0-9._/-]`, no `..`, no leading `-` or `.` or `/`, not bare hex
+/// long enough to be a full object id, and not a `HEAD`-family pseudo-ref.
+/// Slashes flatten to `-` (`origin/master` → `origin-master`), matching how
+/// branch worktree directories are named. Everything else — `HEAD~2`,
+/// `@{-1}`, `v1^{}`, a 40-hex SHA — describes a *position*, not a name: its
+/// spelling names a different commit tomorrow (or is unwieldy), so the
+/// directory takes [`derived_dirname`] of the commit it resolved to.
+///
+/// Not [`crate::core::layout::template`]'s `sanitize` (which only maps
+/// slashes) nor `temp_worktree`'s slug (`/` → `--`): commit-ish spellings
+/// need the reject-set, and a rejected spelling must fall through to the
+/// commit-derived name rather than being force-sanitized into something that
+/// lies.
+pub fn sandbox_dirname(spelling: &str) -> Option<String> {
+    if spelling.is_empty()
+        || spelling.starts_with('-')
+        || spelling.starts_with('.')
+        || spelling.starts_with('/')
+        || spelling.contains("..")
+    {
+        return None;
+    }
+    if !spelling
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '/' | '-'))
+    {
+        return None;
+    }
+    // Pseudo-refs describe positions, never names.
+    if spelling == "HEAD" || spelling.ends_with("_HEAD") {
+        return None;
+    }
+    // Bare hex at object-id length is a position too.
+    if spelling.len() >= 40 && spelling.chars().all(|c| c.is_ascii_hexdigit()) {
+        return None;
+    }
+    Some(spelling.replace('/', "-"))
+}
+
+/// Visit the canonical sandbox for `params.commit`: navigate to it if it
+/// exists, materialize it otherwise. The `daft go <commit-ish>` engine.
+pub fn execute_visit(
+    params: &SandboxParams,
+    git: &GitCommand,
+    project_root: &Path,
+    sink: &mut (impl ProgressSink + HookRunner),
+) -> Result<SandboxResult> {
+    let git_dir = crate::core::repo::get_git_common_dir()?;
+
+    let entries = detached_entries(git)?;
+    let records = super::identity_store::read_identities(&git_dir);
+
+    // Idempotence A — the spelling's own directory name. A detached worktree
+    // already sitting at that name is the destination, unless it is a fork:
+    // forks are private, and resolution must never route a visitor into one.
+    // (No record at all — a foreign detached worktree parked at this name —
+    // navigates too: the alternative is a confusing "directory exists" error
+    // for something that is exactly the worktree the user asked for.)
+    if let Some(dir) = sandbox_dirname(&params.spelling)
+        && let Some(entry) = entries
+            .iter()
+            .find(|e| e.path.file_name().is_some_and(|f| f == dir.as_str()))
+    {
+        let kind = record_for(&records, &entry.path).map(|r| r.kind);
+        if kind != Some(WorktreeKind::Fork) {
+            return navigate(&dir, &entry.path.clone(), &params.commit, &git_dir, sink);
+        }
+    }
+
+    // Idempotence B — the commit. Whatever the spelling (`HEAD~2` today, the
+    // tag yesterday, the raw SHA in a script), one commit has at most one
+    // canonical sandbox. Forks are excluded by construction (`Canonical`
+    // match only); a record whose worktree is gone is dropped so the next
+    // visit rebuilds cleanly.
+    let mut canonical: Vec<&WorktreeIdentityRow> = records
+        .values()
+        .filter(|r| r.kind == WorktreeKind::Canonical)
+        .filter(|r| r.pinned_commit.as_deref() == Some(params.commit.as_str()))
+        .collect();
+    canonical.sort_by_key(|r| std::cmp::Reverse(r.updated_at));
+    for row in canonical {
+        let live = entries.iter().find(|e| {
+            super::identity_store::worktree_id_for(&e.path).as_deref() == Some(&row.worktree_id)
+        });
+        match live {
+            Some(entry) => {
+                return navigate(
+                    &row.branch,
+                    &entry.path.clone(),
+                    &params.commit,
+                    &git_dir,
+                    sink,
+                );
+            }
+            None => {
+                // The worktree is gone but the record survived (removed
+                // outside daft). Best-effort cleanup, then keep looking.
+                if let Some(store) = super::identity_store::IdentityStore::open(&git_dir) {
+                    store.forget_id(&row.worktree_id);
+                }
+            }
+        }
+    }
+
+    create_sandbox(params, git, project_root, &git_dir, sink)
+}
+
+/// Mint a fresh sandbox at `params.commit`, unconditionally. The
+/// `daft start --fork` engine: the caller owns naming and has already
+/// claimed the directory.
+pub fn execute_create(
+    params: &SandboxParams,
+    git: &GitCommand,
+    project_root: &Path,
+    sink: &mut (impl ProgressSink + HookRunner),
+) -> Result<SandboxResult> {
+    let git_dir = crate::core::repo::get_git_common_dir()?;
+    create_sandbox(params, git, project_root, &git_dir, sink)
+}
+
+/// The shared creation pipeline: path, plan, carry, hooks, `git worktree add
+/// --detach`, provenance, links, propagation. Mirrors the order of
+/// [`super::checkout::execute`]'s creation arm.
+fn create_sandbox(
+    params: &SandboxParams,
+    git: &GitCommand,
+    project_root: &Path,
+    git_dir: &Path,
+    sink: &mut (impl ProgressSink + HookRunner),
+) -> Result<SandboxResult> {
+    let source_worktree =
+        super::checkout_branch::resolve_source_worktree(git, git_dir, &params.remote_name, None)?;
+
+    let worktree_path = if let Some(ref at) = params.at_path {
+        at.clone()
+    } else if let Some(ref layout) = params.layout {
+        // Wrapped non-bare layouts: the template expects the wrapper
+        // directory, one level above the clone (see checkout::execute).
+        let effective_root = if layout.needs_wrapper() {
+            project_root
+                .parent()
+                .map(|p| p.to_path_buf())
+                .unwrap_or_else(|| project_root.to_path_buf())
+        } else {
+            project_root.to_path_buf()
+        };
+        let ctx = build_template_context(&effective_root, &params.dirname);
+        layout.worktree_path(&ctx)?
+    } else {
+        let remote_for_path = params
+            .remote
+            .clone()
+            .unwrap_or_else(|| params.multi_remote_default.clone());
+        calculate_worktree_path(
+            project_root,
+            &params.dirname,
+            &remote_for_path,
+            params.multi_remote_enabled,
+        )
+    };
+
+    sink.on_step(&format!(
+        "Path: {}, Commit: {}, Project Root: {}",
+        worktree_path.display(),
+        short_oid(&params.commit),
+        project_root.display()
+    ));
+
+    if !params.path_preclaimed && worktree_path.exists() {
+        // A worktree already lives here — enter it rather than erroring on
+        // the deterministic path (the identity store may have been
+        // unavailable when it was created, so the lookups above can miss).
+        if worktree_path.join(".git").is_file() {
+            sink.on_step(&format!(
+                "Sandbox directory '{}' already exists, switching to it",
+                worktree_path.display()
+            ));
+            return navigate(
+                &params.dirname,
+                &worktree_path,
+                &params.commit,
+                git_dir,
+                sink,
+            );
+        }
+        // An empty directory is claimable (a crashed earlier attempt);
+        // anything else is in the way.
+        let occupied = worktree_path.is_file()
+            || std::fs::read_dir(&worktree_path).map(|mut d| d.next().is_some())?;
+        if occupied {
+            anyhow::bail!(
+                "directory '{}' already exists and is not a worktree",
+                worktree_path.display()
+            );
+        }
+    }
+
+    // Commit the execution plan: the path is resolved and everything left is
+    // planned work.
+    let should_carry = params.carry || (!params.no_carry && params.checkout_carry);
+    let annotation = if params.commit.starts_with(&params.spelling) {
+        format!("detached @ {}", short_oid(&params.commit))
+    } else {
+        format!(
+            "\u{2190} {} @ {}",
+            params.spelling,
+            short_oid(&params.commit)
+        )
+    };
+    let mut plan_rows = vec![
+        Row::Step(StepSpec::new(StepKey::new(StageId::PreCreateHooks))),
+        Row::Step(StepSpec::new(StepKey::new(StageId::CheckOut)).with_annotation(annotation)),
+        Row::Step(
+            StepSpec::new(StepKey::new(StageId::CreateWorktree))
+                .with_annotation(super::branch_delete::display_path(&worktree_path)),
+        ),
+    ];
+    if should_carry {
+        plan_rows.push(Row::Step(StepSpec::new(StepKey::new(StageId::Carry))));
+    }
+    let planned_shared =
+        crate::core::shared::read_shared_paths(&source_worktree).unwrap_or_default();
+    crate::core::shared::push_shared_section(&mut plan_rows, &planned_shared);
+    plan_rows.push(Row::Step(StepSpec::new(StepKey::new(
+        StageId::PostCreateHooks,
+    ))));
+    sink.on_plan(PlanCommit::new(plan_rows));
+
+    let stash_created = stash_if_carry(should_carry, git, sink)?;
+
+    // Pre-create hook, with the branchless context: DAFT_BRANCH_NAME is
+    // empty and the pinned commit carries the identity.
+    let hook_ctx = HookContext::new(
+        HookType::PreCreate,
+        "checkout",
+        project_root,
+        git_dir,
+        &params.remote_name,
+        &source_worktree,
+        &worktree_path,
+        "",
+    )
+    .with_new_branch(false)
+    .with_commit(&params.commit);
+
+    let hook_outcome = sink.run_hook(&hook_ctx)?;
+    if !hook_outcome.success && !hook_outcome.skipped {
+        restore_stash_on_failure(stash_created, git, sink);
+        return Err(anyhow::anyhow!("Pre-create hook failed"));
+    }
+
+    sink.on_stage(&StepKey::new(StageId::CheckOut), StageEvent::Started);
+    if let Err(e) = git.worktree_add_detached(&worktree_path, &params.commit) {
+        sink.on_stage(
+            &StepKey::new(StageId::CheckOut),
+            StageEvent::Failed {
+                detail: "failed (see below)".to_string(),
+            },
+        );
+        restore_stash_on_failure(stash_created, git, sink);
+        return Err(anyhow::anyhow!("Failed to create git worktree: {e}"));
+    }
+    sink.on_stage(
+        &StepKey::new(StageId::CheckOut),
+        StageEvent::Completed { annotation: None },
+    );
+
+    sink.on_stage(&StepKey::new(StageId::CreateWorktree), StageEvent::Started);
+    if !worktree_path.exists() {
+        sink.on_stage(
+            &StepKey::new(StageId::CreateWorktree),
+            StageEvent::Failed {
+                detail: "directory was not created".to_string(),
+            },
+        );
+        anyhow::bail!(
+            "Worktree directory was not created at '{}'",
+            worktree_path.display()
+        );
+    }
+    // Remember what this sandbox is, while we still know: the dirname is its
+    // identity, the spelling and commit its provenance. This is what names
+    // the row in `daft list`, gives revisits their return trip, and lets
+    // removal warn when HEAD later moves off the pin. Best-effort.
+    if let Some(store) = super::identity_store::IdentityStore::open(git_dir) {
+        store.record_sandbox(
+            &worktree_path,
+            &params.dirname,
+            params.kind,
+            &params.spelling,
+            &params.commit,
+        );
+    }
+    sink.on_stage(
+        &StepKey::new(StageId::CreateWorktree),
+        StageEvent::Completed { annotation: None },
+    );
+
+    if let Err(e) = auto_gitignore_if_needed(project_root, &worktree_path, params.layout.as_ref()) {
+        sink.on_warning(&format!("Could not update .gitignore: {e}"));
+    }
+
+    sink.on_step(&format!(
+        "Sandbox created at '{}' pinned at {}",
+        worktree_path.display(),
+        short_oid(&params.commit)
+    ));
+    change_directory(&worktree_path)?;
+
+    if stash_created {
+        sink.on_stage(&StepKey::new(StageId::Carry), StageEvent::Started);
+    }
+    let (stash_applied, stash_conflict) = apply_stash(stash_created, git, sink);
+    super::resolve_carry_row(should_carry, stash_created, stash_applied, sink);
+
+    // Visitor-config propagation, keyed by the sandbox's dirname where a
+    // branch name would go. See checkout_branch.rs for the canonical audit
+    // comment covering all worktree-creating entry points.
+    match crate::hooks::visitor_propagation::propagate(&source_worktree, &worktree_path) {
+        Ok(result) => {
+            for filename in &result.files_propagated {
+                crate::log_debug!("propagated {} to new worktree", filename);
+            }
+            if !result.files_propagated.is_empty()
+                && let Some(seeds) = crate::hooks::visitor_seeds::SeedsContext::open(git_dir)
+            {
+                seeds.record_seeds(&params.dirname, &worktree_path, &result.files_propagated);
+            }
+        }
+        Err(e) => {
+            sink.on_warning(&format!("visitor-config propagation failed: {e}"));
+        }
+    }
+
+    // Shared links after propagation, before hooks — order is load-bearing
+    // (see checkout::execute).
+    let link_result =
+        crate::core::shared::link_shared_files_on_create(&worktree_path, git_dir, project_root);
+    crate::core::shared::report_link_results(&link_result, &planned_shared, sink);
+
+    let post_hook_ctx = HookContext::new(
+        HookType::PostCreate,
+        "checkout",
+        project_root,
+        git_dir,
+        &params.remote_name,
+        &source_worktree,
+        &worktree_path,
+        "",
+    )
+    .with_new_branch(false)
+    .with_commit(&params.commit);
+
+    let post_hook_outcome = sink.run_hook(&post_hook_ctx)?;
+
+    Ok(SandboxResult {
+        dirname: params.dirname.clone(),
+        worktree_path,
+        commit: params.commit.clone(),
+        already_existed: false,
+        cd_target: get_current_directory()?,
+        git_dir: git_dir.to_path_buf(),
+        stash_applied,
+        stash_conflict,
+        post_hook_outcome,
+    })
+}
+
+/// Enter an existing sandbox: the navigation arm shared by both idempotence
+/// lookups and the on-disk fallback.
+///
+/// Deliberately does *not* observe into the identity store: `observe_all`
+/// fills in missing records as branch identities, which would mislabel a
+/// foreign detached worktree the moment someone visited it.
+fn navigate(
+    dirname: &str,
+    worktree_path: &Path,
+    commit: &str,
+    git_dir: &Path,
+    sink: &mut impl ProgressSink,
+) -> Result<SandboxResult> {
+    sink.on_step(&format!(
+        "Sandbox '{dirname}' already exists at '{}', switching to it",
+        worktree_path.display()
+    ));
+    change_directory(worktree_path)?;
+    Ok(SandboxResult {
+        dirname: dirname.to_string(),
+        worktree_path: worktree_path.to_path_buf(),
+        commit: commit.to_string(),
+        already_existed: true,
+        cd_target: get_current_directory()?,
+        git_dir: git_dir.to_path_buf(),
+        stash_applied: false,
+        stash_conflict: false,
+        post_hook_outcome: HookOutcome {
+            success: true,
+            skipped: true,
+            skip_reason: None,
+        },
+    })
+}
+
+/// Detached, non-bare porcelain entries — the only worktrees a sandbox
+/// lookup may ever match.
+fn detached_entries(git: &GitCommand) -> Result<Vec<super::porcelain::WorktreeListEntry>> {
+    let porcelain = git.worktree_list_porcelain()?;
+    Ok(super::porcelain::parse_worktree_list_porcelain(&porcelain)
+        .into_iter()
+        .filter(|e| !e.is_bare && e.is_detached)
+        .collect())
+}
+
+/// The identity record for the worktree at `path`, if any.
+fn record_for<'a>(
+    records: &'a std::collections::HashMap<String, WorktreeIdentityRow>,
+    path: &Path,
+) -> Option<&'a WorktreeIdentityRow> {
+    let id = super::identity_store::worktree_id_for(path)?;
+    records.get(&id)
+}
+
+/// Stash uncommitted changes when carry is on. Same contract as checkout's,
+/// minus the `CheckoutParams` coupling.
+fn stash_if_carry(
+    should_carry: bool,
+    git: &GitCommand,
+    sink: &mut impl ProgressSink,
+) -> Result<bool> {
+    let in_worktree = git.rev_parse_is_inside_work_tree().unwrap_or(false);
+    if !(should_carry && in_worktree) {
+        return Ok(false);
+    }
+    match git.has_uncommitted_changes() {
+        Ok(true) => {
+            sink.on_step("Stashing uncommitted changes...");
+            if let Err(e) = git.stash_push_with_untracked("daft: carry changes to worktree") {
+                anyhow::bail!("Failed to stash uncommitted changes: {e}");
+            }
+            Ok(true)
+        }
+        Ok(false) => {
+            sink.on_step("No uncommitted changes to carry");
+            Ok(false)
+        }
+        Err(e) => {
+            sink.on_warning(&format!("Could not check for uncommitted changes: {e}"));
+            Ok(false)
+        }
+    }
+}
+
+/// Restore stashed changes when sandbox creation fails.
+fn restore_stash_on_failure(stash_created: bool, git: &GitCommand, sink: &mut impl ProgressSink) {
+    if stash_created {
+        sink.on_step("Restoring stashed changes due to worktree creation failure...");
+        if let Err(pop_err) = git.stash_pop() {
+            sink.on_warning(&format!(
+                "Your changes are still in the stash. Run 'git stash pop' to restore them. \
+                 Error: {pop_err}"
+            ));
+        }
+    }
+}
+
+/// Apply stashed changes inside the new sandbox.
+fn apply_stash(
+    stash_created: bool,
+    git: &GitCommand,
+    sink: &mut impl ProgressSink,
+) -> (bool, bool) {
+    if !stash_created {
+        return (false, false);
+    }
+    sink.on_step("Applying stashed changes to worktree...");
+    if let Err(e) = git.stash_pop() {
+        sink.on_warning(&format!(
+            "Stash could not be applied cleanly. Resolve conflicts and run 'git stash pop'. \
+             Error: {e}"
+        ));
+        (false, true)
+    } else {
+        sink.on_step("Changes successfully applied to worktree");
+        (true, false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::NullBridge;
+    use serial_test::serial;
+
+    // ── sandbox_dirname (pure) ──────────────────────────────────────────────
+
+    #[test]
+    fn stable_spellings_name_themselves() {
+        assert_eq!(sandbox_dirname("v1.18.0").as_deref(), Some("v1.18.0"));
+        assert_eq!(
+            sandbox_dirname("origin/master").as_deref(),
+            Some("origin-master")
+        );
+        assert_eq!(sandbox_dirname("rc_2").as_deref(), Some("rc_2"));
+        // Containing HEAD is not being a HEAD pseudo-ref.
+        assert_eq!(
+            sandbox_dirname("release-HEAD-x").as_deref(),
+            Some("release-HEAD-x")
+        );
+        // Hex below object-id length is a legitimate tag-like name.
+        assert_eq!(sandbox_dirname("abc123d").as_deref(), Some("abc123d"));
+    }
+
+    #[test]
+    fn derived_spellings_yield_none() {
+        // Position expressions: their spelling names a different commit
+        // tomorrow.
+        assert_eq!(sandbox_dirname("HEAD"), None);
+        assert_eq!(sandbox_dirname("HEAD~2"), None);
+        assert_eq!(sandbox_dirname("FETCH_HEAD"), None);
+        assert_eq!(sandbox_dirname("ORIG_HEAD"), None);
+        assert_eq!(sandbox_dirname("@{-1}"), None);
+        assert_eq!(sandbox_dirname("master^0"), None);
+        assert_eq!(sandbox_dirname("v1^{}"), None);
+        // Full object ids are positions too.
+        assert_eq!(sandbox_dirname(&"a".repeat(40)), None);
+        assert_eq!(sandbox_dirname(&"0123456789abcdef".repeat(4)), None);
+    }
+
+    #[test]
+    fn hostile_spellings_yield_none() {
+        assert_eq!(sandbox_dirname(""), None);
+        assert_eq!(sandbox_dirname("-rf"), None);
+        assert_eq!(sandbox_dirname(".hidden"), None);
+        assert_eq!(sandbox_dirname("/etc/passwd"), None);
+        assert_eq!(sandbox_dirname("a/../b"), None);
+        assert_eq!(sandbox_dirname("with space"), None);
+        assert_eq!(sandbox_dirname("semi;colon"), None);
+    }
+
+    #[test]
+    fn derived_dirname_is_a_hex_prefix() {
+        let oid = "0123456789abcdef0123456789abcdef01234567";
+        assert_eq!(derived_dirname(oid), "0123456789ab");
+        assert_eq!(short_oid(oid), "0123456");
+    }
+
+    // ── execute_visit / execute_create (real git) ───────────────────────────
+
+    fn git(dir: &Path, args: &[&str]) {
+        // Ambient user config must not steer the fixture: a global
+        // `tag.gpgSign`/`commit.gpgsign` would turn `git tag v1` into an
+        // annotated signing prompt ("fatal: no tag message?").
+        let out = crate::utils::git_command_at(dir)
+            .args(["-c", "commit.gpgsign=false", "-c", "tag.gpgSign=false"])
+            .args(args)
+            .env("GIT_AUTHOR_NAME", "Test")
+            .env("GIT_AUTHOR_EMAIL", "test@test.com")
+            .env("GIT_COMMITTER_NAME", "Test")
+            .env("GIT_COMMITTER_EMAIL", "test@test.com")
+            .output()
+            .expect("git runs");
+        assert!(
+            out.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    fn git_out(dir: &Path, args: &[&str]) -> String {
+        let out = crate::utils::git_command_at(dir)
+            .args(args)
+            .output()
+            .unwrap();
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
+    }
+
+    /// Restore the test process's cwd on drop — `execute_*` chdirs into the
+    /// sandbox it creates.
+    struct CwdGuard {
+        original: PathBuf,
+    }
+    impl CwdGuard {
+        fn new() -> Self {
+            Self {
+                original: std::env::current_dir().expect("cwd readable"),
+            }
+        }
+    }
+    impl Drop for CwdGuard {
+        fn drop(&mut self) {
+            let _ = std::env::set_current_dir(&self.original);
+        }
+    }
+
+    /// A repo with two commits and tag `v1` on the first. Returns
+    /// (tempdir, repo path, v1's full OID).
+    fn repo_with_tag() -> (tempfile::TempDir, PathBuf, String) {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        git(&repo, &["init", "-q", "-b", "main"]);
+        git(&repo, &["commit", "--allow-empty", "-q", "-m", "one"]);
+        git(&repo, &["tag", "v1"]);
+        git(&repo, &["commit", "--allow-empty", "-q", "-m", "two"]);
+        let oid = git_out(&repo, &["rev-parse", "v1^{commit}"]);
+        (tmp, repo, oid)
+    }
+
+    fn params(spelling: &str, commit: &str, kind: WorktreeKind, at: PathBuf) -> SandboxParams {
+        SandboxParams {
+            spelling: spelling.to_string(),
+            commit: commit.to_string(),
+            dirname: at.file_name().unwrap().to_string_lossy().into_owned(),
+            kind,
+            path_preclaimed: false,
+            carry: false,
+            no_carry: true,
+            checkout_carry: false,
+            remote: None,
+            remote_name: "origin".to_string(),
+            multi_remote_enabled: false,
+            multi_remote_default: "origin".to_string(),
+            layout: None,
+            at_path: Some(at),
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn a_visit_materializes_a_detached_worktree_and_records_provenance() {
+        let _state = crate::store::paths::IsolatedStateDir::new();
+        let _cwd = CwdGuard::new();
+        let (tmp, repo, oid) = repo_with_tag();
+        std::env::set_current_dir(&repo).unwrap();
+
+        let wt = tmp.path().join("v1");
+        let result = execute_visit(
+            &params("v1", &oid, WorktreeKind::Canonical, wt.clone()),
+            &GitCommand::new(true),
+            &repo,
+            &mut NullBridge,
+        )
+        .expect("visit materializes");
+
+        assert!(!result.already_existed);
+        assert!(wt.join(".git").is_file(), "a linked worktree was created");
+        assert_eq!(git_out(&wt, &["rev-parse", "HEAD"]), oid, "pinned at v1");
+        assert_eq!(
+            git_out(&wt, &["symbolic-ref", "-q", "HEAD"]),
+            "",
+            "HEAD is detached"
+        );
+
+        let records = super::super::identity_store::read_identities(&repo.join(".git"));
+        let row = records
+            .values()
+            .find(|r| r.branch == "v1")
+            .expect("recorded");
+        assert_eq!(row.kind, WorktreeKind::Canonical);
+        assert_eq!(row.source_spelling.as_deref(), Some("v1"));
+        assert_eq!(row.pinned_commit.as_deref(), Some(oid.as_str()));
+    }
+
+    #[test]
+    #[serial]
+    fn revisiting_the_same_spelling_navigates_instead_of_creating() {
+        let _state = crate::store::paths::IsolatedStateDir::new();
+        let _cwd = CwdGuard::new();
+        let (tmp, repo, oid) = repo_with_tag();
+        std::env::set_current_dir(&repo).unwrap();
+
+        let wt = tmp.path().join("v1");
+        let p = params("v1", &oid, WorktreeKind::Canonical, wt.clone());
+        execute_visit(&p, &GitCommand::new(true), &repo, &mut NullBridge).unwrap();
+        std::env::set_current_dir(&repo).unwrap();
+
+        let second = execute_visit(&p, &GitCommand::new(true), &repo, &mut NullBridge)
+            .expect("revisit succeeds");
+        assert!(second.already_existed, "the second visit navigates");
+        assert_eq!(second.worktree_path.file_name().unwrap(), "v1");
+    }
+
+    /// Different spellings of one commit converge on one canonical sandbox:
+    /// the tag created it, the raw SHA finds it by pinned commit.
+    #[test]
+    #[serial]
+    fn a_derived_spelling_of_the_same_commit_converges_by_pin() {
+        let _state = crate::store::paths::IsolatedStateDir::new();
+        let _cwd = CwdGuard::new();
+        let (tmp, repo, oid) = repo_with_tag();
+        std::env::set_current_dir(&repo).unwrap();
+
+        let wt = tmp.path().join("v1");
+        execute_visit(
+            &params("v1", &oid, WorktreeKind::Canonical, wt.clone()),
+            &GitCommand::new(true),
+            &repo,
+            &mut NullBridge,
+        )
+        .unwrap();
+        std::env::set_current_dir(&repo).unwrap();
+
+        // Visit again by the full OID: dirname would be derived, but the
+        // commit-keyed lookup lands in the tag's sandbox.
+        let by_sha = params(
+            &oid.clone(),
+            &oid,
+            WorktreeKind::Canonical,
+            tmp.path().join(derived_dirname(&oid)),
+        );
+        let result = execute_visit(&by_sha, &GitCommand::new(true), &repo, &mut NullBridge)
+            .expect("the sha visit resolves");
+        assert!(result.already_existed);
+        assert_eq!(
+            result.worktree_path.file_name().unwrap(),
+            "v1",
+            "one commit, one canonical sandbox"
+        );
+    }
+
+    /// Forks are private: a visit at the same commit must never route into
+    /// one, even when it is the only worktree pinned there.
+    #[test]
+    #[serial]
+    fn a_visit_never_enters_a_fork_pinned_at_the_same_commit() {
+        let _state = crate::store::paths::IsolatedStateDir::new();
+        let _cwd = CwdGuard::new();
+        let (tmp, repo, oid) = repo_with_tag();
+        std::env::set_current_dir(&repo).unwrap();
+
+        let fork_wt = tmp.path().join("main-fork");
+        execute_create(
+            &params("HEAD", &oid, WorktreeKind::Fork, fork_wt.clone()),
+            &GitCommand::new(true),
+            &repo,
+            &mut NullBridge,
+        )
+        .expect("fork creation succeeds");
+        std::env::set_current_dir(&repo).unwrap();
+
+        let visit_wt = tmp.path().join(derived_dirname(&oid));
+        let result = execute_visit(
+            &params(
+                &oid.clone(),
+                &oid,
+                WorktreeKind::Canonical,
+                visit_wt.clone(),
+            ),
+            &GitCommand::new(true),
+            &repo,
+            &mut NullBridge,
+        )
+        .expect("the visit creates its own sandbox");
+        assert!(!result.already_existed, "the fork was not matched");
+        assert_ne!(result.worktree_path, fork_wt);
+    }
+
+    /// The hook context on the sandbox path is branchless: an empty branch
+    /// name plus the pinned commit.
+    #[test]
+    #[serial]
+    fn sandbox_hooks_get_the_branchless_context() {
+        struct RecordingRunner {
+            contexts: Vec<(String, Option<String>)>,
+        }
+        impl ProgressSink for RecordingRunner {
+            fn on_step(&mut self, _msg: &str) {}
+            fn on_warning(&mut self, _msg: &str) {}
+            fn on_debug(&mut self, _msg: &str) {}
+        }
+        impl HookRunner for RecordingRunner {
+            fn run_hook(&mut self, ctx: &HookContext) -> Result<HookOutcome> {
+                self.contexts
+                    .push((ctx.branch_name.clone(), ctx.commit.clone()));
+                Ok(HookOutcome {
+                    success: true,
+                    skipped: true,
+                    skip_reason: None,
+                })
+            }
+        }
+
+        let _state = crate::store::paths::IsolatedStateDir::new();
+        let _cwd = CwdGuard::new();
+        let (tmp, repo, oid) = repo_with_tag();
+        std::env::set_current_dir(&repo).unwrap();
+
+        let mut sink = RecordingRunner { contexts: vec![] };
+        execute_visit(
+            &params("v1", &oid, WorktreeKind::Canonical, tmp.path().join("v1")),
+            &GitCommand::new(true),
+            &repo,
+            &mut sink,
+        )
+        .unwrap();
+
+        assert_eq!(sink.contexts.len(), 2, "pre- and post-create hooks fired");
+        for (branch, commit) in &sink.contexts {
+            assert_eq!(branch, "", "sandbox hooks see no branch");
+            assert_eq!(commit.as_deref(), Some(oid.as_str()));
+        }
+    }
+
+    /// `execute_create` never reuses: two creations at one commit are two
+    /// worktrees.
+    #[test]
+    #[serial]
+    fn create_is_never_idempotent() {
+        let _state = crate::store::paths::IsolatedStateDir::new();
+        let _cwd = CwdGuard::new();
+        let (tmp, repo, oid) = repo_with_tag();
+        std::env::set_current_dir(&repo).unwrap();
+
+        let first = tmp.path().join("main-fork");
+        let second = tmp.path().join("main-fork-2");
+        for wt in [&first, &second] {
+            std::env::set_current_dir(&repo).unwrap();
+            let result = execute_create(
+                &params("HEAD", &oid, WorktreeKind::Fork, wt.clone()),
+                &GitCommand::new(true),
+                &repo,
+                &mut NullBridge,
+            )
+            .expect("fork creation succeeds");
+            assert!(!result.already_existed);
+        }
+        assert!(first.join(".git").is_file());
+        assert!(second.join(".git").is_file());
+    }
+}

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -67,6 +67,34 @@ impl GitCommand {
         Ok(())
     }
 
+    /// `git worktree add --detach <path> <commit-ish>` — a worktree pinned at
+    /// a commit with no branch attached (an anonymous sandbox).
+    ///
+    /// Callers pass the resolved full OID, never the user's spelling: rev
+    /// syntax has already been resolved by then, and a symbolic spelling like
+    /// `origin/master` would make git print misleading tracking hints.
+    pub fn worktree_add_detached(&self, path: &Path, commitish: &str) -> Result<()> {
+        let mut cmd = Command::new("git");
+        cmd.args(["worktree", "add", "--detach"]);
+
+        if self.quiet {
+            cmd.arg("--quiet");
+        }
+
+        cmd.arg(path).arg(commitish);
+
+        let output = cmd
+            .output()
+            .context("Failed to execute git worktree add command")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("Git worktree add failed: {}", stderr);
+        }
+
+        Ok(())
+    }
+
     pub fn worktree_add_orphan(&self, path: &Path, branch_name: &str) -> Result<()> {
         let mut cmd = Command::new("git");
         cmd.args(["worktree", "add", "--orphan"]);

--- a/src/hooks/environment.rs
+++ b/src/hooks/environment.rs
@@ -35,8 +35,14 @@ pub struct HookContext {
     /// Target worktree (being created or removed).
     pub worktree_path: PathBuf,
 
-    /// Branch name (for the target worktree).
+    /// Branch name (for the target worktree). Empty for a branchless
+    /// (anonymous sandbox) worktree — the contract is "empty string means no
+    /// branch", and `commit` carries the identity instead.
     pub branch_name: String,
+
+    /// The commit a branchless worktree is pinned at (full OID). Set by the
+    /// sandbox creation/removal paths; `None` for ordinary branch worktrees.
+    pub commit: Option<String>,
 
     /// Whether the branch is newly created.
     pub is_new_branch: bool,
@@ -127,6 +133,7 @@ impl HookContext {
             source_worktree: source_worktree.into(),
             worktree_path: worktree_path.into(),
             branch_name: branch_name.into(),
+            commit: None,
             is_new_branch: false,
             base_branch: None,
             repository_url: None,
@@ -203,6 +210,12 @@ impl HookContext {
         self
     }
 
+    /// Set the pinned commit (for branchless sandbox worktrees).
+    pub fn with_commit(mut self, commit: impl Into<String>) -> Self {
+        self.commit = Some(commit.into());
+        self
+    }
+
     /// Set the repository URL (for clone operations).
     pub fn with_repository_url(mut self, url: impl Into<String>) -> Self {
         self.repository_url = Some(url.into());
@@ -254,6 +267,11 @@ impl HookEnvironment {
         // Worktree-specific variables
         env.set("DAFT_WORKTREE_PATH", ctx.worktree_path.display());
         env.set("DAFT_BRANCH_NAME", &ctx.branch_name);
+        // Branchless (sandbox) worktrees: DAFT_BRANCH_NAME is "" and the
+        // pinned commit carries the identity.
+        if let Some(ref commit) = ctx.commit {
+            env.set("DAFT_COMMIT", commit);
+        }
 
         // Creation-specific variables
         env.set(
@@ -422,6 +440,34 @@ mod tests {
         assert_eq!(env.get("DAFT_BASE_BRANCH"), Some("main"));
     }
 
+    /// The branchless (sandbox) contract: DAFT_BRANCH_NAME is the empty
+    /// string and DAFT_COMMIT carries the pinned OID. Ordinary branch
+    /// contexts emit no DAFT_COMMIT at all.
+    #[test]
+    fn test_hook_environment_branchless_sandbox_context() {
+        let ctx = HookContext::new(
+            HookType::PostCreate,
+            "checkout",
+            "/project",
+            "/project/.git",
+            "origin",
+            "/project/main",
+            "/project/v1",
+            "",
+        )
+        .with_commit("abc123def4567890abc123def4567890abc123de");
+        let env = HookEnvironment::from_context(&ctx);
+
+        assert_eq!(env.get("DAFT_BRANCH_NAME"), Some(""));
+        assert_eq!(
+            env.get("DAFT_COMMIT"),
+            Some("abc123def4567890abc123def4567890abc123de")
+        );
+
+        let branch_env = HookEnvironment::from_context(&make_test_context());
+        assert_eq!(branch_env.get("DAFT_COMMIT"), None);
+    }
+
     #[test]
     fn test_hook_environment_clone_vars() {
         let ctx = HookContext::new(
@@ -550,6 +596,7 @@ mod tests {
             source_worktree: PathBuf::from("/project/old-wt"),
             worktree_path: PathBuf::from("/project/new-wt"),
             branch_name: "feat/new-name".to_string(),
+            commit: None,
             is_new_branch: false,
             base_branch: None,
             repository_url: None,
@@ -586,6 +633,7 @@ mod tests {
             source_worktree: PathBuf::from("/project/src-wt"),
             worktree_path: PathBuf::from("/project/new-wt"),
             branch_name: "feat/new".to_string(),
+            commit: None,
             is_new_branch: true,
             base_branch: None,
             repository_url: None,

--- a/src/hooks/environment.rs
+++ b/src/hooks/environment.rs
@@ -216,6 +216,22 @@ impl HookContext {
         self
     }
 
+    /// The label background-job invocations are registered under — and the
+    /// label removal cancels by. Branch worktrees use the branch name; a
+    /// branchless sandbox (empty `branch_name`) uses the worktree's
+    /// directory name, matching how `daft remove` addresses it. Registering
+    /// under the empty string would orphan a sandbox's jobs: nothing ever
+    /// cancels the `""` label.
+    pub fn worktree_label(&self) -> &str {
+        if !self.branch_name.is_empty() {
+            return &self.branch_name;
+        }
+        self.worktree_path
+            .file_name()
+            .and_then(|f| f.to_str())
+            .unwrap_or("")
+    }
+
     /// Set the repository URL (for clone operations).
     pub fn with_repository_url(mut self, url: impl Into<String>) -> Self {
         self.repository_url = Some(url.into());
@@ -369,6 +385,28 @@ mod tests {
             "/project/feature/new",
             "feature/new",
         )
+    }
+
+    /// Branch worktrees label their background-job invocations by branch
+    /// name; a branchless sandbox labels them by the worktree's directory
+    /// name — the same key `daft remove` cancels by. An empty label would
+    /// orphan the sandbox's jobs on removal (#53 review).
+    #[test]
+    fn worktree_label_falls_back_to_the_dirname_for_branchless_contexts() {
+        let branch_ctx = make_test_context();
+        assert_eq!(branch_ctx.worktree_label(), "feature/new");
+
+        let sandbox_ctx = HookContext::new(
+            HookType::PostCreate,
+            "checkout",
+            "/project",
+            "/project/.git",
+            "origin",
+            "/project/main",
+            "/project/origin-master",
+            "",
+        );
+        assert_eq!(sandbox_ctx.worktree_label(), "origin-master");
     }
 
     #[test]

--- a/src/hooks/executor.rs
+++ b/src/hooks/executor.rs
@@ -187,14 +187,15 @@ pub(crate) fn get_hook_source_worktree(ctx: &HookContext) -> PathBuf {
 /// Pick the display target shown alongside the hook name in the rich
 /// hook-box title (e.g. `worktree-pre-remove  on: feature`).
 ///
-/// Worktree-scoped phases get the branch they're acting on so multi-source
+/// Worktree-scoped phases get the worktree label they're acting on — the
+/// branch, or the dirname for branchless sandbox contexts — so multi-source
 /// flows make it obvious which worktree the hooks are touching. Project-
 /// scoped phases (`pre-merge` / `post-merge` / `post-clone`) return `None`
 /// because the title isn't tied to a single worktree.
 pub(crate) fn header_target_for_ctx(ctx: &HookContext) -> Option<&str> {
     match ctx.hook_type {
         HookType::PreCreate | HookType::PostCreate | HookType::PreRemove | HookType::PostRemove => {
-            Some(ctx.branch_name.as_str())
+            Some(ctx.worktree_label())
         }
         HookType::PreMerge | HookType::PostMerge | HookType::PostClone => None,
     }

--- a/src/hooks/template.rs
+++ b/src/hooks/template.rs
@@ -13,6 +13,7 @@ use super::environment::HookContext;
 /// - `{worktree_root}` — project root directory
 /// - `{worktree_slug}` — sanitized worktree name, safe for docker/DNS use
 /// - `{branch}` — alias for `{worktree_branch}`
+/// - `{commit}` — pinned commit OID (branchless sandbox worktrees only)
 /// - `{job_name}` — name of the current job (if provided)
 /// - `{source_worktree}` — source worktree path
 /// - `{git_dir}` — path to .git directory
@@ -42,6 +43,10 @@ pub fn substitute(command: &str, ctx: &HookContext, job_name: Option<&str>) -> S
 
     if let Some(ref base) = ctx.base_branch {
         result = result.replace("{base_branch}", base);
+    }
+
+    if let Some(ref commit) = ctx.commit {
+        result = result.replace("{commit}", commit);
     }
 
     if let Some(ref url) = ctx.repository_url {
@@ -182,6 +187,32 @@ mod tests {
         assert_eq!(result, "git diff main");
     }
 
+    /// `{commit}` substitutes only on the branchless sandbox path; `{branch}`
+    /// there is the empty string by contract.
+    #[test]
+    fn test_commit_substitution_on_the_sandbox_path() {
+        let ctx = HookContext::new(
+            HookType::PostCreate,
+            "checkout",
+            "/project",
+            "/project/.git",
+            "origin",
+            "/project/main",
+            "/project/v1",
+            "",
+        )
+        .with_commit("abc123d");
+        assert_eq!(
+            substitute("build {commit} on '{branch}'", &ctx, None),
+            "build abc123d on ''"
+        );
+        // Without a commit the placeholder is left alone, like {base_branch}.
+        assert_eq!(
+            substitute("echo {commit}", &make_ctx(), None),
+            "echo {commit}"
+        );
+    }
+
     #[test]
     fn test_worktree_slug_nested_relative_path() {
         // make_ctx: worktree /project/feature/new under root /project.
@@ -243,6 +274,7 @@ mod tests {
             source_worktree: PathBuf::from("/project/old-wt"),
             worktree_path: PathBuf::from("/project/new-wt"),
             branch_name: "feat/new".to_string(),
+            commit: None,
             is_new_branch: false,
             base_branch: None,
             repository_url: None,
@@ -279,6 +311,7 @@ mod tests {
             source_worktree: PathBuf::from("/project/src"),
             worktree_path: PathBuf::from("/project/wt"),
             branch_name: "feat/x".to_string(),
+            commit: None,
             is_new_branch: true,
             base_branch: None,
             repository_url: None,

--- a/src/hooks/yaml_executor/mod.rs
+++ b/src/hooks/yaml_executor/mod.rs
@@ -678,7 +678,7 @@ pub fn execute_yaml_hook_with_rc(
     {
         let mut coord_state =
             crate::coordinator::process::CoordinatorState::new(&repo_hash, &invocation_id)
-                .with_metadata(&trigger_command, hook_name, &ctx.branch_name)
+                .with_metadata(&trigger_command, hook_name, ctx.worktree_label())
                 .with_prefailed(prefailed_bg);
         for spec in bg_specs {
             coord_state.add_job(spec);

--- a/src/output/format.rs
+++ b/src/output/format.rs
@@ -454,8 +454,13 @@ pub fn format_worktree_status(info: &WorktreeInfo) -> String {
         if info.drifted {
             return "drifted".to_string();
         }
-        if info.identity_source == Some(crate::core::worktree::identity::IdentitySource::Persisted)
-        {
+        if matches!(
+            info.identity_source,
+            Some(
+                crate::core::worktree::identity::IdentitySource::Persisted
+                    | crate::core::worktree::identity::IdentitySource::Sandbox
+            )
+        ) {
             return match &info.last_commit_hash {
                 Some(hash) => String::from("detached @ ") + hash,
                 None => "detached".to_string(),

--- a/src/output/tui/columns.rs
+++ b/src/output/tui/columns.rs
@@ -15,8 +15,8 @@ pub enum Column {
     /// Paused git operation and conflict state, in words. The opt-in
     /// `daft list --columns +status` column.
     BranchStatus,
-    /// Branch name.
-    Branch,
+    /// Worktree name: branch name, or sandbox dirname for detached sandboxes.
+    Name,
     /// Worktree path.
     Path,
     /// Disk size of worktree. Opt-in only (requires `--columns +size`); not in
@@ -50,7 +50,7 @@ impl Column {
             Self::Status => "Status",
             Self::Annotation => "",
             Self::BranchStatus => "Status",
-            Self::Branch => "Branch",
+            Self::Name => "Name",
             Self::Path => "Path",
             Self::Size => "Size",
             Self::Base => "Base",
@@ -69,7 +69,7 @@ impl Column {
         match lc {
             ListColumn::Annotation => Column::Annotation,
             ListColumn::Status => Column::BranchStatus,
-            ListColumn::Branch => Column::Branch,
+            ListColumn::Name => Column::Name,
             ListColumn::Path => Column::Path,
             ListColumn::Size => Column::Size,
             ListColumn::Base => Column::Base,
@@ -91,7 +91,7 @@ impl Column {
             Self::Status => None,
             Self::Annotation => Some(ListColumn::Annotation),
             Self::BranchStatus => Some(ListColumn::Status),
-            Self::Branch => Some(ListColumn::Branch),
+            Self::Name => Some(ListColumn::Name),
             Self::Path => Some(ListColumn::Path),
             Self::Size => Some(ListColumn::Size),
             Self::Base => Some(ListColumn::Base),
@@ -113,7 +113,7 @@ impl Column {
 pub(super) const ALL_COLUMNS: &[Column] = &[
     Column::Status,
     Column::Annotation,
-    Column::Branch,
+    Column::Name,
     Column::Path,
     Column::Base,
     Column::Changes,
@@ -196,7 +196,7 @@ pub(super) fn column_content_width(
             // is painted from the same value, so the two cannot disagree.
             Column::Annotation => annotation_slots.width() as u16,
             Column::BranchStatus => v.status.chars().count() as u16,
-            Column::Branch => v.branch.len() as u16,
+            Column::Name => v.branch.len() as u16,
             Column::Path => v.path.len() as u16,
             Column::Size => v.size.len() as u16,
             Column::Base => v.base.len() as u16,
@@ -238,7 +238,7 @@ const COLUMN_SPACING: u16 = 2;
 
 /// Adjust per-column natural widths so the table fits in `available` width.
 ///
-/// Shrinks the widest of {Branch, Path, LastCommit} down to per-column
+/// Shrinks the widest of {Name, Path, LastCommit} down to per-column
 /// minimums until the table fits, mirroring `tabled::Width::truncate(...)
 /// .priority(Priority::max(true))` from the blocking renderer. Returns the
 /// natural widths unchanged when they already fit.
@@ -260,7 +260,7 @@ pub(super) fn fit_widths_to_available(
 
     let shrink_min = |c: Column| -> Option<u16> {
         match c {
-            Column::Branch => Some(BRANCH_MIN_WIDTH),
+            Column::Name => Some(BRANCH_MIN_WIDTH),
             Column::Path => Some(PATH_MIN_WIDTH),
             Column::LastCommit => Some(LAST_COMMIT_MIN),
             _ => None,
@@ -356,7 +356,7 @@ mod tests {
 
     #[test]
     fn fit_widths_passthrough_when_total_fits() {
-        let cols = vec![Column::Branch, Column::Path, Column::Age];
+        let cols = vec![Column::Name, Column::Path, Column::Age];
         let natural = vec![20, 30, 4];
         let out = fit_widths_to_available(&cols, &natural, 200);
         assert_eq!(out, natural);
@@ -367,7 +367,7 @@ mod tests {
         // Branch=80, Path=60, total+spacing = 142. Available = 100.
         // Path is wider, should be shrunk first; Branch shrinks once Path
         // catches it.
-        let cols = vec![Column::Branch, Column::Path];
+        let cols = vec![Column::Name, Column::Path];
         let natural = vec![80, 60];
         let out = fit_widths_to_available(&cols, &natural, 100);
         let total: u16 = out.iter().sum::<u16>() + 2;
@@ -380,7 +380,7 @@ mod tests {
     fn fit_widths_shrinks_lastcommit_too() {
         // LastCommit is the widest, so it should be shrunk first when the
         // table doesn't fit.
-        let cols = vec![Column::Branch, Column::Path, Column::LastCommit];
+        let cols = vec![Column::Name, Column::Path, Column::LastCommit];
         let natural = vec![20, 20, 200];
         let out = fit_widths_to_available(&cols, &natural, 100);
         let total: u16 = out.iter().sum::<u16>() + 4; // 2 gaps = 4
@@ -396,7 +396,7 @@ mod tests {
     fn fit_widths_lastcommit_keeps_room_when_branch_path_huge() {
         // Branch=200, Path=200, LastCommit=80. Total way over. The widest-first
         // policy should shrink Branch and Path before touching LastCommit.
-        let cols = vec![Column::Branch, Column::Path, Column::LastCommit];
+        let cols = vec![Column::Name, Column::Path, Column::LastCommit];
         let natural = vec![200, 200, 80];
         let out = fit_widths_to_available(&cols, &natural, 160);
         let total: u16 = out.iter().sum::<u16>() + 4;
@@ -414,7 +414,7 @@ mod tests {
     fn fit_widths_stops_at_minimums() {
         // Even an absurdly narrow terminal shouldn't shrink Branch/Path below
         // their minimum widths.
-        let cols = vec![Column::Branch, Column::Path];
+        let cols = vec![Column::Name, Column::Path];
         let natural = vec![100, 100];
         let out = fit_widths_to_available(&cols, &natural, 10);
         assert_eq!(out[0], BRANCH_MIN_WIDTH);

--- a/src/output/tui/live_table.rs
+++ b/src/output/tui/live_table.rs
@@ -98,16 +98,14 @@ impl LiveTable {
         // the default branch row in `daft prune` / `daft sync`). Synthesized
         // open-PR rows are seed-final by definition — everything they show
         // came from the forge cache and no collector targets them — so every
-        // cell is marked received (blank means blank, not loading).
+        // cell is marked received (blank means blank, not loading). A
+        // branchless row (sandbox / foreign detached) additionally settles
+        // its BRANCH_KEYED cells: the collector masks those out for it, so
+        // without this they'd shimmer until the whole collection completes
+        // and only then read as blank.
         let received_patches = seed
             .iter()
-            .map(|info| {
-                if info.kind == EntryKind::ForgePr {
-                    FieldSet::ALL
-                } else {
-                    cfg.seeded_fields
-                }
-            })
+            .map(|info| Self::seed_received(info, cfg.seeded_fields))
             .collect();
         let rows: Vec<WorktreeRow> = seed.into_iter().map(WorktreeRow::idle).collect();
         // A cell is stale when the caller pre-populated its value (only SIZE
@@ -337,17 +335,30 @@ impl LiveTable {
     /// should extend this API rather than rely on the default.
     pub fn push_row(&mut self, info: WorktreeInfo) {
         // Synthesized open-PR rows are seed-final wherever they enter (see
-        // `new`); other dynamic rows start all-loading as documented above.
-        let received = if info.kind == EntryKind::ForgePr {
-            FieldSet::ALL
-        } else {
-            FieldSet::EMPTY
-        };
+        // `new`); other dynamic rows start all-loading as documented above,
+        // minus the cells the collector could never patch for them.
+        let received = Self::seed_received(&info, FieldSet::EMPTY);
         self.rows.push(WorktreeRow::idle(info));
         self.received_patches.push(received);
         // Dynamically-discovered rows carry no cache seed, so no field is
         // stale — keep the vector length in lockstep with `received_patches`.
         self.stale_fields.push(FieldSet::EMPTY);
+    }
+
+    /// The received-at-seed bits for a row: `base` (the fields this view's
+    /// collector won't stream at all) plus the bits it will never patch for
+    /// this particular row — everything for a seed-final ForgePr row, the
+    /// `BRANCH_KEYED` cells for a branchless one (the collector masks them
+    /// out per-target; see `list_stream::run_worker`).
+    fn seed_received(info: &WorktreeInfo, base: FieldSet) -> FieldSet {
+        if info.kind == EntryKind::ForgePr {
+            return FieldSet::ALL;
+        }
+        if info.branchless {
+            base | FieldSet::BRANCH_KEYED
+        } else {
+            base
+        }
     }
 }
 
@@ -407,6 +418,49 @@ mod tests {
         assert!(!t.collection_complete);
         t.apply_event(&DagEvent::WorktreeInfoCollectionDone);
         assert!(t.collection_complete);
+    }
+
+    /// A branchless row (sandbox / foreign detached) settles its
+    /// branch-keyed cells at seed: the collector never streams them, so
+    /// without the settle they'd shimmer until the whole collection
+    /// completes and only then read as blank (#53).
+    #[test]
+    fn branchless_rows_settle_branch_keyed_cells_at_seed() {
+        let mut sandbox = info("main-fork");
+        sandbox.is_sandbox = true;
+        sandbox.branchless = true;
+        let t = LiveTable::new(vec![info("feat/x"), sandbox], cfg());
+        let idx =
+            |t: &LiveTable, name: &str| t.rows.iter().position(|r| r.info.name == name).unwrap();
+        let b = idx(&t, "feat/x");
+        let s = idx(&t, "main-fork");
+
+        // Path-derived cells stream for both rows...
+        assert!(t.is_cell_loading(b, FieldSet::CHANGES));
+        assert!(t.is_cell_loading(s, FieldSet::CHANGES));
+        assert!(t.is_cell_loading(s, FieldSet::SIZE));
+        // ...branch-keyed cells load only where a branch exists.
+        assert!(t.is_cell_loading(b, FieldSet::BASE_AHEAD_BEHIND));
+        assert!(!t.is_cell_loading(s, FieldSet::BASE_AHEAD_BEHIND));
+        assert!(!t.is_cell_loading(s, FieldSet::OWNER));
+        assert!(!t.is_cell_loading(s, FieldSet::FORGE_REF));
+    }
+
+    /// Dynamically-pushed branchless rows get the same settle as seeded
+    /// ones — `push_row` shares the seeding rule with `new`.
+    #[test]
+    fn push_row_settles_branch_keyed_cells_for_branchless_rows() {
+        let mut t = LiveTable::new(vec![info("feat/x")], cfg());
+        let mut sandbox = info("brave-otter");
+        sandbox.branchless = true;
+        t.push_row(sandbox);
+        let s = t
+            .rows
+            .iter()
+            .position(|r| r.info.name == "brave-otter")
+            .unwrap();
+        assert!(!t.is_cell_loading(s, FieldSet::BASE_AHEAD_BEHIND));
+        assert!(t.is_cell_loading(s, FieldSet::CHANGES));
     }
 
     #[test]

--- a/src/output/tui/render.rs
+++ b/src/output/tui/render.rs
@@ -267,7 +267,7 @@ pub fn render_table(state: &TuiState, frame: &mut Frame, area: Rect) {
             continue;
         }
         match col {
-            Column::Branch => {
+            Column::Name => {
                 for vals in &mut row_vals {
                     vals.branch = truncate_with_ellipsis(&vals.branch, assigned_widths[i]);
                 }
@@ -796,7 +796,7 @@ fn render_cell(
                 ))
             }
         }
-        Column::Branch => Cell::from(vals.branch.clone()),
+        Column::Name => Cell::from(vals.branch.clone()),
         Column::Path => Cell::from(vals.path.clone()),
         Column::Size => {
             if vals.size.is_empty() {
@@ -1205,7 +1205,7 @@ fn format_child_line(
 fn column_plain_text(col: &Column, vals: &ColumnValues) -> String {
     match col {
         Column::BranchStatus => vals.status.clone(),
-        Column::Branch => vals.branch.clone(),
+        Column::Name => vals.branch.clone(),
         Column::Path => vals.path.clone(),
         Column::Size => vals.size.clone(),
         Column::Base => vals.base.clone(),
@@ -1865,8 +1865,7 @@ mod tests {
             .map(|x| buffer[(x, 0)].symbol().to_string())
             .collect();
         for label in [
-            "Status", "Branch", "Path", "Base", "Changes", "Remote", "Age", "Owner", "Hash",
-            "Commit",
+            "Status", "Name", "Path", "Base", "Changes", "Remote", "Age", "Owner", "Hash", "Commit",
         ] {
             assert!(
                 header.contains(label),
@@ -1910,7 +1909,7 @@ mod tests {
             .map(|x| buffer[(x, 0)].symbol().to_string())
             .collect();
         for label in [
-            "Branch", "Path", "Base", "Changes", "Remote", "Age", "Owner", "Commit",
+            "Name", "Path", "Base", "Changes", "Remote", "Age", "Owner", "Commit",
         ] {
             assert!(
                 header.contains(label),
@@ -1944,7 +1943,7 @@ mod tests {
             PathBuf::from("/tmp/test"),
             Stat::Summary,
             0,
-            Some(vec![Column::Branch, Column::Path, Column::Size]),
+            Some(vec![Column::Name, Column::Path, Column::Size]),
             true,
             None,
             None::<SortSpec>,

--- a/src/store/migrate.rs
+++ b/src/store/migrate.rs
@@ -55,11 +55,12 @@ pub fn coordinator_set() -> MigrationSet {
             M::up(include_str!("migrations/007_forge_health.sql")),
             M::up(include_str!("migrations/008_forge_pr_row_fields.sql")),
             M::up(include_str!("migrations/009_worktree_identities.sql")),
+            M::up(include_str!("migrations/010_worktree_identity_kinds.sql")),
         ]),
         // rusqlite_migration's version counter is `migrations.len() as u32`
         // after every migration is applied. Kept as i64 for consistency with
         // the on-disk `user_version` PRAGMA type.
-        current_version: 9,
+        current_version: 10,
     }
 }
 
@@ -327,6 +328,69 @@ mod tests {
             )
             .unwrap();
         assert_eq!(name, "worktree_identities");
+    }
+
+    #[test]
+    fn worktree_identity_kind_columns_exist_after_migration() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("db.sqlite");
+        let mut conn = connection::open_for_test(&path).unwrap();
+        run(&mut conn, &path).unwrap();
+        // 010 appends the sandbox columns to 009's table.
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('worktree_identities')
+                 WHERE name IN ('kind', 'source_spelling', 'pinned_commit')",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 3);
+    }
+
+    /// A row written before 010 must read back as a branch identity: the
+    /// ADD COLUMN default is what upgrades existing stores in place.
+    #[test]
+    fn pre_010_identity_rows_backfill_as_branch_kind() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("db.sqlite");
+        // Not `open_for_test`: that helper migrates a fresh DB to latest,
+        // and this test needs to stop at 009 to plant a legacy row.
+        let mut conn = open_unmigrated(&path);
+
+        // Migrate up to 009 only, insert a legacy row, then finish the run.
+        let through_009 = Migrations::new(vec![
+            M::up(include_str!("migrations/001_initial.sql")),
+            M::up(include_str!("migrations/002_visitor_seeds.sql")),
+            M::up(include_str!("migrations/003_invocation_status.sql")),
+            M::up(include_str!("migrations/004_hook_profiles.sql")),
+            M::up(include_str!("migrations/005_worktree_sizes.sql")),
+            M::up(include_str!("migrations/006_forge_prs.sql")),
+            M::up(include_str!("migrations/007_forge_health.sql")),
+            M::up(include_str!("migrations/008_forge_pr_row_fields.sql")),
+            M::up(include_str!("migrations/009_worktree_identities.sql")),
+        ]);
+        through_009.to_latest(&mut conn).unwrap();
+        conn.execute(
+            "INSERT INTO worktree_identities
+                 (repo_hash, worktree_id, branch, worktree_path, updated_at)
+             VALUES ('r', 'wt-a', 'feat/x', '/tmp/wt-a', '2026-01-01T00:00:00Z')",
+            [],
+        )
+        .unwrap();
+
+        run(&mut conn, &path).unwrap();
+        let (kind, spelling, pinned): (String, Option<String>, Option<String>) = conn
+            .query_row(
+                "SELECT kind, source_spelling, pinned_commit
+                 FROM worktree_identities WHERE worktree_id = 'wt-a'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(kind, "branch");
+        assert_eq!(spelling, None);
+        assert_eq!(pinned, None);
     }
 
     #[test]

--- a/src/store/migrations/010_worktree_identity_kinds.sql
+++ b/src/store/migrations/010_worktree_identity_kinds.sql
@@ -1,0 +1,29 @@
+-- What *kind* of worktree an identity row describes, so the table can carry
+-- anonymous sandboxes (#53) alongside the branch intents it was built for.
+--
+-- 009 records the branch a worktree was created for. Anonymous worktrees
+-- (detached-HEAD sandboxes) have no branch — their identity is the directory
+-- name, and their one durable fact is which commit they were pinned at and
+-- what spelling asked for it. Rather than a sibling table, the same row now
+-- says which of the two it is:
+--
+--   kind = 'branch'     `branch` holds the branch this worktree is for (009's
+--                       meaning, unchanged; the backfill default).
+--   kind = 'canonical'  the shared sandbox `daft go <commit-ish>` visits;
+--                       `branch` holds the sandbox's directory name.
+--   kind = 'fork'       a private sandbox from `daft start --fork`; `branch`
+--                       holds the directory name. Never matched by `go`'s
+--                       resolution — forks are reachable only by name.
+--
+-- `source_spelling` is what the user typed (`v1.18.0`, `origin/master`,
+-- `HEAD~2`); `pinned_commit` is the full OID the sandbox was created at.
+-- Both are NULL on kind='branch' rows. `pinned_commit` is what lets removal
+-- warn when commits were made on top, and what dedupes different spellings
+-- of one commit onto one canonical sandbox.
+--
+-- Every branch-keyed delete must now discriminate on `kind`, or removing a
+-- branch named like a sandbox directory would take the sandbox's record with
+-- it (and vice versa).
+ALTER TABLE worktree_identities ADD COLUMN kind TEXT NOT NULL DEFAULT 'branch';
+ALTER TABLE worktree_identities ADD COLUMN source_spelling TEXT;
+ALTER TABLE worktree_identities ADD COLUMN pinned_commit TEXT;

--- a/src/store/models/mod.rs
+++ b/src/store/models/mod.rs
@@ -28,5 +28,5 @@ pub use job::JobRow;
 pub use repo_policy::RepoPolicyRow;
 pub use repo_size::RepoSizeRow;
 pub use visitor_seed::VisitorSeedRow;
-pub use worktree_identity::WorktreeIdentityRow;
+pub use worktree_identity::{WorktreeIdentityRow, WorktreeKind};
 pub use worktree_size::WorktreeSizeRow;

--- a/src/store/models/worktree_identity.rs
+++ b/src/store/models/worktree_identity.rs
@@ -2,7 +2,55 @@
 
 use chrono::{DateTime, Utc};
 
-/// The branch a worktree was created for.
+/// What kind of worktree an identity row describes.
+///
+/// Discriminates the two meanings the `branch` column can carry: the branch a
+/// worktree is for (`Branch`), or the directory name of an anonymous sandbox
+/// (`Canonical`/`Fork`). Every branch-keyed delete must filter on this, or a
+/// branch removal could take a like-named sandbox's record with it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorktreeKind {
+    /// A worktree created for a branch — the 009 meaning, and the backfill
+    /// default for rows written before the column existed.
+    Branch,
+    /// The shared detached sandbox `daft go <commit-ish>` visits: at most one
+    /// per commit, matched by go's resolution.
+    Canonical,
+    /// A private detached sandbox from `daft start --fork`: never matched by
+    /// go's resolution, reachable only by its directory name.
+    Fork,
+}
+
+impl WorktreeKind {
+    /// Stable on-disk / machine-facing name.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Branch => "branch",
+            Self::Canonical => "canonical",
+            Self::Fork => "fork",
+        }
+    }
+
+    /// Parse the on-disk value. Unknown values (a newer daft's kind) degrade
+    /// to `Branch` — the conservative reading, since branch rows only ever
+    /// gate display fallbacks.
+    pub fn parse(s: &str) -> Self {
+        match s {
+            "canonical" => Self::Canonical,
+            "fork" => Self::Fork,
+            _ => Self::Branch,
+        }
+    }
+
+    /// Whether the row describes an anonymous sandbox rather than a branch
+    /// worktree.
+    pub fn is_sandbox(self) -> bool {
+        !matches!(self, Self::Branch)
+    }
+}
+
+/// The branch a worktree was created for — or, for sandbox rows
+/// (`kind != Branch`), the sandbox's directory-name identity.
 ///
 /// Read only when live git state cannot name the branch — a plain detached
 /// checkout — and as a cross-check for drift. Derived state always wins: this
@@ -14,9 +62,19 @@ pub struct WorktreeIdentityRow {
     /// `<common-dir>/worktrees/`. Stable across `git worktree move` and
     /// branch renames, which is why it is the key rather than the path.
     pub worktree_id: String,
-    /// The branch this worktree is for, e.g. `feat/x`.
+    /// The branch this worktree is for, e.g. `feat/x` — or the directory name
+    /// when `kind` says the row is a sandbox.
     pub branch: String,
     /// Absolute worktree path, for display and eviction.
     pub worktree_path: String,
     pub updated_at: DateTime<Utc>,
+    /// Which meaning `branch` carries; see [`WorktreeKind`].
+    pub kind: WorktreeKind,
+    /// The spelling that created a sandbox (`v1.18.0`, `origin/master`,
+    /// `HEAD~2`). `None` on branch rows.
+    pub source_spelling: Option<String>,
+    /// Full OID a sandbox was pinned at when created. `None` on branch rows.
+    /// Lets removal warn when HEAD moved, and dedupes different spellings of
+    /// one commit onto one canonical sandbox.
+    pub pinned_commit: Option<String>,
 }

--- a/src/store/repos/worktree_identities.rs
+++ b/src/store/repos/worktree_identities.rs
@@ -1,31 +1,40 @@
 //! Queries against the `worktree_identities` table (a worktree's intended branch).
 
 use crate::store::error::Result;
-use crate::store::models::WorktreeIdentityRow;
+use crate::store::models::{WorktreeIdentityRow, WorktreeKind};
 use crate::store::repos::invocations::parse_rfc3339;
 use rusqlite::{Connection, OptionalExtension, params};
 
 pub struct WorktreeIdentitiesRepo;
 
 impl WorktreeIdentitiesRepo {
-    /// Record what branch a worktree is for. The latest observation wins:
-    /// a worktree's intent changes when it is renamed or re-purposed, and
-    /// there is no first-seen worth preserving.
+    /// Record what a worktree is for. The latest observation wins: a
+    /// worktree's intent changes when it is renamed or re-purposed, and
+    /// there is no first-seen worth preserving. Rewrites the whole row —
+    /// including `kind` — so re-purposing a sandbox into a branch worktree
+    /// (or the reverse) leaves no stale sandbox metadata behind.
     pub fn upsert(conn: &Connection, row: &WorktreeIdentityRow) -> Result<()> {
         conn.execute(
             "INSERT INTO worktree_identities
-                 (repo_hash, worktree_id, branch, worktree_path, updated_at)
-             VALUES (?1, ?2, ?3, ?4, ?5)
+                 (repo_hash, worktree_id, branch, worktree_path, updated_at,
+                  kind, source_spelling, pinned_commit)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
              ON CONFLICT(repo_hash, worktree_id) DO UPDATE SET
-                 branch        = excluded.branch,
-                 worktree_path = excluded.worktree_path,
-                 updated_at    = excluded.updated_at",
+                 branch          = excluded.branch,
+                 worktree_path   = excluded.worktree_path,
+                 updated_at      = excluded.updated_at,
+                 kind            = excluded.kind,
+                 source_spelling = excluded.source_spelling,
+                 pinned_commit   = excluded.pinned_commit",
             params![
                 row.repo_hash,
                 row.worktree_id,
                 row.branch,
                 row.worktree_path,
                 row.updated_at.to_rfc3339(),
+                row.kind.as_str(),
+                row.source_spelling,
+                row.pinned_commit,
             ],
         )?;
         Ok(())
@@ -46,8 +55,9 @@ impl WorktreeIdentitiesRepo {
     pub fn observe(conn: &Connection, row: &WorktreeIdentityRow) -> Result<()> {
         conn.execute(
             "INSERT INTO worktree_identities
-                 (repo_hash, worktree_id, branch, worktree_path, updated_at)
-             VALUES (?1, ?2, ?3, ?4, ?5)
+                 (repo_hash, worktree_id, branch, worktree_path, updated_at,
+                  kind, source_spelling, pinned_commit)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
              ON CONFLICT(repo_hash, worktree_id) DO UPDATE SET
                  worktree_path = excluded.worktree_path,
                  updated_at    = excluded.updated_at",
@@ -57,6 +67,9 @@ impl WorktreeIdentitiesRepo {
                 row.branch,
                 row.worktree_path,
                 row.updated_at.to_rfc3339(),
+                row.kind.as_str(),
+                row.source_spelling,
+                row.pinned_commit,
             ],
         )?;
         Ok(())
@@ -69,7 +82,8 @@ impl WorktreeIdentitiesRepo {
     ) -> Result<Option<WorktreeIdentityRow>> {
         let row = conn
             .query_row(
-                "SELECT repo_hash, worktree_id, branch, worktree_path, updated_at
+                "SELECT repo_hash, worktree_id, branch, worktree_path, updated_at,
+                        kind, source_spelling, pinned_commit
                  FROM worktree_identities
                  WHERE repo_hash = ?1 AND worktree_id = ?2",
                 params![repo_hash, worktree_id],
@@ -83,7 +97,8 @@ impl WorktreeIdentitiesRepo {
     /// The list reads the whole set once rather than querying per worktree.
     pub fn list_for_repo(conn: &Connection, repo_hash: &str) -> Result<Vec<WorktreeIdentityRow>> {
         let mut stmt = conn.prepare(
-            "SELECT repo_hash, worktree_id, branch, worktree_path, updated_at
+            "SELECT repo_hash, worktree_id, branch, worktree_path, updated_at,
+                    kind, source_spelling, pinned_commit
              FROM worktree_identities
              WHERE repo_hash = ?1
              ORDER BY worktree_id ASC",
@@ -108,10 +123,27 @@ impl WorktreeIdentitiesRepo {
     /// it. Removal paths know the branch they are deleting, not the
     /// private-gitdir id — git has usually already unregistered the worktree
     /// by the time they can clean up.
+    ///
+    /// Branch rows only: a sandbox whose directory name happens to match a
+    /// deleted branch is a different worktree and must survive the sweep.
     pub fn delete_for_branch(conn: &Connection, repo_hash: &str, branch: &str) -> Result<usize> {
         let n = conn.execute(
-            "DELETE FROM worktree_identities WHERE repo_hash = ?1 AND branch = ?2",
+            "DELETE FROM worktree_identities
+             WHERE repo_hash = ?1 AND branch = ?2 AND kind = 'branch'",
             params![repo_hash, branch],
+        )?;
+        Ok(n)
+    }
+
+    /// Forget a sandbox by its directory-name identity — the removal
+    /// fallback when the private-gitdir id could no longer be read. The
+    /// mirror image of [`Self::delete_for_branch`]: sandbox rows only, so a
+    /// branch named like the sandbox survives.
+    pub fn delete_sandbox_by_name(conn: &Connection, repo_hash: &str, name: &str) -> Result<usize> {
+        let n = conn.execute(
+            "DELETE FROM worktree_identities
+             WHERE repo_hash = ?1 AND branch = ?2 AND kind IN ('canonical', 'fork')",
+            params![repo_hash, name],
         )?;
         Ok(n)
     }
@@ -119,12 +151,16 @@ impl WorktreeIdentitiesRepo {
 
 fn row_to_identity(row: &rusqlite::Row<'_>) -> rusqlite::Result<WorktreeIdentityRow> {
     let updated_at_str: String = row.get("updated_at")?;
+    let kind_str: String = row.get("kind")?;
     Ok(WorktreeIdentityRow {
         repo_hash: row.get("repo_hash")?,
         worktree_id: row.get("worktree_id")?,
         branch: row.get("branch")?,
         worktree_path: row.get("worktree_path")?,
         updated_at: parse_rfc3339(&updated_at_str, "updated_at")?,
+        kind: WorktreeKind::parse(&kind_str),
+        source_spelling: row.get("source_spelling")?,
+        pinned_commit: row.get("pinned_commit")?,
     })
 }
 
@@ -154,7 +190,18 @@ mod tests {
             // repos-no-format), and the grep does not exempt test code.
             worktree_path: String::from("/tmp/wt/") + worktree_id,
             updated_at: Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap(),
+            kind: WorktreeKind::Branch,
+            source_spelling: None,
+            pinned_commit: None,
         }
+    }
+
+    fn sandbox(worktree_id: &str, name: &str, kind: WorktreeKind) -> WorktreeIdentityRow {
+        let mut row = sample(worktree_id, name);
+        row.kind = kind;
+        row.source_spelling = Some("v1.18.0".into());
+        row.pinned_commit = Some("a".repeat(40));
+        row
     }
 
     #[test]
@@ -314,5 +361,96 @@ mod tests {
             .map(|r| r.branch)
             .collect();
         assert_eq!(remaining, vec!["feat/y"]);
+    }
+
+    /// A sandbox and a branch row round-trip their kind and sandbox fields.
+    #[test]
+    fn sandbox_rows_round_trip_kind_spelling_and_pin() {
+        let (_tmp, conn) = fresh_db();
+        let row = sandbox("wt-s", "v1.18.0", WorktreeKind::Canonical);
+        WorktreeIdentitiesRepo::upsert(&conn, &row).unwrap();
+        assert_eq!(
+            WorktreeIdentitiesRepo::get(&conn, "repo", "wt-s").unwrap(),
+            Some(row)
+        );
+    }
+
+    /// The gate this migration exists for: removing a branch named like a
+    /// sandbox's directory must not take the sandbox's record with it.
+    #[test]
+    fn delete_for_branch_spares_a_same_named_sandbox() {
+        let (_tmp, conn) = fresh_db();
+        WorktreeIdentitiesRepo::upsert(&conn, &sample("wt-a", "scratch")).unwrap();
+        WorktreeIdentitiesRepo::upsert(&conn, &sandbox("wt-s", "scratch", WorktreeKind::Fork))
+            .unwrap();
+
+        assert_eq!(
+            WorktreeIdentitiesRepo::delete_for_branch(&conn, "repo", "scratch").unwrap(),
+            1,
+            "only the branch row goes"
+        );
+        let row = WorktreeIdentitiesRepo::get(&conn, "repo", "wt-s")
+            .unwrap()
+            .expect("the sandbox record survives");
+        assert_eq!(row.kind, WorktreeKind::Fork);
+    }
+
+    /// And the mirror image: forgetting a sandbox by name spares a branch
+    /// that happens to share the spelling.
+    #[test]
+    fn delete_sandbox_by_name_spares_a_same_named_branch() {
+        let (_tmp, conn) = fresh_db();
+        WorktreeIdentitiesRepo::upsert(&conn, &sample("wt-a", "scratch")).unwrap();
+        WorktreeIdentitiesRepo::upsert(&conn, &sandbox("wt-s", "scratch", WorktreeKind::Canonical))
+            .unwrap();
+
+        assert_eq!(
+            WorktreeIdentitiesRepo::delete_sandbox_by_name(&conn, "repo", "scratch").unwrap(),
+            1
+        );
+        let row = WorktreeIdentitiesRepo::get(&conn, "repo", "wt-a")
+            .unwrap()
+            .expect("the branch record survives");
+        assert_eq!(row.kind, WorktreeKind::Branch);
+    }
+
+    /// Observation refreshes path/timestamp but never rewrites what the row
+    /// *is* — including its kind and sandbox metadata.
+    #[test]
+    fn observation_never_rewrites_kind_or_sandbox_fields() {
+        let (_tmp, conn) = fresh_db();
+        let row = sandbox("wt-s", "v1.18.0", WorktreeKind::Canonical);
+        WorktreeIdentitiesRepo::upsert(&conn, &row).unwrap();
+
+        let mut observed = sample("wt-s", "some-branch");
+        observed.worktree_path = "/tmp/wt/moved".into();
+        WorktreeIdentitiesRepo::observe(&conn, &observed).unwrap();
+
+        let read = WorktreeIdentitiesRepo::get(&conn, "repo", "wt-s")
+            .unwrap()
+            .unwrap();
+        assert_eq!(read.kind, WorktreeKind::Canonical, "kind is intent");
+        assert_eq!(read.branch, "v1.18.0", "so is the name");
+        assert_eq!(read.source_spelling.as_deref(), Some("v1.18.0"));
+        assert!(read.pinned_commit.is_some());
+        assert_eq!(read.worktree_path, "/tmp/wt/moved", "the path refreshes");
+    }
+
+    /// A deliberate upsert re-purposes a sandbox into a branch worktree and
+    /// leaves no sandbox metadata behind (doctor --fix relies on this).
+    #[test]
+    fn upsert_repurposes_a_sandbox_into_a_branch_row() {
+        let (_tmp, conn) = fresh_db();
+        WorktreeIdentitiesRepo::upsert(&conn, &sandbox("wt-s", "v1.18.0", WorktreeKind::Fork))
+            .unwrap();
+        WorktreeIdentitiesRepo::upsert(&conn, &sample("wt-s", "feat/adopted")).unwrap();
+
+        let read = WorktreeIdentitiesRepo::get(&conn, "repo", "wt-s")
+            .unwrap()
+            .unwrap();
+        assert_eq!(read.kind, WorktreeKind::Branch);
+        assert_eq!(read.branch, "feat/adopted");
+        assert_eq!(read.source_spelling, None);
+        assert_eq!(read.pinned_commit, None);
     }
 }

--- a/tests/integration/test_shell_init.sh
+++ b/tests/integration/test_shell_init.sh
@@ -784,6 +784,71 @@ test_c_flag_symlink_entry() {
 
 # --- Main Test Runner ---
 
+# #53: `daft start --fork` cd contract through the wrapper — a single fork
+# lands the shell inside the new sandbox; `-n >1` has no single destination
+# and must leave the shell exactly where it was.
+test_fork_cd_through_wrapper() {
+    log "Testing: daft start --fork through wrapper cds into the fork; -n 2 stays put"
+
+    local remote_dir
+    remote_dir=$(create_test_remote "test-fork-wrapper" "main")
+    git-worktree-clone --layout contained "$remote_dir" >/dev/null 2>&1
+    local project_root="$PWD/test-fork-wrapper"
+
+    local out
+    out=$(MAIN_WT="$project_root/main" bash -c '
+        eval "$(daft shell-init bash)"
+        builtin cd "$MAIN_WT" || exit 11
+        daft start --fork >/dev/null 2>&1 || exit 12
+        builtin pwd
+    ' 2>&1) || true
+    if [[ "$(basename "$out")" != "main-fork" ]]; then
+        log_error "single fork did not cd the shell into the fork (pwd: $out)"
+        return 1
+    fi
+
+    out=$(MAIN_WT="$project_root/main" bash -c '
+        eval "$(daft shell-init bash)"
+        builtin cd "$MAIN_WT" || exit 11
+        daft start --fork -n 2 >/dev/null 2>&1 || exit 12
+        builtin pwd
+    ' 2>&1) || true
+    if [[ "$(basename "$out")" != "main" ]]; then
+        log_error "-n 2 moved the shell (pwd: $out); bulk forks must stay put"
+        return 1
+    fi
+
+    log_success "fork cd contract holds: single fork cds, -n 2 stays put"
+    return 0
+}
+
+# #53: `daft go <tag>` (the sandbox rung) must honor the wrapper's cd
+# contract like any other go destination.
+test_go_tag_sandbox_cd_through_wrapper() {
+    log "Testing: daft go <tag> through wrapper lands shell in the sandbox"
+
+    local remote_dir
+    remote_dir=$(create_test_remote "test-go-tag-wrapper" "main")
+    git-worktree-clone --layout contained "$remote_dir" >/dev/null 2>&1
+    local project_root="$PWD/test-go-tag-wrapper"
+
+    local out
+    out=$(MAIN_WT="$project_root/main" bash -c '
+        eval "$(daft shell-init bash)"
+        builtin cd "$MAIN_WT" || exit 11
+        git -c tag.gpgSign=false tag v9.9 >/dev/null 2>&1 || exit 12
+        daft go v9.9 >/dev/null 2>&1 || exit 13
+        builtin pwd
+    ' 2>&1) || true
+    if [[ "$(basename "$out")" != "v9.9" ]]; then
+        log_error "daft go <tag> did not cd the shell into the sandbox (pwd: $out)"
+        return 1
+    fi
+
+    log_success "daft go <tag> through wrapper lands shell at: $out"
+    return 0
+}
+
 main() {
     setup
 
@@ -818,6 +883,8 @@ main() {
     run_test "remove_same_repo_still_rescues_shell" test_remove_same_repo_still_rescues_shell
     run_test "c_flag_no_arg_through_wrapper_errors_cleanly" test_c_flag_no_arg_through_wrapper_errors_cleanly
     run_test "c_flag_symlink_entry" test_c_flag_symlink_entry
+    run_test "fork_cd_through_wrapper" test_fork_cd_through_wrapper
+    run_test "go_tag_sandbox_cd_through_wrapper" test_go_tag_sandbox_cd_through_wrapper
 
     print_summary
 }

--- a/tests/manual/scenarios/branch-delete/remove-foreign-detached-still-refused.yml
+++ b/tests/manual/scenarios/branch-delete/remove-foreign-detached-still-refused.yml
@@ -1,0 +1,33 @@
+name: Remove foreign detached worktree still refused
+description:
+  A detached worktree daft did not create has no identity record, so removal
+  keeps the historical refusal — the sandbox path never weakens it
+
+repos:
+  - name: test-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone and create a raw detached worktree outside daft
+    run: |
+      git-worktree-clone --layout contained $REMOTE_TEST_REPO
+      cd test-repo/main
+      git worktree add --detach ../foreign HEAD
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-repo/foreign"
+
+  - name: Removal by path is refused
+    run: daft remove ../foreign 2>&1
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 1
+      output_contains:
+        - "detached HEAD; specify a branch name"
+
+  - name: The worktree survives
+    run: test -d "$WORK_DIR/test-repo/foreign"
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0

--- a/tests/manual/scenarios/branch-delete/remove-sandbox-by-name.yml
+++ b/tests/manual/scenarios/branch-delete/remove-sandbox-by-name.yml
@@ -1,0 +1,38 @@
+name: Remove sandbox by name
+description:
+  daft remove <sandbox-name> deletes a daft-created detached sandbox — no branch
+  machinery involved, the worktree simply goes
+
+repos:
+  - name: test-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone and create a tag sandbox
+    run: |
+      git-worktree-clone --layout contained $REMOTE_TEST_REPO
+      cd test-repo/main
+      git -c tag.gpgSign=false tag v1.0
+      daft go v1.0 --no-cd
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-repo/v1.0"
+
+  - name: Remove the sandbox by its name
+    run: daft remove v1.0 2>&1
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+
+  - name: The sandbox worktree is gone
+    run: test -d "$WORK_DIR/test-repo/v1.0"
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 1
+
+  - name: The tag itself survives
+    run: git rev-parse --verify --quiet 'v1.0^{commit}'
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0

--- a/tests/manual/scenarios/branch-delete/remove-sandbox-by-path.yml
+++ b/tests/manual/scenarios/branch-delete/remove-sandbox-by-path.yml
@@ -1,0 +1,32 @@
+name: Remove sandbox by path
+description:
+  A sandbox can be removed by its worktree path, exactly like a branch worktree
+  — the identity record is what tells it apart from a foreign detached checkout
+
+repos:
+  - name: test-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone and create a tag sandbox
+    run: |
+      git-worktree-clone --layout contained $REMOTE_TEST_REPO
+      cd test-repo/main
+      git -c tag.gpgSign=false tag v1.0
+      daft go v1.0 --no-cd
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-repo/v1.0"
+
+  - name: Remove the sandbox by path
+    run: daft remove ../v1.0 2>&1
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+
+  - name: The sandbox worktree is gone
+    run: test -d "$WORK_DIR/test-repo/v1.0"
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 1

--- a/tests/manual/scenarios/branch-delete/remove-sandbox-dirty-refused.yml
+++ b/tests/manual/scenarios/branch-delete/remove-sandbox-dirty-refused.yml
@@ -1,0 +1,39 @@
+name: Remove dirty sandbox refused
+description:
+  A sandbox with uncommitted changes refuses removal without -D — the same
+  protection branch worktrees get
+
+repos:
+  - name: test-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone, create a sandbox, and dirty it
+    run: |
+      git-worktree-clone --layout contained $REMOTE_TEST_REPO
+      cd test-repo/main
+      git -c tag.gpgSign=false tag v1.0
+      daft go v1.0 --no-cd
+      echo scratch > ../v1.0/scratch.txt
+    expect:
+      exit_code: 0
+
+  - name: Removal without force is refused
+    run: daft remove v1.0 2>&1
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 1
+      output_contains:
+        - "uncommitted changes"
+
+  - name: Forced removal succeeds
+    run: daft remove v1.0 -f 2>&1
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+
+  - name: The sandbox worktree is gone
+    run: test -d "$WORK_DIR/test-repo/v1.0"
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 1

--- a/tests/manual/scenarios/branch-delete/remove-sandbox-moved-head-refused.yml
+++ b/tests/manual/scenarios/branch-delete/remove-sandbox-moved-head-refused.yml
@@ -1,0 +1,41 @@
+name: Remove sandbox with moved HEAD refused
+description:
+  Commits made on a sandbox's detached HEAD exist nowhere else — removal refuses
+  with the promotion hint until forced
+
+repos:
+  - name: test-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone, create a sandbox, and commit inside it
+    run: |
+      git-worktree-clone --layout contained $REMOTE_TEST_REPO
+      cd test-repo/main
+      git -c tag.gpgSign=false tag v1.0
+      daft go v1.0 --no-cd
+      cd ../v1.0
+      git -c user.name=Test -c user.email=test@test.com commit --allow-empty -m "work in sandbox"
+    expect:
+      exit_code: 0
+
+  - name: Removal without force is refused with the promotion hint
+    run: daft remove v1.0 2>&1
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 1
+      output_contains:
+        - "moved off its pinned commit"
+        - "daft start"
+
+  - name: Forced removal succeeds
+    run: daft remove v1.0 -f 2>&1
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+
+  - name: The sandbox worktree is gone
+    run: test -d "$WORK_DIR/test-repo/v1.0"
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 1

--- a/tests/manual/scenarios/branch-delete/remove-sandbox-pre-remove-hook.yml
+++ b/tests/manual/scenarios/branch-delete/remove-sandbox-pre-remove-hook.yml
@@ -1,0 +1,64 @@
+name: Sandbox removal fires pre-remove hooks
+description: >
+  daft remove on a sandbox worktree fires worktree-pre-remove hooks from the
+  sandbox itself, under the branchless contract - DAFT_BRANCH_NAME is empty and
+  DAFT_COMMIT carries the pinned commit. The #53 field find was the rail
+  resolving hook rows by branch name, which made these runs look skipped for
+  sandbox targets; the marker files prove the hook fires inside the sandbox.
+
+repos:
+  - name: test-repo
+    default_branch: main
+    branches:
+      - name: main
+        files:
+          - path: README.md
+            content: "# Sandbox pre-remove hook test"
+        commits:
+          - message: "Initial commit"
+    daft_yml: |
+      hooks:
+        worktree-pre-remove:
+          jobs:
+            - name: marker
+              run: |
+                echo "ran-in $(pwd)" >> "${WORK_DIR}/hook-markers.txt"
+                echo "DAFT_BRANCH_NAME=[${DAFT_BRANCH_NAME}]" >> "${WORK_DIR}/hook-env.txt"
+                echo "DAFT_COMMIT=[${DAFT_COMMIT}]" >> "${WORK_DIR}/hook-env.txt"
+
+steps:
+  - name: Clone and trust the repository
+    run: |
+      git-worktree-clone --layout contained $REMOTE_TEST_REPO
+      cd $WORK_DIR/test-repo/main
+      daft hooks trust --force 2>&1
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-repo/main"
+
+  - name: Mint a fork sandbox
+    run: daft start --fork
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-repo/main-fork"
+
+  - name: Remove the sandbox — the pre-remove hook runs inside it
+    run: daft remove main-fork 2>&1
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+      files_not_exist:
+        - "$WORK_DIR/test-repo/main-fork"
+      files_exist:
+        - "$WORK_DIR/hook-markers.txt"
+
+  - name: The hook ran in the sandbox under the branchless contract
+    run: |
+      grep -q "ran-in .*/main-fork" "$WORK_DIR/hook-markers.txt" &&
+      grep -q "DAFT_BRANCH_NAME=\[\]" "$WORK_DIR/hook-env.txt" &&
+      grep -Eq "DAFT_COMMIT=\[[0-9a-f]{40}\]" "$WORK_DIR/hook-env.txt"
+    expect:
+      exit_code: 0

--- a/tests/manual/scenarios/branch-delete/remove-sandbox-wildcard.yml
+++ b/tests/manual/scenarios/branch-delete/remove-sandbox-wildcard.yml
@@ -1,0 +1,60 @@
+name: Remove sandboxes by wildcard
+description:
+  daft remove 'main-fork*' expands the pattern over sandbox names — every fork
+  goes in one sweep, while branches whose names also match are never touched and
+  a pattern matching nothing fails closed
+
+repos:
+  - name: test-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone, mint three forks, and add a similarly named branch
+    run: |
+      git-worktree-clone --layout contained $REMOTE_TEST_REPO
+      cd $WORK_DIR/test-repo/main
+      daft start --fork -n 3 >/dev/null 2>&1
+      git-worktree-checkout -b main-forky
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-repo/main-fork"
+        - "$WORK_DIR/test-repo/main-fork-2"
+        - "$WORK_DIR/test-repo/main-fork-3"
+        - "$WORK_DIR/test-repo/main-forky"
+
+  - name: Remove every fork with one pattern
+    run: daft remove 'main-fork*' 2>&1
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+      files_not_exist:
+        - "$WORK_DIR/test-repo/main-fork"
+        - "$WORK_DIR/test-repo/main-fork-2"
+        - "$WORK_DIR/test-repo/main-fork-3"
+
+  - name: The matching branch and its worktree survive
+    run:
+      test -d ../main-forky && git show-ref --verify --quiet
+      refs/heads/main-forky
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+
+  - name: A pattern matching only branches refuses and names them
+    run: daft remove 'main-forky*' 2>&1
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 1
+      output_contains:
+        - "matches no sandbox worktrees"
+        - "main-forky"
+        - "never target branches"
+
+  - name: A pattern matching nothing fails closed
+    run: daft remove 'nosuch*' 2>&1
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 1
+      output_contains:
+        - "matches no sandbox worktrees"

--- a/tests/manual/scenarios/checkout-branch/start-commitish-base.yml
+++ b/tests/manual/scenarios/checkout-branch/start-commitish-base.yml
@@ -1,0 +1,54 @@
+name: Start with a commit-ish base
+description:
+  daft start <branch> <base> accepts any commit-ish base — a tag or a raw SHA,
+  not just a branch — through select_checkout_base's fall-through
+
+repos:
+  - name: test-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone the repository
+    run: git-worktree-clone --layout contained $REMOTE_TEST_REPO
+    expect:
+      exit_code: 0
+
+  - name: Tag develop's commit
+    run: git -c tag.gpgSign=false tag v1.0 develop
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+
+  - name: Start a branch based on the tag
+    run: daft start from-tag v1.0
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-repo/from-tag"
+
+  - name: The new branch exists and sits at the tagged commit, not main's tip
+    run: |
+      git show-ref --verify --quiet refs/heads/from-tag
+      test "$(git -C ../from-tag rev-parse HEAD)" = "$(git rev-parse 'v1.0^{commit}')"
+      test "$(git -C ../from-tag rev-parse HEAD)" != "$(git rev-parse main)"
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+
+  - name: Start a branch based on a raw SHA
+    run: |
+      daft start from-sha "$(git rev-parse 'v1.0^{commit}')"
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-repo/from-sha"
+
+  - name: The SHA-based branch sits at that commit
+    run: |
+      git show-ref --verify --quiet refs/heads/from-sha
+      test "$(git -C ../from-sha rev-parse HEAD)" = "$(git rev-parse 'v1.0^{commit}')"
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0

--- a/tests/manual/scenarios/checkout-branch/start-fork-base.yml
+++ b/tests/manual/scenarios/checkout-branch/start-fork-base.yml
@@ -1,0 +1,38 @@
+name: Start fork with a base
+description:
+  daft start <base> --fork pins the fork at the named position — the slot that
+  would be the branch name is the base under --fork
+
+repos:
+  - name: test-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone the repository
+    run: git-worktree-clone --layout contained $REMOTE_TEST_REPO
+    expect:
+      exit_code: 0
+
+  - name: Fork the develop branch's position
+    run: daft start develop --fork 2>/dev/null
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-repo/develop-fork"
+      output_contains:
+        - "develop-fork"
+
+  - name: The fork is pinned at develop's commit, with no branch
+    run: |
+      test "$(git -C ../develop-fork rev-parse HEAD)" = "$(git rev-parse develop)"
+      git -C ../develop-fork symbolic-ref -q HEAD && exit 1 || exit 0
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+
+  - name: No branch was created for the fork
+    run: git show-ref --verify --quiet refs/heads/develop-fork
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 1

--- a/tests/manual/scenarios/checkout-branch/start-fork-basic.yml
+++ b/tests/manual/scenarios/checkout-branch/start-fork-basic.yml
@@ -1,0 +1,51 @@
+name: Start fork basic
+description:
+  daft start --fork mints an anonymous detached worktree at HEAD — the created
+  path is the stdout record (narration stays on stderr), named <branch>-fork
+  under the derived scheme
+
+repos:
+  - name: test-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone the repository
+    run: git-worktree-clone --layout contained $REMOTE_TEST_REPO
+    expect:
+      exit_code: 0
+
+  - name: Fork prints exactly the created path on stdout
+    run:
+      WT=$(daft start --fork 2>/dev/null) && test -d "$WT" && test "$(basename
+      "$WT")" = "main-fork"
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-repo/main-fork"
+
+  - name: The fork has a detached HEAD pinned at the source commit
+    run: |
+      test "$(git -C ../main-fork rev-parse HEAD)" = "$(git rev-parse HEAD)"
+      git -C ../main-fork symbolic-ref -q HEAD && exit 1 || exit 0
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+
+  - name: Stdout carries no narration
+    run: daft start --fork 2>/dev/null
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "main-fork-2"
+      output_not_contains:
+        - "Forking"
+
+  - name: Narration goes to stderr
+    run: daft start --fork >/dev/null
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "Forking"

--- a/tests/manual/scenarios/checkout-branch/start-fork-count.yml
+++ b/tests/manual/scenarios/checkout-branch/start-fork-count.yml
@@ -1,0 +1,37 @@
+name: Start fork count
+description:
+  daft start --fork -n N mints N fresh forks in one invocation — one path per
+  line on stdout, sequentially suffixed under the derived scheme
+
+repos:
+  - name: test-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone the repository
+    run: git-worktree-clone --layout contained $REMOTE_TEST_REPO
+    expect:
+      exit_code: 0
+
+  - name: Three forks in one invocation
+    run: daft start --fork -n 3 2>/dev/null
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-repo/main-fork"
+        - "$WORK_DIR/test-repo/main-fork-2"
+        - "$WORK_DIR/test-repo/main-fork-3"
+      output_contains:
+        - "main-fork"
+        - "main-fork-2"
+        - "main-fork-3"
+
+  - name: Every fork is detached at the same commit
+    run: |
+      for wt in main-fork main-fork-2 main-fork-3; do
+        test "$(git -C ../$wt rev-parse HEAD)" = "$(git rev-parse HEAD)" || exit 1
+      done
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0

--- a/tests/manual/scenarios/checkout-branch/start-fork-naming-memorable.yml
+++ b/tests/manual/scenarios/checkout-branch/start-fork-naming-memorable.yml
@@ -1,0 +1,29 @@
+name: Start fork memorable naming
+description:
+  daft.start.forkNaming = memorable swaps the derived <branch>-fork names for
+  adjective-noun handles — the path on stdout is still the contract
+
+repos:
+  - name: test-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone and enable memorable naming
+    run: |
+      git-worktree-clone --layout contained $REMOTE_TEST_REPO
+      cd test-repo/main
+      git config daft.start.forkNaming memorable
+    expect:
+      exit_code: 0
+
+  - name: The fork gets a memorable name, not a derived one
+    run: |
+      WT=$(daft start --fork 2>/dev/null)
+      test -d "$WT" || exit 1
+      case "$WT" in
+        *main-fork*) exit 1 ;;
+      esac
+      git -C "$WT" symbolic-ref -q HEAD && exit 1 || exit 0
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0

--- a/tests/manual/scenarios/checkout-branch/start-from-detached.yml
+++ b/tests/manual/scenarios/checkout-branch/start-from-detached.yml
@@ -1,0 +1,39 @@
+name: Start from a detached sandbox promotes its commits
+description:
+  daft start <name> from inside a sandbox bases the new branch on the detached
+  HEAD — the promotion gesture that rescues work minted anonymously
+
+repos:
+  - name: test-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone, open a tag sandbox, and commit inside it
+    run: |
+      git-worktree-clone --layout contained $REMOTE_TEST_REPO
+      cd test-repo/main
+      git -c tag.gpgSign=false tag v1.0
+      daft go v1.0 --no-cd
+      cd ../v1.0
+      git -c user.name=Test -c user.email=test@test.com commit --allow-empty -m "work in sandbox"
+    expect:
+      exit_code: 0
+
+  - name: Promote the sandbox's position into a real branch
+    run: daft start promoted --local 2>&1
+    cwd: "$WORK_DIR/test-repo/v1.0"
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-repo/promoted"
+      is_git_worktree:
+        - dir: "$WORK_DIR/test-repo/promoted"
+          branch: promoted
+
+  - name: The promoted branch carries the sandbox's commit
+    run: git -C "$WORK_DIR/test-repo/promoted" log -1 --format=%s
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "work in sandbox"

--- a/tests/manual/scenarios/checkout/go-autostart-loses-to-tag.yml
+++ b/tests/manual/scenarios/checkout/go-autostart-loses-to-tag.yml
@@ -1,0 +1,37 @@
+name: Go autoStart loses to an existing tag
+description:
+  Ambient daft.go.autoStart auto-creates branches for unknown names, but an
+  existing entity beats ambient config — a tag opens its sandbox instead of
+  minting a branch named like it (the catalog rung's own precedent)
+
+repos:
+  - name: test-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone the repository
+    run: git-worktree-clone --layout contained $REMOTE_TEST_REPO
+    expect:
+      exit_code: 0
+
+  - name: Enable autoStart and tag the tip
+    run: |
+      git config daft.go.autoStart true
+      git -c tag.gpgSign=false tag v2
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+
+  - name: Go to the tag opens a sandbox, not a new branch
+    run: daft go v2 2>&1
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "detached sandbox"
+
+  - name: No branch named after the tag was created
+    run: git show-ref --verify --quiet refs/heads/v2
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 1

--- a/tests/manual/scenarios/checkout/go-branch-beats-tag.yml
+++ b/tests/manual/scenarios/checkout/go-branch-beats-tag.yml
@@ -1,0 +1,33 @@
+name: Go branch beats a same-named tag
+description:
+  When a branch and a tag share a spelling, the branch rung wins — the sandbox
+  rung claims only inputs that were errors before it existed
+
+repos:
+  - name: test-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone the repository
+    run: git-worktree-clone --layout contained $REMOTE_TEST_REPO
+    expect:
+      exit_code: 0
+
+  - name: Tag the tip with an existing branch's name
+    run: git -c tag.gpgSign=false tag develop
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+
+  - name: Go resolves the branch, not the tag
+    run: daft go develop 2>&1
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-repo/develop"
+      is_git_worktree:
+        - dir: "$WORK_DIR/test-repo/develop"
+          branch: develop
+      output_not_contains:
+        - "detached sandbox"

--- a/tests/manual/scenarios/checkout/go-head-relative-sandbox.yml
+++ b/tests/manual/scenarios/checkout/go-head-relative-sandbox.yml
@@ -1,0 +1,44 @@
+name: Go HEAD-relative sandbox
+description:
+  daft go HEAD~1 — a spelling that can never be a branch name — resolves through
+  the pre-validation rung into a sandbox named by the commit it resolved to
+
+repos:
+  - name: test-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone the repository
+    run: git-worktree-clone --layout contained $REMOTE_TEST_REPO
+    expect:
+      exit_code: 0
+
+  - name: Add a commit so HEAD~1 exists
+    run:
+      git -c user.name=Test -c user.email=test@test.com commit --allow-empty -m
+      "tip"
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+
+  - name: Go to HEAD~1 creates a derived-name sandbox
+    run: daft go HEAD~1 2>&1
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "detached sandbox"
+
+  - name: The sandbox directory is named by the commit's hex prefix
+    run: test -d "../$(git rev-parse HEAD~1 | cut -c1-12)"
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+
+  - name: The sandbox is pinned at HEAD~1's commit
+    run:
+      test "$(git -C "../$(git rev-parse HEAD~1 | cut -c1-12)" rev-parse HEAD)"
+      = "$(git rev-parse HEAD~1)"
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0

--- a/tests/manual/scenarios/checkout/go-sandbox-idempotent.yml
+++ b/tests/manual/scenarios/checkout/go-sandbox-idempotent.yml
@@ -1,0 +1,38 @@
+name: Go sandbox idempotent revisit
+description:
+  Revisiting a sandbox spelling navigates into the existing worktree — without
+  the interrupted-rebase warning that foreign detached worktrees get
+
+repos:
+  - name: test-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone the repository
+    run: git-worktree-clone --layout contained $REMOTE_TEST_REPO
+    expect:
+      exit_code: 0
+
+  - name: Tag the current tip
+    run: git -c tag.gpgSign=false tag v1.0
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+
+  - name: First visit materializes the sandbox
+    run: daft go v1.0
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-repo/v1.0"
+
+  - name: Second visit navigates without the rebase warning
+    run: daft go v1.0 2>&1
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "existing worktree"
+      output_not_contains:
+        - "interrupted rebase"

--- a/tests/manual/scenarios/checkout/go-start-suppresses-sandbox.yml
+++ b/tests/manual/scenarios/checkout/go-start-suppresses-sandbox.yml
@@ -1,0 +1,33 @@
+name: Go --start suppresses the sandbox rung
+description:
+  Explicit --start declares branch-creation intent, so a name that happens to
+  resolve as a tag still creates a branch — the sandbox rung never fires
+
+repos:
+  - name: test-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone the repository
+    run: git-worktree-clone --layout contained $REMOTE_TEST_REPO
+    expect:
+      exit_code: 0
+
+  - name: Tag the current tip
+    run: git -c tag.gpgSign=false tag v9
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+
+  - name: Go --start creates a branch despite the tag
+    run: daft go v9 --start 2>&1
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-repo/v9"
+      is_git_worktree:
+        - dir: "$WORK_DIR/test-repo/v9"
+          branch: v9
+      output_not_contains:
+        - "detached sandbox"

--- a/tests/manual/scenarios/checkout/go-tag-sandbox.yml
+++ b/tests/manual/scenarios/checkout/go-tag-sandbox.yml
@@ -1,0 +1,42 @@
+name: Go tag sandbox
+description:
+  daft go <tag> opens a detached sandbox worktree named after the tag —
+  hooks-ready, pinned at the tag's commit, with no branch attached
+
+repos:
+  - name: test-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone the repository
+    run: git-worktree-clone --layout contained $REMOTE_TEST_REPO
+    expect:
+      exit_code: 0
+
+  - name: Tag the current tip
+    run: git -c tag.gpgSign=false tag v1.0
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+
+  - name: Go to the tag creates a detached sandbox
+    run: daft go v1.0 2>&1
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-repo/v1.0"
+      output_contains:
+        - "detached sandbox"
+
+  - name: The sandbox has a detached HEAD
+    run: git symbolic-ref -q HEAD
+    cwd: "$WORK_DIR/test-repo/v1.0"
+    expect:
+      exit_code: 1
+
+  - name: The sandbox is pinned at the tag's commit
+    run: test "$(git rev-parse HEAD)" = "$(git rev-parse 'v1.0^{commit}')"
+    cwd: "$WORK_DIR/test-repo/v1.0"
+    expect:
+      exit_code: 0

--- a/tests/manual/scenarios/list/columns-config.yml
+++ b/tests/manual/scenarios/list/columns-config.yml
@@ -12,7 +12,7 @@ steps:
       exit_code: 0
 
   - name: Set columns config
-    run: git config daft.list.columns "branch,path"
+    run: git config daft.list.columns "name,path"
     cwd: "$WORK_DIR/test-repo/main"
     expect:
       exit_code: 0
@@ -23,18 +23,18 @@ steps:
     expect:
       exit_code: 0
       output_contains:
-        - "Branch"
+        - "Name"
         - "Path"
       output_not_contains:
         - "Base"
         - "Changes"
 
   - name: CLI flag overrides config
-    run: NO_COLOR=1 git-worktree-list --columns branch,path,age 2>&1
+    run: NO_COLOR=1 git-worktree-list --columns name,path,age 2>&1
     cwd: "$WORK_DIR/test-repo/main"
     expect:
       exit_code: 0
       output_contains:
-        - "Branch"
+        - "Name"
         - "Path"
         - "Age"

--- a/tests/manual/scenarios/list/columns-errors.yml
+++ b/tests/manual/scenarios/list/columns-errors.yml
@@ -12,7 +12,7 @@ steps:
       exit_code: 0
 
   - name: Unknown column name
-    run: git-worktree-list --columns branch,foo 2>&1
+    run: git-worktree-list --columns name,foo 2>&1
     cwd: "$WORK_DIR/test-repo/main"
     expect:
       exit_code: 1
@@ -20,7 +20,7 @@ steps:
         - "unknown column 'foo'"
 
   - name: Mixed mode error
-    run: git-worktree-list --columns branch,+age 2>&1
+    run: git-worktree-list --columns name,+age 2>&1
     cwd: "$WORK_DIR/test-repo/main"
     expect:
       exit_code: 1
@@ -28,7 +28,7 @@ steps:
         - "cannot mix"
 
   - name: Duplicate column error
-    run: git-worktree-list --columns branch,path,branch 2>&1
+    run: git-worktree-list --columns name,path,name 2>&1
     cwd: "$WORK_DIR/test-repo/main"
     expect:
       exit_code: 1

--- a/tests/manual/scenarios/list/columns-json.yml
+++ b/tests/manual/scenarios/list/columns-json.yml
@@ -12,7 +12,7 @@ steps:
       exit_code: 0
 
   - name: JSON with subset of columns
-    run: git-worktree-list --format json --columns branch,path 2>&1
+    run: git-worktree-list --format json --columns name,path 2>&1
     cwd: "$WORK_DIR/test-repo/main"
     expect:
       exit_code: 0

--- a/tests/manual/scenarios/list/columns-modifier.yml
+++ b/tests/manual/scenarios/list/columns-modifier.yml
@@ -17,7 +17,7 @@ steps:
     expect:
       exit_code: 0
       output_contains:
-        - "Branch"
+        - "Name"
         - "Path"
 
   - name: Remove multiple columns
@@ -28,7 +28,7 @@ steps:
     expect:
       exit_code: 0
       output_contains:
-        - "Branch"
+        - "Name"
         - "Path"
         - "Base"
         - "Changes"

--- a/tests/manual/scenarios/list/columns-replace.yml
+++ b/tests/manual/scenarios/list/columns-replace.yml
@@ -12,12 +12,12 @@ steps:
       exit_code: 0
 
   - name: List with subset of columns
-    run: NO_COLOR=1 git-worktree-list --columns branch,path 2>&1
+    run: NO_COLOR=1 git-worktree-list --columns name,path 2>&1
     cwd: "$WORK_DIR/test-repo/main"
     expect:
       exit_code: 0
       output_contains:
-        - "Branch"
+        - "Name"
         - "Path"
       output_not_contains:
         - "Base"
@@ -27,10 +27,10 @@ steps:
         - "Last Commit"
 
   - name: List with reversed column order
-    run: NO_COLOR=1 git-worktree-list --columns age,branch 2>&1
+    run: NO_COLOR=1 git-worktree-list --columns age,name 2>&1
     cwd: "$WORK_DIR/test-repo/main"
     expect:
       exit_code: 0
       output_contains:
         - "Age"
-        - "Branch"
+        - "Name"

--- a/tests/manual/scenarios/list/hash-column.yml
+++ b/tests/manual/scenarios/list/hash-column.yml
@@ -18,17 +18,17 @@ steps:
       exit_code: 0
       output_contains:
         - "Hash"
-        - "Branch"
+        - "Name"
         - "Commit"
 
   - name: Hash column in replace mode
-    run: NO_COLOR=1 git-worktree-list --columns=branch,hash 2>&1
+    run: NO_COLOR=1 git-worktree-list --columns=name,hash 2>&1
     cwd: "$WORK_DIR/test-repo/main"
     expect:
       exit_code: 0
       output_contains:
         - "Hash"
-        - "Branch"
+        - "Name"
       output_not_contains:
         - "Path"
         - "Age"

--- a/tests/manual/scenarios/list/owner-column.yml
+++ b/tests/manual/scenarios/list/owner-column.yml
@@ -35,7 +35,7 @@ steps:
       exit_code: 0
 
   - name: List with owner column shows author name
-    run: NO_COLOR=1 git-worktree-list --columns branch,owner 2>&1
+    run: NO_COLOR=1 git-worktree-list --columns name,owner 2>&1
     cwd: "$WORK_DIR/test-repo/develop"
     expect:
       exit_code: 0

--- a/tests/manual/scenarios/list/owner-fallback-reflog.yml
+++ b/tests/manual/scenarios/list/owner-fallback-reflog.yml
@@ -30,7 +30,7 @@ steps:
       exit_code: 0
 
   - name: Owner column shows the reflog creator for the fresh branch
-    run: NO_COLOR=1 git-worktree-list --branches --columns branch,owner 2>&1
+    run: NO_COLOR=1 git-worktree-list --branches --columns name,owner 2>&1
     cwd: "$WORK_DIR/reflog-repo/main"
     expect:
       exit_code: 0

--- a/tests/manual/scenarios/list/owner-json-shape.yml
+++ b/tests/manual/scenarios/list/owner-json-shape.yml
@@ -38,7 +38,7 @@ steps:
       exit_code: 0
 
   - name: JSON output has owner_name and owner_email as flat fields
-    run: NO_COLOR=1 git-worktree-list --format json --columns branch,owner
+    run: NO_COLOR=1 git-worktree-list --format json --columns name,owner
     cwd: "$WORK_DIR/json-shape-repo/develop"
     expect:
       exit_code: 0

--- a/tests/manual/scenarios/list/owner-strategy-plurality.yml
+++ b/tests/manual/scenarios/list/owner-strategy-plurality.yml
@@ -45,7 +45,7 @@ steps:
       exit_code: 0
 
   - name: Owner column reports the plurality author (Me Testuser)
-    run: NO_COLOR=1 git-worktree-list --columns branch,owner 2>&1
+    run: NO_COLOR=1 git-worktree-list --columns name,owner 2>&1
     cwd: "$WORK_DIR/strat-plur-repo/main"
     expect:
       exit_code: 0

--- a/tests/manual/scenarios/list/owner-strategy-recency.yml
+++ b/tests/manual/scenarios/list/owner-strategy-recency.yml
@@ -45,7 +45,7 @@ steps:
 
   - name:
       Owner column reports the recency-weighted plurality author (Me Testuser)
-    run: NO_COLOR=1 git-worktree-list --columns branch,owner 2>&1
+    run: NO_COLOR=1 git-worktree-list --columns name,owner 2>&1
     cwd: "$WORK_DIR/strat-rec-repo/main"
     expect:
       exit_code: 0

--- a/tests/manual/scenarios/list/owner-strategy-tip.yml
+++ b/tests/manual/scenarios/list/owner-strategy-tip.yml
@@ -45,7 +45,7 @@ steps:
       exit_code: 0
 
   - name: Owner column reports the tip author (Bob)
-    run: NO_COLOR=1 git-worktree-list --columns branch,owner 2>&1
+    run: NO_COLOR=1 git-worktree-list --columns name,owner 2>&1
     cwd: "$WORK_DIR/strat-tip-repo/main"
     expect:
       exit_code: 0

--- a/tests/manual/scenarios/list/pr-default-column.yml
+++ b/tests/manual/scenarios/list/pr-default-column.yml
@@ -31,7 +31,7 @@ steps:
     expect:
       exit_code: 0
       output_contains:
-        - "Branch"
+        - "Name"
       output_not_contains:
         - "PR"
 
@@ -72,7 +72,7 @@ steps:
     expect:
       exit_code: 0
       output_contains:
-        - "Branch"
+        - "Name"
       output_not_contains:
         - "PR"
 

--- a/tests/manual/scenarios/prune/columns.yml
+++ b/tests/manual/scenarios/prune/columns.yml
@@ -12,7 +12,7 @@ steps:
       exit_code: 0
 
   - name: Status column cannot be controlled
-    run: git-worktree-prune --columns status,branch 2>&1
+    run: git-worktree-prune --columns status,name 2>&1
     cwd: "$WORK_DIR/test-repo/main"
     expect:
       exit_code: 1

--- a/tests/manual/scenarios/sync/columns.yml
+++ b/tests/manual/scenarios/sync/columns.yml
@@ -12,7 +12,7 @@ steps:
       exit_code: 0
 
   - name: Status column cannot be controlled
-    run: git-worktree-sync --columns status,branch 2>&1
+    run: git-worktree-sync --columns status,name 2>&1
     cwd: "$WORK_DIR/test-repo/main"
     expect:
       exit_code: 1


### PR DESCRIPTION
Makes worktrees decoupled from branches first-class. Anonymous worktrees are
plain detached-HEAD sandboxes — no branch, no tracking, no push — living exactly
as long as their directory. Two entrances along the existing verb taxonomy:
**`go` visits anything that exists; `start` mints anything new.**

## What's new

- **`daft go <commit-ish>`** — *visit* a point in history. A new rung slots into
  `go`'s resolution ladder after the catalog fallback, before autoStart: it
  claims only inputs that error today (tags, raw SHAs, `HEAD~2`, remote refs).
  Idempotent and **commit-keyed**, so `go v1.18.0` and `go <its-sha>` converge on
  one canonical sandbox. Matches canonical sandboxes only — never routes a
  visitor into someone's private fork.
  ```
  daft go v1.18.0                              # tag → sandbox 'v1.18.0', hooks run, cd in
  daft go $(git merge-base HEAD origin/master) # inspect a PR's "before"
  ```
- **`daft start --fork [<base>]`** — *mint* a private, always-fresh sandbox.
  Positionals reshape to `[<base>]` (defaults to HEAD). daft chooses the name and
  therefore **prints the path on stdout** (narration → stderr), one per line.
  `-n/--count N` provisions a fleet and stays put. `daft.start.forkNaming` =
  `derived` (default) | `memorable`.
  ```
  daft start --fork                  # fork current position, cd in
  daft start --fork -n 10 master     # ten fresh worktrees, stay put, paths on stdout
  ```
- **`daft remove`** learns branchless targets by dirname or path (variadic, so
  shell globs work), and **refuses unless `-f`** when HEAD has moved off the
  pinned commit — those commits die with the worktree; promote first.
- **`daft list`** shows the sandbox dirname instead of a uniform `(detached)`,
  keeping the dim `○` glyph and sort-last from #736.
- **Completions**: `go` completes tags and existing sandbox dirnames; `start`
  slots complete bases under `--fork`.
- **Hooks** run for sandboxes (`worktree-{pre,post}-{create,remove}`) with a
  branchless template context: `{branch}` empty, the commit exposed via
  `DAFT_COMMIT` / `{commit}`.

Promotion has a working gesture from day one: `daft start <real-name>` from
inside a sandbox mints the branch at the detached HEAD (this PR also fixes
`resolve_base_branch` to fall back to HEAD's OID on a detached cwd).

## Storage

Migration **010** ALTERs `worktree_identities` (`kind` / `source_spelling` /
`pinned_commit`); `kind` gates every branch-name-keyed delete so a same-named
sandbox is never clobbered. The dirname is recorded in the name column, so
`list` surfaces sandbox names with zero list plumbing.

## Commit sequence

Ordered, each commit green (`fmt`, `clippy`, `test:unit`):

1. `feat: record sandbox identity kinds in the worktree-identity store`
2. `feat: add the detached-sandbox core engine`
3. `feat(go): open detached sandboxes for commit-ish arguments`
4. `feat(remove): delete sandboxes by name or path, guarded by their pin`
5. `feat(start): mint anonymous fork worktrees with --fork`
6. `feat(completions): offer tags and sandbox names where they now navigate`
7. `docs: teach the anonymous-worktree workflow across skill, docs, and man`
   (+ two follow-up docs commits naming commit-ish in the go/start help)

## Testing

- **Unit**: start-grammar arities/conflicts, `sandbox_dirname` + `resolve_commitish`
  guards, sandbox create/visit/idempotence/fork-skip, identity resolver sandbox
  tier + collision degrade, migration 010 columns + backfill, `delete_for_branch`
  spares sandboxes, pinned-drift refusal, detached base fallback, settings parse.
- **YAML scenarios**: go tag/sha/HEAD-relative/remote-ref sandboxes, idempotent
  revisit, catalog-vs-sandbox precedence, `--start` suppression, fork stdout
  contract + `-n`, remove by name/path + moved-HEAD refusal, commit-ish bases.
- **Bash integration** + a scratch-repo manual smoke.

Follow-ups filed separately: parallel hook fan-out for `-n`, `carry × -n` via
stash-apply, cross-repo forms, in-place promotion (`--here`), derivation sugar.

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)
