### PR TITLE
ci: gate daft's own merges on the CI parity rings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -376,6 +376,11 @@ jobs:
           echo "Committed CLI docs are up-to-date!"
 
       - name: Run xtask unit tests
+        # Deliberately raw cargo, matching the rest of this job: installing
+        # mise here would export RUSTUP_TOOLCHAIN from mise.toml and silently
+        # move the job off `stable` onto the pinned MSRV. `mise run test:xtask`
+        # is the local mirror that daft.yml's xtask-tests ring invokes — keep
+        # the two commands in step by hand.
         run: cargo test --package xtask
 
   # Build release binary once, share across integration test matrix

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,13 +89,17 @@ Rings invoke the same `mise run` task as the CI job they mirror, so a local
 refusal names the check that would have failed on GitHub;
 `merge: { ff: only, source_worktree: clean }` is what makes that mean anything —
 the tree the rings tested is the tree that lands. Slow rings (integration
-matrix, MSRV, Windows) get `tags: [deep]` and are dropped per invocation with
-`--skip-tag deep`, never trimmed from the gate to make it feel fast;
-`--skip-hooks` / `--skip-tag` skip _rings_, never _policy_. Never weaken a gate
-to make a merge pass — fix the check or the code.
+matrix, MSRV, licence audit, completions, docs build) get `tags: [deep]` and are
+dropped per invocation with `--skip-tag deep`, never trimmed from the gate to
+make it feel fast; `--skip-hooks` / `--skip-tag` skip _rings_, never _policy_.
+Never weaken a gate to make a merge pass — fix the check or the code.
 
-This repo's own rings land with #387 (`docs/hooks/yaml-reference.md` for ring
-config) — until then, still add the `mise run` task when you add a CI job.
+This repo's own rings live in `daft.yml` under `hooks: pre-merge:`
+(`docs/hooks/yaml-reference.md` for ring config). A CI job that exists only as
+inline `run:` steps in the workflow cannot be mirrored, which is why every job
+needs its `mise run` task — add the task in the same PR as the job. Four checks
+are deliberately CI-only and say so in `daft.yml`: `windows-check`,
+`release-env-guard`, `homebrew-simulation`, and `bench.yml`.
 `claude-pr-review.yml` is out of the parity set: Critical Rule #3 governs it.
 
 ## Profiling

--- a/daft.yml
+++ b/daft.yml
@@ -1,3 +1,13 @@
+# Merge policy — what makes a green pre-merge ring mean anything. `ff: only`
+# refuses to land a track that does not already contain the trunk tip, so the
+# tree the rings tested is the tree that lands; `source_worktree: clean` closes
+# the gap between the working tree the rings see and the committed tree that
+# merges. Relax either per-invocation with `--no-ff-only` / `--source-worktree
+# any` when you know what you are doing; both refusals name what to fix.
+merge:
+  ff: only
+  source_worktree: clean
+
 hooks:
   post-clone:
     jobs:
@@ -56,6 +66,151 @@ hooks:
       - name: sandbox-clean
         description: Remove the sandbox for this worktree
         run: mise run sandbox:clean
