### PR TITLE
fix(hooks): honor failMode=warn for worktree-pre-create

### DIFF
--- a/docs/hooks/lifecycle.md
+++ b/docs/hooks/lifecycle.md
@@ -134,12 +134,20 @@ Continuing would run them against a half-set-up worktree and exit `0`. The
 worktree itself is deliberately kept so you can inspect or repair it; the error
 names the path and how to re-run the hook.
 
+A `worktree-pre-create` hook is a gate: it runs before `git worktree add`, so a
+non-zero exit cancels creation and nothing is left on disk. Downgrading it to
+`warn` runs the gate but ignores its veto — the worktree is created anyway.
+
 Override per-hook:
 
 ```bash
 # Let creation commands continue past a failing post-create hook
 # (runs -x, warns, exits 0)
 git config daft.hooks.worktreePostCreate.failMode warn
+
+# Create the worktree even when the pre-create gate fails
+# (creates it anyway, warns, exits 0)
+git config daft.hooks.worktreePreCreate.failMode warn
 ```
 
 Hook failures during moves produce **warnings**, not errors. The move operation

--- a/src/core/worktree/checkout.rs
+++ b/src/core/worktree/checkout.rs
@@ -560,10 +560,11 @@ pub fn execute(
     )
     .with_new_branch(false);
 
-    let hook_outcome = sink.run_hook(&hook_ctx)?;
-    if !hook_outcome.success && !hook_outcome.skipped {
-        return Err(anyhow::anyhow!("Pre-create hook failed").into());
-    }
+    // The pre-create hook's fail mode is honored inside the executor (#767):
+    // under the default `Abort` it bails here via `?`; under `warn` it returns
+    // `Ok(success: false)` and creation continues — symmetric with every other
+    // hook. Do not re-add a guard that force-aborts the `warn` case.
+    sink.run_hook(&hook_ctx)?;
 
     // Create worktree. `git worktree add` materializes the branch checkout
     // and the worktree in one call; the two plan rows resolve around it as a

