### PR TITLE
feat(hooks): add tracked daft.yml fail_mode: key for hook failure mode

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -381,7 +381,9 @@ worktree stays on disk. Fix the cause, then
 `daft hooks run worktree-post-create` from inside that worktree to finish setup
 — do not treat the worktree as missing.
 `git config daft.hooks.worktreePostCreate.failMode warn` opts back into
-continue-on-failure.
+continue-on-failure; a repo can also commit `fail_mode: warn` (or `abort`) on a
+hook in `daft.yml` to ship that default to every clone, with the git config
+taking precedence over the committed value.
 
 `pre-merge` aborts the merge on failure; `post-merge` warns but never rolls
 back. Both expose `DAFT_MERGE_*` env vars: `SOURCES`, `TARGET_BRANCH`,

--- a/docs/hooks/lifecycle.md
+++ b/docs/hooks/lifecycle.md
@@ -150,6 +150,10 @@ git config daft.hooks.worktreePostCreate.failMode warn
 git config daft.hooks.worktreePreCreate.failMode warn
 ```
 
+A repo can also **commit** a hook's default fail mode in `daft.yml` via
+`fail_mode:` (`abort` or `warn`), shipping it to every clone; the git config
+above still takes precedence.
+
 Hook failures during moves produce **warnings**, not errors. The move operation
 (rename, transform, adopt) always completes. This prevents a broken hook from
 leaving the worktree in a half-moved state.
@@ -191,6 +195,10 @@ git config daft.hooks.preMerge.failMode warn
 # Restore the default abort behavior
 git config --unset daft.hooks.preMerge.failMode
 ```
+
+The same choice can be **committed** in `daft.yml`
+(`hooks.pre-merge.fail_mode: warn`) to ship it to every clone; a local
+`git config` override still takes precedence.
 
 With `failMode=warn`, a failing pre-merge hook prints
 `pre-merge hook failed with exit code N (continuing anyway)` and the merge

