### PR TITLE
fix: write the cd target before -x runs, so an interrupt cannot cost it

### DIFF
--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -869,6 +869,14 @@ fn run_start_fork(args: StartArgs, base: Option<String>, count: u32) -> Result<(
         timeline.abandon_planning();
         match create_result {
             Ok(result) => {
+                // The single-fork cd, written before the `-x` sequence starts
+                // — on the rail that sequence runs inside the region just
+                // below, so an interrupted command must not be able to cost
+                // the redirect (#811). Bulk forks (`-n N`) have no single
+                // destination and must leave the shell where it is.
+                if count == 1 {
+                    output.cd_path(&result.cd_target);
+                }
                 // Per-fork exec, inside the fork (core chdir'd there). On the
                 // rail it is the plan's tail (#812) and runs before the
                 // receipt closes; the path record still follows the footer,
@@ -897,13 +905,14 @@ fn run_start_fork(args: StartArgs, base: Option<String>, count: u32) -> Result<(
         }
     }
 
-    if count == 1
-        && failures.is_empty()
-        && let Some(result) = completed.last()
-    {
+    // Gating on `completed` rather than `failures` (#811): with `count == 1`
+    // a creation failure leaves `completed` empty, so this still routes back
+    // to `original_dir` — but a *created* fork whose `-x` failed now keeps
+    // the shell inside it, matching go/start/visit, which have always cd'd
+    // on exec failure. The cd itself was written pre-exec, up in the loop.
+    if count == 1 && !completed.is_empty() {
         // Stay inside the fork (the cwd already is) and honor the wrapper's
         // cd contract.
-        output.cd_path(&result.cd_target);
         maybe_show_shell_hint(&mut output)?;
         if let Some(src) = source_worktree
             && let Ok(git_dir) = get_git_common_dir()
@@ -2209,6 +2218,20 @@ fn run_checkout(
         }
     };
 
+    // The worktree exists and its hooks have run: the shell belongs there,
+    // whatever `-x` goes on to do. The cd target is written before the exec
+    // sequence starts — on the rail that sequence runs below, inside the
+    // region — so a Ctrl-C aimed at `-x 'pnpm dev'` cannot cost the redirect
+    // (#811). The wrapper only reads the file once daft has exited, so
+    // writing it early is free.
+    //
+    // The other half of the guarantee lives in `exec::spawn`, which arms the
+    // interrupt dispatcher so daft *exits* on SIGINT rather than dying from
+    // it. Both are required: bash and zsh abandon the enclosing function when
+    // a foreground child is signal-killed, so without the arming the wrapper
+    // never reaches its `cd` no matter how early the file was written.
+    output.cd_path(&result.cd_target);
+
     // The `-x` sequence is the plan's tail (#812): run it while the region is
     // still live, so the rows that promised it are the rows that resolve it.
     let exec_tail = crate::exec::run_on_rail(&args.exec, &mut timeline);
@@ -2227,10 +2250,10 @@ fn run_checkout(
     // where they always have.
     let exec_result = run_exec_tail(exec_tail, &args.exec, output);
 
-    output.cd_path(&result.cd_target);
     maybe_show_shell_hint(output)?;
 
-    // Propagate exec error after cd_path is written
+    // A failed `-x` still leaves the shell in the new worktree; only the
+    // exit code carries the failure.
     exec_result?;
 
     Ok(result.already_existed)
@@ -2356,6 +2379,11 @@ fn run_sandbox_visit(
         }
     };
 
+    // cd before the `-x` sequence starts, so an interrupted command still
+    // lands the shell in the sandbox (#811); see run_checkout for the full
+    // reasoning.
+    output.cd_path(&result.cd_target);
+
     // The `-x` sequence is the plan's tail (#812) — see `run_checkout`. A
     // visit that navigated to an EXISTING sandbox committed no plan, so it
     // carries no rows and the commands run off the rail below, unchanged.
@@ -2370,7 +2398,6 @@ fn run_sandbox_visit(
 
     let exec_result = run_exec_tail(exec_tail, &args.exec, output);
 
-    output.cd_path(&result.cd_target);
     maybe_show_shell_hint(output)?;
 
     exec_result?;
@@ -2420,14 +2447,21 @@ fn run_create_branch(
     // core — the timeline lives and closes there.
     let (result, exec_tail) = run_create_branch_core(args, settings, git, output, &args.exec)?;
 
+    // The unconditional tail write, and the only one when there is no `-x`
+    // to run. A sequence is always preceded by its own write — the core made
+    // it before running the rows (#811) — so by here the target may already
+    // be on disk; rewriting the same path costs one small write and keeps the
+    // tail's contract uniform with every other command that cds.
+    output.cd_path(&result.cd_target);
+
     // Off the rail, the commands run here — after the record line, exactly
     // where they always have.
     let exec_result = run_exec_tail(exec_tail, &args.exec, output);
 
-    output.cd_path(&result.cd_target);
     maybe_show_shell_hint(output)?;
 
-    // Propagate exec error after cd_path is written
+    // A failed `-x` still leaves the shell in the new worktree; only the exit
+    // code carries the failure.
     exec_result?;
 
     Ok(())
@@ -2620,6 +2654,17 @@ fn run_create_branch_core(
         }
     };
 
+    // Whoever runs the `-x` sequence writes the cd target first (#811): the
+    // rows run inside the region just below, and a Ctrl-C aimed at one of
+    // them takes daft with it, so a redirect written afterwards is never
+    // written at all. The core only owns a sequence for `run_create_branch`,
+    // which is also the only caller that cds — `--with-related` passes none
+    // and keeps the write in its own tail, and the sibling repos it creates
+    // must never redirect the shell at all.
+    if !exec_on_rail.is_empty() {
+        output.cd_path(&result.cd_target);
+    }
+
     // The `-x` sequence is the plan's tail (#812) — see `run_checkout`.
     let exec_tail = crate::exec::run_on_rail(exec_on_rail, &mut timeline);
     let footer = ready_footer(&exec_tail, &timeline);
@@ -2748,8 +2793,11 @@ fn run_start_with_related(
     if current_post_create_failed {
         maybe_show_shell_hint(&mut output)?;
     } else {
-        let exec_result = crate::exec::run_exec_commands(&args.exec, &mut output);
+        // cd before `-x` (#811). The #765 gate above still decides *whether*
+        // to cd at all; this only moves the write ahead of the exec sequence
+        // so an interrupted command cannot cost the redirect.
         output.cd_path(&current_cd_target);
+        let exec_result = crate::exec::run_exec_commands(&args.exec, &mut output);
         maybe_show_shell_hint(&mut output)?;
         exec_result?;
     }

--- a/src/commands/clone.rs
+++ b/src/commands/clone.rs
@@ -812,11 +812,15 @@ fn run_clone(args: &Args, settings: &DaftSettings, output: &mut dyn Output) -> R
             timeline.finish(&format!("Ready in {}", timeline.elapsed_display()));
         }
 
-        let exec_result = crate::exec::run_exec_commands(&args.exec, output);
-
+        // cd before `-x`, so an interrupted `-x 'pnpm install'` still lands
+        // the shell in the fresh clone (#811); see run_checkout in
+        // commands/checkout.rs for the full reasoning.
         if let Some(ref cd_target) = result.cd_target {
             output.cd_path(cd_target);
         }
+
+        let exec_result = crate::exec::run_exec_commands(&args.exec, output);
+
         maybe_show_shell_hint(output)?;
 
         exec_result?;

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -206,15 +206,17 @@ pub fn run_with_output(args: &Args, output: &mut dyn Output) -> Result<()> {
     render_init_result(&result, output);
 
     if !result.bare_mode {
-        // Run exec commands (after hooks, before cd_path)
-        let exec_result = crate::exec::run_exec_commands(&args.exec, output);
-
+        // cd before `-x`, so an interrupted command still lands the shell in
+        // the new worktree (#811); see run_checkout for the full reasoning.
         if let Some(ref cd_target) = result.cd_target {
             output.cd_path(cd_target);
         }
+
+        // Run exec commands (after hooks, after cd_path)
+        let exec_result = crate::exec::run_exec_commands(&args.exec, output);
+
         maybe_show_shell_hint(output)?;
 
-        // Propagate exec error after cd_path is written
         exec_result?;
     }
 

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -248,6 +248,17 @@ fn capture_aliases() -> Option<AliasCache> {
 /// spawn site for both paths, so the rail cannot drift from the legacy one in
 /// how a command is built or what it can reach.
 fn spawn(cmd: &str, alias_cache: Option<&AliasCache>) -> std::io::Result<std::process::ExitStatus> {
+    // The command shares daft's process group, so a terminal Ctrl-C aimed at
+    // `-x 'pnpm dev'` hits daft too — and dying *from* the signal is what
+    // costs the user the cd. bash and zsh abandon the enclosing function when
+    // a foreground child is signal-killed, so `__daft_wrapper` never reaches
+    // its `cd` and the target written before the sequence is read by nobody
+    // (#811). Arming the dispatcher makes that an ordinary exit(130) instead.
+    // A live region arms it as a side effect of its own collapse behavior;
+    // doing it here is what carries the guarantee through `-q`, redirected
+    // stderr, and every other path that opens no region at all.
+    crate::interrupt::arm_default_exit();
+
     let spec = CommandSpec::Shell(cmd.to_string());
     build_command(&spec, alias_cache)
         // `DAFT_CD_FILE` is the wrapper's private channel for *this*

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -250,6 +250,13 @@ fn capture_aliases() -> Option<AliasCache> {
 fn spawn(cmd: &str, alias_cache: Option<&AliasCache>) -> std::io::Result<std::process::ExitStatus> {
     let spec = CommandSpec::Shell(cmd.to_string());
     build_command(&spec, alias_cache)
+        // `DAFT_CD_FILE` is the wrapper's private channel for *this*
+        // invocation's destination. Inheriting it lets a nested bare daft —
+        // `-x 'daft go other'` — write the outer shell's cd target and
+        // teleport the user somewhere they never asked to go. The callers
+        // write that target *before* the sequence runs (#811), so nothing
+        // downstream may touch the file.
+        .env_remove(crate::CD_FILE_ENV)
         .stdin(std::process::Stdio::inherit())
         .stdout(std::process::Stdio::inherit())
         .stderr(std::process::Stdio::inherit())

--- a/src/executor/command.rs
+++ b/src/executor/command.rs
@@ -72,6 +72,14 @@ pub fn run_command(
     command.args(["-c", cmd]);
     command.current_dir(working_dir);
     command.envs(env);
+    // A hook is lifecycle automation, never the arbiter of where the user's
+    // shell ends up. Inheriting `DAFT_CD_FILE` lets a hook that shells out to
+    // daft — `daft go other` — write the outer invocation's cd target. Most
+    // paths mask it by writing the real target afterwards, but the ones that
+    // deliberately write *nothing* do not: a failed post-create hook must not
+    // teleport the user into the half-set-up worktree (#765), and a bulk
+    // `--fork -n N` has no single destination to move to. Scrub it (#811).
+    command.env_remove(crate::CD_FILE_ENV);
 
     // Non-interactive commands must not inherit stdin -- a child process
     // (e.g. mise, cargo) might block waiting for input that will never come.
@@ -209,6 +217,9 @@ pub fn run_command_interactive(
     command.args(["-c", cmd]);
     command.current_dir(working_dir);
     command.envs(env);
+    // Same reasoning as the non-interactive path above: a hook does not get
+    // to choose the user's destination (#811).
+    command.env_remove(crate::CD_FILE_ENV);
 
     // Inherit stdin/stdout/stderr for interactive mode
     command.stdin(Stdio::inherit());

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -49,6 +49,21 @@ fn ensure_installed() {
     });
 }
 
+/// Install the dispatcher without arming a phase behavior, so a Ctrl-C that
+/// arrives while the slot is empty exits *normally* with 130 instead of
+/// killing the process by signal.
+///
+/// The distinction is invisible in daft's own output and load-bearing for the
+/// shell wrapper (#811). bash and zsh abort the enclosing function when a
+/// foreground child dies from SIGINT, so a signal-killed daft never reaches
+/// `__daft_wrapper`'s `cd` — the cd target is written but never read, and the
+/// user is left behind in the old worktree. An ordinary exit lets the tail
+/// run. A live timeline region installs this as a side effect of arming its
+/// collapse; callers that must not depend on the rail being live say so here.
+pub fn arm_default_exit() {
+    ensure_installed();
+}
+
 /// A previously installed behavior, saved by [`swap_behavior`] so a nested
 /// phase can put it back. Opaque: the only thing to do with one is hand it
 /// to [`restore_behavior`].

--- a/tests/integration/test_checkout.sh
+++ b/tests/integration/test_checkout.sh
@@ -944,6 +944,98 @@ test_go_fetch_hop_no_rail_receipt() {
     return 0
 }
 
+# #811: a real terminal Ctrl-C during `-x` must still leave the shell in the
+# new worktree. Two things have to hold and only a pty can test either:
+#
+#   1. daft writes the cd target *before* the exec sequence, so the signal
+#      cannot arrive between the command and the write; and
+#   2. daft *exits* on SIGINT (130) instead of dying from it (pty_run reports
+#      a signal death as 254, Python's -2). This is the load-bearing half:
+#      bash and zsh abandon the enclosing function when a foreground child is
+#      signal-killed, so a signal-killed daft never reaches `__daft_wrapper`'s
+#      `cd` and the target it wrote is read by nobody.
+#
+# `--ctty` makes daft a session leader owning the pty, so writing \x03 raises
+# SIGINT in the foreground process group exactly as a keyboard Ctrl-C does —
+# the group-wide delivery a `kill -INT <pid>` cannot reproduce. The cue is
+# emitted by the -x command itself: daft's own "Executing" step never reaches
+# the pty under the rail, and pty_run splits a cue on its first colon, so a
+# self-authored colon-free marker is the only reliable trigger.
+#
+# The cue must be ASSEMBLED AT RUNTIME, never a literal in the command text.
+# Since #812 the rail plans each `-x` command as a row labelled with the
+# command exactly as typed, so a literal marker is painted on screen while the
+# row is still pending — the Ctrl-C then lands during planning, before the
+# worktree exists, and the test interrupts the wrong thing while still
+# reporting 130. `printf 'XCUE%s\n' READY` keeps `XCUEREADY` out of the label
+# and puts it only in the output the command produces when it actually runs.
+_X_CUE_CMD="printf 'XCUE%s\n' READY; sleep 10"
+_assert_interrupted_go_kept_cd() {
+    local branch="$1" log="$2" cd_file="$3" status="$4"
+
+    if [ "$status" != "130" ]; then
+        log_error "expected exit 130 (interrupted, exited cleanly), got $status"
+        # 254 is pty_run relaying Python's -2: daft died *from* SIGINT, which
+        # is precisely the state that strands the shell.
+        [ "$status" = "254" ] && log_error "daft was signal-killed — the wrapper would abandon its cd"
+        return 1
+    fi
+    if ! grep -q "XCUEREADY" "$log"; then
+        log_error "-x never started; the interrupt proved nothing"
+        return 1
+    fi
+    assert_directory_exists "../$branch" || return 1
+    if [ ! -s "$cd_file" ]; then
+        log_error "DAFT_CD_FILE empty after interrupt — the shell would stay put"
+        return 1
+    fi
+    local want got
+    want=$(cd "../$branch" && pwd -P)
+    got=$(cd "$(cat "$cd_file")" && pwd -P)
+    if [ "$got" != "$want" ]; then
+        log_error "cd target '$got' != '$want'"
+        return 1
+    fi
+    return 0
+}
+
+test_go_exec_interrupt_keeps_cd() {
+    local remote_repo=$(create_test_remote "test-repo-x-interrupt" "main")
+    git-worktree-clone --layout contained "$remote_repo" || return 1
+    cd "test-repo-x-interrupt/main"
+
+    local log="$PWD/go-x-interrupt.log"
+    local cd_file="$PWD/go-x-interrupt.cd"
+    : > "$cd_file"
+    local status=0
+    DAFT_CD_FILE="$cd_file" _rail_daft "$CHECKOUT_PTY_RUN" --ctty \
+        --send-after 'XCUEREADY:\x03' "$log" \
+        daft go develop -x "$_X_CUE_CMD" || status=$?
+
+    _assert_interrupted_go_kept_cd develop "$log" "$cd_file" "$status"
+}
+
+# The same guarantee without a rail. Before #811's interrupt arming this was
+# the case that failed even with the cd target written early: with no live
+# timeline region nothing installed a SIGINT handler, daft died from the
+# signal, and the wrapper abandoned its `cd`. Keep both — the rail path can
+# pass on the timeline's handler alone and hide a regression here.
+test_go_exec_interrupt_quiet_keeps_cd() {
+    local remote_repo=$(create_test_remote "test-repo-x-interrupt-q" "main")
+    git-worktree-clone --layout contained "$remote_repo" || return 1
+    cd "test-repo-x-interrupt-q/main"
+
+    local log="$PWD/go-x-interrupt-q.log"
+    local cd_file="$PWD/go-x-interrupt-q.cd"
+    : > "$cd_file"
+    local status=0
+    DAFT_CD_FILE="$cd_file" _rail_daft "$CHECKOUT_PTY_RUN" --ctty \
+        --send-after 'XCUEREADY:\x03' "$log" \
+        daft go develop -q -x "$_X_CUE_CMD" || status=$?
+
+    _assert_interrupted_go_kept_cd develop "$log" "$cd_file" "$status"
+}
+
 # The counterpart guard: when resolution does warrant a worktree, the
 # collapsed face must expand into the full rail — persisted header, the
 # probe fetch as a pre-completed receipt row, and a Ready footer.
@@ -1151,6 +1243,10 @@ run_checkout_tests() {
     run_test "start_exec_rows_on_rail" "test_start_exec_rows_on_rail"
     run_test "start_exec_failure_on_rail" "test_start_exec_failure_on_rail"
     run_test "start_exec_multiline_label_stays_one_row" "test_start_exec_multiline_label_stays_one_row"
+
+    # Interrupted -x keeps the cd redirect (#811)
+    run_test "go_exec_interrupt_keeps_cd" "test_go_exec_interrupt_keeps_cd"
+    run_test "go_exec_interrupt_quiet_keeps_cd" "test_go_exec_interrupt_quiet_keeps_cd"
 }
 
 # Main execution

--- a/tests/integration/test_shell_init.sh
+++ b/tests/integration/test_shell_init.sh
@@ -911,35 +911,48 @@ test_go_exec_cd_through_wrapper() {
     local project_root="$PWD/test-go-exec-wrapper"
 
     # `-x` runs through a `$SHELL -c` daft spawns directly, so `$PPID` inside
-    # the command is daft's own pid: `kill -INT $PPID` is the signal a terminal
-    # Ctrl-C delivers, with no timing race.
+    # the command is daft's own pid and `kill -INT $PPID` interrupts daft with
+    # no timing race. Each case pins daft's exit code as well as the landing
+    # directory: without that, the interrupt case is indistinguishable from a
+    # `$PPID` the spawned shell does not support, where `kill` simply fails,
+    # the -x command exits 1, and the wrapper cds anyway — a green test for
+    # the one path it exists to cover. 130 is the interrupt, 1 is a plain
+    # command failure.
     local -a cases=(
-        "true:develop"
-        "false:release-x"
-        'kill -INT $PPID:hotfix-x'
+        "true|develop|0"
+        "false|release-x|1"
+        'kill -INT $PPID|hotfix-x|130'
     )
-    local case_spec cmd branch out
+    local case_spec cmd branch want_rc out got_rc got_pwd
     for case_spec in "${cases[@]}"; do
-        cmd="${case_spec%:*}"
-        branch="${case_spec##*:}"
+        IFS='|' read -r cmd branch want_rc <<< "$case_spec"
         # `develop` exists on the remote; the other two are created locally so
         # each case gets a worktree of its own.
         out=$(MAIN_WT="$project_root/main" CMD="$cmd" BRANCH="$branch" bash -c '
             eval "$(daft shell-init bash)"
             builtin cd "$MAIN_WT" || exit 11
+            rc=0
             if [ "$BRANCH" = "develop" ]; then
-                daft go "$BRANCH" -x "$CMD" >/dev/null 2>&1
+                daft go "$BRANCH" -x "$CMD" >/dev/null 2>&1 || rc=$?
             else
-                daft start "$BRANCH" -x "$CMD" >/dev/null 2>&1
+                daft start "$BRANCH" -x "$CMD" >/dev/null 2>&1 || rc=$?
             fi
+            echo "RC=$rc"
             builtin pwd
         ' 2>&1) || true
 
-        if [[ "$(basename "$out")" != "$branch" ]]; then
-            log_error "-x '$cmd' did not cd the shell into '$branch' (pwd: $out)"
+        got_rc=$(echo "$out" | grep '^RC=' | head -1 | cut -d= -f2)
+        got_pwd=$(echo "$out" | tail -1)
+
+        if [[ "$got_rc" != "$want_rc" ]]; then
+            log_error "-x '$cmd' exited $got_rc, expected $want_rc (no signal delivered?)"
             return 1
         fi
-        log_success "-x '$cmd' landed the shell at: $out"
+        if [[ "$(basename "$got_pwd")" != "$branch" ]]; then
+            log_error "-x '$cmd' did not cd the shell into '$branch' (pwd: $got_pwd)"
+            return 1
+        fi
+        log_success "-x '$cmd' exited $got_rc and landed the shell at: $got_pwd"
     done
 
     log_success "go/start -x cd contract holds across success, failure and interrupt"

--- a/tests/integration/test_shell_init.sh
+++ b/tests/integration/test_shell_init.sh
@@ -896,6 +896,56 @@ test_go_tag_sandbox_cd_through_wrapper() {
     return 0
 }
 
+# Regression for #811: `daft go <branch> -x <cmd>` must land the shell in the
+# new worktree whether the command succeeds, fails, or is interrupted. The
+# interrupted case is the one that was broken — daft wrote the cd target after
+# the exec sequence, so a Ctrl-C aimed at `-x 'pnpm dev'` killed daft first and
+# the file was never written. Only the wrapper layer can prove the shell
+# actually moved; the YAML scenarios drive the binary directly.
+test_go_exec_cd_through_wrapper() {
+    log "Testing: daft go -x through wrapper cds on success, failure and interrupt"
+
+    local remote_dir
+    remote_dir=$(create_test_remote "test-go-exec-wrapper" "main")
+    git-worktree-clone --layout contained "$remote_dir" >/dev/null 2>&1
+    local project_root="$PWD/test-go-exec-wrapper"
+
+    # `-x` runs through a `$SHELL -c` daft spawns directly, so `$PPID` inside
+    # the command is daft's own pid: `kill -INT $PPID` is the signal a terminal
+    # Ctrl-C delivers, with no timing race.
+    local -a cases=(
+        "true:develop"
+        "false:release-x"
+        'kill -INT $PPID:hotfix-x'
+    )
+    local case_spec cmd branch out
+    for case_spec in "${cases[@]}"; do
+        cmd="${case_spec%:*}"
+        branch="${case_spec##*:}"
+        # `develop` exists on the remote; the other two are created locally so
+        # each case gets a worktree of its own.
+        out=$(MAIN_WT="$project_root/main" CMD="$cmd" BRANCH="$branch" bash -c '
+            eval "$(daft shell-init bash)"
+            builtin cd "$MAIN_WT" || exit 11
+            if [ "$BRANCH" = "develop" ]; then
+                daft go "$BRANCH" -x "$CMD" >/dev/null 2>&1
+            else
+                daft start "$BRANCH" -x "$CMD" >/dev/null 2>&1
+            fi
+            builtin pwd
+        ' 2>&1) || true
+
+        if [[ "$(basename "$out")" != "$branch" ]]; then
+            log_error "-x '$cmd' did not cd the shell into '$branch' (pwd: $out)"
+            return 1
+        fi
+        log_success "-x '$cmd' landed the shell at: $out"
+    done
+
+    log_success "go/start -x cd contract holds across success, failure and interrupt"
+    return 0
+}
+
 main() {
     setup
 
@@ -932,6 +982,7 @@ main() {
     run_test "c_flag_symlink_entry" test_c_flag_symlink_entry
     run_test "fork_cd_through_wrapper" test_fork_cd_through_wrapper
     run_test "go_tag_sandbox_cd_through_wrapper" test_go_tag_sandbox_cd_through_wrapper
+    run_test "go_exec_cd_through_wrapper" test_go_exec_cd_through_wrapper
     run_test "warm_force_rescues_shell_from_a_replaced_cache" test_warm_force_rescues_shell_from_a_replaced_cache
 
     print_summary

--- a/tests/manual/scenarios/checkout-branch/start-fork-exec-failure-cd.yml
+++ b/tests/manual/scenarios/checkout-branch/start-fork-exec-failure-cd.yml
@@ -1,0 +1,53 @@
+name: A created fork keeps its cd target when -x fails
+description:
+  A single fork whose `-x` command failed was still created, so the shell
+  belongs inside it — matching go/start/visit, which have always cd'd on exec
+  failure. Bulk forks (`-n N`) have no single destination and still stay put.
+
+repos:
+  - name: test-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone the repository
+    run: daft clone --layout contained $REMOTE_TEST_REPO
+    expect:
+      exit_code: 0
+
+  - name: A failing -x does not cost the fork its redirect
+    # Pre-#811 the fork tail gated the cd on `failures.is_empty()`, and a
+    # failed `-x` pushes into `failures` — so a perfectly good fork was
+    # created and the user was left standing outside it.
+    run: |
+      cd_file=$(mktemp)
+      rc=0
+      DAFT_CD_FILE="$cd_file" daft start --fork -x 'false' >/dev/null 2>&1 || rc=$?
+      target=$(cat "$cd_file")
+      test "$rc" -ne 0 || { echo "FAIL: a failing -x must still exit non-zero"; exit 1; }
+      test -d "$WORK_DIR/test-repo/main-fork" || { echo "FAIL: fork was never created"; exit 1; }
+      test -n "$target" || { echo "FAIL: DAFT_CD_FILE not written — the shell would stay put"; exit 1; }
+      expected=$(python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$WORK_DIR/test-repo/main-fork")
+      resolved=$(python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$target")
+      test "$resolved" = "$expected" || { echo "FAIL: cd target '$resolved' != '$expected'"; exit 1; }
+      echo OK
+      rm -f "$cd_file"
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "OK"
+
+  - name: Bulk forks still leave the shell where it was
+    # The `count == 1` gate on the pre-exec write: -n N has no single
+    # destination, so nothing may be written.
+    run: |
+      cd_file=$(mktemp)
+      DAFT_CD_FILE="$cd_file" daft start --fork -n 2 >/dev/null 2>&1
+      test ! -s "$cd_file" || { echo "FAIL: bulk fork wrote a cd target: $(cat "$cd_file")"; exit 1; }
+      echo OK
+      rm -f "$cd_file"
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "OK"

--- a/tests/manual/scenarios/checkout-branch/start-fork-exec-failure-cd.yml
+++ b/tests/manual/scenarios/checkout-branch/start-fork-exec-failure-cd.yml
@@ -40,9 +40,21 @@ steps:
   - name: Bulk forks still leave the shell where it was
     # The `count == 1` gate on the pre-exec write: -n N has no single
     # destination, so nothing may be written.
+    #
+    # The empty-cd-file assertion is only worth anything once the forks are
+    # known to have happened: `mktemp` yields an empty file, so on its own
+    # `test ! -s` also passes when the command aborted before creating
+    # anything — a green step for a command that did nothing. Pin the exit
+    # code and count the worktrees (by delta, so the fork-naming scheme stays
+    # free to change) before concluding the shell was deliberately left put.
     run: |
       cd_file=$(mktemp)
-      DAFT_CD_FILE="$cd_file" daft start --fork -n 2 >/dev/null 2>&1
+      rc=0
+      before=$(git worktree list | wc -l | tr -d ' ')
+      DAFT_CD_FILE="$cd_file" daft start --fork -n 2 >/dev/null 2>&1 || rc=$?
+      after=$(git worktree list | wc -l | tr -d ' ')
+      test "$rc" -eq 0 || { echo "FAIL: bulk fork exited $rc"; exit 1; }
+      test $((after - before)) -eq 2 || { echo "FAIL: expected 2 new worktrees, got $((after - before))"; exit 1; }
       test ! -s "$cd_file" || { echo "FAIL: bulk fork wrote a cd target: $(cat "$cd_file")"; exit 1; }
       echo OK
       rm -f "$cd_file"

--- a/tests/manual/scenarios/checkout/exec-interrupt-keeps-cd.yml
+++ b/tests/manual/scenarios/checkout/exec-interrupt-keeps-cd.yml
@@ -1,0 +1,44 @@
+name: Interrupted -x keeps the cd redirect
+description:
+  A `-x` command killed by SIGINT still leaves the cd target written — daft
+  writes it before the exec sequence, so Ctrl-C on a long-running `-x` cannot
+  cost the shell its move into the worktree that was just created
+
+repos:
+  - name: test-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone the repository
+    run: daft clone --layout contained $REMOTE_TEST_REPO
+    expect:
+      exit_code: 0
+
+  - name: SIGINT during -x still writes DAFT_CD_FILE
+    # `-x` runs through a `$SHELL -c` that daft spawns directly, so inside the
+    # command `$PPID` is daft's own pid — `kill -INT $PPID` delivers what a
+    # terminal Ctrl-C sends to the foreground process group, without the
+    # timing race a background `sleep` + `pkill` would carry.
+    #
+    # Before #811 the cd target was written *after* the exec sequence, so a
+    # signal killed daft first and the file stayed empty: the worktree existed
+    # and the shell was left standing outside it.
+    run: |
+      cd_file=$(mktemp)
+      rc=0
+      DAFT_CD_FILE="$cd_file" daft go develop -x 'kill -INT $PPID' || rc=$?
+      echo "RC=$rc"
+      target=$(cat "$cd_file")
+      test "$rc" -ne 0 || { echo "FAIL: daft was not interrupted (rc=$rc)"; exit 1; }
+      test -d "$WORK_DIR/test-repo/develop" || { echo "FAIL: worktree was never created"; exit 1; }
+      test -n "$target" || { echo "FAIL: DAFT_CD_FILE not written — the shell would stay put"; exit 1; }
+      expected=$(python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$WORK_DIR/test-repo/develop")
+      resolved=$(python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$target")
+      test "$resolved" = "$expected" || { echo "FAIL: cd target '$resolved' != '$expected'"; exit 1; }
+      echo OK
+      rm -f "$cd_file"
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "OK"

--- a/tests/manual/scenarios/checkout/exec-interrupt-keeps-cd.yml
+++ b/tests/manual/scenarios/checkout/exec-interrupt-keeps-cd.yml
@@ -16,9 +16,16 @@ steps:
 
   - name: SIGINT during -x still writes DAFT_CD_FILE
     # `-x` runs through a `$SHELL -c` that daft spawns directly, so inside the
-    # command `$PPID` is daft's own pid — `kill -INT $PPID` delivers what a
-    # terminal Ctrl-C sends to the foreground process group, without the
-    # timing race a background `sleep` + `pkill` would carry.
+    # command `$PPID` is daft's own pid and `kill -INT $PPID` interrupts daft
+    # mid-exec with no timing race.
+    #
+    # Scope, precisely: this signals daft's *pid*, where a keyboard Ctrl-C
+    # signals the whole foreground process group. That difference decides
+    # whether the user's own shell also gets the signal, so it cannot be
+    # reproduced here without killing the test runner. The group-wide case,
+    # and the exit-cleanly-vs-die-from-the-signal distinction it turns on, is
+    # covered under a real pty by `go_exec_interrupt_keeps_cd` in
+    # tests/integration/test_checkout.sh.
     #
     # Before #811 the cd target was written *after* the exec sequence, so a
     # signal killed daft first and the file stayed empty: the worktree existed
@@ -29,7 +36,12 @@ steps:
       DAFT_CD_FILE="$cd_file" daft go develop -x 'kill -INT $PPID' || rc=$?
       echo "RC=$rc"
       target=$(cat "$cd_file")
-      test "$rc" -ne 0 || { echo "FAIL: daft was not interrupted (rc=$rc)"; exit 1; }
+      # 130 == interrupted. Asserting the exact code is what keeps this
+      # honest: a merely non-zero rc is also what an unsupported `$PPID`
+      # produces (`kill` fails, the -x command exits 1, daft reports it), and
+      # that path would satisfy every assertion below while never delivering
+      # a signal at all — a green test for the one case it exists to cover.
+      test "$rc" -eq 130 || { echo "FAIL: expected exit 130 (interrupted), got $rc — no signal was delivered"; exit 1; }
       test -d "$WORK_DIR/test-repo/develop" || { echo "FAIL: worktree was never created"; exit 1; }
       test -n "$target" || { echo "FAIL: DAFT_CD_FILE not written — the shell would stay put"; exit 1; }
       expected=$(python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$WORK_DIR/test-repo/develop")

--- a/tests/manual/scenarios/checkout/exec-nested-cd-no-hijack.yml
+++ b/tests/manual/scenarios/checkout/exec-nested-cd-no-hijack.yml
@@ -1,0 +1,52 @@
+name: A nested daft inside -x cannot hijack the cd target
+description:
+  DAFT_CD_FILE is this invocation's private channel to the shell wrapper — a
+  bare daft run from inside `-x` must not inherit it and redirect the outer
+  shell somewhere the user never asked to go
+
+repos:
+  - name: test-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone the repository
+    run: daft clone --layout contained $REMOTE_TEST_REPO
+    expect:
+      exit_code: 0
+
+  - name: The -x child does not inherit DAFT_CD_FILE
+    # The direct reading of the scrub: whatever the child does with the
+    # variable, it cannot see one.
+    run: |
+      cd_file=$(mktemp)
+      DAFT_CD_FILE="$cd_file" daft go develop -x 'echo "INNER_SEES=[$DAFT_CD_FILE]"'
+      target=$(cat "$cd_file")
+      test -n "$target" || { echo "FAIL: outer cd target not written"; exit 1; }
+      echo OK
+      rm -f "$cd_file"
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "INNER_SEES=[]"
+        - "OK"
+
+  - name: A nested daft go leaves the outer cd target intact
+    # End-to-end: the outer `go` owns the redirect. Pre-#811 the inner daft
+    # wrote its own destination into the outer file and only the outer
+    # post-exec write (since moved ahead of the exec sequence) papered over it.
+    run: |
+      cd_file=$(mktemp)
+      DAFT_CD_FILE="$cd_file" daft go feature/test-feature -x 'daft go develop'
+      target=$(cat "$cd_file")
+      test -n "$target" || { echo "FAIL: outer cd target not written"; exit 1; }
+      expected=$(python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$WORK_DIR/test-repo/feature/test-feature")
+      resolved=$(python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$target")
+      test "$resolved" = "$expected" || { echo "FAIL: nested daft hijacked the redirect — cd target '$resolved' != '$expected'"; exit 1; }
+      echo OK
+      rm -f "$cd_file"
+    cwd: "$WORK_DIR/test-repo/main"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "OK"

--- a/tests/manual/scenarios/hooks/hook-cd-file-scrub.yml
+++ b/tests/manual/scenarios/hooks/hook-cd-file-scrub.yml
@@ -1,0 +1,62 @@
+name: A hook cannot hijack the cd target
+description: DAFT_CD_FILE is the shell wrapper's private channel for one
+  invocation's destination. A lifecycle hook is automation, never the arbiter of
+  where the user's shell ends up, so hook commands must not inherit it —
+  otherwise a hook that shells out to daft writes the outer invocation's
+  redirect. Most paths mask that by writing the real target afterwards; the ones
+  that deliberately write nothing (a failed post-create hook, #765) do not.
+
+repos:
+  - name: test-hook-cd-scrub
+    default_branch: main
+    branches:
+      - name: main
+        files:
+          - path: README.md
+            content: "# hook cd scrub test"
+        commits:
+          - message: "Initial commit"
+      - name: feature/scrubbed
+        from: main
+    daft_yml: |
+      hooks:
+        worktree-post-create:
+          jobs:
+            - name: report-cd-file
+              run: echo "HOOK_SEES=[$DAFT_CD_FILE]" > "$DAFT_WORKTREE_PATH/cd-observed.txt"
+
+steps:
+  - name: Clone the repository with --trust-hooks
+    run:
+      git-worktree-clone --trust-hooks --layout contained
+      $REMOTE_TEST_HOOK_CD_SCRUB 2>&1
+    expect:
+      exit_code: 0
+
+  - name: The post-create hook sees no DAFT_CD_FILE
+    # The hook records what it saw to a file rather than stdout — hook output
+    # is rendered through the timeline and does not reach the step's captured
+    # stdout, so an `output_contains` assertion on it would be vacuous.
+    #
+    # An unscrubbed hook records the outer invocation's tempfile path, and
+    # anything it can name it can write. The outer redirect must still land:
+    # scrubbing the child must not cost the parent its own cd target.
+    run: |
+      cd_file=$(mktemp)
+      DAFT_CD_FILE="$cd_file" daft go feature/scrubbed 2>&1
+      observed=$(cat "$WORK_DIR/test-hook-cd-scrub/feature/scrubbed/cd-observed.txt")
+      echo "$observed"
+      test "$observed" = "HOOK_SEES=[]" || { echo "FAIL: hook inherited DAFT_CD_FILE — $observed"; exit 1; }
+      target=$(cat "$cd_file")
+      test -n "$target" || { echo "FAIL: outer cd target not written"; exit 1; }
+      expected=$(python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$WORK_DIR/test-hook-cd-scrub/feature/scrubbed")
+      resolved=$(python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$target")
+      test "$resolved" = "$expected" || { echo "FAIL: cd target '$resolved' != '$expected'"; exit 1; }
+      echo OK
+      rm -f "$cd_file"
+    cwd: "$WORK_DIR/test-hook-cd-scrub/main"
+    expect:
+      exit_code: 0
+      output_contains:
+        - "HOOK_SEES=[]"
+        - "OK"


### PR DESCRIPTION
`daft go <branch> -x <cmd>` left the shell where it was when the command was
interrupted. Two things had to be true for the redirect to survive, and
neither was.

## What was actually broken

Measured before any change, in an isolated repo:

| `-x` command | exit | `DAFT_CD_FILE` |
| --- | --- | --- |
| `true` | 0 | written |
| `false` | 1 | written |
| interrupted | -2 | **empty** |

The deferred `?` already handled exec *failure*. Only the signal path was
broken — exactly the `-x 'pnpm dev'` + Ctrl-C case in the report.

## The fix, both halves

**1. Write the cd target before the sequence runs.** Since #814 the commands
run inside the timeline region, so the write moved above `run_on_rail` (and
into `run_create_branch_core`, which now owns the sequence for the one caller
that also cds). Off the rail it precedes `run_exec_tail`. Same reorder in
`clone.rs` and `init.rs` — `daft clone -x 'pnpm install'` had identical
exposure. The two `cd_path` calls with no exec tail are untouched.

**2. Exit on SIGINT instead of dying from it.** This is the half the review
caught, and on its own the first half is inert. bash and zsh abandon the
enclosing function when a foreground child is signal-killed, so a
signal-killed daft never reaches `__daft_wrapper`'s `cd` no matter how early
the file was written. Measured under a pty, both shells:

| child fate | function tail runs? |
| --- | --- |
| killed by SIGINT | **no** |
| exits 130 | yes |

daft only exited cleanly when a live region had armed the interrupt
dispatcher, so the fix worked on a TTY and silently did nothing under `-q`,
redirected stderr, or any rail-less path. End-to-end with the real wrapper:
`-q` landed the shell in the old worktree before, the new worktree after.
`exec::spawn` now arms the dispatcher — one site, both rail and off-rail.

## Two adjacent defects

- **`start --fork` gated its cd on `failures.is_empty()`**, and a failed `-x`
  pushes into `failures` — a created fork the user was left outside of. Now
  `count == 1 && !completed.is_empty()`: a *creation* failure still routes
  back, an *exec* failure keeps the shell in the fork.
- **`DAFT_CD_FILE` leaked into children.** A nested `-x 'daft go other'` wrote
  the outer shell's destination; only the outer post-exec write papered over
  it, so the reorder alone would have regressed it. Hooks leaked it too —
  proven, a hook printed the real outer tempfile path. That one is not
  cosmetic: on the paths that deliberately write *nothing*, a hook shelling
  out to daft could teleport the user into the half-set-up worktree #765
  exists to keep them out of. Scrubbed at both spawn sites.

## Tests

Four YAML scenarios (CI-gated) and two real-pty tests in `test_checkout.sh`,
which `test_all.sh` sources — unlike `test_shell_init.sh`. `--ctty` makes daft
a session leader owning the pty, so `\x03` raises SIGINT in the foreground
process group as a keyboard Ctrl-C does; `pty_run` reports a signal death as
254 against a clean 130, which is the exact discriminator. Each was verified
to fail on pre-fix source:

- `go_exec_interrupt_quiet_keeps_cd` → 254 (the arming)
- rail variant → cd file empty, worktree created (the ordering)
- hook scrub → `HOOK_SEES=[/var/.../tmp.N7pIV3fTwe]` (the leak)

Three test corrections from review, each a false green:

- The interrupt tests asserted only a non-zero exit — which an unsupported
  `$PPID` also produces, since `kill` then fails, `-x` exits 1, and daft
  reports it. Green for the one case they exist to cover. Pinned to 130.
- The bulk-fork step asserted an empty cd file against an empty `mktemp` file,
  which also passes when the command created nothing. Pinned to the exit code
  and the worktree-count delta.
- The pty cue was a literal in the `-x` text — and since #814 the rail paints
  each command as a *planned row label*, so it matched while the row was still
  pending and the Ctrl-C landed during planning, before the worktree existed,
  still reporting 130. The cue is now assembled at runtime
  (`printf 'XCUE%s\n' READY`) so it can only appear in real output.

`test_shell_init.sh` is still not in `test_all.sh`, so CI does not gate it. Run
directly: 27/29, versus a 26/28 baseline — the same two `*_aliases` assertions
are red on master.

Local: 3783 unit, 819 scenarios / 3517 steps, 357 bash integration, clippy and
fmt clean. Rebased onto master over #814.

Fixes #811
