### PR TITLE
feat: breathe stale cached cells in the live list until fresh values land

### DIFF
--- a/src/commands/list_live.rs
+++ b/src/commands/list_live.rs
@@ -19,7 +19,7 @@ use crate::{
         },
     },
     git::GitCommand,
-    output::tui::{Column, TuiRenderer, TuiState},
+    output::tui::{Column, TuiRenderer, TuiState, live_table::ForgePrStaleness},
     settings::DaftSettings,
 };
 use anyhow::Result;
@@ -172,7 +172,7 @@ pub fn run_live(args: Args) -> Result<()> {
     //   failed) → the cache renders as-is.
     let mut forge_refresh_pending = false;
     let mut forge_loading = false;
-    let mut forge_stale = false;
+    let mut forge_stale = ForgePrStaleness::Fresh;
     let mut forge_repo_hash: Option<String> = None;
     let mut forge_lookup: Option<ForgePrLookup> = None;
     let mut forge_finished_baseline = None;
@@ -193,9 +193,13 @@ pub fn run_live(args: Args) -> Result<()> {
             // breathe; no refresh → the cache is final, nothing animates.
             (forge_lookup, forge_loading, forge_stale) =
                 match (forge_refresh_pending, gate.ever_succeeded()) {
-                    (true, false) => (None, true, false),
-                    (true, true) => (lookup.map(ForgePrLookup::identity_only), false, true),
-                    (false, _) => (lookup, false, false),
+                    (true, false) => (None, true, ForgePrStaleness::Fresh),
+                    (true, true) => (
+                        lookup.map(ForgePrLookup::identity_only),
+                        false,
+                        ForgePrStaleness::Refreshing,
+                    ),
+                    (false, _) => (lookup, false, ForgePrStaleness::Fresh),
                 };
         }
     }

--- a/src/commands/list_live.rs
+++ b/src/commands/list_live.rs
@@ -172,6 +172,7 @@ pub fn run_live(args: Args) -> Result<()> {
     //   failed) → the cache renders as-is.
     let mut forge_refresh_pending = false;
     let mut forge_loading = false;
+    let mut forge_stale = false;
     let mut forge_repo_hash: Option<String> = None;
     let mut forge_lookup: Option<ForgePrLookup> = None;
     let mut forge_finished_baseline = None;
@@ -187,11 +188,15 @@ pub fn run_live(args: Args) -> Result<()> {
             // Reuse the lookup read alongside the health gate (one store open);
             // the mid-run refresh reload below re-reads fresh.
             let lookup = gate.lookup.clone();
-            (forge_lookup, forge_loading) = match (forge_refresh_pending, gate.ever_succeeded()) {
-                (true, false) => (None, true),
-                (true, true) => (lookup.map(ForgePrLookup::identity_only), false),
-                (false, _) => (lookup, false),
-            };
+            // Cold cache + refresh → shimmer; warm cache + refresh → stale
+            // (identity now, fates when the refresh lands) so those cells
+            // breathe; no refresh → the cache is final, nothing animates.
+            (forge_lookup, forge_loading, forge_stale) =
+                match (forge_refresh_pending, gate.ever_succeeded()) {
+                    (true, false) => (None, true, false),
+                    (true, true) => (lookup.map(ForgePrLookup::identity_only), false, true),
+                    (false, _) => (lookup, false, false),
+                };
         }
     }
 