--- a/src/core/worktree/checkout_branch.rs
+++ b/src/core/worktree/checkout_branch.rs
@@ -208,10 +208,11 @@ pub fn execute(
     .with_new_branch(true)
     .with_base_branch(&base_branch);
 
-    let hook_outcome = sink.run_hook(&hook_ctx)?;
-    if !hook_outcome.success && !hook_outcome.skipped {
-        anyhow::bail!("Pre-create hook failed");
-    }
+    // Fail mode is honored inside the executor (#767): the default `Abort`
+    // bails here via `?`; `warn` returns `Ok(success: false)` and creation
+    // continues — symmetric with every other hook. Do not re-add a guard that
+    // force-aborts the `warn` case.
+    sink.run_hook(&hook_ctx)?;
 
     sink.on_step(&format!(
         "Creating worktree at '{}' with new branch '{}' from '{}'",

--- a/tests/manual/scenarios/hooks/pre-create-abort.yml
+++ b/tests/manual/scenarios/hooks/pre-create-abort.yml
@@ -1,40 +1,94 @@
-name: Pre-create hook abort prevents worktree creation
-description: Pre-create hook that exits 1 produces error in output
+name: Pre-create hook failure aborts by default, failMode=warn opts out
+description:
+  "A failing worktree-pre-create hook aborts creation before `git worktree add`
+  runs, so no worktree is left behind and the -x/--exec tail never runs. Setting
+  daft.hooks.worktreePreCreate.failMode=warn makes creation continue — the
+  worktree is created and -x runs — symmetric with every other hook's fail mode
+  (#767). Covers both the existing-branch and new-branch creation paths."
 
 repos:
-  - name: test-hooks-abort
+  - name: test-pre-abort
     default_branch: main
     branches:
       - name: main
         files:
           - path: README.md
-            content: "# Hook abort test"
+            content: "# Pre-create abort test"
         commits:
           - message: "Initial commit"
-      - name: feature/should-fail
+      - name: feat-abort
+        from: main
+      - name: feat-warn
         from: main
     daft_yml: |
       hooks:
         worktree-pre-create:
           jobs:
-            - name: block
+            - name: gate
               run: exit 1
 
 steps:
   - name: Clone the repository
-    run: git-worktree-clone --layout contained $REMOTE_TEST_HOOKS_ABORT
+    run: git-worktree-clone --layout contained $REMOTE_TEST_PRE_ABORT
     expect:
       exit_code: 0
 
   - name: Trust the repository
     run: daft hooks trust --force 2>&1
-    cwd: "$WORK_DIR/test-hooks-abort/main"
+    cwd: "$WORK_DIR/test-pre-abort/main"
     expect:
       exit_code: 0
 
-  - name: Checkout with failing pre-create hook shows error
-    run: git-worktree-checkout feature/should-fail 2>&1
-    cwd: "$WORK_DIR/test-hooks-abort/main"
+  - name:
+      Existing-branch checkout with failing pre-create aborts before creation
+    run: git-worktree-checkout feat-abort -x 'touch exec-marker.txt' 2>&1
+    cwd: "$WORK_DIR/test-pre-abort/main"
     expect:
+      exit_code: 1
       output_contains:
-        - "hook failed"
+        - "worktree-pre-create hook failed"
+      files_not_exist:
+        - "$WORK_DIR/test-pre-abort/feat-abort/README.md"
+        - "$WORK_DIR/test-pre-abort/feat-abort/exec-marker.txt"
+
+  - name:
+      New-branch creation with failing pre-create also aborts before creation
+    run: git-worktree-checkout -b feat-new-abort -x 'touch exec-marker.txt' 2>&1
+    cwd: "$WORK_DIR/test-pre-abort/main"
+    expect:
+      exit_code: 1
+      output_contains:
+        - "worktree-pre-create hook failed"
+      files_not_exist:
+        - "$WORK_DIR/test-pre-abort/feat-new-abort/README.md"
+        - "$WORK_DIR/test-pre-abort/feat-new-abort/exec-marker.txt"
+
+  - name: failMode=warn opts out of the pre-create gate
+    run: git config daft.hooks.worktreePreCreate.failMode warn
+    cwd: "$WORK_DIR/test-pre-abort/main"
+    expect:
+      exit_code: 0
+
+  - name: Existing-branch checkout under warn creates the worktree and runs -x
+    run: git-worktree-checkout feat-warn -x 'touch exec-marker.txt' 2>&1
+    cwd: "$WORK_DIR/test-pre-abort/main"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "continuing anyway"
+      dirs_exist:
+        - "$WORK_DIR/test-pre-abort/feat-warn"
+      files_exist:
+        - "$WORK_DIR/test-pre-abort/feat-warn/exec-marker.txt"
+
+  - name: New-branch creation under warn also creates the worktree and runs -x
+    run: git-worktree-checkout -b feat-new-warn -x 'touch exec-marker.txt' 2>&1
+    cwd: "$WORK_DIR/test-pre-abort/main"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "continuing anyway"
+      dirs_exist:
+        - "$WORK_DIR/test-pre-abort/feat-new-warn"
+      files_exist:
+        - "$WORK_DIR/test-pre-abort/feat-new-warn/exec-marker.txt"


### PR DESCRIPTION
## Summary

The `worktree-pre-create` hook path hardcoded an abort guard right after
`run_hook`, silently overriding `daft.hooks.worktreePreCreate.failMode warn`.
That guard was **dead code under the default `Abort`** (the executor already
`bail!`s inside `run_hook`, so `?` aborts first) and fired **only under
`warn`** — where the executor returns `Ok(success: false)` "continuing anyway",
then the guard re-aborted the one case that asked to continue. After #766 taught
`worktree-post-create` to honor `warn`, pre-create was the lone hook that
swallowed it.

This deletes the guard at both creation sites so the executor's fail-mode
handling is authoritative:

- **`Abort` (default)** — still aborts, via `?` propagation. Behavior unchanged.
- **`warn`** — creation now proceeds past a failing pre-create gate, symmetric
  with post-create and every other hook.

This is **option 1 (honor `warn`)** from the issue, chosen over option 2
(document pre-create as always-abort) for parity across the hook surface.

## Changes

- **`src/core/worktree/checkout.rs` + `checkout_branch.rs`** — remove the
  `if !success && !skipped { bail }` guard on both the existing-branch and
  new-branch paths; the executor decides. The now-unreachable
  `"Pre-create hook failed"` string is retired in favor of the executor's
  richer `"worktree-pre-create hook failed with exit code N"`.
- **`tests/manual/scenarios/hooks/pre-create-abort.yml`** — upgrade the
  pre-existing smoke test into a proper regression test: abort (exit 1, no
  worktree created) **plus** the `warn` opt-out, across both creation paths.
- **`docs/hooks/lifecycle.md`** — document the `worktreePreCreate.failMode warn`
  downgrade next to the existing post-create example.

## Testing

- `mise run test:unit` — **2960 passed**
- New scenario `hooks/pre-create-abort.yml` — **7/7 steps**
- Broader `hooks` + `checkout-branch` + `checkout` suites — **158/158 scenarios
  (630 steps)**, confirming the guard removal regressed nothing
- `mise run fmt` clean, `mise run clippy` zero warnings

Pre-create runs before `git worktree add`, so an aborted gate leaves nothing on
disk — no cleanup path or enriched recovery message needed (unlike
post-create's keep-on-disk handling).

Fixes #767

🤖 Generated with [Claude Code](https://claude.com/claude-code)
