### PR TITLE
fix(go): don't close a Failed rail on a cross-repo hop

### DIFF
--- a/docs/reference/progress-timeline.md
+++ b/docs/reference/progress-timeline.md
@@ -66,40 +66,42 @@ hook renderer's summary also speaks), failure details and skip reasons always
 render plain, and a dimmed row — pending glyphs, expected skips, `(not run)` —
 never keeps an identity ink.
 
-- The rail opens the moment the command starts (after any pre-flight prompts):
-  the header, a grey planning row (`⠹ Validating branches`,
-  `⠹ Resolving branch`, `⠹ Cloning repository`), and the ticking stopwatch
-  appear immediately, and the committed plan replaces the middle in place as
-  soon as the command has resolved its work. The label follows the resolve phase
-  — `daft clone` runs its whole network clone under the face, flips to
-  `⠹ Resolving branches`, and commits a plan led by the already-done
-  `✓ Cloned repository` row. A prompt that must own the terminal mid-resolve
-  (the first-clone layout prompt) makes the face step aside tracelessly and
-  return once answered. A run that resolves into a navigation early-exit or a
-  resolve-phase error collapses the face without a trace and keeps its
-  single-line response.
+- The rail opens the moment the command starts (after any pre-flight prompts) as
+  a single collapsed line — the active spinner, the header's own text, and the
+  ticking stopwatch on its tail. That line is the whole rail until a plan gives
+  it a body: the `┌ │ └` frame appears only when the command has resolved work
+  worth framing, expanding the line in place with the committed plan beneath it.
+  The text follows the resolve phase — `daft clone` runs its whole network clone
+  under the collapsed line, flips to `Resolving branches`, and commits a plan
+  led by the already-done `✓ Cloned repository` row; `daft go` flips to
+  `Fetching origin` while a `daft.checkout.fetch` round-trip runs. A prompt that
+  must own the terminal mid-resolve (the first-clone layout prompt) makes the
+  line step aside tracelessly and return, on the same phase, once answered. A
+  run that resolves into a navigation early-exit, a hop to another cataloged
+  repo, or a resolve-phase error collapses the line without a trace and keeps
+  its single-line response.
 - The header names the resolved intent (`Starting <branch> ← <base>`); the
   footer closes the rail with the outcome and total duration. While the command
   runs, the pending footer is a stopwatch — a dim elapsed counter (`└ 1.2s`)
   ticking from the moment the rail opens until the outcome replaces it.
-- With `daft.checkout.fetch` on, the remote fetch is planned work committed
-  before the network round-trip: `daft start` opens its rail with the
-  `Fetch remote` and `Set up tracking` rows, and `daft go` leads its plan with a
-  `Fetch remote` row and notes the branch's provenance (`← origin/x`,
-  `tracking origin/x`, `local only`) onto the pending `Check out branch` row
-  once the fetch lands. A failed fetch turns its row yellow
-  (`↓ Fetch remote  failed — continuing with local refs`) and the command
-  proceeds on local refs. A branch the fetch fails to reveal closes `daft go`'s
-  rail as a `Failed` receipt with the error below it; with the fetch off, the
-  branch probe precedes the plan and an unknown branch keeps the plain error.
-  When the morph into branch creation is armed (`daft go --start`, or
-  `daft.go.autoStart`), the fetch runs under the planning face instead and the
-  plan commits only for a branch that exists — leading with the already-done
-  `✓ Fetched remote` row; a missing branch dissolves the face tracelessly and
-  `daft start`'s rail is the only rail the run leaves behind. For `daft start`
-  the header names the requested base; when the fetch reveals a fresher remote
-  ref, the `Created branch` row carries the resolved provenance
-  (`← origin/main`).
+- With `daft.checkout.fetch` on, `daft go` runs the fetch under the collapsed
+  line and commits its plan only once the branch is known to exist — leading
+  with the already-done `✓ Fetched remote` row, the branch's provenance
+  (`← origin/x`, `tracking origin/x`, `local only`) already resolved onto the
+  `Check out branch` row. A name the fetch fails to reveal is never this rail's
+  work: the line dissolves tracelessly, and whatever the name turns out to be —
+  another cataloged repo, a tag or commit that opens a sandbox, a branch
+  `--start` (or `daft.go.autoStart`) creates, or a plain error — owns the run's
+  only output. A failed fetch warns, turns its row yellow
+  (`↓ Fetch remote  failed — continuing with local refs`), and the command
+  proceeds on the refs it has. With the fetch off, the branch probe precedes the
+  plan and an unknown branch keeps the plain error. `daft start` and forge
+  targets (`daft go pr:123`) plan the fetch as work committed before the
+  round-trip instead — `daft start` opens its rail with the `Fetch remote` and
+  `Set up tracking` rows, and a forge miss falls back to the PR/MR head ref
+  rather than failing to find a branch. For `daft start` the header names the
+  requested base; when the fetch reveals a fresher remote ref, the
+  `Created branch` row carries the resolved provenance (`← origin/main`).
 - The rail lists only work that happens. A step known to be off at planning time
   (push with `daft.checkout.push` off or `--local`) plans no row, and a step
   that resolves as a no-op (carry with a clean tree) removes its row — the

--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -854,7 +854,7 @@ fn run_start_fork(args: StartArgs, base: Option<String>, count: u32) -> Result<(
             format!("Forking {dirname}"),
         );
         timeline.set_verbose_density(hook_output_config.verbose);
