### PR TITLE
feat: show -x commands as rows on the plan-execute rail

### DIFF
--- a/docs/reference/progress-timeline.md
+++ b/docs/reference/progress-timeline.md
@@ -165,6 +165,18 @@ never keeps an identity ink.
   `↓` rows; jobs skipped by their own `skip:`/`only:` conditions leave no trace,
   and a whole phase skipped that way vanishes with them. Background jobs get a
   blue `↻ name  background` receipt — `daft hooks jobs` manages them from there.
+- `-x`/`--exec` commands are planned where they run: last, after the post-create
+  hooks. One row per `-x` occurrence, labelled with the command exactly as you
+  typed it, under an `├─ exec` anchor once there are two or more — so two
+  identical commands stay two rows. A command owns the terminal for its whole
+  run (`-x` inherits stdio and may be interactive), so its own output prints
+  above the rail and its row then resolves green, or red with the exit status
+  (`✗ npm ci  exit 1`). A failure stops the sequence, and the commands that
+  never got their turn say so (`↓ cargo test  not run`). The worktree exists and
+  your shell still moves into it, so the footer reads
+  `Ready with failures in 2.4s` rather than claiming the creation failed.
+  Navigating to an **existing** worktree commits no plan and so has no rail: the
+  commands still run, with the single-line output that path has always had.
 - The `pre-push` gate is git's hook, not daft's — git dispatches it inside
   `git push` and daft sees one output stream. When that stream is a **hook
   manager** (lefthook 2.x — every released 2.x version is covered), daft

--- a/docs/reference/progress-timeline.md
+++ b/docs/reference/progress-timeline.md
@@ -167,16 +167,23 @@ never keeps an identity ink.
   blue `↻ name  background` receipt — `daft hooks jobs` manages them from there.
 - `-x`/`--exec` commands are planned where they run: last, after the post-create
   hooks. One row per `-x` occurrence, labelled with the command exactly as you
-  typed it, under an `├─ exec` anchor once there are two or more — so two
-  identical commands stay two rows. A command owns the terminal for its whole
-  run (`-x` inherits stdio and may be interactive), so its own output prints
-  above the rail and its row then resolves green, or red with the exit status
+  typed it (flattened to one line, so a pasted multi-line snippet stays one
+  row), under an `├─ exec` anchor once there are two or more — so two identical
+  commands stay two rows. A command owns the terminal for its whole run (`-x`
+  inherits stdio and may be interactive), so its own output prints above the
+  rail and its row then resolves green, or red with the exit status
   (`✗ npm ci  exit 1`). A failure stops the sequence, and the commands that
   never got their turn say so (`↓ cargo test  not run`). The worktree exists and
   your shell still moves into it, so the footer reads
   `Ready with failures in 2.4s` rather than claiming the creation failed.
-  Navigating to an **existing** worktree commits no plan and so has no rail: the
-  commands still run, with the single-line output that path has always had.
+
+  This is the worktree-creation family — `checkout`/`go`, `start`, a fork, a
+  sandbox visit that materializes. Everywhere else `-x` keeps the single-line
+  `Executing: <cmd>` record it has always had: navigating to an **existing**
+  worktree commits no plan and so has no rail at all, and `daft clone -x`,
+  `daft init -x`, and `start --with-related`'s post-fan-out sequence run their
+  commands outside the rail's lifetime — after the receipt, not inside it.
+
 - The `pre-push` gate is git's hook, not daft's — git dispatches it inside
   `git push` and daft sees one output stream. When that stream is a **hook
   manager** (lefthook 2.x — every released 2.x version is covered), daft