+
+  # The quality gate. One ring per .github/workflows/test.yml job, each
+  # invoking the same `mise run` task as the CI job it mirrors, so a local
+  # refusal names the check that would have failed on GitHub. See CLAUDE.md
+  # "Quality Gates: CI <-> Merge-Gate Parity" — add, remove, or rename a check
+  # in CI, in `mise run ci`, or here, and change all three in the same PR.
+  #
+  # Rings run in the *source* worktree (`root: "{merge_source_path}"`): that is
+  # where the contained code lives and where the caches are warm. The `merge:`
+  # policy above is what makes that safe — ff-only means the tested tree is the
+  # landed tree.
+  #
+  # Parallel (the default mode), deliberately: a gate's job is to surface every
+  # problem in one pass. Stopping at the first red (`piped`) hides every check
+  # behind it and turns one bad merge into a fix-rerun-fix loop, which is also
+  # not what a forge does with its required checks. Failure cascades only to a
+  # job's *dependents*, so `needs:` carries the one real ordering (mirroring
+  # CI's `integration-tests: needs: build`) and every independent ring still
+  # reports. Runtime is not this file's problem: the resource governor
+  # (`daft.governor.mode`, Auto by default) caps concurrency and throttles under
+  # memory pressure, and cargo's build-directory lock serializes the
+  # compile-heavy rings on its own. Order below is cheapest-first only so the
+  # quick verdicts land on the rail first.
+  #
+  # `tags: [deep]` marks the slow rings. Drop them for a quick iteration with
+  # `daft merge --skip-tag deep` — never by trimming them from the gate.
+  #
+  # Deliberately NOT replicated locally:
+  #   windows-check        msvc cross-check is blocked by bundled rusqlite's C
+  #                        toolchain; the cfg(not(unix)) stub-drift class stays
+  #                        CI-only
+  #   release-env-guard    packaging/release concern, not a correctness gate
+  #   homebrew-simulation  same
+  #   bench.yml            benchmarks measure, they do not gate
+  #
+  # CI's `changes` path filters are mirrored only where the saving is large and
+  # the pattern has a single upstream source (docs-build, dep-age-check).
+  # Everything else runs on every merge: locally the safe direction is to run
+  # more checks, not fewer.
+  pre-merge:
+    jobs:
+      - name: fmt-check
+        description: "CI: lint — cargo fmt --check + prettier over md/yml"
+        root: "{merge_source_path}"
+        run: mise run fmt:check
+
+      - name: dep-age-check
+        description: "CI: dep-age-check — no dep entries younger than 7 days"
+        root: "{merge_source_path}"
+        # Mirrors the `lockfile` class of the workflow's `changes` filter.
+        glob:
+          - Cargo.lock
+          - bun.lock
+          - .dep-age-allowlist
+          - cooldown.toml
+          - bunfig.toml
+          - deny.toml
+        # CI compares against the PR base; the local equivalent is the branch
+        # being merged into. An empty BASE_REF falls back to origin/master
+        # inside the task — fine here (that is the trunk), but it means a green
+        # result would not prove the var resolved, so change the two together.
+        run: BASE_REF="$DAFT_MERGE_TARGET_BRANCH" mise run deps:check-age
+
+      - name: clippy
+        description: "CI: lint — clippy must pass with zero warnings"
+        root: "{merge_source_path}"
+        run: mise run clippy
+
+      - name: xtask-tests
+        description: "CI: xtask-test — xtask unit tests"
+        root: "{merge_source_path}"
+        run: mise run test:xtask
+
+      - name: man-verify
+        description: "CI: xtask-test — committed man pages match source"
+        root: "{merge_source_path}"
+        run: mise run man:verify
+
+      - name: cli-docs-verify
+        description: "CI: xtask-test — committed CLI docs match source"
+        root: "{merge_source_path}"
+        run: mise run docs:cli:verify
+
+      - name: unit-tests
+        description: "CI: unit-tests — the Rust unit suite"
+        root: "{merge_source_path}"
+        run: mise run test:unit
+
+      - name: build
+        description: "CI: build — the release binaries actually link"
+        root: "{merge_source_path}"
+        run: mise run build
+
+      - name: dep-license-check
+        description:
+          "CI: dep-license-check — cargo-deny licence/advisory policy"
+        root: "{merge_source_path}"
+        tags: [deep]
+        run: mise run deny
+
+      - name: completions-test
+        description: "CI: integration-tests — shell completion suite"
+        root: "{merge_source_path}"
+        tags: [deep]
+        # Execs the release binary, so a red build tells the whole story and
+        # this adds nothing. CI expresses the same edge as `needs: build`.
+        needs: [build]
+        run: mise run completions:test
+
+      - name: docs-build
+        description: "CI: docs.yml — the VitePress site builds"
+        root: "{merge_source_path}"
+        tags: [deep]
+        # Mirrors docs.yml's own `paths:` trigger.
+        glob:
+          - docs/**
+          - Cargo.toml
+          - .github/workflows/docs.yml
+        run: mise run docs:site:build
+
+      - name: msrv-check
+        description: "CI: msrv-check — cargo check at the declared MSRV"
+        root: "{merge_source_path}"
+        tags: [deep]
+        run: mise run validate:msrv
+
+      - name: integration-tests
+        description: "CI: integration-tests — the full bash + YAML matrix"
+        root: "{merge_source_path}"
+        tags: [deep]
+        needs: [build]
+        run: mise run test:integration
+
+  # A tripwire, not a second suite. test.yml has no `push: master` trigger, so
+  # GitHub never re-validates the trunk after a merge; this is the one check
+  # that the tree the rings gated is the tree that actually landed. Warn rather
+  # than abort (also the default for post-merge): the ref has already moved, so
+  # failing the command here would report a verdict on work that is done — the
+  # useful outcome is a loud notice, not an error exit.
+  post-merge:
+    fail_mode: warn
+    jobs:
+      - name: landed-matches-gated
+        description: The landed tree is the tree the rings tested
+        run: mise run merge:landed-check
 
 tasks:
   run:

--- a/mise-tasks/merge/landed-check
+++ b/mise-tasks/merge/landed-check
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#MISE description="Post-merge tripwire: the landed tree is the tree the gate tested"
+set -euo pipefail
+
+# Run from daft.yml's post-merge hook, whose cwd is the target worktree.
+#
+# .github/workflows/test.yml has no `push: master` trigger, so GitHub never
+# re-validates the trunk after a merge. This is the one check that what the
+# pre-merge rings gated is what actually landed.
+
+# daft can be invoked from inside a git hook, where an inherited GIT_DIR would
+# silently retarget the commands below at the *parent* repo (the same trap
+# CLAUDE.md's Test Hygiene section documents for git subprocesses). Clear the
+# discovery vars so the working directory is authoritative.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE
+
+sources="${DAFT_MERGE_SOURCE_SHAS:-}"
+if [ -z "$sources" ]; then
+    echo "merge:landed-check: DAFT_MERGE_SOURCE_SHAS is empty" >&2
+    echo "  (this task only makes sense from a post-merge hook)" >&2
+    exit 1
+fi
+
+# Newline-joined, one entry per source. `merge: ff: only` plus a configured
+# pre-merge hook restrict a gated merge to a single source, so the first entry
+# is the whole story; a multi-source merge would have been refused upstream.
+source_sha="$(printf '%s\n' "$sources" | head -n1)"
+
+landed="$(git rev-parse --verify "HEAD^{tree}")"
+gated="$(git rev-parse --verify "${source_sha}^{tree}")"
+
+if [ "$landed" != "$gated" ]; then
+    echo "the landed tree is NOT the tree the rings gated:" >&2
+    echo "  gated   ${source_sha} -> ${gated}" >&2
+    echo "  landed  $(git rev-parse --short HEAD) -> ${landed}" >&2
+    echo "A fast-forward lands the source commit verbatim, so this means the" >&2
+    echo "merge was not one (--no-ff-only?) or the trunk moved underneath it." >&2
+    echo "The gate's verdict does not cover what is on the trunk now." >&2
+    exit 1
+fi
+
+echo "landed tree matches the gated tree (${landed})"

--- a/mise-tasks/test/xtask
+++ b/mise-tasks/test/xtask
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#MISE description="Run xtask unit tests"
+set -euo pipefail
+
+# Split out from test:unit, which is root-package only, so the xtask-test CI
+# job is reachable through a mise task and daft.yml's xtask-tests pre-merge
+# ring can mirror it.
+#
+# The workflow deliberately keeps its own `cargo test --package xtask` rather
+# than calling this task: that job has no mise step, and adding one would
+# export RUSTUP_TOOLCHAIN from mise.toml and move it off `stable` onto the
+# pinned MSRV. Keep this command identical to the workflow's by hand.
+echo "Running xtask unit tests..."
+cargo test --package xtask

--- a/mise-tasks/validate/msrv
+++ b/mise-tasks/validate/msrv
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#MISE description="Cargo check at the declared MSRV (Cargo.toml rust-version)"
+set -euo pipefail
+
+# The MSRV is read from Cargo.toml rather than pinned here, so this task tracks
+# a `rust-version` bump on its own. .github/workflows/test.yml cannot do that —
+# its dtolnay/rust-toolchain step pins the version literally — which is exactly
+# why CLAUDE.md's MSRV policy lists the workflow among the files to update by
+# hand after a bump.
+msrv="$(sed -n 's/^rust-version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' Cargo.toml | head -n1)"
+if [ -z "$msrv" ]; then
+    echo "could not read rust-version from Cargo.toml" >&2
+    exit 1
+fi
+
+# `1.95` may be installed as either `1.95-<host>` or `1.95.0-<host>` depending
+# on how it was requested, so allow an optional patch component. Dots are
+# escaped so they cannot match arbitrary characters.
+msrv_re="$(printf '%s' "$msrv" | sed 's/\./\\./g')"
+if ! rustup toolchain list | grep -qE "^${msrv_re}(\.[0-9]+)?-"; then
+    echo "MSRV toolchain ${msrv} is not installed. Install it with:" >&2
+    echo "    rustup toolchain install ${msrv}" >&2
+    exit 1
+fi
+
+echo "Checking at MSRV ${msrv}..."
+rustup run "$msrv" cargo check --all-targets --locked
+echo "MSRV check passed (${msrv})"


### PR DESCRIPTION
Fixes #777

#775 shipped the merge-gate mechanisms and #776 released them (v1.24.0), but
this repo's own `daft.yml` was deliberately left untouched — the boundary
config was slated to land as the first commit on the #387 trunk. That
sequencing reason is gone now that the mechanisms are on master; landing it
standalone means #387 forks against a gate that has already been exercised.
Until this lands, CLAUDE.md's "Quality Gates: CI ↔ Merge-Gate Parity" rule is
a two-surface rule held open by an "until then" clause.

## What lands

**`merge:` policy** — `ff: only` + `source_worktree: clean`. This is what makes
a green ring mean anything: ff-only refuses a track that does not already
contain the trunk tip, so the tree the rings tested is the tree that lands, and
a clean source worktree closes the gap between the working tree the rings see
and the committed tree that merges.

**13 `pre-merge` rings**, one per `test.yml` check, each invoking the same
`mise run` task as the CI job it mirrors, so a local refusal names the check
that would have failed on GitHub. All run `root: "{merge_source_path}"` — in
the track worktree, where the contained code lives and the caches are warm.

- fast: fmt-check, dep-age-check, clippy, xtask-tests, man-verify,
  cli-docs-verify, unit-tests, build
- `tags: [deep]` (drop per-invocation with `--skip-tag deep`):
  dep-license-check, completions-test, docs-build, msrv-check,
  integration-tests

The rings run **in parallel** (the default mode): a gate exists to surface
every problem in one pass, and stopping at the first red would hide every
check behind it — which is also not what a forge does with its required
checks. Failure cascades only to a job's dependents, so `needs: [build]` on
completions-test and integration-tests carries the one real edge (both exec
the release binary; mirrors CI's `integration-tests: needs: build`) while
every independent ring still reports. Runtime is the resource governor's
problem, not this file's: `daft.governor.mode` defaults to Auto and #775 wired
it into exactly this parallel foreground path, and cargo's build-directory
lock serializes the compile-heavy rings on its own.

**`post-merge` tripwire** (`fail_mode: warn`) — `merge:landed-check` asserts
the landed tree is the tree the rings gated. `test.yml` has no `push: master`
trigger, so nothing on GitHub re-validates the trunk after a merge; this is
stricter than the forge setup on exactly that edge. Warn, not abort: the ref
has already moved, so an error exit would report a verdict on finished work.

**New mise tasks**

- `test:xtask` — `cargo test --package xtask` was the one CI check with no
  mise task at all (`test:unit` is root-package only), so it had no local
  equivalent. The workflow keeps calling cargo directly: the `xtask-test` job
  installs no mise, and adding the step would export `RUSTUP_TOOLCHAIN` from
  `mise.toml` and move that job off `stable` onto the pinned MSRV. Same split
  the job already has for man / CLI-docs verification.
- `validate:msrv` — reads `rust-version` from `Cargo.toml`, so it tracks an
  MSRV bump on its own, unlike the workflow's pinned toolchain.
- `merge:landed-check` — the post-merge tripwire.

**CLAUDE.md** — the "until then" clause becomes the standing rule: a CI job
that exists only as inline `run:` steps cannot be mirrored by a ring, which is
why every job needs its `mise run` task. Names the four deliberately CI-only
checks: `windows-check`, `release-env-guard`, `homebrew-simulation`,
`bench.yml`.

## Superseded from #775's reference config

The reference config in the issue predates what #776 actually shipped; its
crutches are all dropped:

| #775 reference                             | now                             |
| ------------------------------------------ | ------------------------------- |
| `single-source` job                        | native policy                   |
| `source-current` job                       | `merge: ff: only`               |
| `source-link` job + `merge:source-link`    | `root: "{merge_source_path}"`   |
| clean-source check inside `source-link`    | `merge: source_worktree: clean` |
| `skip: [{env: DAFT_QUICK_MERGE}]`          | `tags: [deep]`                  |
| `docs-build` "wants glob-gating"           | `glob:` shipped                 |

## Verification

- `daft hooks validate` clean; `hooks dump` shows all 13 rings with correct
  root/tags/glob/needs and the post-merge `fail_mode: warn`.
- Every `mise run X` in `daft.yml` resolves against `mise tasks` (diffed).
- All 7 fast rings run green end to end against this tree.
- `merge:landed-check` exercised on match, drift, and empty-env paths.
- Tag split proven live: `--only-tag deep` selects `dep-license-check` first,
  and `--only-tag deep --skip-tag deep` reports "No jobs matching tags" (skip
  beats only).
- Fail-closed proven: `daft hooks run pre-merge` outside a merge refuses with
  the unresolved-`{merge_source_path}` config error rather than silently
  running in the target worktree.

Known rough edge (mechanism-side, not config): a red `man-verify` /
`cli-docs-verify` regenerates into the track before diffing, so the retry is
refused by `source_worktree: clean` until the regenerated files — which are
exactly the fix — are committed.

The real acceptance run is merging a branch through this gate via
`daft merge`; this PR itself merges through GitHub as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