--- a/docs/hooks/yaml-reference.md
+++ b/docs/hooks/yaml-reference.md
@@ -156,8 +156,31 @@ hooks:
 | `skip`         | bool / string / list |         | Skip condition (see [Skip and only conditions](#skip-and-only-conditions)) |
 | `only`         | bool / string / list |         | Only condition (see [Skip and only conditions](#skip-and-only-conditions)) |
 | `jobs`         | list                 |         | Jobs to execute                                                            |
+| `fail_mode`    | `abort` / `warn`     | varies  | Behavior when this hook fails (see [Failure mode](#failure-mode))          |
 
 Only one of `parallel`, `piped`, or `follow` can be set at a time.
+
+### Failure mode
+
+`fail_mode` controls what happens when a hook exits non-zero:
+
+- `abort` — the failure is fatal and the daft operation stops.
+- `warn` — the failure is reported and the operation continues.
+
+Defaults are per hook type: `worktree-pre-create`, `worktree-post-create`, and
+`pre-merge` default to `abort`; every other hook defaults to `warn`. Committing
+`fail_mode:` ships that choice to every clone, so a repo can mark a best-effort
+hook (a warmup, an optional setup step) non-fatal for everyone.
+
+A local git config `daft.hooks.<hookName>.failMode` overrides the committed
+value, so a developer can always change the mode on their own machine:
+
+```bash
+git config daft.hooks.worktreePostCreate.failMode warn
+```
+
+`fail_mode` has no effect under `tasks:` — `daft run` stops on the first failing
+job regardless.
 
 ## Job entries
 

--- a/docs/hooks/yaml-reference.md
+++ b/docs/hooks/yaml-reference.md
@@ -179,6 +179,11 @@ value, so a developer can always change the mode on their own machine:
 git config daft.hooks.worktreePostCreate.failMode warn
 ```
 
+Both `fail_mode:` and the git config accept `abort` or `warn`
+case-insensitively. If the git config holds an unrecognized value, daft ignores
+it (the committed `fail_mode:` or the default applies) and prints a warning, so
+a typo does not silently change the failure behavior.
+
 `fail_mode` has no effect under `tasks:` — `daft run` stops on the first failing
 job regardless.
 

--- a/docs/recipes/background-warmup.md
+++ b/docs/recipes/background-warmup.md
@@ -63,9 +63,11 @@ the new worktree while the compiler grinds.
 `cargo build` would try to download crates that the parallel fetch is already
 pulling.
 
-The default fail mode for `worktree-post-create` is `warn`, so a failed warmup
-never blocks worktree creation. That's the right default — a warmup is an
-optimization, and an optimization that occasionally fails is still a net win.
+Because `warmup-build` runs in the background, a failed warmup never blocks
+worktree creation — a detached job's exit status doesn't gate the command.
+(Foreground `worktree-post-create` jobs default to `abort`; commit
+`fail_mode: warn` on the hook in `daft.yml` to make a foreground failure
+non-fatal instead.)
 
 ## Variants
 

--- a/docs/recipes/toolchain-bootstrap.md
+++ b/docs/recipes/toolchain-bootstrap.md
@@ -177,6 +177,10 @@ fails, opt into warn-and-continue:
 git config daft.hooks.worktreePostCreate.failMode warn
 ```
 
+To ship that choice to every clone instead of setting it per machine, commit
+`fail_mode: warn` on the `worktree-post-create` hook in `daft.yml` (a local
+`git config` override still takes precedence).
+
 ## Where to next
 
 - **[Background warmup](/recipes/background-warmup)** — once deps are installed,

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -303,6 +303,12 @@ Default fail modes:
 - `preMerge`: `abort` (gates the merge)
 - All others: `warn` (don't block operations)
 
+A hook's fail mode can also be committed per-hook in `daft.yml` via `fail_mode:`
+(`abort` or `warn`), which ships a repo-wide default to every clone. The git
+config above takes precedence, so a developer can still override the committed
+value on their own machine. See the
+[YAML reference](/hooks/yaml-reference#failure-mode).
+
 ### Hook Output Settings
 
 | Key                            | Default | Description                                                                                                                                                                  |

--- a/src/core/settings.rs
+++ b/src/core/settings.rs
@@ -1719,14 +1719,19 @@ fn load_hook_type_config(
         (None, Some(dep)) => git.config_get(&keys::hooks::hook_key(dep, "failMode"))?,
         (None, None) => None,
     };
-    if let Some(value) = fail_mode_value
-        && let Some(mode) = FailMode::parse(&value)
-    {
-        hook_config.fail_mode = mode;
-        // A parsed git value takes precedence over any committed
-        // `daft.yml fail_mode:` (see the executor's `resolve_fail_mode`). An
-        // unparseable value is ignored, leaving the daft.yml value free to win.
-        hook_config.fail_mode_from_git = true;
+    if let Some(value) = fail_mode_value {
+        if let Some(mode) = FailMode::parse(&value) {
+            hook_config.fail_mode = mode;
+            // A parsed git value takes precedence over any committed
+            // `daft.yml fail_mode:` (see the executor's `resolve_fail_mode`).
+            hook_config.fail_mode_from_git = true;
+        } else {
+            // Present but unparseable (e.g. a typo): leave the daft.yml value
+            // (or the default) free to win, but remember the bad value so the
+            // executor can warn that the git override was ignored rather than
+            // silently dropping it.
+            hook_config.fail_mode_git_unparsed = Some(value);
+        }
     }
 
     Ok(())
@@ -1762,14 +1767,19 @@ fn load_hook_type_config_global(
         (None, Some(dep)) => git.config_get_global(&keys::hooks::hook_key(dep, "failMode"))?,
         (None, None) => None,
     };
-    if let Some(value) = fail_mode_value
-        && let Some(mode) = FailMode::parse(&value)
-    {
-        hook_config.fail_mode = mode;
-        // A parsed git value takes precedence over any committed
-        // `daft.yml fail_mode:` (see the executor's `resolve_fail_mode`). An
-        // unparseable value is ignored, leaving the daft.yml value free to win.
-        hook_config.fail_mode_from_git = true;
+    if let Some(value) = fail_mode_value {
+        if let Some(mode) = FailMode::parse(&value) {
+            hook_config.fail_mode = mode;
+            // A parsed git value takes precedence over any committed
+            // `daft.yml fail_mode:` (see the executor's `resolve_fail_mode`).
+            hook_config.fail_mode_from_git = true;
+        } else {
+            // Present but unparseable (e.g. a typo): leave the daft.yml value
+            // (or the default) free to win, but remember the bad value so the
+            // executor can warn that the git override was ignored rather than
+            // silently dropping it.
+            hook_config.fail_mode_git_unparsed = Some(value);
+        }
     }
 
     Ok(())
@@ -2095,6 +2105,110 @@ mod tests {
         assert!(
             global.worktree_post_create.fail_mode_from_git,
             "load_hooks_config_global must also set fail_mode_from_git"
+        );
+    }
+
+    /// #768 (review follow-up): a git-config `failMode` that is present but
+    /// unparseable (a typo) must be *captured* — not silently swallowed — in
+    /// BOTH loaders: `fail_mode_from_git` stays false (so a committed daft.yml
+    /// value is free to win), `fail_mode` stays at the type default, and the
+    /// raw bad value is recorded so the executor can warn instead of quietly
+    /// downgrading a gating hook. Guards the same two-site asymmetry as the
+    /// flag test above.
+    #[test]
+    #[serial_test::serial]
+    fn unparseable_git_fail_mode_is_captured_in_both_loaders() {
+        struct Restore {
+            cwd: Option<std::path::PathBuf>,
+            global: Option<std::ffi::OsString>,
+            nosystem: Option<std::ffi::OsString>,
+        }
+        impl Drop for Restore {
+            fn drop(&mut self) {
+                if let Some(cwd) = &self.cwd {
+                    let _ = std::env::set_current_dir(cwd);
+                }
+                unsafe {
+                    match self.global.take() {
+                        Some(v) => std::env::set_var("GIT_CONFIG_GLOBAL", v),
+                        None => std::env::remove_var("GIT_CONFIG_GLOBAL"),
+                    }
+                    match self.nosystem.take() {
+                        Some(v) => std::env::set_var("GIT_CONFIG_NOSYSTEM", v),
+                        None => std::env::remove_var("GIT_CONFIG_NOSYSTEM"),
+                    }
+                }
+            }
+        }
+
+        let _restore = Restore {
+            cwd: std::env::current_dir().ok(),
+            global: std::env::var_os("GIT_CONFIG_GLOBAL"),
+            nosystem: std::env::var_os("GIT_CONFIG_NOSYSTEM"),
+        };
+
+        let home = tempfile::tempdir().unwrap();
+        let global_cfg = home.path().join("gitconfig-global");
+        std::fs::write(&global_cfg, "").unwrap();
+        unsafe {
+            std::env::set_var("GIT_CONFIG_GLOBAL", &global_cfg);
+            std::env::set_var("GIT_CONFIG_NOSYSTEM", "1");
+        }
+
+        let repo = tempfile::tempdir().unwrap();
+        let repo_path = repo.path().canonicalize().unwrap();
+        let git = |args: &[&str]| {
+            let out = crate::utils::git_command_at(&repo_path)
+                .args(args)
+                .output()
+                .unwrap();
+            assert!(
+                out.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        };
+        git(&["init", "-b", "main"]);
+        // A typo: present but unparseable.
+        git(&["config", "daft.hooks.worktreePostCreate.failMode", "abrot"]);
+
+        std::env::set_current_dir(&repo_path).unwrap();
+
+        // Local (effective) loader.
+        let local = load_hooks_config_with(&GitCommand::new(true)).unwrap();
+        assert!(
+            !local.worktree_post_create.fail_mode_from_git,
+            "an unparseable git value must not flag fail_mode_from_git (local)"
+        );
+        assert_eq!(
+            local.worktree_post_create.fail_mode_git_unparsed.as_deref(),
+            Some("abrot"),
+            "the local loader must capture the unparseable git value"
+        );
+        assert_eq!(
+            local.worktree_post_create.fail_mode,
+            FailMode::Abort,
+            "fail_mode stays at the type default when git is unparseable"
+        );
+
+        // Global-only loader (clone / repo-remove path): SAME capture, or the
+        // executor's override warning never fires at clone time.
+        git(&[
+            "config",
+            "--file",
+            global_cfg.to_str().unwrap(),
+            "daft.hooks.worktreePostCreate.failMode",
+            "abrot",
+        ]);
+        let global = load_hooks_config_global().unwrap();
+        assert!(!global.worktree_post_create.fail_mode_from_git);
+        assert_eq!(
+            global
+                .worktree_post_create
+                .fail_mode_git_unparsed
+                .as_deref(),
+            Some("abrot"),
+            "load_hooks_config_global must also capture the unparseable value"
         );
     }
 

--- a/src/core/settings.rs
+++ b/src/core/settings.rs
@@ -45,7 +45,7 @@
 //! | `daft.hooks.output.tailLines` | `6` | Rolling output tail lines per job (0 = none) |
 //! | `daft.hooks.output.verbose` | `false` | Show skipped jobs and their reasons |
 //! | `daft.hooks.<hookName>.enabled` | `true` | Enable/disable specific hook |
-//! | `daft.hooks.<hookName>.failMode` | varies | Behavior on hook failure (abort/warn). Defaults: `worktreePreCreate`, `worktreePostCreate`, `preMerge` abort; all others warn |
+//! | `daft.hooks.<hookName>.failMode` | varies | Behavior on hook failure (abort/warn). Also settable per-hook in `daft.yml` via `fail_mode:`; this git-config value takes precedence over the committed one. Defaults: `worktreePreCreate`, `worktreePostCreate`, `preMerge` abort; all others warn |
 //!
 //! # Example
 //!
@@ -1723,6 +1723,10 @@ fn load_hook_type_config(
         && let Some(mode) = FailMode::parse(&value)
     {
         hook_config.fail_mode = mode;
+        // A parsed git value takes precedence over any committed
+        // `daft.yml fail_mode:` (see the executor's `resolve_fail_mode`). An
+        // unparseable value is ignored, leaving the daft.yml value free to win.
+        hook_config.fail_mode_from_git = true;
     }
 
     Ok(())
@@ -1762,6 +1766,10 @@ fn load_hook_type_config_global(
         && let Some(mode) = FailMode::parse(&value)
     {
         hook_config.fail_mode = mode;
+        // A parsed git value takes precedence over any committed
+        // `daft.yml fail_mode:` (see the executor's `resolve_fail_mode`). An
+        // unparseable value is ignored, leaving the daft.yml value free to win.
+        hook_config.fail_mode_from_git = true;
     }
 
     Ok(())
@@ -1986,6 +1994,107 @@ mod tests {
         assert!(
             DaftSettings::load_global().unwrap().use_gitoxide,
             "control: global config reads true, so false above came from local"
+        );
+    }
+
+    /// #768: a git-config hook `failMode` must resolve into `HookConfig` with
+    /// `fail_mode_from_git = true` from BOTH loaders — the local (effective)
+    /// one that drives checkout, and the global-only one that drives clone /
+    /// repo-remove. That flag is what gives git config precedence over a
+    /// committed `daft.yml fail_mode:`, so an implementer who sets it in one
+    /// loader but not the other would break clone-time precedence silently.
+    /// A hook with no git override keeps the flag false.
+    #[test]
+    #[serial_test::serial]
+    fn git_fail_mode_sets_from_git_flag_in_both_loaders() {
+        // Restore cwd + git-config env vars on the way out (panic or not).
+        struct Restore {
+            cwd: Option<std::path::PathBuf>,
+            global: Option<std::ffi::OsString>,
+            nosystem: Option<std::ffi::OsString>,
+        }
+        impl Drop for Restore {
+            fn drop(&mut self) {
+                if let Some(cwd) = &self.cwd {
+                    let _ = std::env::set_current_dir(cwd);
+                }
+                unsafe {
+                    restore_var("GIT_CONFIG_GLOBAL", self.global.take());
+                    restore_var("GIT_CONFIG_NOSYSTEM", self.nosystem.take());
+                }
+            }
+        }
+        unsafe fn restore_var(key: &str, prev: Option<std::ffi::OsString>) {
+            match prev {
+                Some(v) => unsafe { std::env::set_var(key, v) },
+                None => unsafe { std::env::remove_var(key) },
+            }
+        }
+
+        let _restore = Restore {
+            cwd: std::env::current_dir().ok(),
+            global: std::env::var_os("GIT_CONFIG_GLOBAL"),
+            nosystem: std::env::var_os("GIT_CONFIG_NOSYSTEM"),
+        };
+
+        // Isolate global + system git config into a temp file (CLAUDE.md
+        // Critical Rule #1), starting empty so the local phase sees no global
+        // failMode.
+        let home = tempfile::tempdir().unwrap();
+        let global_cfg = home.path().join("gitconfig-global");
+        std::fs::write(&global_cfg, "").unwrap();
+        unsafe {
+            std::env::set_var("GIT_CONFIG_GLOBAL", &global_cfg);
+            std::env::set_var("GIT_CONFIG_NOSYSTEM", "1");
+        }
+
+        // A repo whose LOCAL config flips post-create failMode to warn (the
+        // type default is abort, #765, so warn is an observable override).
+        let repo = tempfile::tempdir().unwrap();
+        let repo_path = repo.path().canonicalize().unwrap();
+        let git = |args: &[&str]| {
+            let out = crate::utils::git_command_at(&repo_path)
+                .args(args)
+                .output()
+                .unwrap();
+            assert!(
+                out.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        };
+        git(&["init", "-b", "main"]);
+        git(&["config", "daft.hooks.worktreePostCreate.failMode", "warn"]);
+
+        std::env::set_current_dir(&repo_path).unwrap();
+
+        // Local (effective) loader: the repo-local value resolves and is
+        // flagged as git-set; an untouched hook keeps the flag false.
+        let local = load_hooks_config_with(&GitCommand::new(true)).unwrap();
+        assert_eq!(local.worktree_post_create.fail_mode, FailMode::Warn);
+        assert!(
+            local.worktree_post_create.fail_mode_from_git,
+            "a git-set failMode must flag fail_mode_from_git (local loader)"
+        );
+        assert!(
+            !local.post_clone.fail_mode_from_git,
+            "a hook with no git override must leave the flag false"
+        );
+
+        // Global-only loader (clone / repo-remove path): the SAME flag must be
+        // set from the global scope, or clone-time precedence breaks silently.
+        git(&[
+            "config",
+            "--file",
+            global_cfg.to_str().unwrap(),
+            "daft.hooks.worktreePostCreate.failMode",
+            "warn",
+        ]);
+        let global = load_hooks_config_global().unwrap();
+        assert_eq!(global.worktree_post_create.fail_mode, FailMode::Warn);
+        assert!(
+            global.worktree_post_create.fail_mode_from_git,
+            "load_hooks_config_global must also set fail_mode_from_git"
         );
     }
 

--- a/src/hooks/config_merge.rs
+++ b/src/hooks/config_merge.rs
@@ -138,6 +138,7 @@ pub fn merge_hook_defs(base: HookDef, overlay: HookDef) -> HookDef {
         only,
         jobs,
         commands,
+        fail_mode,
     } = overlay;
 
     let mut merged = base;
@@ -166,6 +167,9 @@ pub fn merge_hook_defs(base: HookDef, overlay: HookDef) -> HookDef {
     }
     if only.is_some() {
         merged.only = only;
+    }
+    if fail_mode.is_some() {
+        merged.fail_mode = fail_mode;
     }
 
     // Jobs: merge named jobs by name, append unnamed
@@ -527,6 +531,7 @@ fn merge3_hook_defs(
         only: b_only,
         jobs: b_jobs,
         commands: b_commands,
+        fail_mode: b_fail_mode,
     } = base;
 
     HookDef {
@@ -594,6 +599,13 @@ fn merge3_hook_defs(
             b_commands,
             &ours.commands,
             &theirs.commands,
+            tally,
+        ),
+        fail_mode: pick3(
+            &format!("{prefix}.fail_mode"),
+            b_fail_mode,
+            &ours.fail_mode,
+            &theirs.fail_mode,
             tally,
         ),
     }
@@ -981,6 +993,19 @@ mod tests {
         };
         let merged = merge_hook_defs(HookDef::default(), overlay);
         assert_eq!(merged.background, Some(true));
+    }
+
+    #[test]
+    fn merge_hook_defs_preserves_fail_mode() {
+        use crate::hooks::FailMode;
+        // `fail_mode` is a scalar that must survive the overlay merge like the
+        // others, so `extends`/overlays can carry a committed failure mode.
+        let overlay = HookDef {
+            fail_mode: Some(FailMode::Abort),
+            ..Default::default()
+        };
+        let merged = merge_hook_defs(HookDef::default(), overlay);
+        assert_eq!(merged.fail_mode, Some(FailMode::Abort));
     }
 
     // ── merge3 ───────────────────────────────────────────────────────

--- a/src/hooks/executor.rs
+++ b/src/hooks/executor.rs
@@ -32,6 +32,29 @@ fn resolve_fail_mode(hook_config: &HookConfig, yaml: Option<FailMode>) -> FailMo
     }
 }
 
+/// Build a warning when an *unparseable* git-config `failMode` is silently
+/// overridden by a committed `daft.yml fail_mode:`.
+///
+/// Under "git wins", a present git value is expected to override the committed
+/// one — but a typo (`abrot`) does not parse, so it is ignored and the YAML
+/// value wins instead. Left silent, someone who ran `git config … failMode
+/// abrot` to restore local gating would believe they had, while a failing
+/// gating hook is quietly downgraded to the committed `warn`. Scoped to the
+/// exact harm: only fires when a YAML value is actually present to be
+/// overridden. Returns `None` (no warning) otherwise.
+fn unparsed_git_fail_mode_warning(
+    hook_config: &HookConfig,
+    yaml: Option<FailMode>,
+) -> Option<String> {
+    match (&hook_config.fail_mode_git_unparsed, yaml) {
+        (Some(bad), Some(yaml_mode)) => Some(format!(
+            "Ignoring invalid git config failMode {bad:?} (expected \"abort\" or \"warn\"); \
+             using the committed daft.yml fail_mode: {yaml_mode}"
+        )),
+        _ => None,
+    }
+}
+
 /// Result of a hook execution.
 #[derive(Debug, Clone)]
 pub struct HookResult {
@@ -379,6 +402,13 @@ impl HookExecutor {
         // every `Ok(Some(...))` exit below so the caller can translate a failure
         // per the resolved mode.
         let effective_fail_mode = resolve_fail_mode(hook_config, hook_def.fail_mode);
+
+        // Surface an unparseable git `failMode` that is being silently
+        // overridden by the committed value, so the misconfiguration is visible
+        // rather than a quiet gating downgrade.
+        if let Some(msg) = unparsed_git_fail_mode_warning(hook_config, hook_def.fail_mode) {
+            output.warning(&msg);
+        }
 
         // Check trust level (unless bypassed by explicit invocation)
         if !self.bypass_trust {
@@ -850,6 +880,32 @@ mod tests {
             FailMode::Abort
         );
         assert_eq!(resolve_fail_mode(&cfg, None), FailMode::Abort);
+    }
+
+    #[test]
+    fn unparsed_git_fail_mode_warns_only_when_overriding_a_committed_value() {
+        let mut cfg = HookConfig::new(HookType::PreMerge);
+
+        // No unparseable git value recorded → never warns.
+        assert!(unparsed_git_fail_mode_warning(&cfg, Some(FailMode::Warn)).is_none());
+        assert!(unparsed_git_fail_mode_warning(&cfg, None).is_none());
+
+        // A present-but-unparseable git value (e.g. a `failMode abrot` typo)...
+        cfg.fail_mode_git_unparsed = Some("abrot".to_string());
+
+        // ...with a committed daft.yml value being silently overridden → warn,
+        // naming the bad value. This is the precise harm: the user believes
+        // their git override re-gated the hook, but the committed value wins.
+        let msg = unparsed_git_fail_mode_warning(&cfg, Some(FailMode::Warn))
+            .expect("must warn when a committed value silently wins over a bad git value");
+        assert!(
+            msg.contains("abrot"),
+            "warning should name the bad value: {msg}"
+        );
+
+        // ...but with no committed value nothing is being overridden (the
+        // default applies either way), so stay quiet to avoid noise.
+        assert!(unparsed_git_fail_mode_warning(&cfg, None).is_none());
     }
 
     #[test]

--- a/src/hooks/executor.rs
+++ b/src/hooks/executor.rs
@@ -17,6 +17,21 @@ use anyhow::Result;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+/// Resolve a hook's effective fail mode from the two sources that can set it.
+///
+/// Precedence is **git wins**: a git-config `daft.hooks.<hook>.failMode`
+/// (recorded in `hook_config.fail_mode_from_git`) overrides a committed
+/// `daft.yml fail_mode:`, which in turn overrides the hook-type default. When
+/// git did not set the value, `hook_config.fail_mode` still holds that default,
+/// so the committed YAML value is used if present and the default otherwise.
+fn resolve_fail_mode(hook_config: &HookConfig, yaml: Option<FailMode>) -> FailMode {
+    if hook_config.fail_mode_from_git {
+        hook_config.fail_mode
+    } else {
+        yaml.unwrap_or(hook_config.fail_mode)
+    }
+}
+
 /// Result of a hook execution.
 #[derive(Debug, Clone)]
 pub struct HookResult {
@@ -279,23 +294,23 @@ impl HookExecutor {
         let hook_source_worktree = get_hook_source_worktree(ctx);
 
         // Try YAML config first. `try_yaml_hook` returns:
-        // * `Ok(Some(result))` when the YAML hook was run (including failed
-        //   runs — the caller translates those to Err-or-warn based on the
-        //   configured fail mode below).
+        // * `Ok(Some((result, fail_mode)))` when the YAML hook was run
+        //   (including failed runs — the caller translates those to Err-or-warn
+        //   based on the resolved fail mode below).
         // * `Ok(None)` when no YAML config applies to this hook type.
         // * `Err(_)` only when YAML loading/parsing itself failed — an
         //   infrastructure error that we treat as "fall back to legacy"
         //   rather than a hook-semantic failure.
         match self.try_yaml_hook(ctx, &hook_source_worktree, hook_config, output, &presenter) {
-            Ok(Some(result)) => {
+            Ok(Some((result, fail_mode))) => {
                 // The YAML hook was invoked. If the hook itself failed
                 // (exit != 0) and was not skipped, translate per its
-                // configured fail mode — Abort bails, Warn logs and
+                // resolved fail mode — Abort bails, Warn logs and
                 // returns a success-ish HookResult so the caller can
                 // continue. Skipped or successful results pass through
                 // unchanged.
                 if !result.success && !result.skipped {
-                    return self.handle_hook_failure(ctx.hook_type, hook_config, result, output);
+                    return self.handle_hook_failure(ctx.hook_type, fail_mode, result, output);
                 }
                 return Ok(result);
             }
@@ -313,7 +328,7 @@ impl HookExecutor {
 
     /// Try to execute a hook via YAML configuration.
     ///
-    /// Returns `Ok(Some(result))` if YAML config exists and defines this
+    /// Returns `Ok(Some((result, fail_mode)))` if YAML config exists and defines this
     /// hook — including failed runs. Failure translation (Abort-vs-Warn)
     /// is the caller's responsibility via `handle_hook_failure`.
     /// Returns `Ok(None)` if no YAML config or no definition for this
@@ -323,10 +338,10 @@ impl HookExecutor {
         &self,
         ctx: &HookContext,
         hook_source_worktree: &Path,
-        _hook_config: &HookConfig,
+        hook_config: &HookConfig,
         output: &mut dyn Output,
         presenter: &Arc<dyn JobPresenter>,
-    ) -> Result<Option<HookResult>> {
+    ) -> Result<Option<(HookResult, FailMode)>> {
         let yaml_config = if ctx.hook_type == HookType::PreCreate {
             // For PreCreate, the target worktree doesn't exist yet.
             // Load config from the target branch via git show, falling back
@@ -359,6 +374,12 @@ impl HookExecutor {
             }
         };
 
+        // Resolve the effective fail mode now, while both the git-derived
+        // `hook_config` and the parsed `hook_def` are in scope. Threaded through
+        // every `Ok(Some(...))` exit below so the caller can translate a failure
+        // per the resolved mode.
+        let effective_fail_mode = resolve_fail_mode(hook_config, hook_def.fail_mode);
+
         // Check trust level (unless bypassed by explicit invocation)
         if !self.bypass_trust {
             let trust_level = self.get_verified_trust_level(&ctx.git_dir, output);
@@ -380,14 +401,20 @@ impl HookExecutor {
                     output.debug(&format!(
                         "Skipping {hook_name} YAML hooks: repository not trusted"
                     ));
-                    return Ok(Some(HookResult::skipped("Repository not trusted")));
+                    return Ok(Some((
+                        HookResult::skipped("Repository not trusted"),
+                        effective_fail_mode,
+                    )));
                 }
                 TrustLevel::Prompt => {
                     let prompt_msg =
                         format!("Repository has YAML hook config for '{hook_name}'. Execute?");
                     if let Some(ref callback) = self.prompt_callback {
                         if !callback(&prompt_msg) {
-                            return Ok(Some(HookResult::skipped("User declined hook execution")));
+                            return Ok(Some((
+                                HookResult::skipped("User declined hook execution"),
+                                effective_fail_mode,
+                            )));
                         }
                     } else {
                         output.warning(&format!(
@@ -395,7 +422,10 @@ impl HookExecutor {
                             crate::daft_cmd("hooks trust")
                         ));
                         trust_skip::record_skip(ctx, SKIP_REASON_PROMPT_UNAVAILABLE);
-                        return Ok(Some(HookResult::skipped("No permission callback")));
+                        return Ok(Some((
+                            HookResult::skipped("No permission callback"),
+                            effective_fail_mode,
+                        )));
                     }
                 }
                 TrustLevel::Allow => {}
@@ -431,12 +461,12 @@ impl HookExecutor {
         let result =
             yaml_executor::execute_yaml_hook_with_rc(hook_name, hook_def, ctx, output, &cfg)?;
 
-        // Return the raw result — failure translation (Abort → Err, Warn →
-        // logged-and-continue) is the caller's responsibility via
-        // `handle_hook_failure` in `execute`. Doing it here would
-        // misclassify Abort-mode hook failures as "YAML config load error"
+        // Return the raw result plus the resolved fail mode — failure
+        // translation (Abort → Err, Warn → logged-and-continue) is the caller's
+        // responsibility via `handle_hook_failure` in `execute`. Doing it here
+        // would misclassify Abort-mode hook failures as "YAML config load error"
         // at the outer dispatch and silently fall back to legacy scripts.
-        Ok(Some(result))
+        Ok(Some((result, effective_fail_mode)))
     }
 
     /// Execute legacy script-based hooks.
@@ -580,7 +610,12 @@ impl HookExecutor {
                 failed.stdout.clone(),
                 failed.stderr.clone(),
             );
-            return self.handle_hook_failure(ctx.hook_type, hook_config, hook_result, output);
+            return self.handle_hook_failure(
+                ctx.hook_type,
+                hook_config.fail_mode,
+                hook_result,
+                output,
+            );
         }
 
         Ok(HookResult::success())
@@ -620,17 +655,17 @@ impl HookExecutor {
         }
     }
 
-    /// Handle a hook failure based on the fail mode.
+    /// Handle a hook failure based on the resolved fail mode.
     fn handle_hook_failure(
         &self,
         hook_type: HookType,
-        config: &HookConfig,
+        fail_mode: FailMode,
         result: HookResult,
         output: &mut dyn Output,
     ) -> Result<HookResult> {
         let exit_code = result.exit_code.unwrap_or(-1);
 
-        match config.fail_mode {
+        match fail_mode {
             FailMode::Abort => {
                 output.error(&format!(
                     "{} hook failed with exit code {}",
@@ -790,6 +825,31 @@ mod tests {
         }
 
         hook_path
+    }
+
+    #[test]
+    fn resolve_fail_mode_git_beats_yaml_beats_default() {
+        // PostCreate defaults to Abort; git has not set the value.
+        let mut cfg = HookConfig::new(HookType::PostCreate);
+        assert_eq!(cfg.fail_mode, FailMode::Abort);
+        assert!(!cfg.fail_mode_from_git);
+
+        // git unset + yaml set → the committed daft.yml value wins over the default.
+        assert_eq!(
+            resolve_fail_mode(&cfg, Some(FailMode::Warn)),
+            FailMode::Warn
+        );
+        // git unset + yaml unset → the hook-type default.
+        assert_eq!(resolve_fail_mode(&cfg, None), FailMode::Abort);
+
+        // git set (even to the type default) → git config wins over daft.yml.
+        cfg.fail_mode = FailMode::Abort;
+        cfg.fail_mode_from_git = true;
+        assert_eq!(
+            resolve_fail_mode(&cfg, Some(FailMode::Warn)),
+            FailMode::Abort
+        );
+        assert_eq!(resolve_fail_mode(&cfg, None), FailMode::Abort);
     }
 
     #[test]

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -250,7 +250,11 @@ impl fmt::Display for HookType {
 }
 
 /// Behavior when a hook fails (non-zero exit code).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+///
+/// `Serialize` is derived (lowercase). `Deserialize` is hand-written (below) so
+/// a committed `daft.yml fail_mode:` parses case-insensitively — the same rule
+/// the git-config `failMode` surface already uses via [`FailMode::parse`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum FailMode {
     /// Abort the operation if the hook fails.
@@ -261,13 +265,34 @@ pub enum FailMode {
 }
 
 impl FailMode {
-    /// Parse a fail mode from a string.
+    /// Parse a fail mode from a string (case-insensitive).
     pub fn parse(s: &str) -> Option<Self> {
         match s.to_lowercase().as_str() {
             "abort" => Some(FailMode::Abort),
             "warn" => Some(FailMode::Warn),
             _ => None,
         }
+    }
+}
+
+impl<'de> Deserialize<'de> for FailMode {
+    /// Deserialize case-insensitively via [`FailMode::parse`] so a committed
+    /// `daft.yml fail_mode:` accepts the same spellings the git-config
+    /// `failMode` surface does (`abort`, `Abort`, `WARN`, …). A derived
+    /// `rename_all = "lowercase"` deserialize would reject a mis-cased value
+    /// that git config accepts and — because a bad enum value fails the *entire*
+    /// `daft.yml` deserialize — would silently drop every YAML hook for that
+    /// operation to the legacy-script fallback.
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        FailMode::parse(&s).ok_or_else(|| {
+            serde::de::Error::custom(format!(
+                "invalid fail_mode {s:?}, expected \"abort\" or \"warn\""
+            ))
+        })
     }
 }
 
@@ -293,6 +318,13 @@ pub struct HookConfig {
     /// git value left unset lets the `daft.yml` value win over the default.
     /// See `executor::resolve_fail_mode`.
     pub fail_mode_from_git: bool,
+    /// The raw git-config `failMode` value when it was present but did not
+    /// parse (e.g. a typo like `abrot`). `None` when git was unset or supplied
+    /// a valid value. An unparseable git value is ignored — the `daft.yml`
+    /// value (or the default) wins — but the executor surfaces this so the
+    /// silent-override footgun becomes a visible warning. See
+    /// `executor::unparsed_git_fail_mode_warning`.
+    pub fail_mode_git_unparsed: Option<String>,
 }
 
 impl HookConfig {
@@ -302,6 +334,7 @@ impl HookConfig {
             enabled: true,
             fail_mode: hook_type.default_fail_mode(),
             fail_mode_from_git: false,
+            fail_mode_git_unparsed: None,
         }
     }
 }

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -64,6 +64,7 @@ pub use executor::{HookExecutor, HookResult};
 pub use trust::{TrustDatabase, TrustEntry, TrustLevel, get_remote_url_for_git_dir};
 
 use crate::settings::HookOutputConfig;
+use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::path::Path;
 
@@ -249,7 +250,8 @@ impl fmt::Display for HookType {
 }
 
 /// Behavior when a hook fails (non-zero exit code).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum FailMode {
     /// Abort the operation if the hook fails.
     Abort,
@@ -285,6 +287,12 @@ pub struct HookConfig {
     pub enabled: bool,
     /// Behavior when the hook fails.
     pub fail_mode: FailMode,
+    /// Whether `fail_mode` was set explicitly via git config (rather than left
+    /// at the hook-type default). Lets the executor give a git-config
+    /// `failMode` precedence over a committed `daft.yml fail_mode:`, while a
+    /// git value left unset lets the `daft.yml` value win over the default.
+    /// See `executor::resolve_fail_mode`.
+    pub fail_mode_from_git: bool,
 }
 
 impl HookConfig {
@@ -293,6 +301,7 @@ impl HookConfig {
         Self {
             enabled: true,
             fail_mode: hook_type.default_fail_mode(),
+            fail_mode_from_git: false,
         }
     }
 }

--- a/src/hooks/yaml_config.rs
+++ b/src/hooks/yaml_config.rs
@@ -525,6 +525,47 @@ hooks:
     }
 
     #[test]
+    fn fail_mode_deserializes_case_insensitively() {
+        use crate::hooks::FailMode;
+
+        // The git-config `failMode` surface is case-insensitive
+        // (FailMode::parse lowercases), so a committed `daft.yml fail_mode:`
+        // must accept the same spellings. Critically, a mis-cased value must
+        // NOT fail the whole YamlConfig deserialize — that would silently drop
+        // every hook for the operation to the legacy-script fallback.
+        for (spelling, expected) in [
+            ("abort", FailMode::Abort),
+            ("Abort", FailMode::Abort),
+            ("ABORT", FailMode::Abort),
+            ("warn", FailMode::Warn),
+            ("WARN", FailMode::Warn),
+        ] {
+            let yaml = format!(
+                "hooks:\n  worktree-post-create:\n    fail_mode: {spelling}\n    \
+                 jobs:\n      - run: \"true\"\n"
+            );
+            let config: YamlConfig = serde_yaml::from_str(&yaml)
+                .unwrap_or_else(|e| panic!("{spelling:?} should parse, got: {e}"));
+            assert_eq!(
+                config.hooks["worktree-post-create"].fail_mode,
+                Some(expected),
+                "{spelling:?} should deserialize to {expected}"
+            );
+        }
+
+        // A genuine typo still errors — loudly, naming the bad value — rather
+        // than being silently accepted.
+        let err = serde_yaml::from_str::<YamlConfig>(
+            "hooks:\n  worktree-post-create:\n    fail_mode: abrot\n    jobs:\n      - run: \"true\"\n",
+        )
+        .expect_err("a non-abort/warn value must fail to parse");
+        assert!(
+            err.to_string().contains("abrot"),
+            "error should name the bad value: {err}"
+        );
+    }
+
+    #[test]
     fn test_tasks_section_parses_full_job_schema() {
         // A task shares the hook body schema: parallel, and per-job env,
         // root, and needs all deserialize the same way.

--- a/src/hooks/yaml_config.rs
+++ b/src/hooks/yaml_config.rs
@@ -159,6 +159,13 @@ pub struct HookDef {
     /// Legacy alias for jobs (commands map).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub commands: Option<HashMap<String, CommandDef>>,
+
+    /// Failure mode for this hook: `abort` (fatal) or `warn` (report and
+    /// continue). Committed here it is a repo-wide default; a git-config
+    /// `daft.hooks.<hookName>.failMode` overrides it (see the executor's
+    /// `resolve_fail_mode`). Has no effect on `tasks:` entries.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fail_mode: Option<super::FailMode>,
 }
 
 /// Target operating system for platform constraints.

--- a/src/hooks/yaml_config_validate.rs
+++ b/src/hooks/yaml_config_validate.rs
@@ -191,6 +191,22 @@ fn validate_hook_def(section: &str, name: &str, hook: &HookDef, result: &mut Val
             "Both 'jobs' and 'commands' are set; 'commands' will be merged into 'jobs'",
         );
     }
+
+    // A hook entry with neither jobs nor commands runs nothing. A
+    // `fail_mode:`-only entry is the natural way to land here, and for the
+    // `hooks:` section its mere presence still suppresses any legacy script
+    // hook of the same name — so make the no-op visible instead of silent.
+    if hook.jobs.is_none() && hook.commands.is_none() {
+        let suffix = if section == "hooks" {
+            "; being present, it also suppresses any legacy script hook of the same name"
+        } else {
+            ""
+        };
+        result.warn(
+            &path,
+            format!("'{name}' defines no jobs or commands, so it runs nothing{suffix}"),
+        );
+    }
 }
 
 /// Validate a single job definition.
@@ -485,6 +501,30 @@ mod tests {
         let result = validate_config(&config).unwrap();
         assert!(result.is_ok());
         assert!(result.warnings.is_empty());
+    }
+
+    #[test]
+    fn test_fail_mode_only_hook_entry_warns_it_runs_nothing() {
+        // A `fail_mode:`-only hook entry (no jobs, no commands) runs nothing
+        // and, by its mere presence, suppresses any legacy script hook of the
+        // same name. Surface that as a warning rather than a silent no-op.
+        let yaml = r#"
+hooks:
+  worktree-post-create:
+    fail_mode: abort
+"#;
+        let config: YamlConfig = serde_yaml::from_str(yaml).unwrap();
+        let result = validate_config(&config).unwrap();
+        assert!(result.is_ok(), "empty entry is a warning, not an error");
+        assert!(
+            result.warnings.iter().any(|w| {
+                w.path == "hooks.worktree-post-create"
+                    && w.message.contains("runs nothing")
+                    && w.message.contains("legacy")
+            }),
+            "expected a no-op + legacy-suppression warning, got: {:?}",
+            result.warnings
+        );
     }
 
     #[test]

--- a/src/hooks/yaml_config_validate.rs
+++ b/src/hooks/yaml_config_validate.rs
@@ -91,6 +91,13 @@ pub fn validate_config(config: &YamlConfig) -> Result<ValidationResult> {
                 "tasks do not support the legacy 'commands:' form; use 'jobs:'",
             );
         }
+        if task_def.fail_mode.is_some() {
+            result.warn(
+                format!("tasks.{task_name}"),
+                "'fail_mode' has no effect on tasks (daft run exits on the first \
+                 job failure); it applies to lifecycle hooks only",
+            );
+        }
         validate_hook_def("tasks", task_name, task_def, &mut result);
     }
 

--- a/tests/manual/scenarios/hooks/post-create-fail-mode-yaml.yml
+++ b/tests/manual/scenarios/hooks/post-create-fail-mode-yaml.yml
@@ -1,0 +1,74 @@
+name: Committed daft.yml fail_mode is a default that git config overrides
+description:
+  "A committed `fail_mode: warn` on worktree-post-create makes a failing hook
+  non-fatal (exit 0, -x runs), overriding the #765 abort default with no git
+  config at all. A local `git config daft.hooks.worktreePostCreate.failMode
+  abort` then wins over the committed value: the hook aborts creation again,
+  skips -x, and keeps the worktree on disk (#768 precedence: git > daft.yml >
+  default)."
+
+repos:
+  - name: test-pc-failmode
+    default_branch: main
+    branches:
+      - name: main
+        files:
+          - path: README.md
+            content: "# Post-create fail_mode yaml test"
+        commits:
+          - message: "Initial commit"
+      - name: feat-warn-yaml
+        from: main
+      - name: feat-git-abort
+        from: main
+    daft_yml: |
+      hooks:
+        worktree-post-create:
+          fail_mode: warn
+          jobs:
+            - name: setup
+              run: exit 1
+
+steps:
+  - name: Clone the repository
+    run: git-worktree-clone --layout contained $REMOTE_TEST_PC_FAILMODE
+    expect:
+      exit_code: 0
+
+  - name: Trust the repository
+    run: daft hooks trust --force 2>&1
+    cwd: "$WORK_DIR/test-pc-failmode/main"
+    expect:
+      exit_code: 0
+
+  - name:
+      Committed fail_mode=warn makes the failing hook non-fatal (-x runs, exit
+      0)
+    run: git-worktree-checkout feat-warn-yaml -x 'touch exec-marker.txt' 2>&1
+    cwd: "$WORK_DIR/test-pc-failmode/main"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "continuing anyway"
+      files_exist:
+        - "$WORK_DIR/test-pc-failmode/feat-warn-yaml/exec-marker.txt"
+
+  - name:
+      A local git failMode=abort is set to override the committed daft.yml value
+    run: git config daft.hooks.worktreePostCreate.failMode abort
+    cwd: "$WORK_DIR/test-pc-failmode/main"
+    expect:
+      exit_code: 0
+
+  - name: Under git abort the hook aborts creation, skips -x, keeps the worktree
+    run: git-worktree-checkout feat-git-abort -x 'touch exec-marker.txt' 2>&1
+    cwd: "$WORK_DIR/test-pc-failmode/main"
+    expect:
+      exit_code: 1
+      output_contains:
+        - "worktree-post-create hook failed"
+        - "created and kept"
+      files_not_exist:
+        - "$WORK_DIR/test-pc-failmode/feat-git-abort/exec-marker.txt"
+      dirs_exist:
+        - "$WORK_DIR/test-pc-failmode/feat-git-abort"


### PR DESCRIPTION
## What

A hook's **failure mode** (`abort` = fatal, `warn` = report-and-continue) was
settable only via git config (`daft.hooks.<hookName>.failMode`) — local,
per-clone, uncommittable. This adds a committable `fail_mode:` field to each
`daft.yml` hook definition, so a repo can ship a hook's failure mode (e.g. mark
a best-effort warmup non-fatal) to every clone.

#765's acceptance criteria assumed this key already existed; it did not —
`HookDef` had no such field. This is where the knob actually gets designed.

## Precedence (git wins)

```
default_fail_mode()  <  daft.yml fail_mode:  <  git config failMode
```

The committed value is a **repo-wide default**; any git `failMode` (global *or*
local — git collapses them into one effective read, so daft has no slot
*between* them) overrides it, so a developer can always override on their
machine. Mirrors daft's existing `layout` precedence.

## How

`settings.rs` is git-config-only and the parsed YAML is context-dependent (which
branch/worktree — only the executor knows and loads it), so the YAML is **not**
threaded into `settings.rs`. Instead:

- A new `HookConfig.fail_mode_from_git: bool` — set by **both** the local and
  global settings loaders on a successful parse — makes git's explicit-ness
  visible, so a git value set to the type default still beats a committed
  `daft.yml` value.
- `resolve_fail_mode(hook_config, hook_def.fail_mode)` reconciles in the
  executor's `try_yaml_hook`, where both the git-derived `HookConfig` and the
  parsed `HookDef` are in scope. The effective mode is threaded through all four
  `Ok(Some(...))` exits (including the trust/prompt skips).
- `handle_hook_failure` now takes the resolved `FailMode` directly.
- `config_merge.rs`'s two no-`..` destructures compiler-forced the field, so the
  `extends`/overlay merge works for free.

A `bool` beat `Option<FailMode>` because it changes **zero** existing readers.

## Edge cases (deliberate)

- An **unparseable git** `failMode` leaves the flag `false`, so the committed
  `daft.yml` value wins (consistent with today's parse-fails-→-ignored behavior).
- A **typo'd yaml** value fails the whole `daft.yml` deserialize (consistent with
  `TargetOs`/`TargetArch`, which use the same `rename_all = "lowercase"`).
- `fail_mode` is **inert under `tasks:`** (`daft run` exits on the first job
  failure) — validation emits a warning.

## Interaction with #767

#767 (honor `failMode=warn` for `worktree-pre-create`, PR #771) has **merged**;
this branch is rebased on top of it and re-verified green (both touch executor
fail-mode logic). A committed `fail_mode: warn` on `worktree-pre-create` is now
honored end-to-end thanks to #767 — this PR adds *where* the mode is declared.

## Tests

- `resolve_fail_mode` precedence matrix (git-beats-yaml **and** yaml-beats-default).
- A **dual-loader** settings test asserting both the local and global loaders set
  `fail_mode_from_git` — guards the two-site asymmetry (the YAML scenario only
  drives the local loader; the global loader is reached only at clone /
  repo-remove).
- A `config_merge` overlay test.
- YAML scenario `hooks/post-create-fail-mode-yaml.yml` proving both precedence
  directions end-to-end.

Docs updated across yaml-reference, configuration, lifecycle, SKILL, the
`settings.rs` config-key table, and two recipes (including a stale post-#765
line in background-warmup).

Fixes #768

🤖 Generated with [Claude Code](https://claude.com/claude-code)
