### PR TITLE
ci(docs): deploy the site on release tags, not every master push

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,12 +1,27 @@
 name: Deploy Docs
 
 on:
+  # Deploy on release tags only, so the published site describes the released
+  # binary rather than master. Deploying on every master push meant a user who
+  # installed the latest tag read documentation for merged-but-unreleased
+  # commands — with the nav's version indicator (parsed from Cargo.toml, which
+  # only the release PR bumps) rendering the *released* version right beside
+  # them.
+  #
+  # LOAD-BEARING: this fires only because release-flow.yml pushes the tag with
+  # the Wheatley GitHub App token. Refs pushed with the default GITHUB_TOKEN do
+  # not trigger workflows, so switching that job back to GITHUB_TOKEN would
+  # silently strand the docs site at the last App-token-tagged release — green
+  # runs, no deploys, no signal. release.yml triggers on this same tag push, so
+  # the two fail and recover together.
+  #
+  # No paths: filter here on purpose. A release republishes regardless of its
+  # diff shape (CHANGELOG.md is @include'd into docs/about/changelog.md but
+  # would not match the filter list below), and path filters are unreliable
+  # against tag pushes.
   push:
-    branches: [master]
-    paths:
-      - "docs/**"
-      - "Cargo.toml"
-      - ".github/workflows/docs.yml"
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
   # Build (without deploying) on PRs that touch the docs, so a broken VitePress
   # build is caught before merge. This workflow previously only ran on push to
   # master, so bad Markdown (e.g. unclosed angle-bracket placeholders parsed as
@@ -48,9 +63,11 @@ jobs:
         working-directory: docs
         run: bunx vitepress build
 
-      # Deploy only on push to master and manual dispatch — never on PR builds,
-      # which validate the VitePress build without publishing. github.event_name
-      # is a trusted, GitHub-controlled value (no untrusted-input injection).
+      # Deploy only on release-tag pushes and manual dispatch — never on PR
+      # builds, which validate the VitePress build without publishing. Those are
+      # the only three triggers above, so excluding pull_request covers it.
+      # github.event_name is a trusted, GitHub-controlled value (no
+      # untrusted-input injection).
       - name: Deploy to Cloudflare Pages
         if: github.event_name != 'pull_request'
         uses: cloudflare/wrangler-action@v4.0.0


### PR DESCRIPTION
Deploy Docs ran on every push to `master` touching `docs/**`, `Cargo.toml`, or the
workflow itself, so every merged PR carrying a docs change published the site.
Four deploys on 2026-07-30 alone (#796, #807, #808, and the v1.26.0 release).

The published site therefore described `master` while users install the latest
**tag**. Every merged-but-unreleased feature was a documented command nobody could
run — and the nav's version indicator made the mismatch explicit rather than merely
latent, since it is parsed from `Cargo.toml` (`docs/.vitepress/config.ts:9`), which
only the release PR bumps. The site rendered `v1.26.0` beside prose for commits that
had shipped in nothing.

## The change

```diff
 on:
   push:
-    branches: [master]
-    paths:
-      - "docs/**"
-      - "Cargo.toml"
-      - ".github/workflows/docs.yml"
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
```

plus comments recording why, and a corrected comment on the Deploy step (it still
said "on push to master").

The tag glob matches `release.yml`'s exactly, so the docs deploy and the binary
release stay in lockstep — including for prereleases, which match neither glob by
design.

No `paths:` filter on the tag arm, deliberately: a release should republish
regardless of its diff shape, path filters are unreliable against tag pushes, and
the old list had a latent hole — `CHANGELOG.md` is a docs input via the
`@include` in `docs/about/changelog.md` but was never listed, so it only ever
triggered a deploy because `Cargo.toml` happened to change in the same commit.

## What is deliberately untouched

- **The `pull_request` arm.** It builds without deploying, and it is the only thing
  catching a broken VitePress build before merge — added after unclosed
  angle-bracket placeholders reached master and broke every deploy (#641).
- **The deploy gate.** `if: github.event_name != 'pull_request'` stays correct now
  that the only non-PR triggers are tag pushes and `workflow_dispatch`.
- **`workflow_dispatch`.** Already present; it is the escape hatch for an urgent
  docs-only fix that has no release to ride.

## The trap this could have fallen into

A `push: tags:` trigger fires **only if the tag was pushed by something other than
the default `GITHUB_TOKEN`** — token-pushed refs do not trigger workflows. That is
the same class of silent no-op as #803/#804, where exact pins made a scheduled
`mise upgrade` structurally incapable of producing a diff.

It is safe here, and provably so rather than by inference: `release-flow.yml:53-64`
pushes the tag with the Wheatley **GitHub App** token, and `release.yml` triggers on
that identical tag push and has succeeded on every release (v1.23.0 through
v1.26.0). The dependency is now written into the workflow, because regressing it
would strand the docs site silently — green runs, no deploys, no signal.

## Cost

Per `cliff.toml`, `docs:`-typed commits produce no version bump, so a docs-only PR
waits for the next `feat`/`fix`/`perf` to release. Historically that window is
short: 78 `docs:` commits over the project's life, but the last two were 2026-06-21
(#637) and 2026-06-23 (#641) — for the past five weeks every change under `docs/`
rode along with a releasable commit, and release cadence is a few days (v1.22.0 →
v1.26.0 in eleven days). If it ever bites, the follow-up is a `docs` → patch mapping
in `cliff.toml`, not a revert.

## Verification

- Workflow parses; triggers resolve to `push.tags = ["v[0-9]+.[0-9]+.[0-9]+"]`,
  `pull_request.paths` unchanged, `workflow_dispatch`, and the deploy gate still
  `github.event_name != 'pull_request'`.
- `mise run fmt` leaves the file unchanged; lefthook's `prettier-format` agrees.
- This PR touches `.github/workflows/docs.yml`, which is in the `pull_request`
  paths filter — so Deploy Docs runs on this PR under the *modified* workflow and
  self-validates that it still builds and does not deploy.
- No Rust changed, so clippy and the unit tests were not run; lefthook skipped every
  Rust check for the same reason ("no matching staged files").
- No CI ↔ merge-gate parity change: the `docs-build` ring in `daft.yml:198` mirrors
  the docs **build**, which this does not touch.

Note this is CODEOWNERS-gated (`/.github/workflows/ @avihut`).

Fixes #809