-        timeline.open_planning("Pinning commit");
+        timeline.open_planning();
         let create_result = {
             let mut bridge = TimelineBridge::new(
                 &mut output,
@@ -2183,7 +2183,7 @@ fn run_checkout(
     );
     timeline.set_verbose_density(hook_output_config.verbose);
 
-    timeline.open_planning("Resolving branch");
+    timeline.open_planning();
     let checkout_result = {
         let mut bridge = TimelineBridge::new(output, &mut timeline, executor, hook_output_config);
         checkout::execute(&params, git, &project_root, &mut bridge)
@@ -2299,7 +2299,7 @@ fn run_sandbox_visit(
     );
     timeline.set_verbose_density(hook_output_config.verbose);
 
-    timeline.open_planning("Resolving commit");
+    timeline.open_planning();
     let visit_result = {
         let mut bridge = TimelineBridge::new(output, &mut timeline, executor, hook_output_config);
         sandbox::execute_visit(&params, git, &project_root, &mut bridge)
@@ -2512,7 +2512,7 @@ fn run_create_branch_core(
     // (#686's silent-gap concern is covered by the rail itself); core's
     // pause_spinner/resume_spinner bracketing in push_if_enabled stays for
     // the legacy CommandBridge commands.
-    timeline.open_planning("Resolving base branch");
+    timeline.open_planning();
     let checkout_result = {
         let mut bridge =
             TimelineBridge::new(output, &mut timeline, executor, hook_output_config.clone());

--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -2153,13 +2153,15 @@ fn run_checkout(
         },
         layout: Some(layout),
         at_path: args.at.clone(),
-        // The morph (branch missing → run_create_branch) must leave no rail
-        // behind: hold the plan until the branch is known to exist, so the
-        // fetch runs under the planning face and a not-found dissolves the
-        // face tracelessly instead of closing a Failed receipt before
-        // start's rail opens. Forge targets never morph (their misses are
-        // Other, not BranchNotFound), so they don't defer.
-        defer_plan_until_branch_known: !is_forge && (args.start || settings.go_auto_start),
+        // The plan must not commit before the branch is known to exist
+        // (#782): a miss is never this rail's work — it morphs into
+        // run_create_branch (`--start` / autoStart), falls back to the
+        // catalog / a sandbox, or errors — and none of those may leave a
+        // Failed worktree-creation receipt behind. Deferring keeps the
+        // fetch under the planning face; it joins a committed plan as a
+        // pre-completed row. Forge targets don't defer: their misses are
+        // Other, not BranchNotFound, and their fetch is planned work.
+        defer_plan_until_branch_known: !is_forge,
         forge: forge_checkout,
     };
 

--- a/src/commands/clone.rs
+++ b/src/commands/clone.rs
@@ -347,7 +347,7 @@ fn run_clone(args: &Args, settings: &DaftSettings, output: &mut dyn Output) -> R
     let bare_elapsed = bare_started.elapsed();
 
     // The clone landed; the rest of the resolve span is branch work.
-    timeline.set_planning_label("Resolving branches");
+    timeline.set_planning_label(RESOLVING_BRANCHES);
 
     // Phase 2: Read daft.yml from the bare repo (if no --layout flag)
     let yaml_layout = if args.layout.is_none() && !bare_result.is_empty {
@@ -378,11 +378,11 @@ fn run_clone(args: &Args, settings: &DaftSettings, output: &mut dyn Output) -> R
         timeline.abandon_planning();
         match maybe_prompt_layout_choice(output, "Clone cancelled. Nothing was changed.") {
             LayoutPromptResult::Chosen(layout) => {
-                timeline.open_planning();
+                reopen_resolving(&mut timeline);
                 Some(layout)
             }
             LayoutPromptResult::Default => {
-                timeline.open_planning();
+                reopen_resolving(&mut timeline);
                 None
             }
             LayoutPromptResult::Cancelled => {
@@ -840,6 +840,21 @@ fn run_clone(args: &Args, settings: &DaftSettings, output: &mut dyn Output) -> R
     }
 
     Ok(())
+}
+
+/// The collapsed face's copy for everything after the bare clone lands.
+const RESOLVING_BRANCHES: &str = "Resolving branches";
+
+/// Reopen the planning face on the phase it stepped aside from.
+///
+/// `open_planning` seeds the face's text from the region header (`Cloning
+/// <repo>`), which by this point names work that finished before the prompt
+/// — so the label has to be re-applied, or the face advertises the clone for
+/// the whole branch-resolve span and a slow resolve reads as a hung network
+/// clone (#782 review).
+fn reopen_resolving(timeline: &mut Timeline) {
+    timeline.open_planning();
+    timeline.set_planning_label(RESOLVING_BRANCHES);
 }
 
 /// Close the live rail as a failure before propagating `e`: an ordinary

--- a/src/commands/clone.rs
+++ b/src/commands/clone.rs
@@ -330,7 +330,7 @@ fn run_clone(args: &Args, settings: &DaftSettings, output: &mut dyn Output) -> R
         output.is_verbose(),
         format!("Cloning {repo_name}"),
     );
-    timeline.open_planning("Cloning repository");
+    timeline.open_planning();
 
     let bare_started = std::time::Instant::now();
     let bare_result = {
@@ -378,11 +378,11 @@ fn run_clone(args: &Args, settings: &DaftSettings, output: &mut dyn Output) -> R
         timeline.abandon_planning();
         match maybe_prompt_layout_choice(output, "Clone cancelled. Nothing was changed.") {
             LayoutPromptResult::Chosen(layout) => {
-                timeline.open_planning("Resolving branches");
+                timeline.open_planning();
                 Some(layout)
             }
             LayoutPromptResult::Default => {
-                timeline.open_planning("Resolving branches");
+                timeline.open_planning();
                 None
             }
             LayoutPromptResult::Cancelled => {

--- a/src/commands/worktree_branch.rs
+++ b/src/commands/worktree_branch.rs
@@ -774,7 +774,7 @@ fn run_branch_delete(
         // The rail opens immediately; validation runs under the planning
         // face (the consolidation prompts suspend it for their duration)
         // and the plan replaces the face in place when validation commits.
-        timeline.open_planning("Validating branches");
+        timeline.open_planning();
     } else if !push_hook_will_render {
         output.start_spinner("Deleting branches...");
     }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -63,6 +63,17 @@ pub trait ProgressSink {
         let _ = plan;
     }
 
+    /// Name the resolve phase now running, before any plan exists.
+    ///
+    /// Until a plan commits, the rail is a single collapsed line and its
+    /// text is the only thing that can say what daft is doing — a
+    /// multi-second fetch under a face still reading `Opening <branch>` is
+    /// indistinguishable from a hang (#782). Sinks with no live face ignore
+    /// it: the phase is liveness copy, never a durable signal.
+    fn on_resolve_phase(&mut self, phase: &str) {
+        let _ = phase;
+    }
+
     /// Report a lifecycle event for one committed plan step.
     ///
     /// The default renders the legacy stderr lines for `SharedFile` events
@@ -259,6 +270,8 @@ pub struct RecordingStageSink {
     pub events: Vec<(stage::StepKey, stage::StageEvent)>,
     pub steps: Vec<String>,
     pub warnings: Vec<String>,
+    /// Each resolve phase the core named for the collapsed rail line (#782).
+    pub resolve_phases: Vec<String>,
     pub hooks_run: Vec<crate::hooks::HookType>,
 }
 
@@ -270,6 +283,10 @@ impl ProgressSink for RecordingStageSink {
 
     fn on_warning(&mut self, msg: &str) {
         self.warnings.push(msg.to_string());
+    }
+
+    fn on_resolve_phase(&mut self, phase: &str) {
+        self.resolve_phases.push(phase.to_string());
     }
 
     fn on_debug(&mut self, _msg: &str) {}

--- a/src/core/progress.rs
+++ b/src/core/progress.rs
@@ -351,6 +351,10 @@ impl ProgressSink for TimelineSink<'_> {
         route_step(self.output, self.timeline, msg);
     }
 
+    fn on_resolve_phase(&mut self, phase: &str) {
+        self.timeline.set_planning_label(phase);
+    }
+
     fn on_warning(&mut self, msg: &str) {
         route_warning(self.output, self.timeline, msg);
     }
@@ -420,6 +424,10 @@ impl<'a> TimelineBridge<'a> {
 impl ProgressSink for TimelineBridge<'_> {
     fn on_step(&mut self, msg: &str) {
         route_step(self.output, self.timeline, msg);
+    }
+
+    fn on_resolve_phase(&mut self, phase: &str) {
+        self.timeline.set_planning_label(phase);
     }
 
     fn on_warning(&mut self, msg: &str) {

--- a/src/core/progress.rs
+++ b/src/core/progress.rs
@@ -790,7 +790,7 @@ mod tests {
             false,
             "Removing feature",
         );
-        timeline.open_planning("Validating branches");
+        timeline.open_planning();
         assert!(timeline.region_live());
 
         let req = ConsolidationRequest {
@@ -834,7 +834,7 @@ mod tests {
             false,
             "Removing feature",
         );
-        timeline.open_planning("Validating branches");
+        timeline.open_planning();
 
         let req = ConsolidationRequest {
             branch: "feature".into(),

--- a/src/core/worktree/checkout.rs
+++ b/src/core/worktree/checkout.rs
@@ -329,9 +329,11 @@ pub fn execute(
     // errors). With `daft.checkout.fetch` on the probe must follow the
     // network; a deferring caller (every non-forge checkout, #782) runs
     // the fetch under the planning face — its stage events land on no row,
-    // its warnings stay quiet (a probe miss is expected, not alarming) —
-    // and it joins the committed plan as a pre-completed row, so a missing
-    // branch still errors before any plan commits. Only forge targets
+    // and the one warning a probe can expect (the refspec miss on a name
+    // that may not be a branch) waits until the probe says whether it was
+    // an incident at all — and it joins the committed plan as a
+    // pre-completed row, so a missing branch still errors before any plan
+    // commits. Only forge targets
     // fetch as planned work below the commit: their misses are Other
     // (the fork-ref fallback), never BranchNotFound.
     let mut prefetch: Option<Prefetch> = None;
@@ -350,11 +352,20 @@ pub fn execute(
         Some((local_exists, false))
     } else if params.checkout_fetch {
         if params.defer_plan_until_branch_known {
+            // The face is the whole rail until a plan lands, so it has to
+            // name the network work itself — nothing else can (#782 review).
+            sink.on_resolve_phase(&format!("Fetching {}", params.remote_name));
             let fetch_started = std::time::Instant::now();
-            let failed = !fetch_branch(git, &params.remote_name, &params.branch_name, sink, true);
+            let attempt = fetch_branch(
+                git,
+                &params.remote_name,
+                &params.branch_name,
+                sink,
+                FetchVoice::HoldBranchMiss,
+            );
             prefetch = Some(Prefetch {
                 elapsed: fetch_started.elapsed(),
-                failed,
+                failed: !attempt.ok,
             });
             let (local_exists, remote_exists) =
                 check_branch_existence(git, &params.branch_name, &params.remote_name)?;
@@ -362,8 +373,15 @@ pub fn execute(
                 return Err(CheckoutError::BranchNotFound {
                     branch: params.branch_name.clone(),
                     remote: params.remote_name.clone(),
-                    fetch_failed: failed,
+                    fetch_failed: !attempt.ok,
                 });
+            }
+            // The name turned out to be a branch, so the held refspec
+            // failure was an incident, not the probe's answer — and the row
+            // it lands on is green off the general fetch, which says nothing
+            // about this branch failing to move. Voice it.
+            if let Some(warning) = attempt.held_branch_miss {
+                sink.on_warning(&warning);
             }
             Some((local_exists, remote_exists))
         } else {
@@ -481,7 +499,14 @@ pub fn execute(
             local_exists
         }
         None => {
-            let fetch_failed = !fetch_branch(git, source_remote, &params.branch_name, sink, false);
+            let fetch_failed = !fetch_branch(
+                git,
+                source_remote,
+                &params.branch_name,
+                sink,
+                FetchVoice::Announce,
+            )
+            .ok;
             let (local_exists, remote_exists) =
                 check_branch_existence(git, &params.branch_name, source_remote)?;
             if !local_exists && !remote_exists {
@@ -786,24 +811,38 @@ fn find_existing_worktree_for_branch(
     )
 }
 
+/// How a fetch voices the failures it hits.
+enum FetchVoice {
+    /// Planned work: every failure warns where it happens.
+    Announce,
+    /// A resolution probe running under the planning face (the deferred path,
+    /// #782). Only the branch-specific miss is held back — the name being
+    /// probed may not be a branch at all, so its refspec failing is an
+    /// answer, not an incident — and the caller voices it once the probe
+    /// proves the branch does exist. A general fetch failure is never held:
+    /// an unreachable remote is nobody's expected outcome, and on this path
+    /// the warning is the only signal that survives every output mode.
+    HoldBranchMiss,
+}
+
+/// What a [`fetch_branch`] attempt produced.
+struct FetchAttempt {
+    /// At least one leg succeeded — the checkout continues on the refs it has.
+    ok: bool,
+    /// The branch-specific failure [`FetchVoice::HoldBranchMiss`] held back.
+    /// The caller voices it for a branch that exists and drops it on a
+    /// genuine miss, where the miss is its own message.
+    held_branch_miss: Option<String>,
+}
+
 /// Fetch latest changes for a branch from the remote.
-///
-/// Returns `true` if at least the general fetch succeeded, `false` if both
-/// fetches failed.
-///
-/// `quiet_probe` marks a resolution fetch running under the planning face
-/// (the deferred path): transient fetch warnings stay off stderr — a
-/// refspec miss is the expected outcome of probing a name that may not be
-/// a branch at all (#782) — while the durable signals survive: the yellow
-/// Fetch row when a plan commits, and `fetch_failed` on `BranchNotFound`
-/// for the miss messaging.
 fn fetch_branch(
     git: &GitCommand,
     remote_name: &str,
     branch_name: &str,
     sink: &mut impl ProgressSink,
-    quiet_probe: bool,
-) -> bool {
+    voice: FetchVoice,
+) -> FetchAttempt {
     // The fetch is a planned rail row (mirrors checkout_branch's
     // `fetch_remote`): it resolves green on success and yellow — with the
     // continuing-anyway fact — when both fetches failed.
@@ -814,9 +853,7 @@ fn fetch_branch(
     let general_ok = match git.fetch(remote_name, false) {
         Ok(()) => true,
         Err(e) => {
-            if !quiet_probe {
-                sink.on_warning(&format!("Failed to fetch from remote '{remote_name}': {e}"));
-            }
+            sink.on_warning(&format!("Failed to fetch from remote '{remote_name}': {e}"));
             false
         }
     };
@@ -824,23 +861,26 @@ fn fetch_branch(
     sink.on_step(&format!(
         "Fetching specific branch '{branch_name}' from remote '{remote_name}'..."
     ));
+    let mut held_branch_miss = None;
     let specific_ok = match git.fetch_refspec(remote_name, &format!("{branch_name}:{branch_name}"))
     {
         Ok(()) => true,
         Err(e) => {
-            if !quiet_probe {
-                sink.on_warning(&format!("Failed to fetch specific branch: {e}"));
+            let warning = format!("Failed to fetch specific branch: {e}");
+            match voice {
+                FetchVoice::Announce => sink.on_warning(&warning),
+                FetchVoice::HoldBranchMiss => held_branch_miss = Some(warning),
             }
             false
         }
     };
 
-    if general_ok || specific_ok {
+    let ok = general_ok || specific_ok;
+    if ok {
         sink.on_stage(
             &StepKey::new(StageId::Fetch),
             StageEvent::Completed { annotation: None },
         );
-        true
     } else {
         sink.on_stage(
             &StepKey::new(StageId::Fetch),
@@ -848,7 +888,10 @@ fn fetch_branch(
                 reason: super::FETCH_FAILED_REASON.to_string(),
             },
         );
-        false
+    }
+    FetchAttempt {
+        ok,
+        held_branch_miss,
     }
 }
 
@@ -1151,7 +1194,11 @@ mod timeline_tests {
             checkout_fetch: fetch,
             layout: None,
             at_path: Some(at),
-            defer_plan_until_branch_known: false,
+            // Production parity: the command layer defers for every
+            // non-forge checkout (#782). A test that wants the planned-fetch
+            // shape — plan first, probe after — wants `forge_params`, the
+            // only shape that still takes it.
+            defer_plan_until_branch_known: true,
             forge: None,
         }
     }
@@ -1241,12 +1288,13 @@ mod timeline_tests {
         assert!(sink.plan.is_none(), "no plan for a resolve-phase error");
     }
 
-    /// Fetch on: the plan commits before the network — a Fetch row leads it,
-    /// the CheckOut row starts without provenance, and the post-fetch probe
-    /// notes the resolved annotation onto the pending row (#651).
+    /// The planned-fetch shape, which since #782 only forge targets take:
+    /// the plan commits before the network, so the CheckOut row starts
+    /// without provenance and the post-fetch probe notes the resolved
+    /// annotation onto the pending row (#651).
     #[test]
     #[serial]
-    fn fetch_on_plans_the_fetch_row_and_notes_the_annotation() {
+    fn planned_fetch_notes_the_annotation_onto_the_pending_row() {
         // `execute` records the worktree's identity — without this, the
         // write lands in the developer's real state dir (#697).
         let _state = crate::store::paths::IsolatedStateDir::new();
@@ -1264,8 +1312,17 @@ mod timeline_tests {
         let worktree_path = tmp.path().join("feat-y-wt");
         let git_cmd = GitCommand::new(true);
         let mut sink = RecordingStageSink::default();
+        let forge = ForgeCheckout {
+            remote: "origin".to_string(),
+            fork: None,
+            head_fallback: None,
+            display: "PR #12".to_string(),
+            title: "Planned fetch".to_string(),
+            state_note: None,
+            resolve_elapsed: std::time::Duration::from_millis(2),
+        };
         execute(
-            &params("feat-y", worktree_path.clone(), true),
+            &forge_params("feat-y", worktree_path.clone(), forge),
             &git_cmd,
             &work,
             &mut sink,
@@ -1273,19 +1330,9 @@ mod timeline_tests {
         .expect("checkout succeeds");
         assert!(worktree_path.exists());
 
+        // The row order itself is `same_repo_forge_leads_plan_with_resolve_receipt`'s
+        // subject; this test owns what the annotation does across the fetch.
         let plan = sink.plan.as_ref().expect("plan committed");
-        let ids: Vec<StageId> = plan.steps().map(|s| s.key.id).collect();
-        assert_eq!(
-            ids,
-            vec![
-                StageId::Fetch,
-                StageId::PreCreateHooks,
-                StageId::CheckOut,
-                StageId::CreateWorktree,
-                StageId::PostCreateHooks,
-            ],
-            "fetch on => the Fetch row leads the plan"
-        );
         let fetch_annotation = plan
             .steps()
             .find(|s| s.key.id == StageId::Fetch)
@@ -1323,46 +1370,11 @@ mod timeline_tests {
         );
     }
 
-    /// Fetch on + unknown branch: the plan is already committed when the
-    /// post-fetch probe fails — the command layer aborts the rail into a
-    /// Failed receipt (the accepted #651 semantic for fetch-on go).
-    #[test]
-    #[serial]
-    fn fetch_on_unknown_branch_errors_after_the_committed_plan() {
-        // `execute` records the worktree's identity — without this, the
-        // write lands in the developer's real state dir (#697).
-        let _state = crate::store::paths::IsolatedStateDir::new();
-        let _cwd = CwdGuard::new();
-        let tmp = tempfile::tempdir().unwrap();
-        let origin = tmp.path().join("origin");
-        std::fs::create_dir_all(&origin).unwrap();
-        git(&origin, &["init", "-q", "-b", "main"]);
-        git(&origin, &["commit", "--allow-empty", "-q", "-m", "init"]);
-        git(tmp.path(), &["clone", "-q", "origin", "work"]);
-        let work = tmp.path().join("work");
-        std::env::set_current_dir(&work).unwrap();
-
-        let git_cmd = GitCommand::new(true);
-        let mut sink = RecordingStageSink::default();
-        let Err(err) = execute(
-            &params("no-such-branch", tmp.path().join("wt"), true),
-            &git_cmd,
-            &work,
-            &mut sink,
-        ) else {
-            panic!("unknown branch must fail");
-        };
-        assert!(matches!(err, CheckoutError::BranchNotFound { .. }));
-        assert!(
-            sink.plan.is_some(),
-            "fetch on commits the plan before the probe can fail"
-        );
-    }
-
-    /// Morph-armed (`go --start` / autoStart) + fetch on + unknown branch:
-    /// the fetch runs under the planning face and no plan ever commits —
-    /// the face dissolves tracelessly and the morph's own rail is the only
-    /// rail (two rails + a Failed receipt on an exit-0 run otherwise).
+    /// Fetch on + unknown branch: the fetch runs under the planning face and
+    /// no plan ever commits — the face dissolves tracelessly, leaving the
+    /// morph / catalog hop / plain error to own the run's only output. A
+    /// committed plan here would close as a `Failed` receipt on a run that
+    /// goes on to succeed elsewhere, which is #782.
     #[test]
     #[serial]
     fn deferred_unknown_branch_commits_no_plan() {
@@ -1381,22 +1393,31 @@ mod timeline_tests {
 
         let git_cmd = GitCommand::new(true);
         let mut sink = RecordingStageSink::default();
-        let mut p = params("no-such-branch", tmp.path().join("wt"), true);
-        p.defer_plan_until_branch_known = true;
+        let p = params("no-such-branch", tmp.path().join("wt"), true);
         let Err(err) = execute(&p, &git_cmd, &work, &mut sink) else {
             panic!("unknown branch must fail");
         };
         assert!(matches!(err, CheckoutError::BranchNotFound { .. }));
+        // The refspec miss IS the answer here, not an incident: `daft go
+        // <other-repo>` must reach the catalog hop with clean output.
+        assert!(
+            !sink
+                .warnings
+                .iter()
+                .any(|w| w.contains("Failed to fetch specific branch")),
+            "a probe miss must stay quiet: {:?}",
+            sink.warnings
+        );
         assert!(
             sink.plan.is_none(),
-            "a morph-armed miss must leave no plan behind"
+            "a miss must leave no worktree-creation plan behind"
         );
     }
 
-    /// Morph-armed + fetch on + branch exists: the plan commits with the
-    /// already-done fetch leading it as a pre-completed row, and the
-    /// CheckOut row carries its provenance from the moment the plan
-    /// commits (no post-fetch `Note` needed).
+    /// Fetch on + branch exists: the plan commits with the already-done
+    /// fetch leading it as a pre-completed row, and the CheckOut row carries
+    /// its provenance from the moment the plan commits (no post-fetch `Note`
+    /// needed).
     #[test]
     #[serial]
     fn deferred_fetch_leads_the_plan_pre_completed() {
@@ -1417,8 +1438,7 @@ mod timeline_tests {
         let worktree_path = tmp.path().join("feat-z-wt");
         let git_cmd = GitCommand::new(true);
         let mut sink = RecordingStageSink::default();
-        let mut p = params("feat-z", worktree_path.clone(), true);
-        p.defer_plan_until_branch_known = true;
+        let p = params("feat-z", worktree_path.clone(), true);
         execute(&p, &git_cmd, &work, &mut sink).expect("checkout succeeds");
         assert!(worktree_path.exists());
 
@@ -1447,6 +1467,116 @@ mod timeline_tests {
                 .any(|(k, e)| k.id == StageId::CheckOut && matches!(e, StageEvent::Note(_))),
             "no post-fetch Note — the plan already carried the provenance: {:?}",
             sink.events
+        );
+        // The collapsed line is the only thing that can name the network work
+        // it is running (#782 review).
+        assert_eq!(
+            sink.resolve_phases,
+            vec!["Fetching origin".to_string()],
+            "the face names the fetch while it runs"
+        );
+    }
+
+    /// A resolution fetch whose remote is unreachable is nobody's expected
+    /// outcome: it warns, on every path and in every output mode. The
+    /// deferred fetch's compensating yellow row only exists once a plan
+    /// commits, and Plain / quiet / piped runs never commit one — so
+    /// suppressing this warning made an offline `daft go` completely silent
+    /// about the network while it checked out a stale local ref (#782 review).
+    #[test]
+    #[serial]
+    fn deferred_probe_warns_when_the_remote_is_unreachable() {
+        // `execute` records the worktree's identity — without this, the
+        // write lands in the developer's real state dir (#697).
+        let _state = crate::store::paths::IsolatedStateDir::new();
+        let _cwd = CwdGuard::new();
+        let tmp = tempfile::tempdir().unwrap();
+        let origin = tmp.path().join("origin");
+        std::fs::create_dir_all(&origin).unwrap();
+        git(&origin, &["init", "-q", "-b", "main"]);
+        git(&origin, &["commit", "--allow-empty", "-q", "-m", "init"]);
+        git(tmp.path(), &["clone", "-q", "origin", "work"]);
+        let work = tmp.path().join("work");
+        std::env::set_current_dir(&work).unwrap();
+        // A local-only branch, so the checkout succeeds on local refs while
+        // both fetch legs fail against a remote that isn't there.
+        git(&work, &["branch", "local-only"]);
+        git(
+            &work,
+            &[
+                "remote",
+                "set-url",
+                "origin",
+                &tmp.path().join("gone").display().to_string(),
+            ],
+        );
+
+        let worktree_path = tmp.path().join("local-only-wt");
+        let git_cmd = GitCommand::new(true);
+        let mut sink = RecordingStageSink::default();
+        execute(
+            &params("local-only", worktree_path.clone(), true),
+            &git_cmd,
+            &work,
+            &mut sink,
+        )
+        .expect("a local branch checks out without the remote");
+        assert!(worktree_path.exists());
+        assert!(
+            sink.warnings
+                .iter()
+                .any(|w| w.contains("Failed to fetch from remote 'origin'")),
+            "an unreachable remote must say so: {:?}",
+            sink.warnings
+        );
+    }
+
+    /// The branch-specific fetch failing on a name that IS a branch is an
+    /// incident, not the probe's answer — and the row it lands on resolves
+    /// green off the general fetch, which says nothing about this branch
+    /// failing to move. The warning is the only signal, so holding it back
+    /// left a green `✓ Fetched remote` over a stale ref (#782 review).
+    #[test]
+    #[serial]
+    fn deferred_probe_voices_the_branch_miss_once_the_branch_proves_real() {
+        // `execute` records the worktree's identity — without this, the
+        // write lands in the developer's real state dir (#697).
+        let _state = crate::store::paths::IsolatedStateDir::new();
+        let _cwd = CwdGuard::new();
+        let tmp = tempfile::tempdir().unwrap();
+        let origin = tmp.path().join("origin");
+        std::fs::create_dir_all(&origin).unwrap();
+        git(&origin, &["init", "-q", "-b", "main"]);
+        git(&origin, &["commit", "--allow-empty", "-q", "-m", "init"]);
+        git(&origin, &["checkout", "-q", "-b", "div"]);
+        git(&origin, &["commit", "--allow-empty", "-q", "-m", "theirs"]);
+        git(&origin, &["checkout", "-q", "main"]);
+        git(tmp.path(), &["clone", "-q", "origin", "work"]);
+        let work = tmp.path().join("work");
+        std::env::set_current_dir(&work).unwrap();
+        // Local `div` diverges from `origin/div` (neither tip is the other's
+        // ancestor), so `git fetch origin div:div` is rejected non-fast-forward
+        // while the general fetch succeeds.
+        git(&work, &["commit", "--allow-empty", "-q", "-m", "mine"]);
+        git(&work, &["branch", "div"]);
+
+        let worktree_path = tmp.path().join("div-wt");
+        let git_cmd = GitCommand::new(true);
+        let mut sink = RecordingStageSink::default();
+        execute(
+            &params("div", worktree_path.clone(), true),
+            &git_cmd,
+            &work,
+            &mut sink,
+        )
+        .expect("a diverged branch still checks out");
+        assert!(worktree_path.exists());
+        assert!(
+            sink.warnings
+                .iter()
+                .any(|w| w.contains("Failed to fetch specific branch")),
+            "a real branch that could not be updated must say so: {:?}",
+            sink.warnings
         );
     }
 
@@ -1479,8 +1609,11 @@ mod timeline_tests {
     }
 
     fn forge_params(branch: &str, at: PathBuf, forge: ForgeCheckout) -> CheckoutParams {
-        // The command layer forces the fetch on for every forge target.
+        // The command layer forces the fetch on for every forge target, and
+        // never defers one: a forge miss is `Other` (the fork-ref fallback),
+        // never `BranchNotFound`, so its fetch is planned work (#782).
         let mut p = params(branch, at, true);
+        p.defer_plan_until_branch_known = false;
         p.forge = Some(forge);
         p
     }

--- a/src/core/worktree/checkout.rs
+++ b/src/core/worktree/checkout.rs
@@ -78,13 +78,15 @@ pub struct CheckoutParams {
     /// Explicit path override for worktree placement (`--at` flag).
     /// When `Some`, takes priority over both `layout` and the default path computation.
     pub at_path: Option<PathBuf>,
-    /// The caller morphs a missing branch into branch creation (`daft go
-    /// --start` / `daft.go.autoStart`), and the morph must leave no rail
-    /// behind — so with the fetch on, the fetch runs under the planning
-    /// face and the plan commits only once the branch is known to exist,
-    /// leading with the already-done fetch row. Without this, the morph
-    /// rendered go's `Failed` receipt and then start's rail — two rails on
-    /// an exit-0 invocation.
+    /// The caller resolves a missing branch into something other than this
+    /// rail's work — a morph into branch creation (`daft go --start` /
+    /// `daft.go.autoStart`), the catalog / sandbox fallbacks, or a plain
+    /// error — so the plan must not commit until the branch is known to
+    /// exist: with the fetch on, the fetch runs under the planning face and
+    /// joins the committed plan as a pre-completed row. Without this, a
+    /// miss closed a `Failed` worktree-creation receipt for an invocation
+    /// that went on to succeed (#782) — or rendered two rails on the morph
+    /// path.
     pub defer_plan_until_branch_known: bool,
     /// Set when the checkout target was a forge PR/MR reference (`pr:123`,
     /// `mr:45`, or a PR/MR URL). The command layer resolved it via `gh`/`glab`
@@ -325,13 +327,13 @@ pub fn execute(
     // Without a fetch every branch fact is local: probe now, so an unknown
     // branch errors before any plan commits (no rail renders for resolve
     // errors). With `daft.checkout.fetch` on the probe must follow the
-    // network — it moves below the plan commit, and the fetch becomes
-    // planned work instead of hiding behind the planning face. The
-    // exception is a morph-armed caller (`defer_plan_until_branch_known`):
-    // the fetch runs under the face — its stage events land on no row —
-    // and joins the committed plan as a pre-completed row, so a missing
-    // branch still errors before any plan commits and the morph's own rail
-    // is the only rail.
+    // network; a deferring caller (every non-forge checkout, #782) runs
+    // the fetch under the planning face — its stage events land on no row,
+    // its warnings stay quiet (a probe miss is expected, not alarming) —
+    // and it joins the committed plan as a pre-completed row, so a missing
+    // branch still errors before any plan commits. Only forge targets
+    // fetch as planned work below the commit: their misses are Other
+    // (the fork-ref fallback), never BranchNotFound.
     let mut prefetch: Option<Prefetch> = None;
     let pre_plan_probe = if fork.is_some() {
         // Fork PR/MR: the source branch isn't a normal ref on the base repo —
@@ -349,7 +351,7 @@ pub fn execute(
     } else if params.checkout_fetch {
         if params.defer_plan_until_branch_known {
             let fetch_started = std::time::Instant::now();
-            let failed = !fetch_branch(git, &params.remote_name, &params.branch_name, sink);
+            let failed = !fetch_branch(git, &params.remote_name, &params.branch_name, sink, true);
             prefetch = Some(Prefetch {
                 elapsed: fetch_started.elapsed(),
                 failed,
@@ -479,12 +481,15 @@ pub fn execute(
             local_exists
         }
         None => {
-            let fetch_failed = !fetch_branch(git, source_remote, &params.branch_name, sink);
+            let fetch_failed = !fetch_branch(git, source_remote, &params.branch_name, sink, false);
             let (local_exists, remote_exists) =
                 check_branch_existence(git, &params.branch_name, source_remote)?;
             if !local_exists && !remote_exists {
-                // The plan is committed: the command layer aborts the rail
-                // into a Failed receipt, and errors print below it.
+                // The plan is committed: a miss here closes the rail as a
+                // Failed receipt. Non-forge checkouts always defer (#782)
+                // and miss before the commit instead — this return is the
+                // contract for a non-deferring caller, not a path daft
+                // takes today.
                 let Some(fc) = forge else {
                     return Err(CheckoutError::BranchNotFound {
                         branch: params.branch_name.clone(),
@@ -785,11 +790,19 @@ fn find_existing_worktree_for_branch(
 ///
 /// Returns `true` if at least the general fetch succeeded, `false` if both
 /// fetches failed.
+///
+/// `quiet_probe` marks a resolution fetch running under the planning face
+/// (the deferred path): transient fetch warnings stay off stderr — a
+/// refspec miss is the expected outcome of probing a name that may not be
+/// a branch at all (#782) — while the durable signals survive: the yellow
+/// Fetch row when a plan commits, and `fetch_failed` on `BranchNotFound`
+/// for the miss messaging.
 fn fetch_branch(
     git: &GitCommand,
     remote_name: &str,
     branch_name: &str,
     sink: &mut impl ProgressSink,
+    quiet_probe: bool,
 ) -> bool {
     // The fetch is a planned rail row (mirrors checkout_branch's
     // `fetch_remote`): it resolves green on success and yellow — with the
@@ -801,7 +814,9 @@ fn fetch_branch(
     let general_ok = match git.fetch(remote_name, false) {
         Ok(()) => true,
         Err(e) => {
-            sink.on_warning(&format!("Failed to fetch from remote '{remote_name}': {e}"));
+            if !quiet_probe {
+                sink.on_warning(&format!("Failed to fetch from remote '{remote_name}': {e}"));
+            }
             false
         }
     };
@@ -813,7 +828,9 @@ fn fetch_branch(
     {
         Ok(()) => true,
         Err(e) => {
-            sink.on_warning(&format!("Failed to fetch specific branch: {e}"));
+            if !quiet_probe {
+                sink.on_warning(&format!("Failed to fetch specific branch: {e}"));
+            }
             false
         }
     };

--- a/src/output/timeline/mod.rs
+++ b/src/output/timeline/mod.rs
@@ -451,13 +451,14 @@ impl Timeline {
     }
 
     /// Open the live region before the plan is known (Interactive only):
-    /// the seeded header, a static `⠹  <label>` planning row (grey), and
-    /// the stopwatch footer. `commit_plan` replaces the middle in place; a
+    /// the rail collapsed to a single line (#782) — the active dress
+    /// carrying the seeded header's text, with the region stopwatch riding
+    /// its tail. `commit_plan` expands it in place into the full rail; a
     /// command that returns without committing (navigation early exit,
-    /// resolve-phase error) collapses the face without a trace — via
-    /// [`Self::abandon_planning`], or implicitly through `finish`/`abort` —
-    /// and keeps its legacy output.
-    pub fn open_planning(&mut self, planning_label: &str) {
+    /// resolve-phase error, a catalog/sandbox fallback) collapses the face
+    /// without a trace — via [`Self::abandon_planning`], or implicitly
+    /// through `finish`/`abort` — and keeps its legacy output.
+    pub fn open_planning(&mut self) {
         if !self.is_interactive() {
             return;
         }
@@ -468,13 +469,7 @@ impl Timeline {
         let mp = inner.make_multi_progress();
         let header = inner.header.clone();
         let setup = inner.region_setup();
-        inner.core = Some(TimelineCore::open_planning(
-            mp,
-            header,
-            planning_label,
-            setup,
-            self.started,
-        ));
+        inner.core = Some(TimelineCore::open_planning(mp, header, setup, self.started));
     }
 
     /// Opt into plan-ordered receipts: rows may resolve out of completion
@@ -521,7 +516,7 @@ impl Timeline {
         self.handle.toggle_verbose()
     }
 
-    /// Update the planning face's label in place ("Cloning repository" →
+    /// Replace the collapsed face's text in place ("Cloning proj" →
     /// "Resolving branches") — liveness for a resolve phase that moves
     /// between kinds of work. No-op without a face (Plain mode, plan already
     /// committed, abandoned region).
@@ -534,8 +529,8 @@ impl Timeline {
 
     /// Materialize the region (Interactive only; no-op otherwise). Called by
     /// the bridge when the core commits its plan. Over an open planning face
-    /// the plan installs in place (the face's bars leave, the stopwatch
-    /// footer carries on); with no face this is the direct path (a command
+    /// the plan expands in place (the face's line leaves, the stopwatch
+    /// clock carries on); with no face this is the direct path (a command
     /// that commits without opening a planning face first).
     pub fn commit_plan(&mut self, plan: PlanCommit) {
         if !self.is_interactive() {
@@ -1657,30 +1652,29 @@ mod tests {
 
     // ── planning face (the region opens before the plan) ─────────────────
     //
-    // The rail opens at t=0 with the seeded header, a static planning row,
-    // and the stopwatch footer; `commit_plan` replaces the middle in place.
-    // A command that returns without committing collapses the face without
-    // a trace — resolve errors and navigation early exits keep their legacy
-    // single-line output.
+    // The rail opens at t=0 collapsed to a single line — the active dress
+    // with the header's text and the stopwatch on its tail (#782);
+    // `commit_plan` expands it in place into the full rail. A command that
+    // returns without committing collapses the face without a trace —
+    // resolve errors, navigation early exits, and the catalog/sandbox
+    // fallbacks keep their legacy single-line output.
 
     #[test]
-    fn planning_face_paints_header_planning_row_and_stopwatch() {
+    fn planning_face_is_one_line_with_the_stopwatch_on_its_tail() {
         let (mut tl, term) = captured("Removing feat/x");
-        tl.open_planning("Validating branches");
+        tl.open_planning();
         assert!(tl.region_live());
         let contents = term.contents();
         let lines: Vec<&str> = contents.lines().collect();
-        assert_eq!(lines[0], "\u{250c}  Removing feat/x");
-        assert_eq!(lines[1], "\u{2502}");
-        // The spinner glyph varies by tick; the label is the contract.
+        // The spinner glyph varies by tick; the header text and stopwatch
+        // tail are the contract — and no `┌ │ └` frame exists until a plan
+        // gives the rail a body.
         assert!(
-            lines[2].ends_with("  Validating branches"),
-            "planning row: {:?}",
-            lines[2]
+            lines[0].ends_with("  Removing feat/x  0ms"),
+            "collapsed face: {:?}",
+            lines[0]
         );
-        assert_eq!(lines[3], "\u{2502}");
-        assert_eq!(lines[4], "\u{2514}  0ms");
-        assert_eq!(lines.len(), 5);
+        assert_eq!(lines.len(), 1);
         tl.abandon_planning();
     }
 
@@ -1690,11 +1684,10 @@ mod tests {
         direct.commit_plan(plan());
 
         let (mut planned, planned_term) = captured("Opening feat/x");
-        planned.open_planning("Resolving branch");
+        planned.open_planning();
         planned.commit_plan(plan());
 
         // The face leaves no residue: both paths paint the same plan.
-        assert!(!planned_term.contents().contains("Resolving branch"));
         assert_eq!(planned_term.contents(), direct_term.contents());
 
         direct.finish("Ready in 0.1s");
@@ -1705,7 +1698,7 @@ mod tests {
     #[test]
     fn plan_header_override_replaces_the_planning_seed() {
         let (mut tl, term) = captured("Removing 1 branch");
-        tl.open_planning("Validating branches");
+        tl.open_planning();
         tl.commit_plan(
             PlanCommit::new(vec![Row::Step(StepSpec::new(StepKey::scoped(
                 StageId::RemoveWorktree,
@@ -1722,7 +1715,7 @@ mod tests {
     #[test]
     fn finishing_while_planning_collapses_without_a_trace() {
         let (mut tl, term) = captured("Opening feat/x");
-        tl.open_planning("Resolving branch");
+        tl.open_planning();
         tl.finish("Ready in 0.1s");
         assert!(!tl.region_live());
         assert_eq!(term.contents(), "");
@@ -1731,7 +1724,7 @@ mod tests {
     #[test]
     fn aborting_while_planning_collapses_without_a_trace() {
         let (mut tl, term) = captured("Opening feat/x");
-        tl.open_planning("Resolving branch");
+        tl.open_planning();
         tl.abort("Failed after 0.1s");
         assert!(!tl.region_live());
         assert_eq!(term.contents(), "");
@@ -1740,7 +1733,7 @@ mod tests {
     #[test]
     fn abandoned_face_collapses_and_the_late_finish_is_a_noop() {
         let (mut tl, term) = captured("Opening feat/x");
-        tl.open_planning("Resolving branch");
+        tl.open_planning();
         tl.abandon_planning();
         assert!(!tl.region_live());
         // The command epilogue's ordinary finish must not resurrect a footer.
@@ -1751,7 +1744,7 @@ mod tests {
     #[test]
     fn dropped_while_planning_collapses_without_a_trace() {
         let (mut tl, term) = captured("Opening feat/x");
-        tl.open_planning("Resolving branch");
+        tl.open_planning();
         drop(tl);
         assert_eq!(term.contents(), "");
     }
@@ -1759,7 +1752,7 @@ mod tests {
     #[test]
     fn abandon_after_commit_leaves_the_region_alone() {
         let (mut tl, term) = captured("Opening feat/x");
-        tl.open_planning("Resolving branch");
+        tl.open_planning();
         tl.commit_plan(plan());
         tl.abandon_planning();
         assert!(tl.region_live());
@@ -1773,7 +1766,7 @@ mod tests {
     #[test]
     fn warning_during_planning_persists_above_the_face() {
         let (mut tl, term) = captured("Removing feat/x");
-        tl.open_planning("Validating branches");
+        tl.open_planning();
         tl.println_above("warning: remote is unreachable");
         assert!(
             term.contents()
@@ -1807,13 +1800,12 @@ mod tests {
         direct.commit_plan(clone_plan());
 
         let (mut planned, planned_term) = captured("Cloning proj");
-        planned.open_planning("Cloning repository");
+        planned.open_planning();
         planned.commit_plan(clone_plan());
 
         // The pre-completed `✓` row persists above the pending bars on both
         // paths (the println-vs-live-bars ordering the face must not
         // disturb), and the face leaves no residue.
-        assert!(!planned_term.contents().contains("Cloning repository"));
         assert_eq!(planned_term.contents(), direct_term.contents());
         assert!(
             planned_term
@@ -1833,23 +1825,25 @@ mod tests {
     #[test]
     fn planning_label_update_repaints_the_face() {
         let (mut tl, term) = captured("Cloning proj");
-        tl.open_planning("Cloning repository");
+        tl.open_planning();
         tl.set_planning_label("Resolving branches");
         let contents = term.contents();
         let lines: Vec<&str> = contents.lines().collect();
+        // The new text replaces the header's on the single line, in place —
+        // stopwatch tail intact.
         assert!(
-            lines[2].ends_with("  Resolving branches"),
-            "planning row: {:?}",
-            lines[2]
+            lines[0].ends_with("  Resolving branches  0ms"),
+            "collapsed face: {:?}",
+            lines[0]
         );
-        assert!(!contents.contains("Cloning repository"));
+        assert!(!contents.contains("Cloning proj"));
         tl.abandon_planning();
     }
 
     #[test]
     fn planning_label_update_after_commit_is_a_noop() {
         let (mut tl, term) = captured("Opening feat/x");
-        tl.open_planning("Resolving branch");
+        tl.open_planning();
         tl.commit_plan(plan());
         let committed = term.contents();
         tl.set_planning_label("Too late");
@@ -1861,21 +1855,21 @@ mod tests {
     #[test]
     fn reopened_face_after_abandon_commits_cleanly() {
         // The layout-prompt path: the face steps aside for the prompt, then
-        // returns with a fresh label, and the plan lands on the reopened
-        // face. (The test draw target is consumed per region, so the reopen
-        // re-arms it — production regions each get their own stderr target.)
+        // returns, and the plan lands on the reopened face. (The test draw
+        // target is consumed per region, so the reopen re-arms it —
+        // production regions each get their own stderr target.)
         let (mut direct, direct_term) = captured("Cloning proj");
         direct.commit_plan(clone_plan());
 
         let (mut tl, term) = captured("Cloning proj");
-        tl.open_planning("Cloning repository");
+        tl.open_planning();
         tl.abandon_planning();
         assert!(!tl.region_live());
         assert_eq!(term.contents(), "");
         tl.set_test_draw_target(indicatif::ProgressDrawTarget::term_like(Box::new(
             term.clone(),
         )));
-        tl.open_planning("Resolving branches");
+        tl.open_planning();
         assert!(tl.region_live());
         tl.commit_plan(clone_plan());
         assert_eq!(term.contents(), direct_term.contents());
@@ -1884,7 +1878,7 @@ mod tests {
     #[test]
     fn open_planning_is_plain_mode_inert() {
         let mut tl = Timeline::new(TimelineMode::Plain, false, "Opening feat/x");
-        tl.open_planning("Resolving branch");
+        tl.open_planning();
         assert!(!tl.region_live());
     }
 

--- a/src/output/timeline/region.rs
+++ b/src/output/timeline/region.rs
@@ -257,7 +257,7 @@ impl TimelineCore {
         setup: RegionSetup,
         started: Instant,
     ) -> Self {
-        let mut core = Self::scaffold(mp, header, setup, started, true);
+        let mut core = Self::scaffold(mp, header, setup, started);
         core.install_plan(plan);
         core
     }
@@ -289,7 +289,7 @@ impl TimelineCore {
         face.enable_steady_tick(Duration::from_millis(80));
         face.tick();
 
-        let mut core = Self::scaffold(mp, header, setup, started, false);
+        let mut core = Self::scaffold(mp, header, setup, started);
         core.planning_face = Some(face);
         core
     }
@@ -315,18 +315,12 @@ impl TimelineCore {
 
     /// The shared region shell: bottom spacer + stopwatch footer (+ ticker),
     /// echo guard, and the Ctrl-C collapse — everything that survives from
-    /// the planning face into the committed plan. Slots come later via
-    /// [`Self::install_plan`]. With `attach_shell` false (the collapsed
-    /// face's path) the spacer and footer are constructed detached — the
-    /// face is the region's only live line, and [`Self::install_plan`]
-    /// attaches the shell when the plan gives the rail a body.
-    fn scaffold(
-        mp: MultiProgress,
-        header: String,
-        setup: RegionSetup,
-        started: Instant,
-        attach_shell: bool,
-    ) -> Self {
+    /// the planning face into the committed plan. The spacer and footer are
+    /// constructed **detached**: a plan is what gives the rail a body, so
+    /// [`Self::install_plan`] is what attaches them (over a face, the face
+    /// is the region's only live line until then; without one, the two
+    /// happen back to back). Slots come from `install_plan` too.
+    fn scaffold(mp: MultiProgress, header: String, setup: RegionSetup, started: Instant) -> Self {
         let RegionSetup {
             verbose,
             detail_verbose,
@@ -335,7 +329,7 @@ impl TimelineCore {
             row_output,
         } = setup;
         let static_style = line_style();
-        let mut bottom_spacer = line_bar(&static_style, render::spacer(use_color));
+        let bottom_spacer = line_bar(&static_style, render::spacer(use_color));
         // The pending footer is a stopwatch from its first frame: `└  142ms`
         // → `└  1.0s` → … (grey — the rail's duration vocabulary), on the
         // command's own clock so it agrees with the total the outcome footer
@@ -345,18 +339,10 @@ impl TimelineCore {
         // the InMemoryTerm sequence tests assert the committed plan's face,
         // and a wall-clock repaint racing the assertion would flake them
         // (footer_counter is zeroed there for the same reason).
-        let mut footer = line_bar(
+        let footer = line_bar(
             &static_style,
             render::footer(&footer_counter(started, use_color), use_color),
         );
-        if attach_shell {
-            // Attach, then tick: a bar whose message was set while detached
-            // has no pending draw, and under test nothing else forces one.
-            bottom_spacer = mp.add(bottom_spacer);
-            footer = mp.add(footer);
-            bottom_spacer.tick();
-            footer.tick();
-        }
         let footer_done = Arc::new(AtomicBool::new(false));
         // Set once a key listener is watching (#729): the stopwatch line then
         // also offers the key. It rides the footer rather than taking a line
@@ -444,13 +430,10 @@ impl TimelineCore {
         debug_assert!(self.slots.is_empty(), "plan installed twice");
         // The collapsed face leaves without a trace; the plan expands in
         // its place (the guards and the stopwatch clock carry on).
-        let expanding_from_face = if let Some(face) = self.planning_face.take() {
+        if let Some(face) = self.planning_face.take() {
             face.disable_steady_tick();
             self.mp.remove(&face);
-            true
-        } else {
-            false
-        };
+        }
 
         let header = plan.header.clone().unwrap_or_else(|| self.header.clone());
         let use_color = self.use_color;
@@ -485,16 +468,15 @@ impl TimelineCore {
             .ok();
         self.mp.println(render::spacer(use_color)).ok();
 
-        // Over a face the shell was constructed detached (the face was the
-        // region's only live line): attach it now — bottom spacer above the
-        // footer — so the rows below can anchor on it. Attach, then tick:
-        // a bar whose message was set while detached has no pending draw.
-        if expanding_from_face {
-            self.bottom_spacer = self.mp.add(self.bottom_spacer.clone());
-            self.footer = self.mp.add(self.footer.clone());
-            self.bottom_spacer.tick();
-            self.footer.tick();
-        }
+        // The shell was constructed detached — a plan is what earns the rail
+        // a body. Attach it now, bottom spacer above the footer, so the rows
+        // below can anchor on it. Attach, then tick: a bar whose message was
+        // set while detached has no pending draw, and under test nothing
+        // else forces one.
+        self.bottom_spacer = self.mp.add(self.bottom_spacer.clone());
+        self.footer = self.mp.add(self.footer.clone());
+        self.bottom_spacer.tick();
+        self.footer.tick();
 
         let static_style = line_style();
         // Rows insert directly above the surviving bottom spacer; successive

--- a/src/output/timeline/region.rs
+++ b/src/output/timeline/region.rs
@@ -17,7 +17,7 @@ use super::render::{self, RowFace};
 use super::thread_block::{ThreadStyles, ThreadedJob};
 use super::{LiveVerbose, RowOutputConfig};
 use crate::core::stage::{PlanCommit, Row, StepKey, StepSpec};
-use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressState, ProgressStyle};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -199,16 +199,15 @@ pub(super) struct TimelineCore {
     /// Seeded header text, retained until the plan lands (the plan may
     /// replace it with the resolved intent).
     header: String,
-    /// The planning face's removable header (`┌  <seed>`) — `Some` from
-    /// [`Self::open_planning`] until [`Self::install_plan`] persists the
-    /// real header. Doubles as the is-planning flag: the committed header
-    /// is scrollback, only the face's is a bar.
-    header_bar: Option<ProgressBar>,
-    /// The planning face's removable top spacer (`│`).
-    top_spacer_bar: Option<ProgressBar>,
-    /// The static `⠹  <label>` row shown while the command resolves its
-    /// plan; removed when the plan installs or the face collapses.
-    planning_row: Option<ProgressBar>,
+    /// The collapsed planning face (#782): one removable bar wearing the
+    /// active dress with the header's text and the region stopwatch on its
+    /// tail — the whole rail on a single line until a plan gives it a
+    /// body. `Some` from [`Self::open_planning`] until
+    /// [`Self::install_plan`] expands it or [`Self::collapse`] resolves it
+    /// away. Doubles as the is-planning flag — while it is up, the shell
+    /// below (bottom spacer, footer) exists but is not attached to the
+    /// `MultiProgress`.
+    planning_face: Option<ProgressBar>,
     /// Dim `│` above the footer; lives until teardown. Doubles as the
     /// hook-embed anchor when no pending row remains.
     bottom_spacer: ProgressBar,
@@ -258,80 +257,76 @@ impl TimelineCore {
         setup: RegionSetup,
         started: Instant,
     ) -> Self {
-        let mut core = Self::scaffold(mp, header, setup, started);
+        let mut core = Self::scaffold(mp, header, setup, started, true);
         core.install_plan(plan);
         core
     }
 
-    /// Open the region before the plan is known: the seeded header, a `│`,
-    /// and a static planning row render as *bars* (the committed header is
-    /// scrollback; the face's must stay removable), so a command that
-    /// resolves into an early exit or a pre-plan error can collapse the
-    /// whole face without a trace. The stopwatch footer, echo guard, and
-    /// Ctrl-C collapse are the committed region's own — they carry through
-    /// [`Self::install_plan`] untouched, so the swap never blinks.
+    /// Open the region before the plan is known: one live line — the rail
+    /// collapsed (#782). The face wears the active dress (cyan spinner)
+    /// with the header's own text and the region's stopwatch riding its
+    /// tail, so resolution reads as the rail at rest, not a separate
+    /// spinner widget. The `┌ │ └` frame appears only when a plan gives
+    /// the rail a body: [`Self::install_plan`] expands the line in place
+    /// (the detached shell attaches, the stopwatch clock carries on), and
+    /// a command that resolves into an early exit or a pre-plan error
+    /// collapses it without a trace.
     pub(super) fn open_planning(
         mp: MultiProgress,
         header: String,
-        planning_label: &str,
         setup: RegionSetup,
         started: Instant,
     ) -> Self {
         let use_color = setup.use_color;
-        let static_style = line_style();
-        let header_bar = add_line_bar(&mp, &static_style, render::header(&header, None, use_color));
-        let top_spacer_bar = add_line_bar(&mp, &static_style, render::spacer(use_color));
-        // The planning row wears the active-step dress (cyan spinner) with a
-        // grey label — busy, but meta: it is not one of the plan's rows and
-        // vanishes when they land.
-        let planning_row = mp.add(ProgressBar::new_spinner());
-        planning_row.set_style(active_style(use_color, false, false));
-        planning_row.set_message(render::paint(
-            crate::output::palette::GREY,
-            planning_label,
-            use_color,
-        ));
+        let face = mp.add(ProgressBar::new_spinner());
+        face.set_style(planning_face_style(use_color, started));
+        face.set_message(header.clone());
         // No steady tick under cfg(test): a wall-clock spinner repaint would
         // flake the InMemoryTerm sequence assertions (the footer ticker
         // stays off there for the same reason). The explicit tick paints the
         // face immediately.
         #[cfg(not(test))]
-        planning_row.enable_steady_tick(Duration::from_millis(80));
-        planning_row.tick();
+        face.enable_steady_tick(Duration::from_millis(80));
+        face.tick();
 
-        let mut core = Self::scaffold(mp, header, setup, started);
-        core.header_bar = Some(header_bar);
-        core.top_spacer_bar = Some(top_spacer_bar);
-        core.planning_row = Some(planning_row);
+        let mut core = Self::scaffold(mp, header, setup, started, false);
+        core.planning_face = Some(face);
         core
     }
 
     /// Whether the region is still the planning face (no plan installed).
     pub(super) fn is_planning(&self) -> bool {
-        self.header_bar.is_some()
+        self.planning_face.is_some()
     }
 
-    /// Repaint the planning row's label in place — the face's liveness copy
-    /// follows the resolve phase between kinds of work ("Cloning repository"
-    /// → "Resolving branches"). No-op once the plan has installed (the face
-    /// is gone). The explicit tick paints the new label immediately, matching
-    /// [`Self::open_planning`]'s first frame (no steady tick under test).
+    /// Repaint the face's text in place — the liveness copy follows the
+    /// resolve phase between kinds of work ("Cloning proj" → "Resolving
+    /// branches"). The text is the collapsed line's primary copy (it has no
+    /// other), so it renders plain, not grey. No-op once the plan has
+    /// installed (the face is gone). The explicit tick paints the new text
+    /// immediately, matching [`Self::open_planning`]'s first frame (no
+    /// steady tick under test).
     pub(super) fn set_planning_label(&mut self, label: &str) {
-        if let Some(row) = &self.planning_row {
-            row.set_message(render::paint(
-                crate::output::palette::GREY,
-                label,
-                self.use_color,
-            ));
-            row.tick();
+        if let Some(face) = &self.planning_face {
+            face.set_message(label.to_string());
+            face.tick();
         }
     }
 
     /// The shared region shell: bottom spacer + stopwatch footer (+ ticker),
     /// echo guard, and the Ctrl-C collapse — everything that survives from
     /// the planning face into the committed plan. Slots come later via
-    /// [`Self::install_plan`].
-    fn scaffold(mp: MultiProgress, header: String, setup: RegionSetup, started: Instant) -> Self {
+    /// [`Self::install_plan`]. With `attach_shell` false (the collapsed
+    /// face's path) the spacer and footer are constructed detached — the
+    /// face is the region's only live line, and [`Self::install_plan`]
+    /// attaches the shell when the plan gives the rail a body.
+    fn scaffold(
+        mp: MultiProgress,
+        header: String,
+        setup: RegionSetup,
+        started: Instant,
+        attach_shell: bool,
+    ) -> Self {
         let RegionSetup {
             verbose,
             detail_verbose,
@@ -340,7 +335,7 @@ impl TimelineCore {
             row_output,
         } = setup;
         let static_style = line_style();
-        let bottom_spacer = add_line_bar(&mp, &static_style, render::spacer(use_color));
+        let mut bottom_spacer = line_bar(&static_style, render::spacer(use_color));
         // The pending footer is a stopwatch from its first frame: `└  142ms`
         // → `└  1.0s` → … (grey — the rail's duration vocabulary), on the
         // command's own clock so it agrees with the total the outcome footer
@@ -350,11 +345,18 @@ impl TimelineCore {
         // the InMemoryTerm sequence tests assert the committed plan's face,
         // and a wall-clock repaint racing the assertion would flake them
         // (footer_counter is zeroed there for the same reason).
-        let footer = add_line_bar(
-            &mp,
+        let mut footer = line_bar(
             &static_style,
             render::footer(&footer_counter(started, use_color), use_color),
         );
+        if attach_shell {
+            // Attach, then tick: a bar whose message was set while detached
+            // has no pending draw, and under test nothing else forces one.
+            bottom_spacer = mp.add(bottom_spacer);
+            footer = mp.add(footer);
+            bottom_spacer.tick();
+            footer.tick();
+        }
         let footer_done = Arc::new(AtomicBool::new(false));
         // Set once a key listener is watching (#729): the stopwatch line then
         // also offers the key. It rides the footer rather than taking a line
@@ -420,9 +422,7 @@ impl TimelineCore {
             label_width: 0,
             slots: Vec::new(),
             header,
-            header_bar: None,
-            top_spacer_bar: None,
-            planning_row: None,
+            planning_face: None,
             bottom_spacer,
             footer,
             footer_done,
@@ -442,19 +442,15 @@ impl TimelineCore {
     /// bottom spacer.
     pub(super) fn install_plan(&mut self, plan: PlanCommit) {
         debug_assert!(self.slots.is_empty(), "plan installed twice");
-        // The face leaves without a trace; the plan replaces it in place
-        // (the shell below — bottom spacer, footer, guards — carries on).
-        for bar in [
-            self.planning_row.take(),
-            self.top_spacer_bar.take(),
-            self.header_bar.take(),
-        ]
-        .into_iter()
-        .flatten()
-        {
-            bar.disable_steady_tick();
-            self.mp.remove(&bar);
-        }
+        // The collapsed face leaves without a trace; the plan expands in
+        // its place (the guards and the stopwatch clock carry on).
+        let expanding_from_face = if let Some(face) = self.planning_face.take() {
+            face.disable_steady_tick();
+            self.mp.remove(&face);
+            true
+        } else {
+            false
+        };
 
         let header = plan.header.clone().unwrap_or_else(|| self.header.clone());
         let use_color = self.use_color;
@@ -488,6 +484,17 @@ impl TimelineCore {
             ))
             .ok();
         self.mp.println(render::spacer(use_color)).ok();
+
+        // Over a face the shell was constructed detached (the face was the
+        // region's only live line): attach it now — bottom spacer above the
+        // footer — so the rows below can anchor on it. Attach, then tick:
+        // a bar whose message was set while detached has no pending draw.
+        if expanding_from_face {
+            self.bottom_spacer = self.mp.add(self.bottom_spacer.clone());
+            self.footer = self.mp.add(self.footer.clone());
+            self.bottom_spacer.tick();
+            self.footer.tick();
+        }
 
         let static_style = line_style();
         // Rows insert directly above the surviving bottom spacer; successive
@@ -622,15 +629,12 @@ impl TimelineCore {
             "collapse tears down the planning face only"
         );
         self.footer_done.store(true, Ordering::SeqCst);
-        for bar in [&self.planning_row, &self.top_spacer_bar, &self.header_bar]
-            .into_iter()
-            .flatten()
-        {
-            bar.disable_steady_tick();
-            self.mp.remove(bar);
+        if let Some(face) = &self.planning_face {
+            face.disable_steady_tick();
+            self.mp.remove(face);
         }
-        self.mp.remove(&self.bottom_spacer);
-        self.mp.remove(&self.footer);
+        // The shell (bottom spacer, footer) never attached — the face was
+        // the region's only live line, so there is nothing else to remove.
         // Removals alone leave the erase to the rate-limited next draw —
         // which never comes (nothing else touches this region). Clear is
         // the forced final frame.
@@ -1977,8 +1981,36 @@ fn active_style(use_color: bool, in_group: bool, wide: bool) -> ProgressStyle {
         .tick_chars(TICK_CHARS)
 }
 
-fn add_line_bar(mp: &MultiProgress, style: &ProgressStyle, line: String) -> ProgressBar {
-    let bar = mp.add(ProgressBar::new_spinner());
+/// The collapsed planning face's dress (#782): the active row's spinner and
+/// text, with the region's stopwatch riding the tail — the whole rail on one
+/// line until a plan gives it a body. The stopwatch key re-renders on every
+/// spinner tick and shares the footer's clock, format, and cfg(test)
+/// zero-pin via [`footer_counter`].
+fn planning_face_style(use_color: bool, started: Instant) -> ProgressStyle {
+    let base = if use_color {
+        "{spinner:.cyan}  {msg}{stopwatch}"
+    } else {
+        "{spinner}  {msg}{stopwatch}"
+    };
+    ProgressStyle::with_template(base)
+        .expect("planning face template is valid")
+        .with_key(
+            "stopwatch",
+            move |_: &ProgressState, w: &mut dyn std::fmt::Write| {
+                let _ = write!(w, "  {}", footer_counter(started, use_color));
+            },
+        )
+        .tick_chars(TICK_CHARS)
+}
+
+/// A line bar not yet attached to any `MultiProgress` — the collapsed
+/// face's shell is constructed detached and attached only when the plan
+/// lands ([`TimelineCore::install_plan`]). Constructed hidden: a free
+/// `ProgressBar` owns a live stderr target of its own, so without this a
+/// detached shell (and its ticker) paints stray `│` / `└  1ms` lines next
+/// to the face. `MultiProgress::add` re-targets it onto the region.
+fn line_bar(style: &ProgressStyle, line: String) -> ProgressBar {
+    let bar = ProgressBar::with_draw_target(None, ProgressDrawTarget::hidden());
     bar.set_style(style.clone());
     bar.set_message(line);
     bar

--- a/tests/integration/test_checkout.sh
+++ b/tests/integration/test_checkout.sh
@@ -924,6 +924,15 @@ test_go_fetch_hop_no_rail_receipt() {
         log_error "hop committed a worktree-creation plan"
         return 1
     fi
+    # The collapsed line is the region's *only* live line: the rail's shell is
+    # built on a hidden draw target and attaches when a plan lands. Drop that
+    # hidden() and the detached spacer/footer paint themselves beside the face
+    # (`│`, `└  1ms`) — invisible to the InMemoryTerm unit tests, so this is
+    # the only guard that catches it.
+    if echo "$clean" | grep -q "[│└]"; then
+        log_error "detached rail shell painted beside the collapsed line"
+        return 1
+    fi
     if echo "$clean" | grep -q "Failed to fetch"; then
         log_error "probe fetch warning leaked onto the hop"
         return 1

--- a/tests/integration/test_checkout.sh
+++ b/tests/integration/test_checkout.sh
@@ -4,6 +4,29 @@
 
 source "$(dirname "${BASH_SOURCE[0]}")/test_framework.sh"
 
+CHECKOUT_PTY_RUN="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/pty_run.py"
+
+# Run daft with the live rail enabled (pattern from
+# test_exec_verbose_toggle.sh): the framework's DAFT_TESTING hides the
+# interactive region — the subject of the rail tests — so it comes off and
+# the background spawns it suppressed are turned off individually. TERM is
+# pinned because indicatif hides its whole draw target under an unset or
+# `dumb` TERM, as on a bare CI runner.
+_rail_daft() {
+    env -u DAFT_TESTING \
+        TERM=xterm-256color \
+        DAFT_NO_UPDATE_CHECK=1 \
+        DAFT_NO_TRUST_PRUNE=1 \
+        DAFT_NO_LOG_CLEAN=1 \
+        DAFT_NO_HINTS=1 \
+        "$@"
+}
+
+# Strip ANSI and split the pty's carriage-returned repaints into lines.
+_rail_clean() {
+    sed -e 's/\x1b\[[0-9;]*[a-zA-Z]//g' -e 's/\r/\n/g' "$1"
+}
+
 # Test basic checkout functionality
 test_checkout_basic() {
     local remote_repo=$(create_test_remote "test-repo-checkout" "main")
@@ -875,6 +898,73 @@ test_checkout_dash_with_create_branch() {
     return 0
 }
 
+# #782: with daft.checkout.fetch=true, a cross-repo catalog hop must not
+# commit a worktree-creation plan — resolution runs under the collapsed
+# planning face and dissolves without a receipt. The rail only exists on a
+# TTY, so this drives daft under the DSR-answering PTY (pty_run.py); the
+# YAML suite runs with DAFT_TESTING set and never materializes a region.
+test_go_fetch_hop_no_rail_receipt() {
+    local remote_a=$(create_test_remote "test-repo-hop-a" "main")
+    local remote_b=$(create_test_remote "test-repo-hop-b" "main")
+    git-worktree-clone --layout contained "$remote_a" || return 1
+    git-worktree-clone --layout contained "$remote_b" || return 1
+    cd "test-repo-hop-a/main"
+    git config daft.checkout.fetch true
+
+    local log="$PWD/go-hop-rail.log"
+    _rail_daft "$CHECKOUT_PTY_RUN" "$log" daft go test-repo-hop-b || return 1
+
+    local clean
+    clean=$(_rail_clean "$log")
+    if echo "$clean" | grep -q "Failed after"; then
+        log_error "hop closed a Failed rail receipt"
+        return 1
+    fi
+    if echo "$clean" | grep -q "┌"; then
+        log_error "hop committed a worktree-creation plan"
+        return 1
+    fi
+    if echo "$clean" | grep -q "Failed to fetch"; then
+        log_error "probe fetch warning leaked onto the hop"
+        return 1
+    fi
+    if ! echo "$clean" | grep -q "Opening repository 'test-repo-hop-b'"; then
+        log_error "hop line missing from the PTY output"
+        return 1
+    fi
+    return 0
+}
+
+# The counterpart guard: when resolution does warrant a worktree, the
+# collapsed face must expand into the full rail — persisted header, the
+# probe fetch as a pre-completed receipt row, and a Ready footer.
+test_go_fetch_on_rail_expands() {
+    local remote_repo=$(create_test_remote "test-repo-rail-expand" "main")
+    git-worktree-clone --layout contained "$remote_repo" || return 1
+    cd "test-repo-rail-expand/main"
+    git config daft.checkout.fetch true
+
+    local log="$PWD/go-rail-expand.log"
+    _rail_daft "$CHECKOUT_PTY_RUN" "$log" daft go develop || return 1
+
+    local clean
+    clean=$(_rail_clean "$log")
+    if ! echo "$clean" | grep -q "┌  Opening develop"; then
+        log_error "expanded rail header missing"
+        return 1
+    fi
+    if ! echo "$clean" | grep -q "✓  Fetched remote"; then
+        log_error "pre-completed fetch receipt row missing"
+        return 1
+    fi
+    if ! echo "$clean" | grep -q "Ready in"; then
+        log_error "Ready footer missing"
+        return 1
+    fi
+    assert_directory_exists "../develop" || return 1
+    return 0
+}
+
 # Run all checkout tests
 run_checkout_tests() {
     log "Running git-worktree-checkout integration tests..."
@@ -916,6 +1006,10 @@ run_checkout_tests() {
     run_test "checkout_dash_toggle" "test_checkout_dash_toggle"
     run_test "checkout_dash_deleted_previous" "test_checkout_dash_deleted_previous"
     run_test "checkout_dash_with_create_branch" "test_checkout_dash_with_create_branch"
+
+    # Rail behavior under a PTY (#782)
+    run_test "go_fetch_hop_no_rail_receipt" "test_go_fetch_hop_no_rail_receipt"
+    run_test "go_fetch_on_rail_expands" "test_go_fetch_on_rail_expands"
 }
 
 # Main execution

--- a/tests/manual/scenarios/checkout/go-cross-repo-fetch.yml
+++ b/tests/manual/scenarios/checkout/go-cross-repo-fetch.yml
@@ -1,9 +1,10 @@
 name: Go cross-repo navigation with checkout fetch enabled
 description:
   "#782 regression: with daft.checkout.fetch=true the catalog hop must not
-  commit a worktree-creation plan, run a doomed fetch against the current repo's
-  remote, or leak probe-fetch warnings — resolution runs quietly under the
-  collapsed planning face and only the hop's own output appears. A real remote
+  commit a worktree-creation plan or leak the resolution fetch's branch miss as
+  a warning — the probe runs under the collapsed rail line and only the hop's
+  own output appears. The fetch itself still runs against the current repo's
+  remote, which is what makes the miss the signal the hop needs. A real remote
   branch still fetches and creates its worktree, and a genuine miss errors
   without warning noise."
 

--- a/tests/manual/scenarios/checkout/go-cross-repo-fetch.yml
+++ b/tests/manual/scenarios/checkout/go-cross-repo-fetch.yml
@@ -1,0 +1,57 @@
+name: Go cross-repo navigation with checkout fetch enabled
+description:
+  "#782 regression: with daft.checkout.fetch=true the catalog hop must not
+  commit a worktree-creation plan, run a doomed fetch against the current repo's
+  remote, or leak probe-fetch warnings — resolution runs quietly under the
+  collapsed planning face and only the hop's own output appears. A real remote
+  branch still fetches and creates its worktree, and a genuine miss errors
+  without warning noise."
+
+repos:
+  - name: test-repo-a
+    use_fixture: standard-remote
+  - name: test-repo-b
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone both repos
+    run:
+      git-worktree-clone --layout contained $REMOTE_TEST_REPO_A &&
+      git-worktree-clone --layout contained $REMOTE_TEST_REPO_B
+    expect:
+      exit_code: 0
+
+  - name: Enable checkout fetch locally in repo A
+    run: git config daft.checkout.fetch true
+    cwd: "$WORK_DIR/test-repo-a/main"
+    expect:
+      exit_code: 0
+
+  - name: The catalog hop stays clean — no probe-fetch warnings, no receipt
+    run: daft go test-repo-b 2>&1
+    cwd: "$WORK_DIR/test-repo-a/main"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "Opening repository 'test-repo-b'"
+      output_not_contains:
+        - "Failed to fetch"
+        - "Failed after"
+
+  - name: A real remote branch still fetches and creates its worktree
+    run: daft go develop 2>&1
+    cwd: "$WORK_DIR/test-repo-a/main"
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-repo-a/develop"
+      output_not_contains:
+        - "Failed to fetch"
+
+  - name: A genuine miss errors without probe-warning noise
+    run: daft go nosuchbranch 2>&1
+    cwd: "$WORK_DIR/test-repo-a/main"
+    expect:
+      exit_code: 1
+      output_not_contains:
+        - "Failed to fetch specific branch"


### PR DESCRIPTION
`daft go <other-repo>` with `daft.checkout.fetch=true` drew a full
worktree-creation rail, spent a multi-second fetch against the _current_ repo's
remote, and closed the rail as a `Failed` receipt — then hopped to the requested
repo and exited 0. A successful navigation left a failure in scrollback.

## The fix

**Resolution is not the rail's work.** `defer_plan_until_branch_known` now
covers every non-forge checkout rather than only the morph-armed ones, so the
plan commits only once the branch is known to exist. Every miss — catalog hop,
sandbox, `--start` morph, plain error — dissolves without a receipt. Forge
targets keep planning their fetch: their misses are `Other` (the fork-ref
fallback), never `BranchNotFound`.

**The rail opens collapsed.** Finding out where to go is pre-rail work, but it
should not look disconnected from the rail — so it _is_ the rail, on one line:
the active spinner, the header's own text, and the region's stopwatch on its
tail. The `┌ │ └` frame appears only when a plan gives the rail a body,
expanding the line in place. The shell is built on a hidden draw target and
attaches in `install_plan`, so the frame cannot appear without a body by
construction. The line names the phase it is running (`Fetching origin`,
`Resolving branches`) — until a plan lands, nothing else can.

**Nothing done under the line is lost to history.** A resolution fetch that
succeeded joins the committed plan as a pre-completed `✓ Fetched remote` row; a
failed one keeps the normal row and resolves yellow. Fetch failures still warn.

## Review round

A high-effort multi-agent review of the first three commits found nine confirmed
defects; the last four commits fix all nine. The ones worth calling out:

- The blanket probe-quiet swallowed **unreachable-remote** failures too, not
  just the expected refspec miss. Plain / `--quiet` / piped / `DAFT_TESTING`
  runs never commit a plan, so no yellow row exists to compensate — an offline
  `daft go` said nothing at all while checking out a stale local ref.
- `fetch_branch` returns `general_ok || specific_ok`, so a non-fast-forward
  refspec against a diverged local branch resolved the row **green** with the
  one contradicting signal suppressed.
- Dropping `open_planning`'s label parameter left clone's post-prompt reopen
  advertising `Cloning <repo>` for the whole branch-resolve span — a slow
  resolve read as a hung network clone.
- The `hidden()` draw target had no regression guard: reverting it left every
  assertion green while stray `│` / `└  103ms` lines painted beside the line.
- Two unit tests pinned a configuration production can no longer build, and one
  asserted `plan.is_some()` on a miss — the exact contract this PR reverses.

One finding is deliberately not taken: the hop's fetch is silenced, not skipped.
Skipping it when the name matches a live cataloged repo would invert the
local-first precedence in the repo-aware command grammar for a not-yet-fetched
remote branch that shares a name with a repo. That is a semantics call, not a
review fix. The scenario description that claimed the fetch was avoided has been
corrected instead.

## Verification

- 3195 unit tests, including two that fail against the old suppression and one
  that pins the probe's silence on a genuine miss
- A YAML scenario for the piped surface, two PTY tests for the rail itself (the
  hop leaves no frame or receipt; creation still expands with its receipt row)
- The `[│└]` guard verified by reverting `hidden()` and watching it fail
- All 17 PR checks green, including every `integration-tests` matrix cell
  (default/subprocess × bash/yaml), `windows-check` and `homebrew-simulation`
- Locally: unit suite, clippy, `fmt:check`, `man:verify`, the checkout
  integration suite (33/33), and all 777 YAML scenarios

Fixes #782.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