--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -862,23 +862,27 @@ fn run_start_fork(args: StartArgs, base: Option<String>, count: u32) -> Result<(
                 &mut timeline,
                 executor,
                 hook_output_config.clone(),
-            );
+            )
+            .with_plan_suffix(crate::exec::plan_section(&args.exec));
             sandbox::execute_create(&params, &git, &project_root, &mut bridge)
         };
         timeline.abandon_planning();
         match create_result {
             Ok(result) => {
+                // Per-fork exec, inside the fork (core chdir'd there). On the
+                // rail it is the plan's tail (#812) and runs before the
+                // receipt closes; the path record still follows the footer,
+                // and off the rail the whole order is unchanged.
+                let exec_tail = crate::exec::run_on_rail(&args.exec, &mut timeline);
+                let footer = ready_footer(&exec_tail, &timeline);
                 if timeline.region_live() {
-                    timeline.finish(&format!("Ready in {}", timeline.elapsed_display()));
+                    timeline.finish(&footer);
                 }
                 // The path is the record: bare on stdout, exactly once, in
                 // every mode (rail, plain, quiet, redirected).
                 output.raw(&format!("{}\n", result.worktree_path.display()));
-                // Per-fork exec, inside the fork (core chdir'd there). A
-                // failed command marks this fork failed; the worktree stays.
-                if !args.exec.is_empty()
-                    && let Err(e) = crate::exec::run_exec_commands(&args.exec, &mut output)
-                {
+                // A failed command marks this fork failed; the worktree stays.
+                if let Err(e) = run_exec_tail(exec_tail, &args.exec, &mut output) {
                     failures.push((dirname.clone(), e));
                 }
                 completed.push(result);
@@ -2187,7 +2191,8 @@ fn run_checkout(
 
     timeline.open_planning();
     let checkout_result = {
-        let mut bridge = TimelineBridge::new(output, &mut timeline, executor, hook_output_config);
+        let mut bridge = TimelineBridge::new(output, &mut timeline, executor, hook_output_config)
+            .with_plan_suffix(crate::exec::plan_section(&args.exec));
         checkout::execute(&params, git, &project_root, &mut bridge)
     };
     timeline.abandon_planning();
@@ -2197,13 +2202,19 @@ fn run_checkout(
             // With a committed plan (fetch-on branch not found, step
             // failures) this closes the rail into a Failed receipt; a
             // resolve-phase error left no region behind and this no-ops.
+            // Planned `-x` rows persist as dim `(not run)` — true: the
+            // sequence is skipped whenever the creation fails.
             timeline.abort(&format!("Failed after {}", timeline.elapsed_display()));
             return Err(e);
         }
     };
 
+    // The `-x` sequence is the plan's tail (#812): run it while the region is
+    // still live, so the rows that promised it are the rows that resolve it.
+    let exec_tail = crate::exec::run_on_rail(&args.exec, &mut timeline);
+    let footer = ready_footer(&exec_tail, &timeline);
     if timeline.region_live() {
-        timeline.finish(&format!("Ready in {}", timeline.elapsed_display()));
+        timeline.finish(&footer);
     }
     // On the rail, the header + footer are the record; Plain/Hidden (and the
     // no-rail early exits) keep the result line byte-identical to before —
@@ -2212,8 +2223,9 @@ fn run_checkout(
         render_checkout_result(&result, output);
     }
 
-    // Run exec commands (after hooks, before cd_path)
-    let exec_result = crate::exec::run_exec_commands(&args.exec, output);
+    // Off the rail, the commands run here — after the record line, exactly
+    // where they always have.
+    let exec_result = run_exec_tail(exec_tail, &args.exec, output);
 
     output.cd_path(&result.cd_target);
     maybe_show_shell_hint(output)?;
@@ -2222,6 +2234,33 @@ fn run_checkout(
     exec_result?;
 
     Ok(result.already_existed)
+}
+
+/// The receipt footer for a creation journey whose `-x` rows ran on the rail.
+///
+/// A failed `-x` never renders a Failed receipt: the worktree exists, the
+/// shell is about to cd into it, and the red row above already names what
+/// broke. The footer only stops claiming an unqualified success (#812).
+fn ready_footer(tail: &crate::exec::ExecTail, timeline: &Timeline) -> String {
+    let elapsed = timeline.elapsed_display();
+    if tail.failed() {
+        format!("Ready with failures in {elapsed}")
+    } else {
+        format!("Ready in {elapsed}")
+    }
+}
+
+/// Settle a creation journey's `-x` sequence: the rail already ran it, or it
+/// runs here off the rail with its legacy `Executing: <cmd>` lines.
+fn run_exec_tail(
+    tail: crate::exec::ExecTail,
+    commands: &[String],
+    output: &mut dyn Output,
+) -> Result<()> {
+    match tail {
+        crate::exec::ExecTail::OnRail(result) => result,
+        crate::exec::ExecTail::OffRail => crate::exec::run_exec_commands(commands, output),
+    }
 }
 
 /// Shared shell for both sandbox-rung entrances (#53): run the visit, then
@@ -2304,7 +2343,8 @@ fn run_sandbox_visit(
 
     timeline.open_planning();
     let visit_result = {
-        let mut bridge = TimelineBridge::new(output, &mut timeline, executor, hook_output_config);
+        let mut bridge = TimelineBridge::new(output, &mut timeline, executor, hook_output_config)
+            .with_plan_suffix(crate::exec::plan_section(&args.exec));
         sandbox::execute_visit(&params, git, &project_root, &mut bridge)
     };
     timeline.abandon_planning();
@@ -2316,15 +2356,19 @@ fn run_sandbox_visit(
         }
     };
 
+    // The `-x` sequence is the plan's tail (#812) — see `run_checkout`. A
+    // visit that navigated to an EXISTING sandbox committed no plan, so it
+    // carries no rows and the commands run off the rail below, unchanged.
+    let exec_tail = crate::exec::run_on_rail(&args.exec, &mut timeline);
+    let footer = ready_footer(&exec_tail, &timeline);
     if timeline.region_live() {
-        timeline.finish(&format!("Ready in {}", timeline.elapsed_display()));
+        timeline.finish(&footer);
     }
     if !timeline.replaces_stdout_record() || result.already_existed {
         render_sandbox_result(&result, output);
     }
 
-    // Run exec commands (after hooks, before cd_path)
-    let exec_result = crate::exec::run_exec_commands(&args.exec, output);
+    let exec_result = run_exec_tail(exec_tail, &args.exec, output);
 
     output.cd_path(&result.cd_target);
     maybe_show_shell_hint(output)?;
@@ -2372,10 +2416,13 @@ fn run_create_branch(
     git: &GitCommand,
     output: &mut dyn Output,
 ) -> Result<()> {
-    let result = run_create_branch_core(args, settings, git, output)?;
+    // The `-x` sequence belongs to this rail (#812), so it runs inside the
+    // core — the timeline lives and closes there.
+    let (result, exec_tail) = run_create_branch_core(args, settings, git, output, &args.exec)?;
 
-    // Run exec commands (after hooks, before cd_path)
-    let exec_result = crate::exec::run_exec_commands(&args.exec, output);
+    // Off the rail, the commands run here — after the record line, exactly
+    // where they always have.
+    let exec_result = run_exec_tail(exec_tail, &args.exec, output);
 
     output.cd_path(&result.cd_target);
     maybe_show_shell_hint(output)?;
@@ -2386,14 +2433,22 @@ fn run_create_branch(
     Ok(())
 }
 
-/// The create-branch machinery without the terminal tail (exec commands,
-/// cd redirect, shell hint) — reusable per-repo by `--with-related`.
+/// The create-branch machinery without the terminal tail (cd redirect, shell
+/// hint) — reusable per-repo by `--with-related`.
+///
+/// `exec_on_rail` is the `-x` sequence to plan and run as this rail's tail,
+/// before its receipt closes. Callers that run the sequence themselves, later,
+/// pass none: `--with-related` runs it once every sibling repo is created, so
+/// its commands are not this rail's work, and a sibling repo never runs `-x`
+/// at all. The returned [`crate::exec::ExecTail`] says whether the commands
+/// ran here; its error is the caller's to propagate, after the cd is written.
 fn run_create_branch_core(
     args: &Args,
     settings: &DaftSettings,
     git: &GitCommand,
     output: &mut dyn Output,
-) -> Result<checkout_branch::CheckoutBranchResult> {
+    exec_on_rail: &[String],
+) -> Result<(checkout_branch::CheckoutBranchResult, crate::exec::ExecTail)> {
     // A forge PR/MR reference names an existing PR, not a new branch to create.
     // This is the single choke point for the create family (`daft start`,
     // `checkout -b`, `go -b`, `--with-related`).
@@ -2519,7 +2574,8 @@ fn run_create_branch_core(
     timeline.open_planning();
     let checkout_result = {
         let mut bridge =
-            TimelineBridge::new(output, &mut timeline, executor, hook_output_config.clone());
+            TimelineBridge::new(output, &mut timeline, executor, hook_output_config.clone())
+                .with_plan_suffix(crate::exec::plan_section(exec_on_rail));
         checkout_branch::execute(
             &params,
             git,
@@ -2537,14 +2593,17 @@ fn run_create_branch_core(
         }
     };
 
+    // The `-x` sequence is the plan's tail (#812) — see `run_checkout`.
+    let exec_tail = crate::exec::run_on_rail(exec_on_rail, &mut timeline);
+    let footer = ready_footer(&exec_tail, &timeline);
     if timeline.region_live() {
-        timeline.finish(&format!("Ready in {}", timeline.elapsed_display()));
+        timeline.finish(&footer);
     }
     if !timeline.replaces_stdout_record() {
         render_create_result(&result, output);
     }
 
-    Ok(result)
+    Ok((result, exec_tail))
 }
 
 /// `daft start <branch> --with-related`: create `branch` in the primary
@@ -2609,9 +2668,11 @@ fn run_start_with_related(
     let autocd = settings.autocd && !args.no_cd;
     let mut output = CliOutput::new(OutputConfig::with_autocd(args.quiet, args.verbose, autocd));
 
+    // No `-x` on this rail: the sequence runs once the whole fan-out is done
+    // (below), so it is not the primary repo's own work to plan (#812).
     let (current_cd_target, current_post_create_failed) =
-        match run_create_branch_core(&args, &settings, &git, &mut output) {
-            Ok(result) => (result.cd_target, false),
+        match run_create_branch_core(&args, &settings, &git, &mut output, &[]) {
+            Ok((result, _)) => (result.cd_target, false),
             Err(e) => match e.downcast::<crate::core::worktree::PostCreateHookFailed>() {
                 // Worktree created here — only the post-create hook failed.
                 // Surface its recovery hint, then carry on to the fan-out.
@@ -2750,7 +2811,7 @@ fn create_branch_in_related_repo(
             ));
         }
 
-        run_create_branch_core(&repo_args, &settings, &git, output).map(|_| ())
+        run_create_branch_core(&repo_args, &settings, &git, output, &[]).map(|_| ())
     })();
 
     change_directory(&restore).ok();

--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -2442,6 +2442,33 @@ fn run_create_branch(
 /// its commands are not this rail's work, and a sibling repo never runs `-x`
 /// at all. The returned [`crate::exec::ExecTail`] says whether the commands
 /// ran here; its error is the caller's to propagate, after the cd is written.
+/// [`run_create_branch_core`] for the callers that plan no `-x` of their own —
+/// `--with-related`, whose sequence runs once the whole fan-out is done, and
+/// the sibling repos it creates, which never run one.
+///
+/// The single place an [`ExecTail`] is legitimately discarded, and it is
+/// discarded because it is provably empty: passing `&[]` makes
+/// [`run_on_rail`] return `OffRail` without running anything, so there is no
+/// outcome to lose. Routing both callers through here keeps that reasoning in
+/// one commented place instead of two silent `_` bindings — a non-empty
+/// sequence added at either site would otherwise swallow its own failure.
+///
+/// [`ExecTail`]: crate::exec::ExecTail
+/// [`run_on_rail`]: crate::exec::run_on_rail
+fn create_branch_without_exec(
+    args: &Args,
+    settings: &DaftSettings,
+    git: &GitCommand,
+    output: &mut dyn Output,
+) -> Result<checkout_branch::CheckoutBranchResult> {
+    let (result, tail) = run_create_branch_core(args, settings, git, output, &[])?;
+    debug_assert!(
+        matches!(tail, crate::exec::ExecTail::OffRail),
+        "an empty sequence must never claim the rail"
+    );
+    Ok(result)
+}
+
 fn run_create_branch_core(
     args: &Args,
     settings: &DaftSettings,
@@ -2671,8 +2698,8 @@ fn run_start_with_related(
     // No `-x` on this rail: the sequence runs once the whole fan-out is done
     // (below), so it is not the primary repo's own work to plan (#812).
     let (current_cd_target, current_post_create_failed) =
-        match run_create_branch_core(&args, &settings, &git, &mut output, &[]) {
-            Ok((result, _)) => (result.cd_target, false),
+        match create_branch_without_exec(&args, &settings, &git, &mut output) {
+            Ok(result) => (result.cd_target, false),
             Err(e) => match e.downcast::<crate::core::worktree::PostCreateHookFailed>() {
                 // Worktree created here — only the post-create hook failed.
                 // Surface its recovery hint, then carry on to the fan-out.
@@ -2811,7 +2838,7 @@ fn create_branch_in_related_repo(
             ));
         }
 
-        run_create_branch_core(&repo_args, &settings, &git, output, &[]).map(|_| ())
+        create_branch_without_exec(&repo_args, &settings, &git, output).map(|_| ())
     })();
 
     change_directory(&restore).ok();

--- a/src/core/progress.rs
+++ b/src/core/progress.rs
@@ -391,6 +391,7 @@ pub struct TimelineBridge<'a> {
     executor: HookExecutor,
     output_config: HookOutputConfig,
     prompts_enabled: bool,
+    plan_suffix: Vec<crate::core::stage::Row>,
 }
 
 impl<'a> TimelineBridge<'a> {
@@ -406,7 +407,24 @@ impl<'a> TimelineBridge<'a> {
             executor,
             output_config,
             prompts_enabled: true,
+            plan_suffix: Vec::new(),
         }
+    }
+
+    /// Append `rows` to whatever plan the core commits, as its tail.
+    ///
+    /// For work the command layer plans AND runs itself, after the core is
+    /// done but before the receipt closes: `-x` commands (#812) run after the
+    /// post-create hooks, which is exactly where the core's plan ends. The
+    /// core never learns about them — teaching it to plan steps someone else
+    /// executes is how a plan and its receipt drift apart.
+    ///
+    /// A core that returns without committing (the early-exit navigations)
+    /// never renders these rows, which is the wanted behaviour: there is no
+    /// rail to put them on.
+    pub fn with_plan_suffix(mut self, rows: Vec<crate::core::stage::Row>) -> Self {
+        self.plan_suffix = rows;
+        self
     }
 
     /// Answer the consolidation prompts from the [`ConsolidationPrompter`]
@@ -440,7 +458,8 @@ impl ProgressSink for TimelineBridge<'_> {
         route_debug(self.output, self.timeline, msg);
     }
 
-    fn on_plan(&mut self, plan: crate::core::stage::PlanCommit) {
+    fn on_plan(&mut self, mut plan: crate::core::stage::PlanCommit) {
+        plan.rows.append(&mut self.plan_suffix);
         route_plan(self.output, self.timeline, plan);
     }
 

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -17,10 +17,13 @@ use crate::output::timeline::Timeline;
 /// which made these commands unusable for users whose rc files break in
 /// non-interactive contexts.
 ///
-/// This is the off-rail path: `Plain`, `Hidden`, quiet, redirected stdout,
-/// and every journey that never commits a plan (navigating to an existing
-/// worktree). Invocations that DO commit a plan run the same sequence as
-/// planned rail rows instead — see [`run_on_rail`].
+/// This is the off-rail path: `Plain`, `Hidden`, quiet, redirected **stderr**
+/// (that is the stream `TimelineMode::auto` gates on, so a TTY stderr with a
+/// piped stdout still gets the rail), the journeys that never commit a plan
+/// (navigating to an existing worktree), and the commands that do not plan
+/// `-x` at all — `daft clone`, `daft init`, and `start --with-related`'s
+/// post-fan-out sequence. Invocations that DO commit a plan carrying the rows
+/// run the same sequence as planned rail rows instead — see [`run_on_rail`].
 pub fn run_exec_commands(commands: &[String], output: &mut dyn Output) -> Result<()> {
     // Nothing to run, nothing to capture: `ensure` spawns a shell to reload
     // the user's rc files whenever its snapshot has aged out, and every

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -1,7 +1,9 @@
 use anyhow::Result;
 
+use crate::core::stage::{Row, StageEvent, StageId, StepKey, StepSpec};
 use crate::core::worktree::exec::{AliasCache, CommandSpec, build_command};
 use crate::output::Output;
+use crate::output::timeline::Timeline;
 
 /// Run a sequence of `-x` shell commands as part of worktree creation
 /// (`daft clone -x`, `daft init -x`, `daft checkout/go/start -x`).
@@ -14,25 +16,526 @@ use crate::output::Output;
 /// The earlier implementation used `$SHELL -i -c CMD` unconditionally,
 /// which made these commands unusable for users whose rc files break in
 /// non-interactive contexts.
+///
+/// This is the off-rail path: `Plain`, `Hidden`, quiet, redirected stdout,
+/// and every journey that never commits a plan (navigating to an existing
+/// worktree). Invocations that DO commit a plan run the same sequence as
+/// planned rail rows instead — see [`run_on_rail`].
 pub fn run_exec_commands(commands: &[String], output: &mut dyn Output) -> Result<()> {
-    let shell = std::env::var("SHELL").unwrap_or_else(|_| "sh".to_string());
-    // One capture covers the whole `-x` sequence; the snapshot is
-    // shared across commands so a heavy rc-file (oh-my-zsh, p10k) is
-    // paid for at most once per invocation.
-    let alias_cache = AliasCache::ensure(&shell, false);
+    // Nothing to run, nothing to capture: `ensure` spawns a shell to reload
+    // the user's rc files whenever its snapshot has aged out, and every
+    // creation journey calls through here whether or not `-x` was given.
+    if commands.is_empty() {
+        return Ok(());
+    }
+    let alias_cache = capture_aliases();
 
     for cmd in commands {
         output.step(&format!("Executing: {cmd}"));
-        let spec = CommandSpec::Shell(cmd.clone());
-        let status = build_command(&spec, alias_cache.as_ref())
-            .stdin(std::process::Stdio::inherit())
-            .stdout(std::process::Stdio::inherit())
-            .stderr(std::process::Stdio::inherit())
-            .status()?;
-        if !status.success() {
-            let code = status.code().unwrap_or(1);
-            anyhow::bail!("Command '{}' exited with status {}", cmd, code);
+        match CommandOutcome::of(spawn(cmd, alias_cache.as_ref())) {
+            CommandOutcome::Ran => {}
+            CommandOutcome::Exited(code) => anyhow::bail!("{}", failure_message(cmd, code)),
+            CommandOutcome::Unstartable(e) => return Err(e.into()),
         }
     }
     Ok(())
+}
+
+/// Where a creation journey's `-x` sequence ran.
+///
+/// The two arms are exclusive by construction: [`run_on_rail`] returns
+/// `OffRail` without running anything when the committed plan does not carry
+/// the rows, and the caller then runs the sequence the legacy way, after its
+/// record line, so off-rail output stays byte-identical (#812).
+pub enum ExecTail {
+    /// Nothing ran. Either there are no `-x` commands, or no plan committed
+    /// with their rows (Plain/Hidden/quiet/redirected, or an early-exit
+    /// navigation to an existing worktree). The caller runs the sequence
+    /// through [`run_exec_commands`] after its record line.
+    OffRail,
+    /// Ran as planned rows on the live rail, carrying the outcome the caller
+    /// must still propagate — after the cd target is written, as before.
+    OnRail(Result<()>),
+}
+
+impl ExecTail {
+    /// Whether a command that ran on the rail failed. Drives the receipt
+    /// footer: the worktree exists either way, so this never means "Failed".
+    pub fn failed(&self) -> bool {
+        matches!(self, Self::OnRail(Err(_)))
+    }
+}
+
+/// The plan rows for a `-x` sequence (#812).
+///
+/// One row per `-x` **occurrence**, in the order typed, labelled with the
+/// command exactly as the user wrote it — the row's identity IS its subject,
+/// so the [`StageId::ExecCommand`] tense table is a fallback only. Scoped by
+/// index rather than by text so that two identical `-x` strings stay two
+/// distinct rows; [`step_key`] is the single place that derivation lives, and
+/// [`run_on_rail`] resolves its events through the same function, so the plan
+/// and the receipt cannot key differently.
+///
+/// A group anchor appears only for a sequence of two or more: a lone command
+/// is one self-describing row, and an `exec` header above it would cost a
+/// line to say nothing. The section closes its span so any row planned after
+/// it stays ungrouped — today it is always last (the commands run after the
+/// post-create hooks, which is where the plan ends).
+pub fn plan_section(commands: &[String]) -> Vec<Row> {
+    if commands.is_empty() {
+        return Vec::new();
+    }
+    let grouped = commands.len() > 1;
+    let mut rows = Vec::with_capacity(commands.len() + 2 * usize::from(grouped));
+    if grouped {
+        rows.push(Row::Group {
+            label: "exec".into(),
+        });
+    }
+    for (index, cmd) in commands.iter().enumerate() {
+        rows.push(Row::Step(
+            StepSpec::new(step_key(index)).with_label(cmd.as_str()),
+        ));
+    }
+    if grouped {
+        rows.push(Row::EndGroup);
+    }
+    rows
+}
+
+/// The plan key for the `index`-th `-x` command. Scoped by position, never by
+/// the command text — `-x 'make' -x 'make'` is two rows, not one.
+fn step_key(index: usize) -> StepKey {
+    StepKey::scoped(StageId::ExecCommand, index.to_string())
+}
+
+/// Run the `-x` sequence as planned rows on a live rail, or report that no
+/// rail carries them.
+///
+/// The rows must already be in the committed plan (the command layer appends
+/// [`plan_section`] to the core's plan via `TimelineBridge::with_plan_suffix`);
+/// this asks the region for each one rather than assuming, so an invocation
+/// that never committed a plan — the early-exit navigations, `Plain`/`Hidden`
+/// mode — falls back to the legacy path instead of firing events at rows that
+/// do not exist.
+///
+/// Each command owns the terminal for its whole run: `-x` inherits stdin,
+/// stdout and stderr and may be interactive, so the region clears around it
+/// exactly as clone's install step does. Nothing inside that window may touch
+/// `Output` — `suspend` holds the lock a region write would need — which is
+/// why this function takes no `Output` at all.
+pub fn run_on_rail(commands: &[String], timeline: &mut Timeline) -> ExecTail {
+    let Some(keys) = railed_keys(commands, timeline) else {
+        return ExecTail::OffRail;
+    };
+
+    let alias_cache = capture_aliases();
+    let handle = timeline.handle();
+    drive(commands, &keys, timeline, |cmd| {
+        handle.suspend_for_prompt(|| CommandOutcome::of(spawn(cmd, alias_cache.as_ref())))
+    })
+}
+
+/// What one `-x` command did.
+enum CommandOutcome {
+    Ran,
+    /// Ran and exited non-zero, with the status the shell reported.
+    Exited(i32),
+    /// Never started — the shell itself could not be spawned.
+    Unstartable(std::io::Error),
+}
+
+impl CommandOutcome {
+    fn of(spawned: std::io::Result<std::process::ExitStatus>) -> Self {
+        match spawned {
+            Ok(status) if status.success() => Self::Ran,
+            Ok(status) => Self::Exited(status.code().unwrap_or(1)),
+            Err(e) => Self::Unstartable(e),
+        }
+    }
+}
+
+/// The rail loop: resolve each planned row from what running its command did,
+/// and stop the sequence at the first failure — as it always has.
+///
+/// Split from [`run_on_rail`] on the "run one command" seam so the loop's
+/// bookkeeping (which row resolves how, where the sequence stops, what the
+/// caller gets back) is testable without spawning a shell.
+fn drive(
+    commands: &[String],
+    keys: &[StepKey],
+    timeline: &mut Timeline,
+    mut run: impl FnMut(&str) -> CommandOutcome,
+) -> ExecTail {
+    let mut outcome = Ok(());
+
+    for (cmd, key) in commands.iter().zip(keys) {
+        if outcome.is_err() {
+            // Say so on the rows that never ran: `finish` drops unresolved
+            // rows, and a command the user typed vanishing off the receipt is
+            // the one thing the plan promised not to do.
+            timeline.on_stage(
+                key,
+                StageEvent::SkippedAttention {
+                    reason: "not run".into(),
+                },
+            );
+            continue;
+        }
+        timeline.on_stage(key, StageEvent::Started);
+        match run(cmd) {
+            CommandOutcome::Ran => {
+                timeline.on_stage(key, StageEvent::Completed { annotation: None });
+            }
+            CommandOutcome::Exited(code) => {
+                timeline.on_stage(
+                    key,
+                    StageEvent::Failed {
+                        detail: format!("exit {code}"),
+                    },
+                );
+                outcome = Err(anyhow::anyhow!("{}", failure_message(cmd, code)));
+            }
+            CommandOutcome::Unstartable(e) => {
+                timeline.on_stage(
+                    key,
+                    StageEvent::Failed {
+                        detail: format!("{e}"),
+                    },
+                );
+                outcome = Err(e.into());
+            }
+        }
+    }
+    ExecTail::OnRail(outcome)
+}
+
+/// The committed plan's key for every command, or `None` when the rail does
+/// not carry the section — no commands, no live region, or a region still
+/// wearing its planning face (an early-exit navigation never commits, and
+/// `region_live` alone cannot tell the two apart).
+///
+/// All or nothing: a partially planned section would strand rows the footer
+/// then drops, so the whole sequence falls back to the off-rail path.
+fn railed_keys(commands: &[String], timeline: &Timeline) -> Option<Vec<StepKey>> {
+    if commands.is_empty() {
+        return None;
+    }
+    (0..commands.len())
+        .map(|index| {
+            let key = step_key(index);
+            // `resolve_key` falls back to the unscoped key; these rows are
+            // always scoped, so an exact match is the only acceptable answer.
+            timeline
+                .resolve_key(key.id, key.scope.as_deref())
+                .filter(|found| *found == key)
+        })
+        .collect()
+}
+
+/// One capture covers a whole `-x` sequence; the snapshot is shared across
+/// commands so a heavy rc-file (oh-my-zsh, p10k) is paid for at most once per
+/// invocation.
+fn capture_aliases() -> Option<AliasCache> {
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| "sh".to_string());
+    AliasCache::ensure(&shell, false)
+}
+
+/// Spawn one `-x` command with the terminal inherited, and wait. The single
+/// spawn site for both paths, so the rail cannot drift from the legacy one in
+/// how a command is built or what it can reach.
+fn spawn(cmd: &str, alias_cache: Option<&AliasCache>) -> std::io::Result<std::process::ExitStatus> {
+    let spec = CommandSpec::Shell(cmd.to_string());
+    build_command(&spec, alias_cache)
+        .stdin(std::process::Stdio::inherit())
+        .stdout(std::process::Stdio::inherit())
+        .stderr(std::process::Stdio::inherit())
+        .status()
+}
+
+/// The error text for a command that exited non-zero — one wording for both
+/// paths, unchanged from before the rail existed.
+fn failure_message(cmd: &str, code: i32) -> String {
+    format!("Command '{cmd}' exited with status {code}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cmds(list: &[&str]) -> Vec<String> {
+        list.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn nothing_declared_plans_nothing() {
+        assert!(plan_section(&[]).is_empty());
+    }
+
+    #[test]
+    fn a_lone_command_plans_one_ungrouped_row() {
+        let rows = plan_section(&cmds(&["npm install"]));
+        assert_eq!(rows.len(), 1, "no anchor for a single self-describing row");
+        let Row::Step(spec) = &rows[0] else {
+            panic!("expected a step row");
+        };
+        assert_eq!(spec.key.id, StageId::ExecCommand);
+        assert_eq!(spec.label.as_deref(), Some("npm install"));
+    }
+
+    #[test]
+    fn a_sequence_plans_an_anchored_section_labelled_as_typed() {
+        let rows = plan_section(&cmds(&["make", "npm install"]));
+        assert!(matches!(&rows[0], Row::Group { label } if label == "exec"));
+        let labels: Vec<_> = rows
+            .iter()
+            .filter_map(|r| match r {
+                Row::Step(spec) => spec.label.as_deref(),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(labels, ["make", "npm install"], "in the order typed");
+        assert!(
+            matches!(rows.last(), Some(Row::EndGroup)),
+            "the section closes its span so following rows stay ungrouped"
+        );
+    }
+
+    #[test]
+    fn identical_commands_stay_distinct_rows() {
+        let rows = plan_section(&cmds(&["make", "make"]));
+        let keys: Vec<_> = rows
+            .iter()
+            .filter_map(|r| match r {
+                Row::Step(spec) => Some(spec.key.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(keys.len(), 2);
+        assert_ne!(keys[0], keys[1], "scoped by position, not by text");
+        assert_eq!(keys[0], step_key(0));
+        assert_eq!(keys[1], step_key(1));
+    }
+
+    #[test]
+    fn planned_keys_are_the_keys_the_runner_resolves() {
+        // The plan and the receipt derive their keys from one function; this
+        // is the weld. A row planned under a key the runner never emits would
+        // sit pending until `finish` dropped it.
+        let rows = plan_section(&cmds(&["a", "b", "c"]));
+        let planned: Vec<_> = rows
+            .iter()
+            .filter_map(|r| match r {
+                Row::Step(spec) => Some(spec.key.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(planned, (0..3).map(step_key).collect::<Vec<_>>());
+    }
+
+    /// A committed rail carrying `commands`' section, plus the terminal it
+    /// paints on — the same InMemoryTerm setup the timeline's own
+    /// persisted-sequence tests use.
+    fn railed(commands: &[String]) -> (Timeline, indicatif::InMemoryTerm) {
+        let term = indicatif::InMemoryTerm::new(30, 100);
+        let mut timeline = Timeline::new(
+            crate::output::timeline::TimelineMode::Interactive { color: false },
+            false,
+            "Starting feat/x",
+        );
+        timeline.set_test_draw_target(indicatif::ProgressDrawTarget::term_like(Box::new(
+            term.clone(),
+        )));
+        timeline.commit_plan(crate::core::stage::PlanCommit::new(plan_section(commands)));
+        (timeline, term)
+    }
+
+    #[test]
+    fn the_bridge_appends_the_section_the_runner_resolves() {
+        // The weld. The command layer hands `plan_section` to the bridge, the
+        // core commits its own plan knowing nothing about `-x`, and the rows
+        // the runner then resolves must be exactly the rows that landed —
+        // appended after the core's last row, which is where the commands
+        // run. A key derived twice, or a suffix dropped on the floor, shows
+        // up here and nowhere else.
+        use crate::core::ProgressSink;
+        use crate::core::stage::{PlanCommit, StepSpec};
+        use crate::hooks::{HookExecutor, HooksConfig};
+
+        let commands = cmds(&["make", "make"]);
+        let term = indicatif::InMemoryTerm::new(30, 100);
+        let mut output = crate::output::TestOutput::new();
+        let mut timeline = Timeline::new(
+            crate::output::timeline::TimelineMode::Interactive { color: false },
+            false,
+            "Starting feat/x",
+        );
+        timeline.set_test_draw_target(indicatif::ProgressDrawTarget::term_like(Box::new(
+            term.clone(),
+        )));
+        let executor = HookExecutor::new(HooksConfig {
+            enabled: false,
+            ..HooksConfig::default()
+        })
+        .expect("create executor");
+        {
+            let mut bridge = crate::core::TimelineBridge::new(
+                &mut output,
+                &mut timeline,
+                executor,
+                crate::core::settings::HookOutputConfig::default(),
+            )
+            .with_plan_suffix(plan_section(&commands));
+            // A creation core's plan ends at the post-create hooks.
+            bridge.on_plan(PlanCommit::new(vec![Row::Step(StepSpec::new(
+                StepKey::new(StageId::PostCreateHooks),
+            ))]));
+        }
+
+        let keys = railed_keys(&commands, &timeline);
+        assert_eq!(
+            keys,
+            Some(vec![step_key(0), step_key(1)]),
+            "both rows landed, and identical commands stayed distinct"
+        );
+
+        // And they landed AFTER the core's last row — which is where the
+        // commands run: post-create hooks first, then `-x`.
+        let hooks = StepKey::new(StageId::PostCreateHooks);
+        timeline.on_stage(&hooks, StageEvent::Completed { annotation: None });
+        drive(&commands, &keys.unwrap(), &mut timeline, |_| {
+            CommandOutcome::Ran
+        });
+        timeline.finish("Ready in 0.1s");
+        assert_eq!(
+            term.contents(),
+            "\u{250c}  Starting feat/x\n\
+             \u{2502}\n\
+             \u{2713}  post-create hooks\n\
+             \u{2502}\n\
+             \u{251c}\u{2500} exec\n\
+             \u{2502}  \u{2713}  make\n\
+             \u{2502}  \u{2713}  make\n\
+             \u{2502}\n\
+             \u{2514}  Ready in 0.1s"
+        );
+    }
+
+    #[test]
+    fn every_command_resolves_its_own_row() {
+        let commands = cmds(&["make", "npm install"]);
+        let (mut timeline, term) = railed(&commands);
+        let tail = drive(
+            &commands,
+            &railed_keys(&commands, &timeline).expect("the plan carries the section"),
+            &mut timeline,
+            |_| CommandOutcome::Ran,
+        );
+        assert!(!tail.failed());
+        timeline.finish("Ready in 0.1s");
+        assert_eq!(
+            term.contents(),
+            "\u{250c}  Starting feat/x\n\
+             \u{2502}\n\
+             \u{251c}\u{2500} exec\n\
+             \u{2502}  \u{2713}  make\n\
+             \u{2502}  \u{2713}  npm install\n\
+             \u{2502}\n\
+             \u{2514}  Ready in 0.1s"
+        );
+    }
+
+    #[test]
+    fn a_failure_stops_the_sequence_and_says_so_on_the_rows_that_never_ran() {
+        let commands = cmds(&["make", "npm install", "cargo test"]);
+        let (mut timeline, term) = railed(&commands);
+        let keys = railed_keys(&commands, &timeline).expect("the plan carries the section");
+        let tail = drive(&commands, &keys, &mut timeline, |cmd| match cmd {
+            "make" => CommandOutcome::Ran,
+            _ => CommandOutcome::Exited(2),
+        });
+
+        let ExecTail::OnRail(Err(e)) = tail else {
+            panic!("a non-zero exit is the caller's error to propagate");
+        };
+        assert_eq!(
+            e.to_string(),
+            "Command 'npm install' exited with status 2",
+            "the wording the off-rail path has always used"
+        );
+
+        // The receipt: what ran, what broke, and — on the yellow `↓` face —
+        // what never got its turn.
+        timeline.finish("Ready with failures in 0.1s");
+        assert_eq!(
+            term.contents(),
+            "\u{250c}  Starting feat/x\n\
+             \u{2502}\n\
+             \u{251c}\u{2500} exec\n\
+             \u{2502}  \u{2713}  make\n\
+             \u{2502}  \u{2717}  npm install  exit 2\n\
+             \u{2502}  \u{2193}  cargo test   not run\n\
+             \u{2502}\n\
+             \u{2514}  Ready with failures in 0.1s"
+        );
+    }
+
+    #[test]
+    fn a_lone_command_renders_without_an_anchor() {
+        let commands = cmds(&["npm install"]);
+        let (mut timeline, term) = railed(&commands);
+        let keys = railed_keys(&commands, &timeline).expect("the plan carries the section");
+        drive(&commands, &keys, &mut timeline, |_| CommandOutcome::Ran);
+        timeline.finish("Ready in 0.1s");
+        assert_eq!(
+            term.contents(),
+            "\u{250c}  Starting feat/x\n\
+             \u{2502}\n\
+             \u{2713}  npm install\n\
+             \u{2502}\n\
+             \u{2514}  Ready in 0.1s"
+        );
+    }
+
+    #[test]
+    fn an_unstartable_shell_fails_its_row_and_stops_the_sequence() {
+        let commands = cmds(&["make", "npm install"]);
+        let (mut timeline, _term) = railed(&commands);
+        let keys = railed_keys(&commands, &timeline).expect("the plan carries the section");
+        let tail = drive(&commands, &keys, &mut timeline, |_| {
+            CommandOutcome::Unstartable(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "no such file",
+            ))
+        });
+        assert!(tail.failed(), "a shell that never started is a failure");
+    }
+
+    #[test]
+    fn an_empty_sequence_never_claims_the_rail() {
+        let mut timeline = Timeline::new(
+            crate::output::timeline::TimelineMode::Interactive { color: false },
+            false,
+            "Opening feat/x",
+        );
+        timeline.commit_plan(crate::core::stage::PlanCommit::new(plan_section(&[])));
+        assert!(matches!(run_on_rail(&[], &mut timeline), ExecTail::OffRail));
+    }
+
+    #[test]
+    fn an_uncommitted_plan_falls_back_off_rail() {
+        // The early-exit navigations open a planning face and never commit;
+        // the region is live, but it carries no rows to resolve.
+        let mut timeline = Timeline::new(
+            crate::output::timeline::TimelineMode::Interactive { color: false },
+            false,
+            "Opening feat/x",
+        );
+        timeline.open_planning();
+        assert!(timeline.region_live(), "the planning face is a live region");
+        assert!(
+            railed_keys(&cmds(&["true"]), &timeline).is_none(),
+            "a face with no committed plan carries no exec rows"
+        );
+    }
 }

--- a/src/output/live_line.rs
+++ b/src/output/live_line.rs
@@ -54,6 +54,45 @@ use console::measure_text_width;
 pub(crate) fn sanitize(raw: &str) -> String {
     let stripped = strip_ansi(raw.trim_end());
     let seg = stripped.rsplit('\r').next().unwrap_or(&stripped);
+    let mut out = scrub(seg);
+    out.truncate(out.trim_end().len());
+    out
+}
+
+/// Normalize one **fixed row label** for the rail.
+///
+/// Labels are where arbitrary user text becomes rail furniture: a `-x`
+/// command is reproduced exactly as typed (#812), and a shared file's path
+/// is whatever the filesystem allows — which on Unix includes newlines.
+///
+/// This deliberately does **not** share [`sanitize`]'s `\r` rule. A label is
+/// not a repainting progress line, so keeping only the last carriage-returned
+/// segment would silently delete the front of it. Every whitespace run —
+/// newlines included — collapses to a single space instead, so a pasted
+/// multi-line snippet stays one row.
+///
+/// Getting this wrong costs more than looks: the region measures its shared
+/// annotation column from the *rendered* label, so an embedded newline
+/// mis-sizes every row's padding as well as splitting the bar's own line —
+/// the #751 failure mode, reached through a different door.
+pub(crate) fn sanitize_label(raw: &str) -> String {
+    // Whitespace is flattened before scrubbing, not after: `scrub` drops
+    // control characters outright, which would weld the text on either side
+    // of a dropped newline into one word (`echo $f` + `done` → `$fdone`).
+    let flattened: String = strip_ansi(raw)
+        .chars()
+        .map(|c| if c.is_whitespace() { ' ' } else { c })
+        .collect();
+    scrub(&flattened)
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// The shared character scrub: tabs to spaces, control characters and
+/// width-lying combining sequences dropped. Both entry points above run
+/// their own line discipline first, then hand the result here.
+fn scrub(seg: &str) -> String {
     let mut out = String::with_capacity(seg.len());
     let mut chars = seg.chars();
     while let Some(c) = chars.next() {
@@ -81,7 +120,6 @@ pub(crate) fn sanitize(raw: &str) -> String {
             c => out.push(c),
         }
     }
-    out.truncate(out.trim_end().len());
     out
 }
 
@@ -196,5 +234,46 @@ mod tests {
             sanitize("\u{2713} \u{2502} \u{2514} \u{283c} \u{276f} \u{2726}"),
             "\u{2713} \u{2502} \u{2514} \u{283c} \u{276f} \u{2726}"
         );
+    }
+
+    #[test]
+    fn an_ordinary_label_passes_through_untouched() {
+        // Every label the rail carried before `-x`: commands, paths, branches.
+        assert_eq!(sanitize_label("npm ci"), "npm ci");
+        assert_eq!(sanitize_label(".env.local"), ".env.local");
+        assert_eq!(sanitize_label("feat/rows-on-rail"), "feat/rows-on-rail");
+        assert_eq!(sanitize_label(""), "");
+    }
+
+    #[test]
+    fn a_multi_line_label_becomes_one_row() {
+        // A pasted shell snippet is an ordinary thing to hand `-x`. Each
+        // newline has to leave a word boundary behind: dropping it outright
+        // would render `echo $f` + `done` as `$fdone`.
+        assert_eq!(
+            sanitize_label("for f in *; do\n  echo $f\ndone"),
+            "for f in *; do echo $f done"
+        );
+        assert_eq!(sanitize_label("a\r\nb"), "a b");
+        assert_eq!(sanitize_label("wrapped\\\n  --flag"), "wrapped\\ --flag");
+    }
+
+    #[test]
+    fn a_label_never_loses_its_front_to_a_carriage_return() {
+        // `sanitize` keeps only the last `\r` segment — right for a
+        // repainting progress line, silent data loss for a label.
+        assert_eq!(sanitize("kept\rlast"), "last");
+        assert_eq!(sanitize_label("kept\rlast"), "kept last");
+    }
+
+    #[test]
+    fn a_label_cannot_smuggle_escapes_or_width_lies_onto_the_rail() {
+        assert_eq!(sanitize_label("\x1b[31mmake\x1b[0m test"), "make test");
+        // Same VS16 lie as a captured line — a label is measured for the
+        // shared annotation column, so it has to measure what it draws.
+        assert_eq!(sanitize_label("deploy \u{2714}\u{FE0F}"), "deploy \u{2714}");
+        assert_eq!(sanitize_label("tabs\tand   runs"), "tabs and runs");
+        // Leading and trailing whitespace is padding, not content.
+        assert_eq!(sanitize_label("  make  "), "make");
     }
 }

--- a/src/output/timeline/region.rs
+++ b/src/output/timeline/region.rs
@@ -1884,10 +1884,12 @@ fn phase_for(face: &RowFace) -> StepPhase {
 }
 
 fn display_label(spec: &StepSpec, phase: StepPhase) -> String {
-    // A fixed label (a shared file's path) wins in every phase — the face
-    // glyph alone carries the row's state.
+    // A fixed label (a shared file's path, a `-x` command as typed) wins in
+    // every phase — the face glyph alone carries the row's state. It is also
+    // the one label that can carry arbitrary user text, so it is sanitized
+    // here, at the seam the column width is measured through.
     if let Some(label) = &spec.label {
-        return label.clone();
+        return crate::output::live_line::sanitize_label(label);
     }
     let labels = super::plan::labels_for(spec.key.id);
     let base = match phase {

--- a/tests/integration/test_checkout.sh
+++ b/tests/integration/test_checkout.sh
@@ -974,6 +974,133 @@ test_go_fetch_on_rail_expands() {
     return 0
 }
 
+# #812: the `-x` sequence is planned onto the creation rail and runs inside
+# the region's lifetime. None of that is reachable from the YAML suite —
+# `commit_plan` early-returns off Interactive and the runner captures stderr,
+# so every scenario there exercises the off-rail `Executing:` record instead.
+# These are the only tests that execute `run_on_rail` itself: row resolution
+# against the committed plan, the suspend/redraw seam around a child that owns
+# the terminal, and the footer's verdict.
+#
+# SHELL is pinned to one daft does not alias-capture for (`ShellKind::from_path`
+# knows only bash/zsh, and returns None otherwise, short-circuiting the whole
+# snapshot path). The snapshot lives under `dirs::cache_dir()`, which no
+# DAFT_*_DIR override redirects — capturing here would write the developer's
+# real cache directory.
+_exec_rail_daft() {
+    _rail_daft SHELL=/bin/sh "$@"
+}
+
+# Two commands: an `exec` anchor, one row each, labelled as typed, and the
+# commands' own output above a Ready footer.
+test_start_exec_rows_on_rail() {
+    local remote_repo=$(create_test_remote "test-repo-exec-rail" "main")
+    git-worktree-clone --layout contained "$remote_repo" || return 1
+    cd "test-repo-exec-rail/main" || return 1
+
+    local log="$TEMP_BASE_DIR/exec-rail.log"
+    _exec_rail_daft "$CHECKOUT_PTY_RUN" "$log" \
+        daft start feat-exec -x 'echo first-command' -x 'echo second-command' || return 1
+
+    local clean
+    clean=$(_rail_clean "$log")
+    if ! echo "$clean" | grep -q "├─ exec"; then
+        log_error "exec section anchor missing from the rail"
+        return 1
+    fi
+    if ! echo "$clean" | grep -q "echo first-command"; then
+        log_error "first -x row missing (label is the command as typed)"
+        return 1
+    fi
+    if ! echo "$clean" | grep -q "echo second-command"; then
+        log_error "second -x row missing — identical rows must not collapse"
+        return 1
+    fi
+    # The commands really ran, not just got planned.
+    if ! echo "$clean" | grep -q "^first-command"; then
+        log_error "first command's own output missing"
+        return 1
+    fi
+    if ! echo "$clean" | grep -q "^second-command"; then
+        log_error "second command's own output missing"
+        return 1
+    fi
+    if ! echo "$clean" | grep -q "Ready in"; then
+        log_error "Ready footer missing after a clean sequence"
+        return 1
+    fi
+    assert_directory_exists "../feat-exec" || return 1
+    return 0
+}
+
+# A failing `-x` fails its own row, marks the rest not-run, and still lands a
+# worktree — the footer says so rather than claiming the creation failed.
+test_start_exec_failure_on_rail() {
+    local remote_repo=$(create_test_remote "test-repo-exec-fail" "main")
+    git-worktree-clone --layout contained "$remote_repo" || return 1
+    cd "test-repo-exec-fail/main" || return 1
+
+    local log="$TEMP_BASE_DIR/exec-fail.log"
+    # No `|| return 1`: a failing `-x` propagates its status, which is the
+    # behavior under test. pty_run.py exits with the child's status.
+    _exec_rail_daft "$CHECKOUT_PTY_RUN" "$log" \
+        daft start feat-broken -x 'echo ran-first' -x 'false' -x 'echo never-runs'
+
+    local clean
+    clean=$(_rail_clean "$log")
+    if ! echo "$clean" | grep -q "exit 1"; then
+        log_error "failing row missing its exit status"
+        return 1
+    fi
+    if ! echo "$clean" | grep -q "not run"; then
+        log_error "commands after the failure must resolve as not run, not vanish"
+        return 1
+    fi
+    if ! echo "$clean" | grep -q "Ready with failures in"; then
+        log_error "footer must report failures without claiming creation failed"
+        return 1
+    fi
+    if echo "$clean" | grep -q "^never-runs"; then
+        log_error "the sequence continued past a failure"
+        return 1
+    fi
+    # The worktree is the point: a failed command must not undo it.
+    assert_directory_exists "../feat-broken" || return 1
+    return 0
+}
+
+# A pasted multi-line command is ordinary input for `-x`. Its label is
+# flattened to one line so the region's line accounting and its shared
+# annotation column both survive it (#751's failure mode, different door).
+test_start_exec_multiline_label_stays_one_row() {
+    local remote_repo=$(create_test_remote "test-repo-exec-multiline" "main")
+    git-worktree-clone --layout contained "$remote_repo" || return 1
+    cd "test-repo-exec-multiline/main" || return 1
+
+    local log="$TEMP_BASE_DIR/exec-multiline.log"
+    _exec_rail_daft "$CHECKOUT_PTY_RUN" "$log" \
+        daft start feat-multiline -x $'echo alpha\necho beta' || return 1
+
+    local clean
+    clean=$(_rail_clean "$log")
+    # Both halves of the label on one line, in order.
+    if ! echo "$clean" | grep -q "echo alpha echo beta"; then
+        log_error "multi-line -x label was not flattened onto one row"
+        return 1
+    fi
+    # One command is one row, with no section to anchor.
+    if echo "$clean" | grep -q "├─ exec"; then
+        log_error "a lone -x command must not get a section anchor"
+        return 1
+    fi
+    if ! echo "$clean" | grep -q "Ready in"; then
+        log_error "rail did not close cleanly after a multi-line label"
+        return 1
+    fi
+    assert_directory_exists "../feat-multiline" || return 1
+    return 0
+}
+
 # Run all checkout tests
 run_checkout_tests() {
     log "Running git-worktree-checkout integration tests..."
@@ -1019,6 +1146,11 @@ run_checkout_tests() {
     # Rail behavior under a PTY (#782)
     run_test "go_fetch_hop_no_rail_receipt" "test_go_fetch_hop_no_rail_receipt"
     run_test "go_fetch_on_rail_expands" "test_go_fetch_on_rail_expands"
+
+    # `-x` rows on the creation rail under a PTY (#812)
+    run_test "start_exec_rows_on_rail" "test_start_exec_rows_on_rail"
+    run_test "start_exec_failure_on_rail" "test_start_exec_failure_on_rail"
+    run_test "start_exec_multiline_label_stays_one_row" "test_start_exec_multiline_label_stays_one_row"
 }
 
 # Main execution

--- a/tests/manual/scenarios/exec/start-sequence-tail.yml
+++ b/tests/manual/scenarios/exec/start-sequence-tail.yml
@@ -1,0 +1,94 @@
+name: The -x sequence is the creation plan's tail
+description:
+  "`daft start -x cmd -x cmd` runs its commands in the order typed, after the
+  worktree-post-create hooks — the position the rail plans them in (#812). Two
+  identical commands are two runs; a failing one stops the rest while the
+  worktree itself survives; a fork runs the sequence inside the fork it just
+  made."
+
+repos:
+  - name: test-exec-tail
+    default_branch: main
+    branches:
+      - name: main
+        files:
+          - path: README.md
+            content: "# Exec tail test"
+        commits:
+          - message: "Initial commit"
+    daft_yml: |
+      hooks:
+        worktree-post-create:
+          jobs:
+            - name: mark
+              run: printf hook >> "$DAFT_WORKTREE_PATH/order.txt"
+
+steps:
+  - name: Clone the repository
+    run: daft clone --layout contained $REMOTE_TEST_EXEC_TAIL
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-exec-tail/main"
+
+  - name: Trust the repository
+    run: daft hooks trust --force 2>&1
+    cwd: "$WORK_DIR/test-exec-tail/main"
+    expect:
+      exit_code: 0
+
+  - name: The sequence runs in the order typed, after the post-create hooks
+    run:
+      daft start feat-tail -x 'printf +one >> order.txt' -x 'printf +two >>
+      order.txt' 2>&1
+    cwd: "$WORK_DIR/test-exec-tail/main"
+    expect:
+      exit_code: 0
+      file_contains:
+        - path: "$WORK_DIR/test-exec-tail/feat-tail/order.txt"
+          content: "hook+one+two"
+
+  - name: Two identical commands are two runs, not one
+    run:
+      daft start feat-twice -x 'printf x >> twice.txt' -x 'printf x >>
+      twice.txt' 2>&1
+    cwd: "$WORK_DIR/test-exec-tail/main"
+    expect:
+      exit_code: 0
+      file_contains:
+        - path: "$WORK_DIR/test-exec-tail/feat-twice/twice.txt"
+          content: "xx"
+
+  - name: A failing command stops the sequence, and the worktree survives it
+    run:
+      daft start feat-broken -x 'printf one >> broken.txt' -x false -x 'printf
+      three >> broken.txt' 2>&1
+    cwd: "$WORK_DIR/test-exec-tail/main"
+    expect:
+      exit_code: 1
+      dirs_exist:
+        - "$WORK_DIR/test-exec-tail/feat-broken"
+      file_contains:
+        - path: "$WORK_DIR/test-exec-tail/feat-broken/broken.txt"
+          content: "one"
+      file_not_contains:
+        - path: "$WORK_DIR/test-exec-tail/feat-broken/broken.txt"
+          content: "three"
+
+  - name: A fork runs the sequence inside the fork it just made
+    run: daft start --fork -x 'printf forked >> fork-marker.txt' 2>&1
+    cwd: "$WORK_DIR/test-exec-tail/main"
+    expect:
+      exit_code: 0
+      file_contains:
+        - path: "$WORK_DIR/test-exec-tail/main-fork/fork-marker.txt"
+          content: "forked"
+
+  - name: Navigating to an existing worktree still runs the sequence
+    run: daft go feat-tail -x 'printf again >> revisit.txt' 2>&1
+    cwd: "$WORK_DIR/test-exec-tail/main"
+    expect:
+      exit_code: 0
+      file_contains:
+        - path: "$WORK_DIR/test-exec-tail/feat-tail/revisit.txt"
+          content: "again"


### PR DESCRIPTION
`-x` commands were invisible on the rail — not for want of a label, but because
the sequence ran **after** `timeline.finish()` had already torn the region down.
`Executing: <cmd>` landed below a completed receipt, so the plan never told the
user the commands were coming.

## What changed

The command layer now owns both halves. It appends `exec::plan_section(&args.exec)`
to whatever plan the core commits — via a new `TimelineBridge::with_plan_suffix` —
and runs the sequence through `exec::run_on_rail` **before** closing the rail.

The core never learns about `-x`: teaching it to plan steps someone else executes
is how a plan and its receipt drift apart. Both halves key their rows through one
`step_key(index)`, so `-x 'make' -x 'make'` is two rows, never one.

```
✓  Created worktree      ../feat-b
│
├─ post-create hooks
│  ✓  bun-install   (2.9s)
│
├─ exec
│  ✓  true
│  ✗  false                 exit 1
│  ↓  echo never            not run
│
└  Ready with failures in 246ms
```

- **Position**: after the post-create hooks, which is where the commands run.
- **Label**: the command exactly as typed, under an `├─ exec` anchor once there
  are two or more.
- **Terminal**: a command owns it for its whole run (`-x` inherits stdio and may
  be interactive), so the region clears around it exactly as clone's install step
  does — its output prints above the rail.
- **Footer**: a failed command fails its own row, stops the sequence, and marks
  the rest `↓ … not run` rather than letting `finish` silently drop them. The
  footer reads `Ready with failures in …` — the worktree exists and the shell
  still moves into it, so a `Failed` receipt would be a lie.

## Off the rail, nothing changes

`run_on_rail` **asks the committed plan** for its rows rather than assuming they
exist (`region_live()` is true under the planning face too, so it cannot be the
predicate). Plain/Hidden/quiet/redirected output — and every journey that never
commits a plan: navigating to an existing worktree, `go -`, a fetch-off miss —
takes the legacy path with today's byte-identical output, after the record line
as always.

## Scope

Four sites: `daft go`/`checkout`, the sandbox visit, `daft start`, and the fork
loop. Deliberately unchanged, and worth naming:

- **`clone -x` / `init -x`** — not in the ticket; they keep today's output.
- **`start --with-related`** — runs its sequence after the whole fan-out, long
  after the primary repo's rail has closed. Putting the rows on that rail would
  change when the commands run relative to the sibling repos.
- **The fork's failure classification** — a failed `-x` still pushes into
  `failures` and suppresses the cd. That is #811's adjacent defect, not this
  one's.
- **`cd_path`** — stays exactly where it is. The missing cd on `daft go -x` is
  #811's fix.

## Testing

The rail only materializes on a TTY (`commit_plan` returns early when
`!is_interactive()`), so the YAML runner cannot see it. Coverage is split
accordingly:

- **`src/exec.rs` unit tests** prove the rendering against an `InMemoryTerm`:
  the anchored section, the lone-command case with no anchor, the failure row +
  `not run` rows, and the weld — that the rows the bridge appended are exactly
  the rows the runner resolves, landing after the core's last row. `drive()` is
  split from `run_on_rail` on the "run one command" seam so the loop is testable
  without spawning a shell.
- **`tests/manual/scenarios/exec/start-sequence-tail.yml`** covers what an
  end-to-end run can prove off-rail: order after the post-create hooks, two
  identical commands running twice, a failure stopping the sequence while the
  worktree survives, the fork path, and an existing-worktree navigation still
  running its commands.
- Verified by hand under a PTY (`tests/integration/pty_run.py`) against a
  throwaway repo — the screenshot above is that run.
- `mise run fmt`, `mise run clippy`, `mise run test:unit` (3779 passed), and the
  `exec` / `checkout` / `checkout-branch` / `hooks` / `clone` / `init` YAML
  scenario groups (241 scenarios) all green.

Refs #812