### PR TITLE
ci(mise): bump tool pins in the daily upgrade job

### DIFF
--- a/.github/workflows/mise-tool-updates.yml
+++ b/.github/workflows/mise-tool-updates.yml
@@ -1,10 +1,10 @@
 name: mise tool updates
 
-# Weekly job that runs `mise upgrade` to refresh tool versions in mise.lock
-# (and mise.toml when --bump-able), then opens a PR if anything changed.
+# Daily job that runs `mise upgrade --bump` to advance tool versions in
+# mise.toml and mise.lock, then opens a PR if anything changed.
 # The 7-day cooldown in mise.toml's [settings] minimum_release_age means this
 # only ever picks versions that have aged past the gate — no fresh releases
-# enter without intent.
+# enter without intent. `--bump` does not bypass that gate.
 on:
   schedule:
     # Daily 06:00 UTC (= 09:00 Asia/Jerusalem) — matches the Dependabot
@@ -34,16 +34,32 @@ jobs:
         uses: jdx/mise-action@v4.2.1
 
       - name: Run mise upgrade
-        # Stays within the constraints already in mise.toml (e.g. `bun = "1.3"`
-        # → newest 1.3.x). Use `mise upgrade --bump` manually when you want to
-        # advance the constraint itself.
+        # `--bump` advances the pin in mise.toml itself, keeping whatever
+        # precision was there (`2.1.6` → `2.1.10`, `1.3` → `1.4`).
+        #
+        # It is load-bearing, not a convenience. Bare `mise upgrade` stays
+        # inside the constraint already declared in mise.toml, and an exact pin
+        # admits exactly one version — so from #498 (which pinned every tool to
+        # stop CI flake) this job became a guaranteed no-op: green every day,
+        # zero PRs for ~2.5 months, five tools silently stale. See #803.
+        # Do not drop `--bump` without also unpinning the tools.
+        #
+        # Two tools stay out of the automated bump:
+        #   rust   — `--bump` keeps precision, so `1.95` → `1.96`, which is an
+        #            MSRV change. MSRV is `latest_stable - 2`, mirrored across
+        #            six files, and needs human triage for clippy-lint
+        #            escalations and transitive-dep conflicts;
+        #            msrv-staleness-check.yml owns that bump. Plain upgrade
+        #            still carries 1.95.x patches, which is what we want here.
+        #   neovim — the vfox backend records no concrete version in mise.lock;
+        #            mise.toml keeps the "stable" tag selector deliberately.
         env:
           # Per-invocation override for the [settings] minimum_release_age in
           # mise.toml. Empty string falls through to the file-level setting
           # (the safe default for cron + unchecked manual runs); "0" disables
           # the cooldown for this single run when manually requested.
           MISE_MINIMUM_RELEASE_AGE: ${{ inputs.bypass_cooldown && '0' || '' }}
-        run: mise upgrade
+        run: mise upgrade --bump --exclude rust --exclude neovim
 
       - name: Open PR
         uses: peter-evans/create-pull-request@v8
@@ -57,8 +73,11 @@ jobs:
 
             ${{ inputs.bypass_cooldown && '**Cooldown bypassed.** Triggered manually with `bypass_cooldown=true` — `MISE_MINIMUM_RELEASE_AGE=0` was exported for this run, so the 7-day cooldown in `mise.toml` was disabled and the newest available versions (including fresh releases) were picked.' || 'Versions selected are subject to the 7-day cooldown set in `mise.toml` `[settings] minimum_release_age = "7d"`.' }}
 
-            To advance a constraint (e.g. `bun = "1.3"` -> `"1.4"`), run
-            `mise upgrade --bump` locally and commit instead.
+            Runs `mise upgrade --bump`, so the pins in `mise.toml` advance too,
+            not just `mise.lock`. `rust` and `neovim` are excluded on purpose:
+            bumping `rust` is an MSRV change (owned by
+            `msrv-staleness-check.yml`), and `neovim` deliberately tracks the
+            `stable` tag.
 
             Note: PRs opened by the default GITHUB_TOKEN do not trigger other
             workflows. To run CI on this PR, push an empty commit or close


### PR DESCRIPTION
`mise-tool-updates.yml` has opened **zero PRs since 2026-05-04**. It was not
failing — it ran daily, succeeded every time, and could not possibly produce a
diff.

Bare `mise upgrade` stays inside the constraint already declared in `mise.toml`.
An exact pin admits exactly one version, so from #498 (`chore: reduce test.yml
flake — pin mise tools`, which turned `lefthook = "latest"` into
`lefthook = "2.1.6"` and three others alongside it) the job became a guaranteed
no-op. Pinning was the right call; the regression is that it silently changed what
the daily job *can* do and left no signal behind.

## The change

```diff
-        run: mise upgrade
+        run: mise upgrade --bump --exclude rust --exclude neovim
```

plus comments recording why `--bump` is load-bearing, so a future edit cannot
quietly re-freeze the job.

`--bump` advances the pin in `mise.toml` itself while keeping its precision.
`mise.toml` stays pinned at rest and each bump arrives as a reviewable PR — which
preserves exactly what #498 was protecting.

**Two exclusions:**

- **`rust`** — `--bump` preserves precision, so `1.95` becomes `1.96`. That is an
  MSRV change: MSRV is `latest_stable - 2`, mirrored across six files, and needs
  human triage for clippy-lint escalations and transitive-dep conflicts.
  `msrv-staleness-check.yml` owns that bump. Bare upgrade still carries `1.95.x`
  patches, which is the wanted behaviour.
- **`neovim`** — the `vfox` backend records no concrete version in `mise.lock`,
  and `mise.toml` keeps the `"stable"` tag selector deliberately.

## Verification

`mise upgrade --bump --dry-run --exclude rust --exclude neovim` on a clean worktree:

```
Would bump aqua:cargo-bins/cargo-binstall  1.18.1  -> 1.21.0
Would bump lefthook                        2.1.6   -> 2.1.10
Would bump bun                             1.3.13  -> 1.3.14
Would bump cargo:cargo-cooldown            0.3.0   -> 0.3.4
Would bump cargo:cargo-deny                0.19.4  -> 0.20.2
```

Five tools stale, not one — `cargo-deny`, the supply-chain auditor, had drifted a
full minor release.

**The cooldown still holds.** The same run refused a fresher release:

> `mise WARN newer aqua:cargo-bins/cargo-binstall release 1.21.1 (released
> 2026-07-25, eligible 2026-08-01) ignored by minimum_release_age (7d); latest
> eligible release is 1.21.0`

So restoring updates does not weaken the 7-day dependency-cooldown policy — that
was the main risk worth checking before recommending `--bump`.

## Scope notes

- **Workflow only.** No tool versions are bumped here. The next scheduled run
  opens the `deps: bump mise tools` PR with the actual version changes, which
  validates the loop end to end rather than asserting it.
- **Worth eyeballing on that first PR:** `mise.toml` is comment-dense, so confirm
  `--bump`'s in-place edit preserves the surrounding comments.
- **Still open (needs a repo secret, so not done here):** PRs opened by the default
  `GITHUB_TOKEN` do not trigger other workflows, so the deps PR will arrive with no
  checks reported. The workflow body already documents the empty-commit ritual;
  switching the action to a PAT with `workflow` scope would fix it properly.
- No `daft.yml` ring or CI-parity change applies — this is a scheduled maintenance
  job, not a merge gate.
- No Rust changed, so `clippy` / `test:unit` were not run; `prettier` and the
  conventional-commit hook passed.

Fixes #803

🤖 Generated with [Claude Code](https://claude.com/claude-code)