@@ -341,6 +346,7 @@ pub fn run_live(args: Args) -> Result<()> {
     // the one caller that decorates.
     state.live.cfg.forge_prs = forge_lookup;
     state.live.cfg.forge_prs_loading = forge_loading;
+    state.live.cfg.forge_prs_stale = forge_stale;
 
     // Watch the detached refresh conclude while the table is live: poll the
     // store's health stamp (cheap reader-pool read, no network — the render

--- a/src/output/tui/catalog_table.rs
+++ b/src/output/tui/catalog_table.rs
@@ -92,8 +92,8 @@ pub fn tree_glyph(index: usize, count: usize) -> &'static str {
 #[derive(Debug, Clone, Copy)]
 enum SizeCell {
     Loading,
-    /// A persisted, last-known size seeded from the catalog cache. Rendered
-    /// dim (like the worktree table's stale cell) and superseded in place the
+    /// A persisted, last-known size seeded from the catalog cache. Breathes
+    /// (like the worktree table's stale cell) and is superseded in place the
     /// moment the fresh walk's `Loaded` lands. Distinct from `Loaded` so
     /// `is_complete` keeps waiting for the real walk.
     Stale(u64),
@@ -135,9 +135,9 @@ impl CatalogTable {
     }
 
     /// Seed the initial size cells with cached (stale) values where available.
-    /// `stale[i] == Some(b)` renders row `i` as a dim, last-known `b` up front
-    /// — superseded when its fresh walk lands — while `None` leaves the cell
-    /// shimmer-loading. A length mismatch leaves every cell Loading
+    /// `stale[i] == Some(b)` renders row `i` as a breathing, last-known `b` up
+    /// front — superseded when its fresh walk lands — while `None` leaves the
+    /// cell shimmer-loading. A length mismatch leaves every cell Loading
     /// (defensive; callers align `stale` to `rows` by index).
     pub fn with_stale_sizes(mut self, stale: Vec<Option<u64>>) -> Self {
         if stale.len() == self.sizes.len() {
@@ -282,7 +282,7 @@ impl CatalogTable {
         widths
     }
 
-    fn size_cell(&self, index: usize, width: u16, dim: bool) -> Cell<'static> {
+    fn size_cell(&self, index: usize, width: u16, dim: bool, final_frame: bool) -> Cell<'static> {
         match self.sizes[index] {
             SizeCell::Loaded(Some(bytes)) => {
                 let style = if dim {
@@ -293,9 +293,10 @@ impl CatalogTable {
                 Cell::from(Span::styled(format_human_size(bytes), style))
             }
             SizeCell::Loaded(None) => not_loaded_cell(width),
-            // A stale value is real (just not re-measured yet), so show it dim
-            // even after cancel — only never-loaded cells fall to the em-dash.
-            SizeCell::Stale(bytes) => stale_cell(&format_human_size(bytes)),
+            // A stale value is real (just not re-measured yet), so keep showing
+            // it — breathing while the walk runs, settled once the run ends —
+            // even after cancel. Only never-loaded cells fall to the em-dash.
+            SizeCell::Stale(bytes) => stale_cell(&format_human_size(bytes), self.tick, final_frame),
             SizeCell::Loading if self.cancelled => not_loaded_cell(width),
             SizeCell::Loading => loading_shimmer_cell(width, self.tick),
         }
@@ -391,7 +392,7 @@ impl LiveScreen for CatalogTable {
                         truncate_with_ellipsis(row.remote.as_deref().unwrap_or("-"), *width),
                         Style::default().add_modifier(Modifier::DIM),
                     )),
-                    RepoListColumn::Size => self.size_cell(idx, *width, dim),
+                    RepoListColumn::Size => self.size_cell(idx, *width, dim, final_frame),
                 });
             }
             let mut table_row = Row::new(cells);
@@ -683,16 +684,31 @@ mod tests {
     }
 
     #[test]
-    fn stale_seeded_cell_renders_dim_value() {
-        let table = CatalogTable::new(vec![cells("alpha", false, false)], columns())
+    fn stale_seeded_cell_breathes_until_the_fresh_value_lands() {
+        use crate::output::tui::render::SKELETON_BREATH_FRAMES;
+
+        let mut table = CatalogTable::new(vec![cells("alpha", false, false)], columns())
             .with_stale_sizes(vec![Some(2048)]);
-        let backend = TestBackend::new(100, 6);
-        let mut terminal = Terminal::new(backend).unwrap();
-        terminal.draw(|f| table.render(f, false)).unwrap();
-        let buffer = terminal.backend().buffer();
-        let row: String = (0..100)
-            .map(|x| buffer[(x, 1)].symbol().to_string())
-            .collect();
+
+        // Render, returning the row text and the foreground color of the size
+        // unit glyph. Key off "K" — unique to the Size cell here (the
+        // Worktrees column's plain "2" would false-match a bare digit search).
+        let unit_fg =
+            |table: &CatalogTable, final_frame: bool| -> (String, ratatui::style::Color) {
+                let backend = TestBackend::new(100, 6);
+                let mut terminal = Terminal::new(backend).unwrap();
+                terminal.draw(|f| table.render(f, final_frame)).unwrap();
+                let buffer = terminal.backend().buffer();
+                let row: String = (0..100)
+                    .map(|x| buffer[(x, 1)].symbol().to_string())
+                    .collect();
+                let x = (0..100u16)
+                    .find(|x| buffer[(*x, 1)].symbol() == "K")
+                    .expect("size unit rendered");
+                (row, buffer[(x, 1)].fg)
+            };
+
+        let (row, dark) = unit_fg(&table, false);
         assert!(
             !row.contains('\u{25AC}'),
             "stale cell shows a value, not the shimmer: {row:?}"
@@ -701,15 +717,21 @@ mod tests {
             row.contains("2K"),
             "stale cell shows the cached size: {row:?}"
         );
-        // The size glyphs are dim. Key off the unit char "K" — unique to the
-        // Size cell here (the Worktrees column's plain "2" would false-match a
-        // bare digit search).
-        let x = (0..100u16)
-            .find(|x| buffer[(*x, 1)].symbol() == "K")
-            .expect("size unit rendered");
-        assert!(
-            buffer[(x, 1)].style().add_modifier.contains(Modifier::DIM),
-            "stale size value should be dim"
+
+        // The cached value breathes on the shared tick while the walk runs.
+        table.tick = SKELETON_BREATH_FRAMES / 2;
+        let (_, bright) = unit_fg(&table, false);
+        assert_ne!(
+            dark, bright,
+            "stale size value should pulse across the breath (dark={dark:?}, bright={bright:?})"
+        );
+
+        // The final frame settles the breath, so a value the walk never
+        // refreshed is not frozen mid-pulse at near-full brightness.
+        let (_, settled) = unit_fg(&table, true);
+        assert_eq!(
+            settled, dark,
+            "final frame should settle the stale breath to its darkest phase"
         );
     }
 

--- a/src/output/tui/catalog_table.rs
+++ b/src/output/tui/catalog_table.rs
@@ -296,7 +296,19 @@ impl CatalogTable {
             // A stale value is real (just not re-measured yet), so keep showing
             // it — breathing while the walk runs, settled once the run ends —
             // even after cancel. Only never-loaded cells fall to the em-dash.
-            SizeCell::Stale(bytes) => stale_cell(&format_human_size(bytes), self.tick, final_frame),
+            //
+            // `dim` still applies: it is the row-level tombstone signal for a
+            // removed repo, and the breath is a cell-level loading signal. They
+            // compose — without this the one pulsing cell would be the
+            // brightest thing in an otherwise dimmed row.
+            SizeCell::Stale(bytes) => {
+                let cell = stale_cell(&format_human_size(bytes), self.tick, final_frame);
+                if dim {
+                    cell.style(Style::default().add_modifier(Modifier::DIM))
+                } else {
+                    cell
+                }
+            }
             SizeCell::Loading if self.cancelled => not_loaded_cell(width),
             SizeCell::Loading => loading_shimmer_cell(width, self.tick),
         }
@@ -732,6 +744,51 @@ mod tests {
         assert_eq!(
             settled, dark,
             "final frame should settle the stale breath to its darkest phase"
+        );
+    }
+
+    /// A removed repo's row is dimmed whole — that is the tombstone signal.
+    /// The stale breath is a cell-level signal and must compose with it, not
+    /// override it: without the row's DIM the one pulsing cell would be the
+    /// brightest thing in an otherwise muted row, pulling the eye to the repo
+    /// that is going away.
+    #[test]
+    fn stale_cell_on_a_removed_row_keeps_the_row_dim() {
+        use crate::output::tui::render::SKELETON_BREATH_FRAMES;
+        use ratatui::style::Modifier;
+
+        let unit_style = |removed: bool| -> (Modifier, ratatui::style::Color) {
+            let mut table = CatalogTable::new(vec![cells("alpha", false, removed)], columns())
+                .with_stale_sizes(vec![Some(2048)]);
+            // Mid-breath: the phase where the ramp is brightest, i.e. where a
+            // missing DIM would show up most starkly against the dimmed row.
+            table.tick = SKELETON_BREATH_FRAMES / 2;
+            let backend = TestBackend::new(100, 6);
+            let mut terminal = Terminal::new(backend).unwrap();
+            terminal.draw(|f| table.render(f, false)).unwrap();
+            let buffer = terminal.backend().buffer();
+            let x = (0..100u16)
+                .find(|x| buffer[(*x, 1)].symbol() == "K")
+                .expect("size unit rendered");
+            (buffer[(x, 1)].modifier, buffer[(x, 1)].fg)
+        };
+
+        let (removed_mod, removed_fg) = unit_style(true);
+        let (live_mod, live_fg) = unit_style(false);
+
+        assert!(
+            removed_mod.contains(Modifier::DIM),
+            "a removed row's stale size must stay dimmed with the rest of its row"
+        );
+        assert!(
+            !live_mod.contains(Modifier::DIM),
+            "a live row's stale size breathes undimmed — the ramp is the whole signal"
+        );
+        // The two signals compose rather than replace: dimming the row must
+        // not cost the cell its place on the breath ramp.
+        assert_eq!(
+            removed_fg, live_fg,
+            "the tombstone dim layers over the breath colour, it does not override it"
         );
     }
 

--- a/src/output/tui/driver.rs
+++ b/src/output/tui/driver.rs
@@ -322,7 +322,7 @@ impl LiveScreen for TuiState {
         ])
         .split(area);
         render::render_header(self, frame, chunks[0]);
-        render::render_table(self, frame, chunks[1]);
+        render::render_table(self, frame, chunks[1], final_frame);
         render::render_footer(self, frame, chunks[2]);
 
         if final_frame {

--- a/src/output/tui/live_table.rs
+++ b/src/output/tui/live_table.rs
@@ -54,7 +54,8 @@ pub struct LiveTableConfig {
     /// post-set after `TuiState::new` (like `unowned_start_index`); `None`
     /// for commands that don't decorate. While a refresh is in flight the
     /// seed is stripped to identity (`ForgePrLookup::identity_only`) —
-    /// statuses only render once `ForgePrsRefreshed` delivers fresh data.
+    /// statuses only render once `ForgePrsRefreshed` delivers fresh data, and
+    /// the identity breathes in the meantime (`forge_prs_stale`).
     pub forge_prs: Option<ForgePrLookup>,
     /// True while no PR snapshot has *ever* been taken and a refresh is in
     /// flight: PR cells without a value render the loading skeleton until
@@ -62,6 +63,14 @@ pub struct LiveTableConfig {
     /// Unlike per-cell patch state this survives collection completing —
     /// the refresh is out-of-band — but cancel clears it like any shimmer.
     pub forge_prs_loading: bool,
+    /// True while a *warm* PR cache is showing identity-only values and a
+    /// refresh is in flight — the PR analogue of a stale size cell: the number
+    /// is real, its fate is still loading. Those cells breathe until
+    /// `ForgePrsRefreshed` concludes, which clears this whether or not the
+    /// refresh produced data (a failed refresh leaves them honestly
+    /// statusless — see the handler). Mutually exclusive with
+    /// `forge_prs_loading`: cold cache shimmers, warm cache breathes.
+    pub forge_prs_stale: bool,
 }
 
 pub struct LiveTable {
@@ -164,6 +173,10 @@ impl LiveTable {
                     self.pending_resort = true;
                 }
                 self.cfg.forge_prs_loading = false;
+                // Conclusion settles the breath either way: on success the
+                // fresh statuses have swapped in, on failure the identity-only
+                // seed is final. Nothing is loading, so nothing should move.
+                self.cfg.forge_prs_stale = false;
             }
             DagEvent::WorktreeInfoUpdated {
                 branch_name,
@@ -320,7 +333,17 @@ impl LiveTable {
     /// `collection_complete`: a value the walk never refreshes stays honestly
     /// muted rather than promoting to "fresh" at collection end (the final
     /// frame settles its breath — see `render::stale_cell`).
+    ///
+    /// PR cells are stale table-wide rather than per-row: a warm cache is
+    /// stripped to identity for every row at once (`forge_prs_stale`), and the
+    /// refresh concludes for every row at once. Like `forge_prs_loading` this
+    /// is out-of-band, so it deliberately outlives collection completing.
+    /// Unlike the shimmer it is *not* cleared by cancel — an unrefreshed value
+    /// stays honestly stale, and the final frame settles its breath.
     pub fn is_cell_stale(&self, row_idx: usize, field: FieldSet) -> bool {
+        if field.contains(FieldSet::FORGE_REF) && self.cfg.forge_prs_stale {
+            return true;
+        }
         self.stale_fields[row_idx].contains(field)
             && !self.received_patches[row_idx].contains(field)
     }
@@ -400,6 +423,7 @@ mod tests {
             annotation_slots: Default::default(),
             forge_prs: None,
             forge_prs_loading: false,
+            forge_prs_stale: false,
         }
     }
 
@@ -551,6 +575,58 @@ mod tests {
             "a concluded-without-data refresh settles the skeleton"
         );
         assert!(t.cfg.forge_prs.is_none(), "no data means no decorations");
+    }
+
+    /// Warm cache + refresh in flight: the identity-only PR cells are stale,
+    /// not loading — they breathe a real number rather than shimmering an
+    /// empty one — and the conclusion settles them whether or not it carried
+    /// data (a failed refresh leaves the identity honestly statusless).
+    #[test]
+    fn forge_warm_cache_is_stale_until_the_refresh_concludes() {
+        use crate::core::worktree::forge_ref::ForgePrLookup;
+        use crate::core::worktree::pr_rows::ForgePrRowsRefresh;
+
+        for outcome_has_data in [false, true] {
+            let mut t = LiveTable::new(vec![info("feat/x")], cfg());
+            t.cfg.forge_prs_stale = true;
+
+            // Out-of-band like the skeleton: survives collection completing.
+            t.apply_event(&DagEvent::WorktreeInfoCollectionDone);
+            assert!(t.is_cell_stale(0, FieldSet::FORGE_REF));
+            assert!(
+                !t.is_cell_loading(0, FieldSet::FORGE_REF),
+                "a warm cache breathes its value; it must not also shimmer"
+            );
+            assert!(
+                !t.is_cell_stale(0, FieldSet::SIZE),
+                "only the PR cell rides the repo-level flag"
+            );
+
+            let outcome = outcome_has_data.then(|| ForgePrRowsRefresh {
+                lookup: ForgePrLookup::default(),
+                add_rows: vec![],
+                drop_rows: vec![],
+            });
+            t.apply_event(&DagEvent::ForgePrsRefreshed(outcome));
+            assert!(
+                !t.is_cell_stale(0, FieldSet::FORGE_REF),
+                "a concluded refresh settles the breath (data: {outcome_has_data})"
+            );
+        }
+    }
+
+    /// Unlike the shimmer, cancel does NOT clear the stale breath: the cached
+    /// identity is still a real value that was never refreshed, so it stays
+    /// honestly stale and the final frame settles it (see `render::stale_cell`).
+    #[test]
+    fn forge_warm_cache_stays_stale_across_cancel() {
+        let mut t = LiveTable::new(vec![info("feat/x")], cfg());
+        t.cfg.forge_prs_stale = true;
+        t.mark_cancelled();
+        assert!(
+            t.is_cell_stale(0, FieldSet::FORGE_REF),
+            "an unrefreshed cached value must not promote to fresh on cancel"
+        );
     }
 
     /// Cancel must clear the PR skeleton like any other shimmer — the final

--- a/src/output/tui/live_table.rs
+++ b/src/output/tui/live_table.rs
@@ -315,10 +315,11 @@ impl LiveTable {
 
     /// True when the cell for `field` on `row_idx` holds a persisted (stale)
     /// value that a fresh patch has not yet superseded — the render path
-    /// styles it DIM to signal "last known, refreshing". Goes false the
+    /// breathes it to signal "last known, refreshing". Goes false the
     /// instant the matching patch lands. Deliberately not gated on
     /// `collection_complete`: a value the walk never refreshes stays honestly
-    /// dim rather than promoting to "fresh" at collection end.
+    /// muted rather than promoting to "fresh" at collection end (the final
+    /// frame settles its breath — see `render::stale_cell`).
     pub fn is_cell_stale(&self, row_idx: usize, field: FieldSet) -> bool {
         self.stale_fields[row_idx].contains(field)
             && !self.received_patches[row_idx].contains(field)

--- a/src/output/tui/live_table.rs
+++ b/src/output/tui/live_table.rs
@@ -63,14 +63,30 @@ pub struct LiveTableConfig {
     /// Unlike per-cell patch state this survives collection completing —
     /// the refresh is out-of-band — but cancel clears it like any shimmer.
     pub forge_prs_loading: bool,
-    /// True while a *warm* PR cache is showing identity-only values and a
-    /// refresh is in flight — the PR analogue of a stale size cell: the number
-    /// is real, its fate is still loading. Those cells breathe until
-    /// `ForgePrsRefreshed` concludes, which clears this whether or not the
-    /// refresh produced data (a failed refresh leaves them honestly
-    /// statusless — see the handler). Mutually exclusive with
+    /// How the PR column's *warm*-cache identities read right now — the PR
+    /// analogue of a stale size cell. Mutually exclusive with
     /// `forge_prs_loading`: cold cache shimmers, warm cache breathes.
-    pub forge_prs_stale: bool,
+    pub forge_prs_stale: ForgePrStaleness,
+}
+
+/// How a warm PR cache's identity-only values should render while (and after)
+/// a refresh runs. Three states rather than a bool because "the refresh ended"
+/// and "the value was verified" are different facts, and a cached PR number
+/// that nothing ever verified must not read like a fresh one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ForgePrStaleness {
+    /// Nothing cached is awaiting verification: values render plain.
+    #[default]
+    Fresh,
+    /// A warm cache stripped to identity (`ForgePrLookup::identity_only`) with
+    /// a refresh in flight — the number is real, its fate is still loading.
+    /// Breathes until `ForgePrsRefreshed` concludes.
+    Refreshing,
+    /// The refresh concluded without superseding the identities (it failed, or
+    /// the 20s deadline passed while it was still running). The numbers are
+    /// still cached-and-unverified, so they stay muted — but nothing is loading
+    /// any more, so they hold still instead of breathing.
+    Unrefreshed,
 }
 
 pub struct LiveTable {
@@ -173,10 +189,19 @@ impl LiveTable {
                     self.pending_resort = true;
                 }
                 self.cfg.forge_prs_loading = false;
-                // Conclusion settles the breath either way: on success the
-                // fresh statuses have swapped in, on failure the identity-only
-                // seed is final. Nothing is loading, so nothing should move.
-                self.cfg.forge_prs_stale = false;
+                // The breath stops either way, but for different reasons — and
+                // only one of them makes the value fresh. Success supersedes
+                // the identities with verified data. Failure leaves them
+                // cached and unverified, so they keep their muted ink and
+                // merely stop moving; clearing to `Fresh` there would promote
+                // an unverified number to full brightness, which is the exact
+                // lie the stale breath exists to prevent (and what the Size
+                // path refuses at collection end — see `is_cell_stale`).
+                self.cfg.forge_prs_stale = if outcome.is_some() {
+                    ForgePrStaleness::Fresh
+                } else {
+                    ForgePrStaleness::Unrefreshed
+                };
             }
             DagEvent::WorktreeInfoUpdated {
                 branch_name,
@@ -338,14 +363,30 @@ impl LiveTable {
     /// stripped to identity for every row at once (`forge_prs_stale`), and the
     /// refresh concludes for every row at once. Like `forge_prs_loading` this
     /// is out-of-band, so it deliberately outlives collection completing.
-    /// Unlike the shimmer it is *not* cleared by cancel — an unrefreshed value
-    /// stays honestly stale, and the final frame settles its breath.
+    /// Unlike the shimmer it is *not* cleared by cancel, nor by a refresh that
+    /// failed — an unrefreshed value stays honestly stale either way.
     pub fn is_cell_stale(&self, row_idx: usize, field: FieldSet) -> bool {
-        if field.contains(FieldSet::FORGE_REF) && self.cfg.forge_prs_stale {
+        if field.contains(FieldSet::FORGE_REF)
+            && self.cfg.forge_prs_stale != ForgePrStaleness::Fresh
+        {
             return true;
         }
         self.stale_fields[row_idx].contains(field)
             && !self.received_patches[row_idx].contains(field)
+    }
+
+    /// True when a stale cell should hold still rather than breathe: its
+    /// refresh has definitively concluded without superseding it, so the value
+    /// stays muted (still unverified) but no longer signals activity that will
+    /// never come.
+    ///
+    /// Only the PR column can know this today — `ForgePrsRefreshed(None)` is an
+    /// explicit "nothing more is coming" verdict. A stale *size* has no such
+    /// per-row signal (the walk simply never patches that row), so it keeps
+    /// breathing until the final frame settles it.
+    pub fn is_cell_stale_settled(&self, field: FieldSet) -> bool {
+        field.contains(FieldSet::FORGE_REF)
+            && self.cfg.forge_prs_stale == ForgePrStaleness::Unrefreshed
     }
 
     /// Append a new row, keeping `received_patches` in lockstep so
@@ -423,7 +464,7 @@ mod tests {
             annotation_slots: Default::default(),
             forge_prs: None,
             forge_prs_loading: false,
-            forge_prs_stale: false,
+            forge_prs_stale: ForgePrStaleness::Fresh,
         }
     }
 
@@ -579,8 +620,12 @@ mod tests {
 
     /// Warm cache + refresh in flight: the identity-only PR cells are stale,
     /// not loading — they breathe a real number rather than shimmering an
-    /// empty one — and the conclusion settles them whether or not it carried
-    /// data (a failed refresh leaves the identity honestly statusless).
+    /// empty one — until the refresh concludes.
+    ///
+    /// How it concludes decides what "concluded" means. Fresh data supersedes
+    /// the identities, so they go plain. No data leaves them cached and
+    /// unverified, so they must stay muted (and merely stop moving) — clearing
+    /// to `Fresh` there would promote an unverified number to full brightness.
     #[test]
     fn forge_warm_cache_is_stale_until_the_refresh_concludes() {
         use crate::core::worktree::forge_ref::ForgePrLookup;
@@ -588,11 +633,15 @@ mod tests {
 
         for outcome_has_data in [false, true] {
             let mut t = LiveTable::new(vec![info("feat/x")], cfg());
-            t.cfg.forge_prs_stale = true;
+            t.cfg.forge_prs_stale = ForgePrStaleness::Refreshing;
 
             // Out-of-band like the skeleton: survives collection completing.
             t.apply_event(&DagEvent::WorktreeInfoCollectionDone);
             assert!(t.is_cell_stale(0, FieldSet::FORGE_REF));
+            assert!(
+                !t.is_cell_stale_settled(FieldSet::FORGE_REF),
+                "a refresh in flight breathes; it must not hold still"
+            );
             assert!(
                 !t.is_cell_loading(0, FieldSet::FORGE_REF),
                 "a warm cache breathes its value; it must not also shimmer"
@@ -609,8 +658,20 @@ mod tests {
             });
             t.apply_event(&DagEvent::ForgePrsRefreshed(outcome));
             assert!(
-                !t.is_cell_stale(0, FieldSet::FORGE_REF),
-                "a concluded refresh settles the breath (data: {outcome_has_data})"
+                !t.is_cell_loading(0, FieldSet::FORGE_REF),
+                "the conclusion settles the skeleton either way"
+            );
+            assert_eq!(
+                t.is_cell_stale(0, FieldSet::FORGE_REF),
+                !outcome_has_data,
+                "fresh data supersedes the identity; no data leaves it \
+                 unverified and therefore still stale"
+            );
+            assert_eq!(
+                t.is_cell_stale_settled(FieldSet::FORGE_REF),
+                !outcome_has_data,
+                "an unrefreshed identity holds still — muted, but no longer \
+                 advertising a refresh that already gave up"
             );
         }
     }
@@ -621,7 +682,7 @@ mod tests {
     #[test]
     fn forge_warm_cache_stays_stale_across_cancel() {
         let mut t = LiveTable::new(vec![info("feat/x")], cfg());
-        t.cfg.forge_prs_stale = true;
+        t.cfg.forge_prs_stale = ForgePrStaleness::Refreshing;
         t.mark_cancelled();
         assert!(
             t.is_cell_stale(0, FieldSet::FORGE_REF),

--- a/src/output/tui/render.rs
+++ b/src/output/tui/render.rs
@@ -397,6 +397,7 @@ pub fn render_table(state: &TuiState, frame: &mut Frame, area: Rect, final_frame
                             |fs| state.live.is_cell_loading(row_idx, fs),
                             |fs| state.live.is_cell_unloaded(row_idx, fs),
                             |fs| state.live.is_cell_stale(row_idx, fs),
+                            |fs| state.live.is_cell_stale_settled(fs),
                             final_frame,
                         )
                     } else {
@@ -420,6 +421,7 @@ pub fn render_table(state: &TuiState, frame: &mut Frame, area: Rect, final_frame
                         |fs| state.live.is_cell_loading(row_idx, fs),
                         |fs| state.live.is_cell_unloaded(row_idx, fs),
                         |fs| state.live.is_cell_stale(row_idx, fs),
+                        |fs| state.live.is_cell_stale_settled(fs),
                         final_frame,
                     )
                 })
@@ -768,18 +770,16 @@ const STALE_SETTLED_TICK: usize = 0;
 /// loading shimmer, and supersedes cleanly (to the plain, full-brightness
 /// value) the moment the fresh patch lands.
 ///
-/// On `final_frame` the breath settles to its darkest phase instead of
-/// freezing wherever the tick happened to land: a stale value that outlives
-/// the run (cancelled, or never refreshed) stays honestly dim.
+/// When `settled` the breath rests at its darkest phase instead of moving (or
+/// freezing wherever the tick happened to land). That covers both the last
+/// draw of the run and a refresh that concluded without superseding the value:
+/// either way the figure is cached-and-unverified, so it keeps its muted ink
+/// but stops advertising activity that is not happening.
 ///
 /// Shared by the worktree and catalog tables so the stale convention lives in
 /// one place — any column rendered through it inherits the breath for free.
-pub(super) fn stale_cell(value: &str, tick: usize, final_frame: bool) -> Cell<'static> {
-    let phase = if final_frame {
-        STALE_SETTLED_TICK
-    } else {
-        tick
-    };
+pub(super) fn stale_cell(value: &str, tick: usize, settled: bool) -> Cell<'static> {
+    let phase = if settled { STALE_SETTLED_TICK } else { tick };
     Cell::from(Span::styled(
         value.to_string(),
         Style::default().fg(Color::Indexed(skeleton_pulse_color(phase))),
@@ -794,6 +794,8 @@ pub(super) fn stale_cell(value: &str, tick: usize, final_frame: bool) -> Cell<'s
 /// patch arrived; takes precedence over `is_cell_loading`.
 /// `is_cell_stale` returns true when the cell holds a persisted value awaiting
 /// a fresh walk; applies only to cells that already have a value to show.
+/// `is_cell_stale_settled` narrows that: the awaited refresh has concluded
+/// without superseding the value, so it stays muted but stops breathing.
 /// `final_frame` settles animated cells on the last draw — see `stale_cell`.
 #[allow(clippy::too_many_arguments)]
 fn render_cell(
@@ -807,6 +809,7 @@ fn render_cell(
     is_cell_loading: impl Fn(FieldSet) -> bool,
     is_cell_unloaded: impl Fn(FieldSet) -> bool,
     is_cell_stale: impl Fn(FieldSet) -> bool,
+    is_cell_stale_settled: impl Fn(FieldSet) -> bool,
     final_frame: bool,
 ) -> Cell<'static> {
     match col {
@@ -835,7 +838,11 @@ fn render_cell(
                     Cell::from(vals.size.clone())
                 }
             } else if is_cell_stale(FieldSet::SIZE) {
-                stale_cell(&vals.size, tick, final_frame)
+                stale_cell(
+                    &vals.size,
+                    tick,
+                    final_frame || is_cell_stale_settled(FieldSet::SIZE),
+                )
             } else {
                 Cell::from(vals.size.clone())
             }
@@ -902,8 +909,14 @@ fn render_cell(
                 // A warm cache stripped to identity: the number is real, its
                 // fate is still in flight. No status has loaded yet, so there
                 // is no color to preserve — breathe the identity itself until
-                // the refresh lands and the colored value supersedes it.
-                stale_cell(&vals.pr, tick, final_frame)
+                // the refresh lands and the colored value supersedes it. If
+                // the refresh ends without data the number stays muted (it was
+                // never verified) but stops moving.
+                stale_cell(
+                    &vals.pr,
+                    tick,
+                    final_frame || is_cell_stale_settled(FieldSet::FORGE_REF),
+                )
             } else {
                 // Color carries the status here (a ratatui buffer can't hold
                 // the colorless glyph fallback's escape-free sibling — plain
@@ -1678,6 +1691,7 @@ mod tests {
                         |_fs| false, // not loading (cancelled implies collection_complete)
                         |_fs| true,  // is_cell_unloaded → true
                         |_fs| false, // not stale
+                        |_fs| false, // not settled-stale
                         false,       // not the final frame
                     );
                     let table = Table::new(vec![Row::new(vec![cell])], &[Constraint::Length(10)]);
@@ -1731,6 +1745,7 @@ mod tests {
                     |_fs| false, // not loading
                     |_fs| false, // not unloaded — received
                     |_fs| false, // not stale
+                    |_fs| false, // not settled-stale
                     false,       // not the final frame
                 );
                 let table = Table::new(vec![Row::new(vec![cell])], &[Constraint::Length(10)]);
@@ -1793,6 +1808,7 @@ mod tests {
                         |_fs| false, // not loading
                         |_fs| false, // not unloaded
                         |_fs| stale,
+                        |_fs| false, // settled-stale is exercised via `final_frame` here
                         final_frame,
                     );
                     let table = Table::new(vec![Row::new(vec![cell])], &[Constraint::Length(10)]);
@@ -1884,6 +1900,7 @@ mod tests {
         let render_at = |status: Option<PrStatus>,
                          tick: usize,
                          stale: bool,
+                         settled: bool,
                          final_frame: bool|
          -> (String, Color) {
             let l = lookup(status);
@@ -1911,6 +1928,7 @@ mod tests {
                         |_fs| false, // not loading — the cache has a value
                         |_fs| false, // not unloaded
                         |_fs| stale,
+                        |_fs| settled,
                         final_frame,
                     );
                     let table = Table::new(vec![Row::new(vec![cell])], &[Constraint::Length(12)]);
@@ -1928,24 +1946,39 @@ mod tests {
         };
 
         // Identity-only + refresh in flight: the real number, breathing.
-        let (row, dark) = render_at(None, 0, true, false);
+        let (row, dark) = render_at(None, 0, true, false, false);
         assert!(
             row.contains("42"),
             "a stale PR cell shows its cached identity; got {row:?}"
         );
-        let (_, bright) = render_at(None, SKELETON_BREATH_FRAMES / 2, true, false);
+        let (_, bright) = render_at(None, SKELETON_BREATH_FRAMES / 2, true, false, false);
         assert_eq!(dark, Color::Indexed(SKELETON_GRAY_DARKEST));
         assert_eq!(bright, Color::Indexed(SKELETON_GRAY_BRIGHTEST));
 
         // The final frame settles it — an unrefreshed PR must not freeze
         // bright and read as a fresh, status-bearing value.
-        let (_, settled) = render_at(None, SKELETON_BREATH_FRAMES / 2, true, true);
+        let (_, settled) = render_at(None, SKELETON_BREATH_FRAMES / 2, true, false, true);
         assert_eq!(settled, Color::Indexed(SKELETON_GRAY_DARKEST));
+
+        // A refresh that concluded without data settles the cell mid-run: the
+        // number was never verified, so it keeps the muted ink — but nothing
+        // is loading any more, so it stops moving well before the last frame.
+        let (row, unrefreshed) = render_at(None, SKELETON_BREATH_FRAMES / 2, true, true, false);
+        assert_eq!(
+            unrefreshed,
+            Color::Indexed(SKELETON_GRAY_DARKEST),
+            "an unrefreshed identity holds at the muted end of the ramp"
+        );
+        assert!(
+            row.contains("42"),
+            "settling must not drop the cached identity; got {row:?}"
+        );
 
         // Refresh landed: no longer stale, and the fate now carries the color.
         let (_, passing) = render_at(
             Some(PrStatus::Ci(CiStatus::Pass)),
             SKELETON_BREATH_FRAMES / 2,
+            false,
             false,
             false,
         );

--- a/src/output/tui/render.rs
+++ b/src/output/tui/render.rs
@@ -113,7 +113,10 @@ pub fn render_footer(state: &TuiState, frame: &mut Frame, area: Rect) {
 }
 
 /// Render the worktree status table.
-pub fn render_table(state: &TuiState, frame: &mut Frame, area: Rect) {
+///
+/// `final_frame` marks the last draw of the run, settling animated cells so
+/// nothing freezes mid-animation — see `stale_cell`.
+pub fn render_table(state: &TuiState, frame: &mut Frame, area: Rect, final_frame: bool) {
     let now = chrono::Utc::now().timestamp();
     let ctx = ColumnContext {
         project_root: &state.live.cfg.project_root,
@@ -394,6 +397,7 @@ pub fn render_table(state: &TuiState, frame: &mut Frame, area: Rect) {
                             |fs| state.live.is_cell_loading(row_idx, fs),
                             |fs| state.live.is_cell_unloaded(row_idx, fs),
                             |fs| state.live.is_cell_stale(row_idx, fs),
+                            final_frame,
                         )
                     } else {
                         Cell::from("")
@@ -416,6 +420,7 @@ pub fn render_table(state: &TuiState, frame: &mut Frame, area: Rect) {
                         |fs| state.live.is_cell_loading(row_idx, fs),
                         |fs| state.live.is_cell_unloaded(row_idx, fs),
                         |fs| state.live.is_cell_stale(row_idx, fs),
+                        final_frame,
                     )
                 })
                 .collect()
@@ -689,8 +694,9 @@ fn render_remote_cell(info: &WorktreeInfo, stat: Stat) -> Cell<'static> {
 
 /// Frames in one full breath (dim → bright → dim). At the driver's 80ms tick
 /// rate, 16 frames = ~1.3s full cycle. Halve for a snappier pulse, double
-/// for a slower one.
-const SKELETON_BREATH_FRAMES: usize = 16;
+/// for a slower one. Shared by the loading skeleton and the stale-value
+/// breath so both animate on one cadence.
+pub(super) const SKELETON_BREATH_FRAMES: usize = 16;
 
 /// xterm 256-color grayscale ramp endpoints. Indices 232 (near-black) through
 /// 255 (white) form a 24-step ramp — supported by every terminal that does
@@ -748,16 +754,35 @@ pub(super) fn not_loaded_cell(width: u16) -> Cell<'static> {
     Cell::from(Span::styled(padded, Style::default().fg(Color::Gray)))
 }
 
+/// Tick that renders a stale value settled — phase 0 of the breath, i.e. the
+/// darkest point of the ramp. Used on the final frame so a value the walk
+/// never refreshed cannot freeze mid-breath at near-full brightness and pass
+/// for a fresh figure.
+const STALE_SETTLED_TICK: usize = 0;
+
 /// Render a persisted (stale) cell value — a last-known figure shown while a
-/// fresh walk runs in the background. Styled `DIM` and nothing else: never
-/// colored, never the loading shimmer, so it reads as "real but not yet
-/// refreshed" and supersedes cleanly (to the plain, full-brightness value)
-/// the moment the fresh patch lands. Shared by the worktree and catalog
-/// tables so the stale convention lives in one place.
-pub(super) fn stale_cell(value: &str) -> Cell<'static> {
+/// fresh walk runs in the background. The value stays fully legible (it is a
+/// real figure) but breathes along the same grayscale ramp, cadence, and
+/// shared `tick` as the loading skeleton, so it reads as "real, and actively
+/// refreshing" rather than merely dim. It is never colored and never the
+/// loading shimmer, and supersedes cleanly (to the plain, full-brightness
+/// value) the moment the fresh patch lands.
+///
+/// On `final_frame` the breath settles to its darkest phase instead of
+/// freezing wherever the tick happened to land: a stale value that outlives
+/// the run (cancelled, or never refreshed) stays honestly dim.
+///
+/// Shared by the worktree and catalog tables so the stale convention lives in
+/// one place — any column rendered through it inherits the breath for free.
+pub(super) fn stale_cell(value: &str, tick: usize, final_frame: bool) -> Cell<'static> {
+    let phase = if final_frame {
+        STALE_SETTLED_TICK
+    } else {
+        tick
+    };
     Cell::from(Span::styled(
         value.to_string(),
-        Style::default().add_modifier(Modifier::DIM),
+        Style::default().fg(Color::Indexed(skeleton_pulse_color(phase))),
     ))
 }
 
@@ -769,6 +794,7 @@ pub(super) fn stale_cell(value: &str) -> Cell<'static> {
 /// patch arrived; takes precedence over `is_cell_loading`.
 /// `is_cell_stale` returns true when the cell holds a persisted value awaiting
 /// a fresh walk; applies only to cells that already have a value to show.
+/// `final_frame` settles animated cells on the last draw — see `stale_cell`.
 #[allow(clippy::too_many_arguments)]
 fn render_cell(
     col: &Column,
@@ -781,6 +807,7 @@ fn render_cell(
     is_cell_loading: impl Fn(FieldSet) -> bool,
     is_cell_unloaded: impl Fn(FieldSet) -> bool,
     is_cell_stale: impl Fn(FieldSet) -> bool,
+    final_frame: bool,
 ) -> Cell<'static> {
     match col {
         Column::Status => render_status_cell(wt, tick),
@@ -808,7 +835,7 @@ fn render_cell(
                     Cell::from(vals.size.clone())
                 }
             } else if is_cell_stale(FieldSet::SIZE) {
-                stale_cell(&vals.size)
+                stale_cell(&vals.size, tick, final_frame)
             } else {
                 Cell::from(vals.size.clone())
             }
@@ -1645,6 +1672,7 @@ mod tests {
                         |_fs| false, // not loading (cancelled implies collection_complete)
                         |_fs| true,  // is_cell_unloaded → true
                         |_fs| false, // not stale
+                        false,       // not the final frame
                     );
                     let table = Table::new(vec![Row::new(vec![cell])], &[Constraint::Length(10)]);
                     frame.render_widget(table, frame.area());
@@ -1697,6 +1725,7 @@ mod tests {
                     |_fs| false, // not loading
                     |_fs| false, // not unloaded — received
                     |_fs| false, // not stale
+                    false,       // not the final frame
                 );
                 let table = Table::new(vec![Row::new(vec![cell])], &[Constraint::Length(10)]);
                 frame.render_widget(table, frame.area());
@@ -1719,9 +1748,11 @@ mod tests {
     }
 
     #[test]
-    fn render_cell_size_stale_renders_value_dimmed() {
-        // A stale (persisted, not-yet-refreshed) Size cell renders its value
-        // DIM — visible but muted — never the shimmer, never an em-dash.
+    fn render_cell_size_stale_breathes_on_the_skeleton_ramp() {
+        // A stale (persisted, not-yet-refreshed) Size cell renders its value —
+        // never the shimmer, never an em-dash — breathing along the same
+        // grayscale ramp and cadence as the loading skeleton, so it reads as
+        // "real, and actively refreshing" rather than merely dim.
         use crate::output::format::{ColumnContext, compute_column_values};
         use crate::output::tui::state::WorktreeRow;
 
@@ -1738,31 +1769,42 @@ mod tests {
         };
         let vals = compute_column_values(&info, &ctx);
 
-        let backend = TestBackend::new(10, 1);
-        let mut terminal = Terminal::new(backend).unwrap();
-        terminal
-            .draw(|frame| {
-                let cell = render_cell(
-                    &Column::Size,
-                    &wt,
-                    &vals,
-                    0,
-                    Stat::Summary,
-                    10,
-                    Default::default(),
-                    |_fs| false, // not loading
-                    |_fs| false, // not unloaded
-                    |_fs| true,  // stale → dim
-                );
-                let table = Table::new(vec![Row::new(vec![cell])], &[Constraint::Length(10)]);
-                frame.render_widget(table, frame.area());
-            })
-            .unwrap();
-        let buffer = terminal.backend().buffer();
-        let row: String = (0..10)
-            .map(|x| buffer[(x, 0)].symbol().to_string())
-            .collect();
-        // Value is shown (not shimmer/em-dash) …
+        // Render the Size cell, returning the row text and the foreground
+        // color of its first painted glyph.
+        let render_at = |tick: usize, stale: bool, final_frame: bool| -> (String, Color) {
+            let backend = TestBackend::new(10, 1);
+            let mut terminal = Terminal::new(backend).unwrap();
+            terminal
+                .draw(|frame| {
+                    let cell = render_cell(
+                        &Column::Size,
+                        &wt,
+                        &vals,
+                        tick,
+                        Stat::Summary,
+                        10,
+                        Default::default(),
+                        |_fs| false, // not loading
+                        |_fs| false, // not unloaded
+                        |_fs| stale,
+                        final_frame,
+                    );
+                    let table = Table::new(vec![Row::new(vec![cell])], &[Constraint::Length(10)]);
+                    frame.render_widget(table, frame.area());
+                })
+                .unwrap();
+            let buffer = terminal.backend().buffer();
+            let row: String = (0..10)
+                .map(|x| buffer[(x, 0)].symbol().to_string())
+                .collect();
+            let first_glyph = (0..10)
+                .find(|&x| buffer[(x, 0)].symbol().trim() != "")
+                .expect("stale cell should paint at least one glyph");
+            (row, buffer[(first_glyph, 0)].fg)
+        };
+
+        // The value is shown — not a shimmer bar, not an em-dash.
+        let (row, dark) = render_at(0, true, false);
         assert!(
             !row.contains('\u{25AC}') && !row.contains('\u{2014}'),
             "stale cell must render the value, not a placeholder; got {row:?}"
@@ -1773,13 +1815,33 @@ mod tests {
                 .any(|c| c.is_ascii_digit() || c == 'B' || c == 'K'),
             "stale Size cell should render the numeric/unit value; got {row:?}"
         );
-        // … and it is dimmed. Find the first glyph cell and assert DIM.
-        let first_glyph = (0..10)
-            .find(|&x| buffer[(x, 0)].symbol().trim() != "")
-            .expect("stale cell should paint at least one glyph");
-        assert!(
-            buffer[(first_glyph, 0)].modifier.contains(Modifier::DIM),
-            "stale Size value should carry the DIM modifier"
+
+        // It breathes across the exact skeleton ramp, at the exact cadence.
+        let (_, bright) = render_at(SKELETON_BREATH_FRAMES / 2, true, false);
+        assert_eq!(dark, Color::Indexed(SKELETON_GRAY_DARKEST));
+        assert_eq!(bright, Color::Indexed(SKELETON_GRAY_BRIGHTEST));
+        assert_ne!(
+            dark, bright,
+            "stale value should pulse across the breath (dark={dark:?}, bright={bright:?})"
+        );
+
+        // The final frame settles to the darkest phase instead of freezing
+        // mid-breath — a value the walk never refreshed must not be left
+        // looking fresh.
+        let (_, settled) = render_at(SKELETON_BREATH_FRAMES / 2, true, true);
+        assert_eq!(
+            settled,
+            Color::Indexed(SKELETON_GRAY_DARKEST),
+            "final frame should settle the stale breath to its darkest phase"
+        );
+
+        // Once the fresh patch lands the cell is no longer stale: plain,
+        // full-brightness text with no ramp color left behind.
+        let (_, fresh) = render_at(SKELETON_BREATH_FRAMES / 2, false, false);
+        assert_eq!(
+            fresh,
+            Color::Reset,
+            "a superseded cell should render plain, with no lingering pulse"
         );
     }
 
@@ -1857,7 +1919,7 @@ mod tests {
         let mut terminal = Terminal::new(backend).unwrap();
         terminal
             .draw(|frame| {
-                render_table(&state, frame, frame.area());
+                render_table(&state, frame, frame.area(), false);
             })
             .unwrap();
         let buffer = terminal.backend().buffer();
@@ -1901,7 +1963,7 @@ mod tests {
         let mut terminal = Terminal::new(backend).unwrap();
         terminal
             .draw(|frame| {
-                render_table(&state, frame, frame.area());
+                render_table(&state, frame, frame.area(), false);
             })
             .unwrap();
         let buffer = terminal.backend().buffer();
@@ -1958,7 +2020,7 @@ mod tests {
         let mut terminal = Terminal::new(backend).unwrap();
         terminal
             .draw(|frame| {
-                render_table(&state, frame, frame.area());
+                render_table(&state, frame, frame.area(), false);
             })
             .unwrap();
         let buffer = terminal.backend().buffer();

--- a/src/output/tui/render.rs
+++ b/src/output/tui/render.rs
@@ -898,6 +898,12 @@ fn render_cell(
                 } else {
                     Cell::from(vals.pr.clone())
                 }
+            } else if is_cell_stale(FieldSet::FORGE_REF) {
+                // A warm cache stripped to identity: the number is real, its
+                // fate is still in flight. No status has loaded yet, so there
+                // is no color to preserve — breathe the identity itself until
+                // the refresh lands and the colored value supersedes it.
+                stale_cell(&vals.pr, tick, final_frame)
             } else {
                 // Color carries the status here (a ratatui buffer can't hold
                 // the colorless glyph fallback's escape-free sibling — plain
@@ -1842,6 +1848,111 @@ mod tests {
             fresh,
             Color::Reset,
             "a superseded cell should render plain, with no lingering pulse"
+        );
+    }
+
+    /// The PR column is the second consumer of the stale convention: a warm
+    /// forge cache is stripped to identity while the refresh runs, so the
+    /// number breathes until its fate lands and the colored value supersedes.
+    #[test]
+    fn render_cell_pr_stale_breathes_then_supersedes_to_its_status_color() {
+        use crate::core::worktree::forge_ref::{
+            CiStatus, ForgeBranchRef, ForgePrLookup, ForgeRefKind, PrDecoration, PrStatus,
+        };
+        use crate::output::format::{ColumnContext, compute_column_values};
+        use crate::output::tui::state::WorktreeRow;
+
+        let info = WorktreeInfo::empty("feat/x");
+        let wt = WorktreeRow::idle(info.clone());
+
+        // `status: None` is what `ForgePrLookup::identity_only` leaves behind
+        // while a refresh is in flight — the number without its fate.
+        let lookup = |status: Option<PrStatus>| {
+            let mut l = ForgePrLookup::default();
+            l.by_branch.insert(
+                "feat/x".into(),
+                PrDecoration {
+                    r: ForgeBranchRef::new(ForgeRefKind::GithubPr, 42),
+                    status,
+                    url: None,
+                    author: None,
+                },
+            );
+            l
+        };
+
+        let render_at = |status: Option<PrStatus>,
+                         tick: usize,
+                         stale: bool,
+                         final_frame: bool|
+         -> (String, Color) {
+            let l = lookup(status);
+            let ctx = ColumnContext {
+                project_root: &PathBuf::from("/tmp"),
+                cwd: &PathBuf::from("/tmp"),
+                now: 0,
+                stat: Stat::Summary,
+                forge_prs: Some(&l),
+                colors: true,
+            };
+            let vals = compute_column_values(&info, &ctx);
+            let backend = TestBackend::new(12, 1);
+            let mut terminal = Terminal::new(backend).unwrap();
+            terminal
+                .draw(|frame| {
+                    let cell = render_cell(
+                        &Column::Pr,
+                        &wt,
+                        &vals,
+                        tick,
+                        Stat::Summary,
+                        12,
+                        Default::default(),
+                        |_fs| false, // not loading — the cache has a value
+                        |_fs| false, // not unloaded
+                        |_fs| stale,
+                        final_frame,
+                    );
+                    let table = Table::new(vec![Row::new(vec![cell])], &[Constraint::Length(12)]);
+                    frame.render_widget(table, frame.area());
+                })
+                .unwrap();
+            let buffer = terminal.backend().buffer();
+            let row: String = (0..12)
+                .map(|x| buffer[(x, 0)].symbol().to_string())
+                .collect();
+            let first_glyph = (0..12)
+                .find(|&x| buffer[(x, 0)].symbol().trim() != "")
+                .expect("PR cell should paint at least one glyph");
+            (row, buffer[(first_glyph, 0)].fg)
+        };
+
+        // Identity-only + refresh in flight: the real number, breathing.
+        let (row, dark) = render_at(None, 0, true, false);
+        assert!(
+            row.contains("42"),
+            "a stale PR cell shows its cached identity; got {row:?}"
+        );
+        let (_, bright) = render_at(None, SKELETON_BREATH_FRAMES / 2, true, false);
+        assert_eq!(dark, Color::Indexed(SKELETON_GRAY_DARKEST));
+        assert_eq!(bright, Color::Indexed(SKELETON_GRAY_BRIGHTEST));
+
+        // The final frame settles it — an unrefreshed PR must not freeze
+        // bright and read as a fresh, status-bearing value.
+        let (_, settled) = render_at(None, SKELETON_BREATH_FRAMES / 2, true, true);
+        assert_eq!(settled, Color::Indexed(SKELETON_GRAY_DARKEST));
+
+        // Refresh landed: no longer stale, and the fate now carries the color.
+        let (_, passing) = render_at(
+            Some(PrStatus::Ci(CiStatus::Pass)),
+            SKELETON_BREATH_FRAMES / 2,
+            false,
+            false,
+        );
+        assert_eq!(
+            passing,
+            Color::Green,
+            "a superseded PR cell carries its status color, not the breath"
         );
     }
 

--- a/src/output/tui/state.rs
+++ b/src/output/tui/state.rs
@@ -231,6 +231,7 @@ impl TuiState {
             // pattern as `unowned_start_index` below).
             forge_prs: None,
             forge_prs_loading: false,
+            forge_prs_stale: false,
         };
         let mut live = LiveTable::new(worktree_infos, cfg);
         live.unowned_start_index = unowned_start_index;

--- a/src/output/tui/state.rs
+++ b/src/output/tui/state.rs
@@ -231,7 +231,7 @@ impl TuiState {
             // pattern as `unowned_start_index` below).
             forge_prs: None,
             forge_prs_loading: false,
-            forge_prs_stale: false,
+            forge_prs_stale: crate::output::tui::live_table::ForgePrStaleness::Fresh,
         };
         let mut live = LiveTable::new(worktree_infos, cfg);
         live.unowned_start_index = unowned_start_index;


### PR DESCRIPTION
The live list has two loading states, and only one of them ever moved.

An empty cell whose value has not arrived yet renders a skeleton bar that
breathes on the gray ramp. But a cell showing a **cached value while a fresh one
refreshes in the background** rendered as static dim text — motionless, every
frame, indistinguishable from a value that had finished loading and was simply
dim. The one loading state with no motion was the one where the user is looking
at a real number and cannot tell whether it is the answer.

This makes those cells breathe until the fresh value lands, then snap to plain
full brightness.

## The animation

Exactly the skeleton's: same colors, same values, same timing — the 239 → 252
xterm grayscale ramp via `skeleton_pulse_color`, driven by the same tick. Not a
scaled `DIM`, so a stale cell and a skeleton bar pulse in lockstep rather than in
two dialects of "loading".

No new plumbing was needed for the motion itself. The driver already redraws
every loop iteration and ticks every 80 ms for as long as `is_complete()` is
false, and stale deliberately does not count as complete — so a breathing stale
cell repaints for free.

## Where it lives

In the shared `stale_cell` helper, so the whole stale convention stays in one
place and every current and future cached-then-refresh column inherits it. Two
consumers exist today — the worktree list's size column and `daft repo list`'s
`SizeCell::Stale` — and both were already passing `tick`.

## The final-frame settle

`stale_cell` also owns the settle, and it could not key on any of the cheap
signals in scope. `is_cell_unloaded` and `CatalogTable.cancelled` both cover only
Ctrl-C, but `is_cell_stale` is deliberately not gated on `collection_complete` —
a value the walk never refreshes stays honestly stale. Such a value therefore
reaches the final draw with `cancelled == false`, and would freeze wherever the
breath happened to be, possibly at full brightness, reading as a fresh figure.

So the real `final_frame` flag is threaded from the driver's render through
`render_table` -> `render_cell` -> `stale_cell`, and the last draw pins phase 0 —
the darkest point of the ramp. That threading is why the diff is mechanical in
places rather than three lines.

## The PR column

The second commit extends the same treatment to the forge column, which the
issue names as the motivating next example.

The color conflict this looked like it would have does not exist. A PR cell
normally carries its status as its _color_, which a gray ramp would erase — but
while stale the lookup is `ForgePrLookup::identity_only()`, which keeps the PR
number and nulls `status` and `url`. A stale PR cell is a bare number with no
status color at all, so there is no hue to destroy; the color arrives _with_ the
fresh value. The identical gray breath applies cleanly.

`forge_prs_stale` mirrors `forge_prs_loading` and is repo-level rather than
per-row, because a warm cache is stripped for every row at once — so
`is_cell_stale` early-returns on `FORGE_REF` the same way `is_cell_loading`
already does. It is set at the single `identity_only` producer and cleared by
`ForgePrsRefreshed` whether or not the refresh carried data: a failed refresh
leaves the identity honestly statusless, and nothing is loading, so nothing
should move.

One deliberate asymmetry: cancel clears the shimmer but must **not** clear
`forge_prs_stale`. A cached value that was never refreshed is still a real
unrefreshed value, so it stays stale and the final frame settles it — otherwise
Ctrl-C would quietly promote it to looking fresh.

## Out of scope

The empty-cell skeleton (already breathes), the cancelled em-dash, and the
non-live path (piped, `--format`, non-TTY, `DAFT_NO_LIVE`, `--merging`) — which
has no loading state to animate.

## Testing

The two tests that asserted static dim were rewritten in place to assert the ramp
endpoints, the settle, and the plain supersede; three new tests cover the PR
column's staleness bookkeeping, its survival across cancel, and that the column
actually routes through `stale_cell` and comes back status-colored once
superseded. No external goldens are affected — the stale render is a live-TTY
behavior covered by unit + `TestBackend`, as
`tests/manual/scenarios/repo/size-cache-persist.yml` says of itself.

`mise run fmt`, `mise run clippy` (zero warnings), `mise run test:unit` (3690
passed, 0 failed).

Fixes #770

🤖 Generated with [Claude Code](https://claude.com/claude-code)
