### PR TITLE
fix: worktree shorthands report the resolved worktree, not the raw path argument

### DIFF
--- a/docs/reference/progress-timeline.md
+++ b/docs/reference/progress-timeline.md
@@ -21,7 +21,7 @@ receipt.
 ✓  Set up tracking
 ✓  Created branch     ← origin/main
 ✓  Checked out branch
-✓  Created worktree   ../daft-652/cool-feature
+✓  Created worktree   daft-652/cool-feature
 ✓  Pushed             → origin/daft-652/cool-feature  (1.8s)
 │
 ├─ copied paths from 'main'
@@ -63,12 +63,14 @@ Color follows one grammar. State lives in the glyph (green done, bold-red
 failed, yellow attention, cyan spinner) and daft's own vocabulary stays plain,
 with section headings bold. Subjects wear identity inks that never change with
 state — so the committed plan is as readable as the receipt: remote names and
-refs (`origin`, `← origin/master`, `→ origin/x`) are cyan, worktree paths are
-manila, shared files are violet, and background work is blue. The exceptions are
-deliberate: hook job names take their outcome's color (the scheme the standalone
-hook renderer's summary also speaks), failure details and skip reasons always
-render plain, and a dimmed row — pending glyphs, expected skips, `(not run)` —
-never keeps an identity ink.
+refs (`origin`, `← origin/master`, `→ origin/x`) are cyan, paths are manila,
+shared files are violet, and background work is blue. A row whose subject is a
+worktree names it — the branch it is for, or a sandbox's directory name — and
+stays plain; manila is for rows whose subject really is a location. The
+exceptions are deliberate: hook job names take their outcome's color (the scheme
+the standalone hook renderer's summary also speaks), failure details and skip
+reasons always render plain, and a dimmed row — pending glyphs, expected skips,
+`(not run)` — never keeps an identity ink.
 
 - The rail opens the moment the command starts (after any pre-flight prompts) as
   a single collapsed line — the active spinner, the header's own text, and the

--- a/docs/reference/progress-timeline.md
+++ b/docs/reference/progress-timeline.md
@@ -63,14 +63,15 @@ Color follows one grammar. State lives in the glyph (green done, bold-red
 failed, yellow attention, cyan spinner) and daft's own vocabulary stays plain,
 with section headings bold. Subjects wear identity inks that never change with
 state — so the committed plan is as readable as the receipt: remote names and
-refs (`origin`, `← origin/master`, `→ origin/x`) are cyan, paths are manila,
-shared files are violet, and background work is blue. A row whose subject is a
-worktree names it — the branch it is for, or a sandbox's directory name — and
-stays plain; manila is for rows whose subject really is a location. The
-exceptions are deliberate: hook job names take their outcome's color (the scheme
-the standalone hook renderer's summary also speaks), failure details and skip
-reasons always render plain, and a dimmed row — pending glyphs, expected skips,
-`(not run)` — never keeps an identity ink.
+refs (`origin`, `← origin/master`, `→ origin/x`) are cyan, filesystem entities
+are manila, shared files are violet, and background work is blue. Manila types
+the entity rather than the spelling, so a row whose subject is a worktree wears
+it whether the row names that worktree — the branch it is for, or a sandbox's
+directory name — or spells the directory it occupies. The exceptions are
+deliberate: hook job names take their outcome's color (the scheme the standalone
+hook renderer's summary also speaks), failure details and skip reasons always
+render plain, and a dimmed row — pending glyphs, expected skips, `(not run)` —
+never keeps an identity ink.
 
 - The rail opens the moment the command starts (after any pre-flight prompts) as
   a single collapsed line — the active spinner, the header's own text, and the

--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -1004,7 +1004,7 @@ fn fork_stem(spelling: &str, commit: &str, git: &GitCommand) -> String {
             .map(|b| b.replace('/', "-"))
             .unwrap_or_else(|| sandbox::derived_dirname(commit))
     } else {
-        sandbox::sandbox_dirname(spelling).unwrap_or_else(|| sandbox::derived_dirname(commit))
+        sandbox::dirname_for(spelling, commit)
     }
 }
 
@@ -1728,9 +1728,9 @@ fn run_in_repo(
 
     let result = if let Some(commit) = sandbox_early {
         output.result(&format!(
-            "'{}' is not a branch; opening a detached sandbox at {}",
+            "'{}' is not a branch; opening detached sandbox '{}'",
             args.branch_name,
-            crate::core::worktree::sandbox::short_oid(&commit)
+            crate::core::worktree::sandbox::dirname_for(&args.branch_name, &commit)
         ));
         sandbox_entry(
             &args,
@@ -1809,9 +1809,9 @@ fn run_in_repo(
                 {
                     change_directory(&original_dir).ok();
                     output.result(&format!(
-                        "Branch '{branch}' not found; opening a detached sandbox at {} \
+                        "Branch '{branch}' not found; opening detached sandbox '{}' \
                          (use --start to create a branch named '{branch}')",
-                        crate::core::worktree::sandbox::short_oid(&commit)
+                        crate::core::worktree::sandbox::dirname_for(branch, &commit)
                     ));
                     sandbox_entry(&args, &branch.clone(), commit, &settings, &git, &mut output)
                 } else {
@@ -2395,8 +2395,7 @@ fn run_sandbox_visit(
         });
     }
 
-    let dirname =
-        sandbox::sandbox_dirname(spelling).unwrap_or_else(|| sandbox::derived_dirname(&commit));
+    let dirname = sandbox::dirname_for(spelling, &commit);
     let params = sandbox::SandboxParams {
         spelling: spelling.to_string(),
         commit,

--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -1726,11 +1726,14 @@ fn run_in_repo(
         None
     };
 
+    // Explains the reinterpretation; deliberately does not name the sandbox.
+    // Nothing here has resolved one yet — idempotence may land this visit in a
+    // sandbox another spelling of the same commit minted, under that name —
+    // and the rail's header on the very next line names it correctly (#813).
     let result = if let Some(commit) = sandbox_early {
         output.result(&format!(
-            "'{}' is not a branch; opening detached sandbox '{}'",
+            "'{}' is not a branch; opening a detached sandbox",
             args.branch_name,
-            crate::core::worktree::sandbox::dirname_for(&args.branch_name, &commit)
         ));
         sandbox_entry(
             &args,
@@ -1808,10 +1811,12 @@ fn run_in_repo(
                     && let Some(commit) = resolve_commitish(branch)
                 {
                     change_directory(&original_dir).ok();
+                    // Unnamed for the same reason as the early-sandbox arm
+                    // above: the rail's header names the worktree once the
+                    // visit has resolved which one it is.
                     output.result(&format!(
-                        "Branch '{branch}' not found; opening detached sandbox '{}' \
-                         (use --start to create a branch named '{branch}')",
-                        crate::core::worktree::sandbox::dirname_for(branch, &commit)
+                        "Branch '{branch}' not found; opening a detached sandbox \
+                         (use --start to create a branch named '{branch}')"
                     ));
                     sandbox_entry(&args, &branch.clone(), commit, &settings, &git, &mut output)
                 } else {
@@ -2422,14 +2427,13 @@ fn run_sandbox_visit(
     // (#813): `daft go <full-sha>` opens a worktree called `baddade`, and
     // seeding the spelling puts forty hex characters in the identity slot.
     // A sandbox visit never commits a plan, so this seed is the whole run —
-    // there is no `PlanCommit::header` replacement to correct it later. When
-    // the spelling *is* the dirname (a tag, an existing sandbox addressed by
-    // name) this resolves to the same string.
-    let mut timeline = Timeline::new(
-        TimelineMode::auto(output.is_quiet()),
-        output.is_verbose(),
-        format!("Opening {}", params.dirname),
-    );
+    // there is no `PlanCommit::header` replacement to correct it later, which
+    // is also why the seed asks where the visit will *land* rather than what a
+    // fresh sandbox would be called: one commit reached by two spellings has
+    // one sandbox, under whichever name minted it first.
+    let mode = TimelineMode::auto(output.is_quiet());
+    let header = sandbox::visit_header_name(&params, git, mode.renders_header());
+    let mut timeline = Timeline::new(mode, output.is_verbose(), format!("Opening {header}"));
     timeline.set_verbose_density(hook_output_config.verbose);
 
     timeline.open_planning();

--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -2419,10 +2419,17 @@ fn run_sandbox_visit(
     let hook_output_config = hooks_config.output.with_cli_verbose(output.is_verbose());
     let executor = HookExecutor::new(hooks_config)?.with_hook_mode(args.hooks, &args.skip_hooks);
 
+    // The header names the sandbox, not the spelling that summoned it
+    // (#813): `daft go <full-sha>` opens a worktree called `baddade`, and
+    // seeding the spelling puts forty hex characters in the identity slot.
+    // A sandbox visit never commits a plan, so this seed is the whole run —
+    // there is no `PlanCommit::header` replacement to correct it later. When
+    // the spelling *is* the dirname (a tag, an existing sandbox addressed by
+    // name) this resolves to the same string.
     let mut timeline = Timeline::new(
         TimelineMode::auto(output.is_quiet()),
         output.is_verbose(),
-        format!("Opening {spelling}"),
+        format!("Opening {}", params.dirname),
     );
     timeline.set_verbose_density(hook_output_config.verbose);
 

--- a/src/commands/completions/bash.rs
+++ b/src/commands/completions/bash.rs
@@ -1,9 +1,31 @@
 use super::{
-    allows_path_completion, command_has_repo_flag, command_has_repo_positional,
-    command_has_worktree_from_flag, emit_formats_for, extract_flags, get_command_for_name,
-    repo_flag_capture, uses_fetch_on_miss, uses_rich_completions, value_taking_flags,
+    allows_path_completion, command_has_hooks_flag, command_has_repo_flag,
+    command_has_repo_positional, command_has_worktree_from_flag, emit_formats_for, extract_flags,
+    get_command_for_name, repo_flag_capture, uses_fetch_on_miss, uses_rich_completions,
+    value_taking_flags,
 };
 use anyhow::{Context, Result};
+
+/// The `--hooks <MODE>` value block, shared by the plain and rich generators.
+///
+/// Both spell the current and previous words the same way (`$cur` / `$prev`,
+/// from `_init_completion`) at the same indent, so one string serves both — a
+/// second copy is how the two drift. The mode list is read from
+/// [`HookMode::variants`](crate::hooks::HookMode::variants) rather than spelled
+/// out; bash has no per-candidate description, so the glosses from
+/// `HookMode::describe` stay behind in zsh and Fig.
+fn hooks_mode_block() -> String {
+    let modes = crate::hooks::HookMode::variants().join(" ");
+    format!(
+        r#"    # Hook-mode value completion for --hooks
+    if [[ "$prev" == "--hooks" ]]; then
+        COMPREPLY=( $(compgen -W "{modes}" -- "$cur") )
+        return 0
+    fi
+
+"#
+    )
+}
 
 /// Generate bash completion string
 pub(super) fn generate_bash_completion_string(command_name: &str) -> Result<String> {
@@ -83,6 +105,11 @@ pub(super) fn generate_bash_completion_string(command_name: &str) -> Result<Stri
         output.push_str("        return 0\n");
         output.push_str("    fi\n");
         output.push('\n');
+    }
+
+    // Value completion for --hooks flag (the run's hook execution mode)
+    if command_has_hooks_flag(command_name) {
+        output.push_str(&hooks_mode_block());
     }
 
     // Value completion for --columns flag
@@ -384,12 +411,20 @@ fn generate_bash_rich_completion(command_name: &str) -> String {
         ""
     };
 
+    // …and its `--hooks` mode, from the same shared block the plain generator
+    // emits. Both sit before the `-*` branch: a flag value is not a flag.
+    let hooks_pre = if command_has_hooks_flag(command_name) {
+        hooks_mode_block()
+    } else {
+        String::new()
+    };
+
     let mut output = format!(
         r#"_{func_name}() {{
     local cur prev words cword
     {init_completion}
 
-{repo_flag_pre}{from_flag_pre}{skip_hooks_pre}    if [[ "$cur" == -* ]]; then
+{repo_flag_pre}{from_flag_pre}{skip_hooks_pre}{hooks_pre}    if [[ "$cur" == -* ]]; then
         local flags="{flags_joined}"
         COMPREPLY=( $(compgen -W "$flags" -- "$cur") )
         return 0
@@ -954,6 +989,13 @@ _daft() {
             local branches
             branches=$(git for-each-ref --format='%(refname:short)' refs/heads refs/remotes 2>/dev/null)
             COMPREPLY=( $(compgen -W "$branches" -- "$cur") )
+            return 0
+        fi
+        # --hooks mode values. Spelled out, not read from HookMode::variants():
+        # this const does not interpolate. `hooks_flag_offers_every_mode_in_every_shell`
+        # is what keeps the literal honest.
+        if [[ "$prev" == "--hooks" ]]; then
+            COMPREPLY=( $(compgen -W "auto foreground background off" -- "$cur") )
             return 0
         fi
         # --cleanup mode values

--- a/src/commands/completions/fig.rs
+++ b/src/commands/completions/fig.rs
@@ -318,6 +318,24 @@ pub(super) fn generate_fig_completion_string(command_name: &str) -> Result<Strin
                     suggestions: Some(suggestions),
                     template: None,
                 })
+            } else if long == "--hooks" {
+                // The standalone commands' half of what
+                // `hooks_option_suggestions_for_merge` guards by hand for
+                // `daft merge`. Fig is the one engine that shows a gloss
+                // beside each candidate, so it reads both halves of the enum's
+                // declaration.
+                Some(FigOptionArg {
+                    suggestions: Some(
+                        crate::hooks::HookMode::variants()
+                            .iter()
+                            .map(|mode| FigSuggestion {
+                                name: (*mode).to_string(),
+                                description: crate::hooks::HookMode::describe(mode).to_string(),
+                            })
+                            .collect(),
+                    ),
+                    template: None,
+                })
             } else if long == "--format" {
                 emit_formats_for(command_name).map(|formats| {
                     let suggestions = formats

--- a/src/commands/completions/fish.rs
+++ b/src/commands/completions/fish.rs
@@ -1,7 +1,7 @@
 use super::{
-    VERB_ALIAS_GROUPS, allows_path_completion, command_has_repo_positional, emit_formats_for,
-    get_command_for_name, get_flag_descriptions, uses_fetch_on_miss, uses_rich_completions,
-    value_taking_flags,
+    VERB_ALIAS_GROUPS, allows_path_completion, command_has_hooks_flag, command_has_repo_positional,
+    emit_formats_for, get_command_for_name, get_flag_descriptions, uses_fetch_on_miss,
+    uses_rich_completions, value_taking_flags,
 };
 use anyhow::{Context, Result};
 
@@ -347,14 +347,7 @@ fn generate_verb_alias_flag_completions() -> String {
 /// cannot interpolate, so `fish_merge_hooks_lists_every_mode` guards that copy
 /// instead.
 fn hooks_mode_completion(command_name: &str, git_subcommand: &str, is_git_command: bool) -> String {
-    if !matches!(
-        command_name,
-        "git-worktree-checkout"
-            | "daft-go"
-            | "daft-start"
-            | "git-worktree-clone"
-            | "git-worktree-flow-adopt"
-    ) {
+    if !command_has_hooks_flag(command_name) {
         return String::new();
     }
     let modes = crate::hooks::HookMode::variants().join(" ");

--- a/src/commands/completions/mod.rs
+++ b/src/commands/completions/mod.rs
@@ -163,6 +163,25 @@ pub(super) fn repo_flag_capture(command_name: &str) -> (&'static str, &'static s
     )
 }
 
+/// Whether a command carries a `--hooks <MODE>` flag whose value completes to
+/// [`HookMode::variants`](crate::hooks::HookMode::variants).
+///
+/// Derived from clap rather than a `matches!` list, unlike its neighbours
+/// here: the flag already sits on six commands and is meant to spread to any
+/// command that fires hooks, so a hand-kept list would be one more place to
+/// forget. Every generator asks this — a command that gains `--hooks` gains
+/// its value completion in all four shells with no completions edit at all.
+///
+/// `daft merge` cannot be answered here (its completions are hand-written per
+/// shell, not generated from a `Command`); `hooks_flag_offers_every_mode_in_every_shell`
+/// guards those copies instead.
+pub(super) fn command_has_hooks_flag(command_name: &str) -> bool {
+    get_command_for_name(command_name).is_some_and(|cmd| {
+        cmd.get_arguments()
+            .any(|arg| arg.get_long() == Some("hooks"))
+    })
+}
+
 /// Whether a command carries a `--from <worktree>` flag whose value completes
 /// to worktree names — the same candidate set as its positional, so both slots
 /// answer from the command's own `daft __complete` arm rather than a second
@@ -1608,20 +1627,98 @@ mod tests {
     }
 
     /// Every `--hooks` mode must be offered everywhere the flag is, in every
-    /// shell that hand-maintains its list.
+    /// shell — as *values*, not just as a flag name in a list.
     ///
-    /// The generated completions read `HookMode::variants()`, but two copies
-    /// cannot: `daft merge`'s fish line lives in the `DAFT_FISH_COMPLETIONS`
-    /// const, which does not interpolate, and `daft merge`'s Fig spec is
-    /// hand-written per option (only the standalone `git-worktree-*` commands
-    /// get theirs from `cmd.get_arguments()`). Those are exactly the copies
-    /// that go stale — the first cut of this test guarded only fish, and the
-    /// Fig spec had already shipped without the flag at all. Nothing else
-    /// catches it: no generator reads clap's `possible_values`, so a missing
-    /// mode simply never completes.
+    /// The generated completions read `HookMode::variants()`; the four
+    /// `daft merge` copies cannot. Its bash, zsh, and fish lines live in
+    /// `DAFT_*_COMPLETIONS` consts, which do not interpolate, and its Fig spec
+    /// is hand-written per option (only the standalone commands get theirs
+    /// from `cmd.get_arguments()`). Those are the copies that go stale — the
+    /// first cut of this test guarded fish alone, and both the Fig spec and
+    /// every bash and zsh script had already shipped with the flag completing
+    /// nothing. Nothing else catches it: no generator reads clap's
+    /// `possible_values`, so a missing value set is not silence but a wrong
+    /// answer — `daft go --hooks <TAB>` fell through to branch names.
+    ///
+    /// The two const arms are asserted inside a window cut to the merge block,
+    /// for the reason the Fig assertion goes through the built structure: a
+    /// whole-script search passes on some *other* command's `--hooks` block.
     #[test]
     fn hooks_flag_offers_every_mode_in_every_shell() {
         let modes = crate::hooks::HookMode::variants();
+        let space_separated = modes.join(" ");
+
+        // The generated scripts, per command that carries the flag.
+        for cmd in COMMANDS.iter().filter(|c| command_has_hooks_flag(c)) {
+            let bash = bash::generate_bash_completion_string(cmd)
+                .unwrap_or_else(|e| panic!("bash completion for {cmd}: {e}"));
+            assert!(
+                bash.contains(&format!(
+                    r#"if [[ "$prev" == "--hooks" ]]; then
+        COMPREPLY=( $(compgen -W "{space_separated}" -- "$cur") )"#
+                )),
+                "{cmd}'s bash script must complete --hooks values, not fall through \
+                 to the positional source"
+            );
+
+            let zsh = zsh::generate_zsh_completion_string(cmd)
+                .unwrap_or_else(|e| panic!("zsh completion for {cmd}: {e}"));
+            assert!(
+                zsh.contains("_describe 'hook mode' hook_modes"),
+                "{cmd}'s zsh script must complete --hooks values"
+            );
+            for mode in modes {
+                assert!(
+                    zsh.contains(&format!("'{mode}:")),
+                    "{cmd}'s zsh --hooks block is missing the `{mode}` mode"
+                );
+            }
+
+            // Fig: standalone specs are built from clap, so the assertion is
+            // that the enum reached the option — the shape Fig needs.
+            let fig = fig::generate_fig_completion_string(cmd)
+                .unwrap_or_else(|e| panic!("fig completion for {cmd}: {e}"));
+            for mode in modes {
+                assert!(
+                    fig.contains(&format!(r#""name": "{mode}""#)),
+                    "{cmd}'s Fig spec must suggest the `{mode}` mode for --hooks"
+                );
+            }
+        }
+
+        // `daft merge`'s two hand-written shell arms, each read inside its own
+        // block so a neighbour's `--hooks` cannot satisfy the search.
+        for (shell, script) in [
+            ("bash", bash::DAFT_BASH_COMPLETIONS),
+            ("zsh", zsh::DAFT_ZSH_COMPLETIONS),
+        ] {
+            let start = script
+                .find("# merge: flag + branch completion")
+                .unwrap_or_else(|| panic!("{shell} umbrella must carry a merge arm"));
+            let end = script[start..]
+                .find("# verb aliases:")
+                .map(|o| start + o)
+                .unwrap_or(script.len());
+            let merge_arm = &script[start..end];
+            let hooks_at = merge_arm.find(r#""--hooks" ]]; then"#).unwrap_or_else(|| {
+                panic!("daft merge's {shell} arm lists --hooks but completes no values")
+            });
+            // Narrowed again to the block's own body, because the modes are
+            // ordinary words: the window's opening comment says "not
+            // auto-generated", so a merge-arm-wide `contains("auto")` is true
+            // whether or not the flag completes anything — it passed against a
+            // deliberately gutted value list before this narrowing.
+            let body = &merge_arm[hooks_at..];
+            let body = &body[..body.find("fi\n").unwrap_or(body.len())];
+            for mode in modes {
+                assert!(
+                    body.contains(mode),
+                    "daft merge's {shell} arm is missing the `{mode}` mode; \
+                     update the literal in DAFT_{}_COMPLETIONS",
+                    shell.to_uppercase()
+                );
+            }
+        }
 
         // Fig: the hand-written `daft merge` subcommand spec. Asserted
         // against the built structure rather than the serialized string —
@@ -1637,29 +1734,54 @@ mod tests {
         );
 
         let fish = fish::generate_daft_fish_completions();
-        let expected = modes.join(" ");
         assert!(
             fish.contains(&format!(
-                "__fish_seen_subcommand_from merge worktree-merge' -l hooks -x -a '{expected}'"
+                "__fish_seen_subcommand_from merge worktree-merge' -l hooks -x -a '{space_separated}'"
             )),
             "the hand-written merge line must list every HookMode variant \
-             (expected '{expected}'); update DAFT_FISH_COMPLETIONS"
+             (expected '{space_separated}'); update DAFT_FISH_COMPLETIONS"
         );
 
-        for cmd in [
-            "git-worktree-checkout",
-            "daft-go",
-            "daft-start",
-            "git-worktree-clone",
-            "git-worktree-flow-adopt",
-        ] {
+        for cmd in COMMANDS.iter().filter(|c| command_has_hooks_flag(c)) {
             let script = fish::generate_fish_completion_string(cmd)
                 .unwrap_or_else(|e| panic!("fish completion for {cmd}: {e}"));
             assert!(
-                script.contains(&format!("-l hooks -x -a '{expected}'")),
+                script.contains(&format!("-l hooks -x -a '{space_separated}'")),
                 "{cmd} carries --hooks but does not complete its values"
             );
         }
+    }
+
+    /// The predicate every generator now asks must actually find the commands
+    /// that carry the flag. Deriving from clap removes the hand-kept list, but
+    /// it also removes the thing a reader can eyeball — so pin the set here:
+    /// a rename that makes `get_command_for_name` miss would otherwise turn
+    /// every assertion in `hooks_flag_offers_every_mode_in_every_shell` into a
+    /// loop over nothing, and vacuously pass.
+    #[test]
+    fn hooks_flag_predicate_finds_the_commands_that_carry_it() {
+        let carriers: Vec<&str> = COMMANDS
+            .iter()
+            .copied()
+            .filter(|c| command_has_hooks_flag(c))
+            .collect();
+        assert_eq!(
+            carriers,
+            vec![
+                "git-worktree-clone",
+                "git-worktree-checkout",
+                "git-worktree-flow-adopt",
+                "daft-go",
+                "daft-start",
+            ],
+            "the set of commands carrying --hooks changed; if a command gained \
+             the flag this is the only edit completions need, if one lost it \
+             check nothing else regressed"
+        );
+        assert!(
+            !command_has_hooks_flag("git-worktree-list"),
+            "a command without --hooks must not emit a value block"
+        );
     }
 
     /// The `warm` half of the umbrella dispatch (#387). The hardcoded shell

--- a/src/commands/completions/zsh.rs
+++ b/src/commands/completions/zsh.rs
@@ -1,9 +1,46 @@
 use super::{
-    allows_path_completion, command_has_repo_flag, command_has_repo_positional,
-    command_has_worktree_from_flag, emit_formats_for, extract_flags, get_command_for_name,
-    repo_flag_capture, uses_fetch_on_miss, uses_rich_completions, value_taking_flags,
+    allows_path_completion, command_has_hooks_flag, command_has_repo_flag,
+    command_has_repo_positional, command_has_worktree_from_flag, emit_formats_for, extract_flags,
+    get_command_for_name, repo_flag_capture, uses_fetch_on_miss, uses_rich_completions,
+    value_taking_flags,
 };
 use anyhow::{Context, Result};
+
+/// The `--hooks <MODE>` value block, shared by the plain and rich generators.
+///
+/// `prev_expr` is how the caller's script spells the word before the cursor —
+/// the two generators differ there (`$prev_word` vs an inline `words` index)
+/// and in nothing else, so one string serves both.
+///
+/// Unlike bash, zsh shows a gloss beside each candidate, so this reads both
+/// [`HookMode::variants`](crate::hooks::HookMode::variants) and
+/// [`HookMode::describe`](crate::hooks::HookMode::describe). The glosses are
+/// prose and contain apostrophes (`"Honor each job's own …"`), which would
+/// close the single-quoted `_describe` element early and emit a script that
+/// parses as something else entirely — so each is escaped `'` → `'\''`.
+/// A substring assertion cannot see that breakage; `zsh -n` over the emitted
+/// script can, which is what `test_completions.sh` runs.
+fn hooks_mode_block(prev_expr: &str) -> String {
+    let items: String = crate::hooks::HookMode::variants()
+        .iter()
+        .map(|mode| {
+            let gloss = crate::hooks::HookMode::describe(mode).replace('\'', r"'\''");
+            format!("            '{mode}:{gloss}'\n")
+        })
+        .collect();
+    format!(
+        r#"    # Hook-mode value completion for --hooks
+    if [[ "{prev_expr}" == "--hooks" ]]; then
+        local -a hook_modes
+        hook_modes=(
+{items}        )
+        _describe 'hook mode' hook_modes
+        return
+    fi
+
+"#
+    )
+}
 
 /// Generate zsh completion string
 pub(super) fn generate_zsh_completion_string(command_name: &str) -> Result<String> {
@@ -40,11 +77,18 @@ pub(super) fn generate_zsh_completion_string(command_name: &str) -> Result<Strin
             | "daft-start"
     );
 
+    // Value completion for --hooks flag (the run's hook execution mode)
+    let has_hooks = command_has_hooks_flag(command_name);
+
     // Value completion for --repo flag (catalog repo names)
     let has_repo_flag = command_has_repo_flag(command_name);
 
-    // Emit the prev_word variable once if any prev-based completion is needed
-    if has_branch_completions || has_layout || has_skip_hooks || has_repo_flag {
+    // Emit the prev_word variable once if any prev-based completion is needed.
+    // `has_hooks` earns its own term rather than riding on `has_skip_hooks`:
+    // the two travel together today, but a command that gains `--hooks` alone
+    // would emit a block reading an undeclared variable — which in zsh is
+    // empty, so the block silently never fires.
+    if has_branch_completions || has_layout || has_skip_hooks || has_hooks || has_repo_flag {
         output.push_str("    local prev_word=\"${words[$((CURRENT-1))]}\"\n");
     }
 
@@ -96,6 +140,10 @@ pub(super) fn generate_zsh_completion_string(command_name: &str) -> Result<Strin
         output.push_str("        return\n");
         output.push_str("    fi\n");
         output.push('\n');
+    }
+
+    if has_hooks {
+        output.push_str(&hooks_mode_block("$prev_word"));
     }
 
     // Value completion for --columns flag
@@ -341,6 +389,14 @@ fn generate_zsh_rich_completion(command_name: &str) -> String {
         ""
     };
 
+    // …and its `--hooks` mode, from the same shared block the plain generator
+    // emits. Both sit before the `-*` branch: a flag value is not a flag.
+    let hooks_pre = if command_has_hooks_flag(command_name) {
+        hooks_mode_block("${words[$((CURRENT-1))]}")
+    } else {
+        String::new()
+    };
+
     // Value completion for --repo flag (catalog repo names)
     let repo_flag_pre = if command_has_repo_flag(command_name) {
         "    if [[ \"${words[$((CURRENT-1))]}\" == \"--repo\" ]]; then\n        local -a repos\n        repos=( ${(f)\"$(daft __complete repo-name \"$curword\" 2>/dev/null | cut -f1)\"} )\n        (( ${#repos} )) && compadd -M 'm:{[:lower:][:upper:]}={[:upper:][:lower:]}' -- \"${repos[@]}\"\n        return\n    fi\n\n"
@@ -415,7 +471,7 @@ fn generate_zsh_rich_completion(command_name: &str) -> String {
 __{func_name}_impl() {{
     local curword="${{words[$CURRENT]}}"
 
-{repo_flag_pre}{from_flag_pre}{skip_hooks_pre}    if [[ "$curword" == -* ]]; then
+{repo_flag_pre}{from_flag_pre}{skip_hooks_pre}{hooks_pre}    if [[ "$curword" == -* ]]; then
         local -a flags
         flags=(
 {flags_block}        )
@@ -1152,6 +1208,14 @@ _daft() {
             local -a branches
             branches=(${(f)"$(git for-each-ref --format='%(refname:short)' refs/heads refs/remotes 2>/dev/null)"})
             compadd -a branches
+            return
+        fi
+        # --hooks mode values. Spelled out, not read from HookMode::variants():
+        # this const does not interpolate. `hooks_flag_offers_every_mode_in_every_shell`
+        # is what keeps the literal honest. Bare `compadd`, not the generators'
+        # `_describe` — a gloss here would have to carry its own escaping.
+        if [[ "$prev_word" == "--hooks" ]]; then
+            compadd auto foreground background off
             return
         fi
         # --cleanup values

--- a/src/commands/worktree_branch.rs
+++ b/src/commands/worktree_branch.rs
@@ -712,14 +712,11 @@ fn run_branch_delete(
     let hook_output_config = hooks_config.output.with_cli_verbose(output.is_verbose());
     let executor = HookExecutor::new(hooks_config)?;
 
-    // Plan-execute rail timeline (#651). This header is a seed built from
-    // raw args; the core replaces it at plan commit with the resolved
-    // targets (`daft remove .` → `Removing <branch>`, count as validated).
-    let header = if branches.len() == 1 {
-        format!("Removing {}", branches[0])
-    } else {
-        format!("Removing {} branches", branches.len())
-    };
+    // Plan-execute rail timeline (#651). The seed resolves a worktree-path
+    // shorthand to the branch it names (#813) so the first frame is already
+    // right — including on the paths that never commit a plan and so never
+    // reach the core's `PlanCommit::header` replacement.
+    let header = branch_delete::header_seed(&params);
     let mut timeline = Timeline::new(TimelineMode::auto(quiet), output.is_verbose(), header);
     timeline.set_verbose_density(hook_output_config.verbose);
     let interactive = timeline.is_interactive();

--- a/src/commands/worktree_branch.rs
+++ b/src/commands/worktree_branch.rs
@@ -715,9 +715,11 @@ fn run_branch_delete(
     // Plan-execute rail timeline (#651). The seed resolves a worktree-path
     // shorthand to the branch it names (#813) so the first frame is already
     // right — including on the paths that never commit a plan and so never
-    // reach the core's `PlanCommit::header` replacement.
-    let header = branch_delete::header_seed(&params);
-    let mut timeline = Timeline::new(TimelineMode::auto(quiet), output.is_verbose(), header);
+    // reach the core's `PlanCommit::header` replacement. Only the live
+    // region draws a header, so a non-TTY run skips the resolution probe.
+    let mode = TimelineMode::auto(quiet);
+    let header = branch_delete::header_seed(&params, mode.renders_header());
+    let mut timeline = Timeline::new(mode, output.is_verbose(), header);
     timeline.set_verbose_density(hook_output_config.verbose);
     let interactive = timeline.is_interactive();
 

--- a/src/core/stage.rs
+++ b/src/core/stage.rs
@@ -273,9 +273,15 @@ impl StepSpec {
 #[derive(Clone, PartialEq, Eq, Debug, Default)]
 pub struct PlanCommit {
     /// Optional resolved replacement for the header text seeded at
-    /// `Timeline::new`. The seed is built by the command layer from raw
-    /// args; a core sets this when resolution improves on it (`daft remove
-    /// .` resolves the worktree-path shorthand to its branch name).
+    /// `Timeline::new`. A core sets this when execution learns something the
+    /// seed could not: a wildcard expanding to N sandboxes, or validation
+    /// dropping targets so the count shrinks.
+    ///
+    /// Not for resolving the *spelling* of a target — the command layer does
+    /// that before it seeds (#813), because a replacement only ever lands on
+    /// the runs that commit a plan, and the runs that don't (validation
+    /// failure, early exit) are exactly where a header naming the wrong
+    /// thing does the most damage.
     pub header: Option<String>,
     /// Optional annotation appended to the timeline header (e.g. `← master`
     /// once the base branch is resolved). The header text itself is seeded

--- a/src/core/stage.rs
+++ b/src/core/stage.rs
@@ -44,6 +44,15 @@ pub enum StageId {
     CreateBranch,
     /// Materialize the branch checkout (both journeys).
     CheckOut,
+    /// Materialize a *detached* checkout: the sandbox journey
+    /// (`daft go <commit-ish>`, `daft start --fork`), which pins HEAD to a
+    /// commit and never touches a branch.
+    ///
+    /// Its own id rather than a [`StepSpec::with_label`] override on
+    /// [`Self::CheckOut`], because an override is one fixed string across
+    /// every face and this row still needs its tenses — "Checking out
+    /// commit" while it runs, "Checked out commit" once it has (#813).
+    CheckOutDetached,
     /// Create the worktree directory.
     CreateWorktree,
     /// Push the new branch and set upstream (`daft start`).

--- a/src/core/worktree/branch_delete.rs
+++ b/src/core/worktree/branch_delete.rs
@@ -1323,30 +1323,41 @@ fn validate_branches(
             continue;
         }
 
-        // Check 1: Branch exists locally
+        // Check 1: Branch exists locally.
+        //
+        // A path-shaped argument only reaches here because it matched no
+        // worktree, so git is being asked about `refs/heads/../feat/nope`.
+        // Which arm that lands in is a *backend* detail, not a user-visible
+        // distinction: gitoxide rejects the malformed refname and errors,
+        // `git show-ref` simply finds nothing and answers no. Both mean the
+        // same thing to the person who typed a path, so both say it — telling
+        // them "branch not found" about `../feature/nope` calls their path a
+        // branch, which is the mislabel this whole change exists to remove.
+        let path_shaped_miss = || "no worktree at that path, and not a valid branch name";
         match ctx.git.show_ref_exists(&format!("refs/heads/{branch}")) {
             Ok(true) => {}
             Ok(false) => {
                 errors.push(ValidationError {
                     branch: branch.clone(),
-                    message: "branch not found".to_string(),
+                    message: if looks_like_path(branch) {
+                        path_shaped_miss().to_string()
+                    } else {
+                        "branch not found".to_string()
+                    },
                 });
                 continue;
             }
             Err(e) => {
                 errors.push(ValidationError {
                     branch: branch.clone(),
-                    // A path-shaped argument only reaches here because it
-                    // matched no worktree, so git is being asked about
-                    // `refs/heads/../feat/nope` and answers with a refname
-                    // complaint. Lead with the miss the user made rather than
-                    // the plumbing failure it turned into — but keep git's own
+                    // Lead with the miss the user made rather than the
+                    // plumbing failure it turned into — but keep git's own
                     // words in a trailing clause: `show_ref_exists` also fails
                     // when git cannot be spawned or the repo is locked, and
                     // there the headline is an assertion about the spelling
                     // that was never actually tested.
                     message: if looks_like_path(branch) {
-                        format!("no worktree at that path, and not a valid branch name (git: {e})")
+                        format!("{} (git: {e})", path_shaped_miss())
                     } else {
                         format!("failed to check if branch exists: {e}")
                     },

--- a/src/core/worktree/branch_delete.rs
+++ b/src/core/worktree/branch_delete.rs
@@ -401,8 +401,11 @@ fn build_plan(
     hook_rows: &HookRowPlan,
 ) -> PlanCommit {
     let multi = exec_order.len() > 1;
-    // Replace the seeded header: raw args may be worktree-path shorthands
-    // (`daft remove .`), and the count can shrink during validation.
+    // Replace the seeded header with what validation actually settled on.
+    // The seed already resolves a path shorthand to its branch (#813), so
+    // this is a no-op for the plain single-target case; it earns its keep
+    // when the *count* moves — a wildcard expanding to N sandboxes, or
+    // validation dropping targets down to one.
     let header = if multi {
         format!("Removing {} branches", exec_order.len())
     } else {
@@ -512,6 +515,72 @@ pub(crate) fn display_path(path: &Path) -> String {
         .map(|rel| rel.display().to_string())
         .map(|rel| if rel.is_empty() { ".".to_string() } else { rel })
         .unwrap_or_else(|| path.display().to_string())
+}
+
+// ── Header seed ────────────────────────────────────────────────────────────
+
+/// The rail header for a removal, resolved before the rail opens (#813).
+///
+/// The rail's header carries *identity* — what is being acted on — while the
+/// annotation column beside each step carries *location*. A seed built from
+/// raw args alone puts a path in the identity slot, so `daft remove .`
+/// announces that it is removing `.`, which names nothing the user
+/// recognizes. Resolving here means the first frame already reads
+/// `Removing feat/thing`, and the annotation still reads `.` — the two
+/// together say "the thing at `.` is feat/thing" without narrating it.
+///
+/// It also keeps the header agreeing with the text below it on the paths
+/// that never commit a plan. A dirty worktree aborts with
+/// `cannot delete 'feat/thing': has uncommitted changes` while the seed is
+/// the only line still on screen; a header reading `.` (or a bare count)
+/// disagrees with that error, and no later replacement can fix it because
+/// [`PlanCommit::header`] only lands when a plan commits.
+///
+/// Multi-target keeps its count form: a count is true from raw args and
+/// stays true, and the committed plan names each branch on its own group
+/// row.
+pub fn header_seed(params: &BranchDeleteParams) -> String {
+    match params.branches.as_slice() {
+        [only] => format!(
+            "Removing {}",
+            display_identity(only, params.use_gitoxide, params.is_quiet)
+        ),
+        rest => format!("Removing {} branches", rest.len()),
+    }
+}
+
+/// The identity to render for one raw removal argument.
+///
+/// Display-only and best-effort by construction: it returns a `String` for
+/// rendering, never a target, so it cannot change which entity gets removed
+/// — [`resolve_branch_args`] alone decides that. Anything it fails to
+/// resolve comes back as the user's own spelling, which is what the
+/// validation error will echo too: replacing an unresolvable `../typo` with
+/// a guess is worse than showing a path.
+fn display_identity(arg: &str, use_gitoxide: bool, quiet: bool) -> String {
+    let verbatim = || arg.to_string();
+    let (Ok(project_root), Ok(git_dir)) = (get_project_root(), get_git_common_dir()) else {
+        return verbatim();
+    };
+    let git = GitCommand::new(quiet).with_gitoxide(use_gitoxide);
+    let Ok(entries) = parse_worktree_list(&git) else {
+        return verbatim();
+    };
+
+    match resolve_single_arg(arg, &entries, &project_root) {
+        ResolveResult::Branch(name) => name,
+        // A daft sandbox has no branch, so its dirname is its identity. A
+        // detached worktree daft has no record of keeps the user's spelling:
+        // the removal refuses it either way, and the refusal quotes the path.
+        ResolveResult::DetachedHead(path) => {
+            let identities = crate::core::worktree::identity_store::read_identities(&git_dir);
+            sandbox_target_by_path(&path, &identities)
+                .map_or_else(verbatim, |target| target.dirname)
+        }
+        // A branch name, a sandbox dirname, or a path that matched nothing.
+        // All three are already the best spelling available here.
+        ResolveResult::PassThrough => verbatim(),
+    }
 }
 
 // ── Argument resolution ────────────────────────────────────────────────────
@@ -2577,6 +2646,39 @@ mod tests {
         let b = branch("feat-y");
         let plan = build_plan(&[&a, &b], &params, &all_hook_rows(2));
         assert_eq!(plan.header.as_deref(), Some("Removing 2 branches"));
+    }
+
+    /// #813: multi-target keeps the count form, and it is reachable without
+    /// touching a repo — the seed only resolves when there is exactly one
+    /// argument to resolve. The single-target spellings are covered where
+    /// they actually render, in `tests/integration/test_branch_delete.sh`.
+    #[test]
+    fn header_seed_keeps_the_count_form_for_multiple_targets() {
+        let params = |branches: Vec<String>| BranchDeleteParams {
+            branches,
+            force: false,
+            use_gitoxide: false,
+            is_quiet: true,
+            remote_name: "origin".to_string(),
+            delete_remote: false,
+            remote_only: false,
+            keep_local_branch: false,
+            no_verify: false,
+            push_verify: crate::settings::PushVerify::Auto,
+            prune_cd_target: crate::settings::PruneCdTarget::Root,
+            command_label: "branch-delete".to_string(),
+            skip_merge_validation: false,
+            force_flag_label: "-D/--force".to_string(),
+        };
+
+        assert_eq!(
+            header_seed(&params(vec![".".into(), "feat-y".into()])),
+            "Removing 2 branches"
+        );
+        assert_eq!(
+            header_seed(&params(vec!["a".into(), "b".into(), "c".into()])),
+            "Removing 3 branches"
+        );
     }
 
     #[test]

--- a/src/core/worktree/branch_delete.rs
+++ b/src/core/worktree/branch_delete.rs
@@ -539,12 +539,18 @@ pub(crate) fn display_path(path: &Path) -> String {
 /// Multi-target keeps its count form: a count is true from raw args and
 /// stays true, and the committed plan names each branch on its own group
 /// row.
-pub fn header_seed(params: &BranchDeleteParams) -> String {
+///
+/// `resolve` is the caller's answer to "will this header be drawn?"
+/// ([`TimelineMode::renders_header`]). Only the live region draws it, so a
+/// non-TTY removal — a script, a hook, CI — skips the `git worktree list`
+/// the resolution costs and keeps the raw spelling nobody will read.
+pub fn header_seed(params: &BranchDeleteParams, resolve: bool) -> String {
     match params.branches.as_slice() {
-        [only] => format!(
+        [only] if resolve => format!(
             "Removing {}",
             display_identity(only, params.use_gitoxide, params.is_quiet)
         ),
+        [only] => format!("Removing {only}"),
         rest => format!("Removing {} branches", rest.len()),
     }
 }
@@ -2692,14 +2698,23 @@ mod tests {
             force_flag_label: "-D/--force".to_string(),
         };
 
-        assert_eq!(
-            header_seed(&params(vec![".".into(), "feat-y".into()])),
-            "Removing 2 branches"
-        );
-        assert_eq!(
-            header_seed(&params(vec!["a".into(), "b".into(), "c".into()])),
-            "Removing 3 branches"
-        );
+        // `resolve` is a perf gate on the single-target arm only: a count
+        // never consults the filesystem, so both settings must agree.
+        for resolve in [true, false] {
+            assert_eq!(
+                header_seed(&params(vec![".".into(), "feat-y".into()]), resolve),
+                "Removing 2 branches"
+            );
+            assert_eq!(
+                header_seed(&params(vec!["a".into(), "b".into(), "c".into()]), resolve),
+                "Removing 3 branches"
+            );
+        }
+
+        // With resolution off — the non-TTY path, where no header is drawn —
+        // a single target keeps the raw spelling rather than paying for a
+        // `git worktree list` nobody reads.
+        assert_eq!(header_seed(&params(vec![".".into()]), false), "Removing .");
     }
 
     /// The path classifier gates a *diagnosis*, so a false positive would

--- a/src/core/worktree/branch_delete.rs
+++ b/src/core/worktree/branch_delete.rs
@@ -443,7 +443,7 @@ fn build_plan(
         }
         if let Some(ref wt) = branch.worktree_path {
             rows.push(Row::Step(
-                StepSpec::new(key(StageId::RemoveWorktree)).with_annotation(display_path(wt)),
+                StepSpec::new(key(StageId::RemoveWorktree)).with_annotation(doomed_path(wt)),
             ));
         }
         if !params.remote_only && !params.keep_local_branch && !branch.worktree_only {
@@ -517,6 +517,36 @@ pub(crate) fn display_path(path: &Path) -> String {
         .unwrap_or_else(|| path.display().to_string())
 }
 
+/// Path annotation for the row that *removes* a worktree (#813).
+///
+/// [`display_path`]'s relative spelling is the wrong tool here whenever the
+/// cwd sits inside the doomed directory — the common case, since
+/// `daft remove .` is how you delete the worktree you are standing in. A
+/// relative path is only meaningful while its anchor exists, and this row's
+/// anchor is what the row destroys: `.` (or `..` from a subdirectory) names
+/// a *different* directory by the time the rail closes and the shell has
+/// cd'd out. It also names nothing the user recognizes on the way past.
+///
+/// Absolute, `~`-abbreviated, is true before and after. Every other position
+/// keeps the relative spelling, which stays true and stays short.
+fn doomed_path(worktree: &Path) -> String {
+    doomed_spelling(
+        worktree,
+        std::env::current_dir().ok().as_deref(),
+        display_path(worktree),
+    )
+}
+
+/// The choice itself, with the cwd handed in — the process-global one makes
+/// this untestable in a shared test binary.
+fn doomed_spelling(worktree: &Path, cwd: Option<&Path>, relative: String) -> String {
+    if cwd.is_some_and(|cwd| cwd.starts_with(worktree)) || relative == "." {
+        crate::output::format::tilde_path(&worktree.display().to_string())
+    } else {
+        relative
+    }
+}
+
 // ── Header seed ────────────────────────────────────────────────────────────
 
 /// The rail header for a removal, resolved before the rail opens (#813).
@@ -526,8 +556,9 @@ pub(crate) fn display_path(path: &Path) -> String {
 /// raw args alone puts a path in the identity slot, so `daft remove .`
 /// announces that it is removing `.`, which names nothing the user
 /// recognizes. Resolving here means the first frame already reads
-/// `Removing feat/thing`, and the annotation still reads `.` — the two
-/// together say "the thing at `.` is feat/thing" without narrating it.
+/// `Removing feat/thing`, with the location spelled out beside the row that
+/// removes it ([`doomed_path`]) — the two together say "feat/thing, the one
+/// at ~/code/repo/feat/thing" without narrating it.
 ///
 /// It also keeps the header agreeing with the text below it on the paths
 /// that never commit a plan. A dirty worktree aborts with
@@ -2715,6 +2746,41 @@ mod tests {
         // a single target keeps the raw spelling rather than paying for a
         // `git worktree list` nobody reads.
         assert_eq!(header_seed(&params(vec![".".into()]), false), "Removing .");
+    }
+
+    /// #813: a relative path is only true while its anchor exists, and this
+    /// row's anchor is what the row deletes. Standing anywhere inside the
+    /// doomed worktree must spell it out; standing outside keeps the short
+    /// relative form, which survives the removal.
+    #[test]
+    fn doomed_path_spells_out_the_worktree_the_cwd_stands_in() {
+        let wt = Path::new("/repo/feat/x");
+
+        // The worktree itself, and a subdirectory of it — `.` and `..` both
+        // point somewhere else once the shell is cd'd out.
+        for cwd in ["/repo/feat/x", "/repo/feat/x/src/deep"] {
+            assert_eq!(
+                doomed_spelling(wt, Some(Path::new(cwd)), ".".to_string()),
+                "/repo/feat/x",
+                "cwd {cwd} is inside the doomed worktree"
+            );
+        }
+
+        // A sibling name must not trip the prefix check: `/repo/feat/xy` is
+        // not inside `/repo/feat/x`.
+        assert_eq!(
+            doomed_spelling(wt, Some(Path::new("/repo/feat/xy")), "../x".to_string()),
+            "../x"
+        );
+
+        // Standing outside: the relative spelling stays.
+        assert_eq!(
+            doomed_spelling(wt, Some(Path::new("/repo/main")), "../feat/x".to_string()),
+            "../feat/x"
+        );
+
+        // No cwd at all (a deleted cwd): the `.` fallback still catches it.
+        assert_eq!(doomed_spelling(wt, None, ".".to_string()), "/repo/feat/x");
     }
 
     /// The path classifier gates a *diagnosis*, so a false positive would

--- a/src/core/worktree/branch_delete.rs
+++ b/src/core/worktree/branch_delete.rs
@@ -441,9 +441,13 @@ fn build_plan(
                 StepSpec::new(key(StageId::DeleteRemote)).with_annotation(annotation),
             ));
         }
-        if let Some(ref wt) = branch.worktree_path {
+        // The row's subject is the worktree its label names, not the
+        // directory it occupied (#813) — `branch.name` is the branch for a
+        // branch worktree and the directory name for a sandbox, which is
+        // exactly the identity each answers to.
+        if branch.worktree_path.is_some() {
             rows.push(Row::Step(
-                StepSpec::new(key(StageId::RemoveWorktree)).with_annotation(doomed_path(wt)),
+                StepSpec::new(key(StageId::RemoveWorktree)).with_annotation(branch.name.clone()),
             ));
         }
         if !params.remote_only && !params.keep_local_branch && !branch.worktree_only {
@@ -517,48 +521,16 @@ pub(crate) fn display_path(path: &Path) -> String {
         .unwrap_or_else(|| path.display().to_string())
 }
 
-/// Path annotation for the row that *removes* a worktree (#813).
-///
-/// [`display_path`]'s relative spelling is the wrong tool here whenever the
-/// cwd sits inside the doomed directory — the common case, since
-/// `daft remove .` is how you delete the worktree you are standing in. A
-/// relative path is only meaningful while its anchor exists, and this row's
-/// anchor is what the row destroys: `.` (or `..` from a subdirectory) names
-/// a *different* directory by the time the rail closes and the shell has
-/// cd'd out. It also names nothing the user recognizes on the way past.
-///
-/// Absolute, `~`-abbreviated, is true before and after. Every other position
-/// keeps the relative spelling, which stays true and stays short.
-fn doomed_path(worktree: &Path) -> String {
-    doomed_spelling(
-        worktree,
-        std::env::current_dir().ok().as_deref(),
-        display_path(worktree),
-    )
-}
-
-/// The choice itself, with the cwd handed in — the process-global one makes
-/// this untestable in a shared test binary.
-fn doomed_spelling(worktree: &Path, cwd: Option<&Path>, relative: String) -> String {
-    if cwd.is_some_and(|cwd| cwd.starts_with(worktree)) || relative == "." {
-        crate::output::format::tilde_path(&worktree.display().to_string())
-    } else {
-        relative
-    }
-}
-
 // ── Header seed ────────────────────────────────────────────────────────────
 
 /// The rail header for a removal, resolved before the rail opens (#813).
 ///
-/// The rail's header carries *identity* — what is being acted on — while the
-/// annotation column beside each step carries *location*. A seed built from
-/// raw args alone puts a path in the identity slot, so `daft remove .`
+/// The rail's header carries *identity* — what is being acted on. A seed
+/// built from raw args alone puts a path in that slot, so `daft remove .`
 /// announces that it is removing `.`, which names nothing the user
 /// recognizes. Resolving here means the first frame already reads
-/// `Removing feat/thing`, with the location spelled out beside the row that
-/// removes it ([`doomed_path`]) — the two together say "feat/thing, the one
-/// at ~/code/repo/feat/thing" without narrating it.
+/// `Removing feat/thing`, matching the row that removes it and the error
+/// that may replace them both.
 ///
 /// It also keeps the header agreeing with the text below it on the paths
 /// that never commit a plan. A dirty worktree aborts with
@@ -2746,41 +2718,6 @@ mod tests {
         // a single target keeps the raw spelling rather than paying for a
         // `git worktree list` nobody reads.
         assert_eq!(header_seed(&params(vec![".".into()]), false), "Removing .");
-    }
-
-    /// #813: a relative path is only true while its anchor exists, and this
-    /// row's anchor is what the row deletes. Standing anywhere inside the
-    /// doomed worktree must spell it out; standing outside keeps the short
-    /// relative form, which survives the removal.
-    #[test]
-    fn doomed_path_spells_out_the_worktree_the_cwd_stands_in() {
-        let wt = Path::new("/repo/feat/x");
-
-        // The worktree itself, and a subdirectory of it — `.` and `..` both
-        // point somewhere else once the shell is cd'd out.
-        for cwd in ["/repo/feat/x", "/repo/feat/x/src/deep"] {
-            assert_eq!(
-                doomed_spelling(wt, Some(Path::new(cwd)), ".".to_string()),
-                "/repo/feat/x",
-                "cwd {cwd} is inside the doomed worktree"
-            );
-        }
-
-        // A sibling name must not trip the prefix check: `/repo/feat/xy` is
-        // not inside `/repo/feat/x`.
-        assert_eq!(
-            doomed_spelling(wt, Some(Path::new("/repo/feat/xy")), "../x".to_string()),
-            "../x"
-        );
-
-        // Standing outside: the relative spelling stays.
-        assert_eq!(
-            doomed_spelling(wt, Some(Path::new("/repo/main")), "../feat/x".to_string()),
-            "../feat/x"
-        );
-
-        // No cwd at all (a deleted cwd): the `.` fallback still catches it.
-        assert_eq!(doomed_spelling(wt, None, ".".to_string()), "/repo/feat/x");
     }
 
     /// The path classifier gates a *diagnosis*, so a false positive would

--- a/src/core/worktree/branch_delete.rs
+++ b/src/core/worktree/branch_delete.rs
@@ -1339,11 +1339,14 @@ fn validate_branches(
                     // A path-shaped argument only reaches here because it
                     // matched no worktree, so git is being asked about
                     // `refs/heads/../feat/nope` and answers with a refname
-                    // complaint. Report the miss the user made rather than
-                    // the plumbing failure it turned into; a genuine git
-                    // failure on a real branch name keeps the raw detail.
+                    // complaint. Lead with the miss the user made rather than
+                    // the plumbing failure it turned into — but keep git's own
+                    // words in a trailing clause: `show_ref_exists` also fails
+                    // when git cannot be spawned or the repo is locked, and
+                    // there the headline is an assertion about the spelling
+                    // that was never actually tested.
                     message: if looks_like_path(branch) {
-                        "no worktree at that path, and not a valid branch name".to_string()
+                        format!("no worktree at that path, and not a valid branch name (git: {e})")
                     } else {
                         format!("failed to check if branch exists: {e}")
                     },

--- a/src/core/worktree/branch_delete.rs
+++ b/src/core/worktree/branch_delete.rs
@@ -728,6 +728,17 @@ fn is_wildcard_pattern(arg: &str) -> bool {
     arg.contains(['*', '?'])
 }
 
+/// True when `arg` reads as a filesystem path rather than a branch name.
+///
+/// Deliberately narrow: only the leading spellings git forbids in a refname
+/// (`.`, `..`, a leading slash) qualify, so this can never reclassify a
+/// legitimate branch. A bare `feat/thing` stays a branch name here even
+/// though [`resolve_single_arg`] would also try it as a directory —
+/// misjudging that direction would replace a real git error with a guess.
+fn looks_like_path(arg: &str) -> bool {
+    matches!(arg, "." | "..") || ["/", "./", "../"].iter().any(|p| arg.starts_with(p))
+}
+
 /// Glob-style match over a whole name: `*` matches any run of characters
 /// (including none), `?` matches exactly one, everything else is literal.
 fn wildcard_match(pattern: &str, text: &str) -> bool {
@@ -1316,7 +1327,17 @@ fn validate_branches(
             Err(e) => {
                 errors.push(ValidationError {
                     branch: branch.clone(),
-                    message: format!("failed to check if branch exists: {e}"),
+                    // A path-shaped argument only reaches here because it
+                    // matched no worktree, so git is being asked about
+                    // `refs/heads/../feat/nope` and answers with a refname
+                    // complaint. Report the miss the user made rather than
+                    // the plumbing failure it turned into; a genuine git
+                    // failure on a real branch name keeps the raw detail.
+                    message: if looks_like_path(branch) {
+                        "no worktree at that path, and not a valid branch name".to_string()
+                    } else {
+                        format!("failed to check if branch exists: {e}")
+                    },
                 });
                 continue;
             }
@@ -2679,6 +2700,27 @@ mod tests {
             header_seed(&params(vec!["a".into(), "b".into(), "c".into()])),
             "Removing 3 branches"
         );
+    }
+
+    /// The path classifier gates a *diagnosis*, so a false positive would
+    /// replace a real git failure with a wrong explanation. Only the
+    /// spellings git forbids in a refname may qualify.
+    #[test]
+    fn looks_like_path_never_claims_a_branch_name() {
+        for arg in [".", "..", "./x", "../feat/nope", "/abs/path"] {
+            assert!(looks_like_path(arg), "{arg} should read as a path");
+        }
+        for arg in [
+            "feat/thing",
+            "main",
+            "release-2",
+            "feat.x",
+            "v1.2.3",
+            "main-fork*",
+            "a..b",
+        ] {
+            assert!(!looks_like_path(arg), "{arg} should read as a branch name");
+        }
     }
 
     #[test]

--- a/src/core/worktree/checkout.rs
+++ b/src/core/worktree/checkout.rs
@@ -444,9 +444,11 @@ pub fn execute(
     plan_rows.extend([
         Row::Step(StepSpec::new(StepKey::new(StageId::PreCreateHooks))),
         Row::Step(checkout_spec),
+        // The row's subject is the worktree its label names — the branch it
+        // is for, not the directory it occupies (#813).
         Row::Step(
             StepSpec::new(StepKey::new(StageId::CreateWorktree))
-                .with_annotation(super::branch_delete::display_path(&worktree_path)),
+                .with_annotation(params.branch_name.clone()),
         ),
     ]);
     if should_carry {

--- a/src/core/worktree/checkout_branch.rs
+++ b/src/core/worktree/checkout_branch.rs
@@ -146,9 +146,11 @@ pub fn execute(
         Row::Step(StepSpec::new(StepKey::new(StageId::PreCreateHooks))),
         Row::Step(StepSpec::new(StepKey::new(StageId::CreateBranch))),
         Row::Step(StepSpec::new(StepKey::new(StageId::CheckOut))),
+        // The row's subject is the worktree its label names — the branch it
+        // is for, not the directory it occupies (#813).
         Row::Step(
             StepSpec::new(StepKey::new(StageId::CreateWorktree))
-                .with_annotation(super::branch_delete::display_path(&worktree_path)),
+                .with_annotation(params.new_branch_name.clone()),
         ),
     ]);
     if should_carry {

--- a/src/core/worktree/sandbox.rs
+++ b/src/core/worktree/sandbox.rs
@@ -156,6 +156,17 @@ pub fn sandbox_dirname(spelling: &str) -> Option<String> {
     Some(spelling.replace('/', "-"))
 }
 
+/// The directory a sandbox for `spelling` at `commit` will occupy: the name
+/// the spelling earns, or a hex prefix of the commit when it earns none.
+///
+/// One helper so every render site names the sandbox the same way (#813).
+/// Spelling it out per call site is how `daft go <full-sha>` came to narrate
+/// three names for one worktree — the 40-char spelling, a 7-char
+/// [`short_oid`], and the 12-char directory it actually made.
+pub fn dirname_for(spelling: &str, commit: &str) -> String {
+    sandbox_dirname(spelling).unwrap_or_else(|| derived_dirname(commit))
+}
+
 /// Visit the canonical sandbox for `params.commit`: navigate to it if it
 /// exists, materialize it otherwise. The `daft go <commit-ish>` engine.
 pub fn execute_visit(

--- a/src/core/worktree/sandbox.rs
+++ b/src/core/worktree/sandbox.rs
@@ -351,9 +351,11 @@ fn create_sandbox(
         Row::Step(
             StepSpec::new(StepKey::new(StageId::CheckOutDetached)).with_annotation(annotation),
         ),
+        // A sandbox has no branch, so its name is its directory name — the
+        // identity it answers to in `list`, `go` and `remove` (#813).
         Row::Step(
             StepSpec::new(StepKey::new(StageId::CreateWorktree))
-                .with_annotation(super::branch_delete::display_path(&worktree_path)),
+                .with_annotation(params.dirname.clone()),
         ),
     ];
     if should_carry {

--- a/src/core/worktree/sandbox.rs
+++ b/src/core/worktree/sandbox.rs
@@ -348,7 +348,9 @@ fn create_sandbox(
     };
     let mut plan_rows = vec![
         Row::Step(StepSpec::new(StepKey::new(StageId::PreCreateHooks))),
-        Row::Step(StepSpec::new(StepKey::new(StageId::CheckOut)).with_annotation(annotation)),
+        Row::Step(
+            StepSpec::new(StepKey::new(StageId::CheckOutDetached)).with_annotation(annotation),
+        ),
         Row::Step(
             StepSpec::new(StepKey::new(StageId::CreateWorktree))
                 .with_annotation(super::branch_delete::display_path(&worktree_path)),
@@ -434,10 +436,13 @@ fn create_sandbox(
         return Err(anyhow::anyhow!("Pre-create hook failed"));
     }
 
-    sink.on_stage(&StepKey::new(StageId::CheckOut), StageEvent::Started);
+    sink.on_stage(
+        &StepKey::new(StageId::CheckOutDetached),
+        StageEvent::Started,
+    );
     if let Err(e) = git.worktree_add_detached(&worktree_path, &params.commit) {
         sink.on_stage(
-            &StepKey::new(StageId::CheckOut),
+            &StepKey::new(StageId::CheckOutDetached),
             StageEvent::Failed {
                 detail: "failed (see below)".to_string(),
             },
@@ -446,7 +451,7 @@ fn create_sandbox(
         return Err(anyhow::anyhow!("Failed to create git worktree: {e}"));
     }
     sink.on_stage(
-        &StepKey::new(StageId::CheckOut),
+        &StepKey::new(StageId::CheckOutDetached),
         StageEvent::Completed { annotation: None },
     );
 

--- a/src/core/worktree/sandbox.rs
+++ b/src/core/worktree/sandbox.rs
@@ -176,9 +176,65 @@ pub fn execute_visit(
     sink: &mut (impl ProgressSink + HookRunner),
 ) -> Result<SandboxResult> {
     let git_dir = crate::core::repo::get_git_common_dir()?;
+    let resolution = resolve_visit(params, git, &git_dir)?;
 
+    // Records whose worktree is gone (removed outside daft), dropped so the
+    // next visit rebuilds cleanly. The resolution reports them rather than
+    // forgetting them itself, so the read-only header probe can share it.
+    for id in &resolution.stale_ids {
+        if let Some(store) = super::identity_store::IdentityStore::open(&git_dir) {
+            store.forget_id(id);
+        }
+    }
+
+    match resolution.target {
+        Some(target) => navigate(
+            &target.dirname,
+            &target.path,
+            &params.commit,
+            &params.spelling,
+            &git_dir,
+            sink,
+        ),
+        None => create_sandbox(params, git, project_root, &git_dir, sink),
+    }
+}
+
+/// The existing worktree a visit navigates to.
+pub struct VisitTarget {
+    /// The worktree's own directory name — its identity, which is *not*
+    /// always `params.dirname`: idempotence B matches on the commit, so a
+    /// sandbox minted as `v1.0` is where `daft go <that-sha>` lands (#813).
+    pub dirname: String,
+    pub path: PathBuf,
+}
+
+/// What [`execute_visit`] resolved before doing anything.
+pub struct VisitResolution {
+    /// The worktree to navigate to, or `None` to mint a fresh sandbox.
+    pub target: Option<VisitTarget>,
+    /// Canonical records whose worktree no longer exists. Returned instead of
+    /// being forgotten in place so this stays a pure query: the rail's header
+    /// asks the same question purely to render a name, and a display path must
+    /// not mutate the identity store.
+    stale_ids: Vec<String>,
+}
+
+/// Apply both idempotence rules and report where a visit would land.
+///
+/// Extracted so the rail's header and the visit itself cannot answer
+/// differently. Seeding the header from `params.dirname` was wrong for exactly
+/// one case, and it is the case where being wrong looks most like being right:
+/// arm B navigates by *commit*, so `daft go <sha>` lands in the sandbox a tag
+/// minted yesterday, and the header would announce a plausible-looking
+/// 12-hex name for a directory that does not exist (#813).
+pub fn resolve_visit(
+    params: &SandboxParams,
+    git: &GitCommand,
+    git_dir: &Path,
+) -> Result<VisitResolution> {
     let entries = detached_entries(git)?;
-    let records = super::identity_store::read_identities(&git_dir);
+    let records = super::identity_store::read_identities(git_dir);
 
     // Idempotence A — the spelling's own directory name. A detached worktree
     // already sitting at that name is the destination, unless it is a fork:
@@ -193,54 +249,76 @@ pub fn execute_visit(
     {
         let kind = record_for(&records, &entry.path).map(|r| r.kind);
         if kind != Some(WorktreeKind::Fork) {
-            return navigate(
-                &dir,
-                &entry.path.clone(),
-                &params.commit,
-                &params.spelling,
-                &git_dir,
-                sink,
-            );
+            return Ok(VisitResolution {
+                target: Some(VisitTarget {
+                    dirname: dir,
+                    path: entry.path.clone(),
+                }),
+                stale_ids: Vec::new(),
+            });
         }
     }
 
     // Idempotence B — the commit. Whatever the spelling (`HEAD~2` today, the
     // tag yesterday, the raw SHA in a script), one commit has at most one
     // canonical sandbox. Forks are excluded by construction (`Canonical`
-    // match only); a record whose worktree is gone is dropped so the next
-    // visit rebuilds cleanly.
+    // match only).
     let mut canonical: Vec<&WorktreeIdentityRow> = records
         .values()
         .filter(|r| r.kind == WorktreeKind::Canonical)
         .filter(|r| r.pinned_commit.as_deref() == Some(params.commit.as_str()))
         .collect();
     canonical.sort_by_key(|r| std::cmp::Reverse(r.updated_at));
+    let mut stale_ids = Vec::new();
     for row in canonical {
         let live = entries.iter().find(|e| {
             super::identity_store::worktree_id_for(&e.path).as_deref() == Some(&row.worktree_id)
         });
         match live {
             Some(entry) => {
-                return navigate(
-                    &row.branch,
-                    &entry.path.clone(),
-                    &params.commit,
-                    &params.spelling,
-                    &git_dir,
-                    sink,
-                );
+                return Ok(VisitResolution {
+                    target: Some(VisitTarget {
+                        dirname: row.branch.clone(),
+                        path: entry.path.clone(),
+                    }),
+                    stale_ids,
+                });
             }
-            None => {
-                // The worktree is gone but the record survived (removed
-                // outside daft). Best-effort cleanup, then keep looking.
-                if let Some(store) = super::identity_store::IdentityStore::open(&git_dir) {
-                    store.forget_id(&row.worktree_id);
-                }
-            }
+            None => stale_ids.push(row.worktree_id.clone()),
         }
     }
 
-    create_sandbox(params, git, project_root, &git_dir, sink)
+    Ok(VisitResolution {
+        target: None,
+        stale_ids,
+    })
+}
+
+/// The name to seed the visit rail's header with: the worktree the visit will
+/// actually land on, falling back to the name a fresh sandbox would get.
+///
+/// Display-only and best-effort by construction, like
+/// [`branch_delete::header_seed`](super::branch_delete::header_seed): it
+/// returns a `String`, never a target, so it cannot change where the visit
+/// goes — [`resolve_visit`] alone decides that, and is asked again there.
+///
+/// `resolve` is the caller's answer to "will this header be drawn?"
+/// ([`TimelineMode::renders_header`](crate::output::timeline::TimelineMode::renders_header)).
+/// A visit never commits a plan, so this seed is the only header the run will
+/// ever have — but only the live region draws one, so a non-TTY visit skips
+/// the `git worktree list` the resolution costs.
+pub fn visit_header_name(params: &SandboxParams, git: &GitCommand, resolve: bool) -> String {
+    let derived = || params.dirname.clone();
+    if !resolve {
+        return derived();
+    }
+    let Ok(git_dir) = crate::core::repo::get_git_common_dir() else {
+        return derived();
+    };
+    match resolve_visit(params, git, &git_dir) {
+        Ok(resolution) => resolution.target.map_or_else(derived, |t| t.dirname),
+        Err(_) => derived(),
+    }
 }
 
 /// Mint a fresh sandbox at `params.commit`, unconditionally. The

--- a/src/output/palette.rs
+++ b/src/output/palette.rs
@@ -20,8 +20,9 @@ pub(crate) const BLUE: &str = "\x1b[38;5;75m";
 /// Soft violet — shared files (daft-managed, linked across worktrees).
 pub(crate) const VIOLET: &str = "\x1b[38;5;141m";
 
-/// Manila — ordinary filesystem paths (worktree directories). File folders
-/// are manila; it also sits warm, away from the cool code/network cluster.
+/// Manila — filesystem entities: ordinary paths, and worktrees, which are
+/// directories however a row spells them (#813). File folders are manila; it
+/// also sits warm, away from the cool code/network cluster.
 pub(crate) const MANILA: &str = "\x1b[38;5;180m";
 
 /// Check whether progress visuals should be suppressed entirely.

--- a/src/output/timeline/mod.rs
+++ b/src/output/timeline/mod.rs
@@ -106,6 +106,17 @@ pub enum TimelineMode {
 }
 
 impl TimelineMode {
+    /// Whether the header seeded at [`Timeline::new`] will ever be drawn.
+    ///
+    /// Only the live region renders it — `Plain` leaves commands to their
+    /// legacy output and `Hidden` draws nothing at all. Callers that pay to
+    /// *build* a good header (resolving a path shorthand to the worktree it
+    /// names, #813) ask first, so a non-TTY run does not buy a string
+    /// nobody reads.
+    pub fn renders_header(self) -> bool {
+        matches!(self, Self::Interactive { .. })
+    }
+
     /// Predicate order: quiet → Hidden; `cfg(test)`/`DAFT_TESTING` → Hidden;
     /// non-TTY stderr or colors disabled → Plain; else Interactive.
     ///

--- a/src/output/timeline/plan.rs
+++ b/src/output/timeline/plan.rs
@@ -67,6 +67,15 @@ pub fn labels_for(id: StageId) -> StepLabels {
             done: "Checked out branch",
             skipped: "not checked out",
         },
+        // A sandbox pins HEAD to a commit; there is no branch to name, and
+        // saying "branch" here made the row describe something that does not
+        // exist in the run the user is watching (#813).
+        StageId::CheckOutDetached => StepLabels {
+            pending: "Check out commit",
+            active: "Checking out commit",
+            done: "Checked out commit",
+            skipped: "not checked out",
+        },
         StageId::CreateWorktree | StageId::CreateBaseWorktree => StepLabels {
             pending: "Create worktree",
             active: "Creating worktree",
@@ -226,6 +235,7 @@ pub fn subject_inks_for(id: StageId) -> SubjectInks {
         | StageId::Tracking
         | StageId::CreateBranch
         | StageId::CheckOut
+        | StageId::CheckOutDetached
         | StageId::Push
         | StageId::DeleteRemote
         | StageId::CloneBare => (SubjectInk::Plain, SubjectInk::Remote),

--- a/src/output/timeline/plan.rs
+++ b/src/output/timeline/plan.rs
@@ -211,7 +211,10 @@ pub enum SubjectInk {
     /// A remote name or ref (`origin`, `← origin/master`, `→ origin/x`) —
     /// ANSI cyan, the network.
     Remote,
-    /// An ordinary filesystem path (worktree directory) — manila.
+    /// A filesystem entity — manila. Ordinary paths (`copy:` entries, the
+    /// worktree directory `daft push` resolves), and worktrees themselves:
+    /// a worktree *is* a directory, so it wears manila whether the row
+    /// names it or locates it (#813).
     Path,
     /// A shared file — violet, daft-managed and linked across worktrees.
     Shared,
@@ -239,17 +242,16 @@ pub fn subject_inks_for(id: StageId) -> SubjectInks {
         | StageId::Push
         | StageId::DeleteRemote
         | StageId::CloneBare => (SubjectInk::Plain, SubjectInk::Remote),
-        // Worktree subjects: these rows name the worktree their label
-        // promises — a branch, or a sandbox's directory name — so they stay
-        // plain. Manila would say "path" about something that is not one
-        // (#813).
-        StageId::CreateWorktree | StageId::CreateBaseWorktree | StageId::RemoveWorktree => {
-            (SubjectInk::Plain, SubjectInk::Plain)
-        }
-        // Path subjects: worktree directories are manila. `daft push`'s row
-        // records *where* the pre-push hook will run, which is a location and
-        // stays one.
-        StageId::ResolveWorktree => (SubjectInk::Plain, SubjectInk::Path),
+        // Worktree subjects: manila. A worktree is a filesystem entity, and
+        // the ink types the entity, not the spelling — so these rows stay
+        // manila even though their annotation now names the worktree (its
+        // branch, or a sandbox's directory name) rather than locating it
+        // (#813). `daft push`'s row still spells a directory, because what
+        // it records is *where* the pre-push hook will run.
+        StageId::CreateWorktree
+        | StageId::CreateBaseWorktree
+        | StageId::RemoveWorktree
+        | StageId::ResolveWorktree => (SubjectInk::Plain, SubjectInk::Path),
         // Shared files: the row's label IS the path, violet.
         StageId::SharedFile => (SubjectInk::Shared, SubjectInk::Plain),
         // Copied paths: the row's label is likewise the entry, but manila —
@@ -314,15 +316,18 @@ mod tests {
             subject_inks_for(StageId::Push).annotation,
             SubjectInk::Remote
         );
-        // #813: this row names the worktree its label promises, not the
-        // directory it occupies, so manila would mislabel a name as a path.
+        // #813: these rows annotate with the worktree's *name*, not its
+        // path — but a worktree is a filesystem entity either way, so the
+        // manila ink types it the same. Plain would drop them to the
+        // pending tier's grey (`render::row_body`'s `ann_fallback`), which
+        // is the one thing the identity-ink carve-out exists to prevent.
         assert_eq!(
             subject_inks_for(StageId::CreateWorktree).annotation,
-            SubjectInk::Plain
+            SubjectInk::Path
         );
         assert_eq!(
             subject_inks_for(StageId::RemoveWorktree).annotation,
-            SubjectInk::Plain
+            SubjectInk::Path
         );
         assert_eq!(
             subject_inks_for(StageId::SharedFile).label,

--- a/src/output/timeline/plan.rs
+++ b/src/output/timeline/plan.rs
@@ -239,11 +239,17 @@ pub fn subject_inks_for(id: StageId) -> SubjectInks {
         | StageId::Push
         | StageId::DeleteRemote
         | StageId::CloneBare => (SubjectInk::Plain, SubjectInk::Remote),
-        // Path subjects: worktree directories are manila.
-        StageId::CreateWorktree
-        | StageId::CreateBaseWorktree
-        | StageId::RemoveWorktree
-        | StageId::ResolveWorktree => (SubjectInk::Plain, SubjectInk::Path),
+        // Worktree subjects: these rows name the worktree their label
+        // promises — a branch, or a sandbox's directory name — so they stay
+        // plain. Manila would say "path" about something that is not one
+        // (#813).
+        StageId::CreateWorktree | StageId::CreateBaseWorktree | StageId::RemoveWorktree => {
+            (SubjectInk::Plain, SubjectInk::Plain)
+        }
+        // Path subjects: worktree directories are manila. `daft push`'s row
+        // records *where* the pre-push hook will run, which is a location and
+        // stays one.
+        StageId::ResolveWorktree => (SubjectInk::Plain, SubjectInk::Path),
         // Shared files: the row's label IS the path, violet.
         StageId::SharedFile => (SubjectInk::Shared, SubjectInk::Plain),
         // Copied paths: the row's label is likewise the entry, but manila —
@@ -308,9 +314,15 @@ mod tests {
             subject_inks_for(StageId::Push).annotation,
             SubjectInk::Remote
         );
+        // #813: this row names the worktree its label promises, not the
+        // directory it occupies, so manila would mislabel a name as a path.
         assert_eq!(
             subject_inks_for(StageId::CreateWorktree).annotation,
-            SubjectInk::Path
+            SubjectInk::Plain
+        );
+        assert_eq!(
+            subject_inks_for(StageId::RemoveWorktree).annotation,
+            SubjectInk::Plain
         );
         assert_eq!(
             subject_inks_for(StageId::SharedFile).label,

--- a/src/output/timeline/render.rs
+++ b/src/output/timeline/render.rs
@@ -4,8 +4,9 @@
 //! into one connected object; state lives in the leading glyph; labels speak
 //! daft's vocabulary plain (bold for section headings); subjects wear
 //! identity inks constant across states — cyan for the network, manila for
-//! paths, violet for shared files, blue for background work; durations are
-//! dim, parenthesized, and only shown at ≥ 1s. Outcome colors — green
+//! filesystem entities (paths, and worktrees, whether a row names one or
+//! locates it), violet for shared files, blue for background work; durations
+//! are dim, parenthesized, and only shown at ≥ 1s. Outcome colors — green
 //! success (never bold), bold-red failure, yellow attention — stay on the
 //! glyph for spine steps and additionally flood the name on hook-job rows
 //! (the verbose block's scheme, so both hook presentations agree). Dim is
@@ -452,10 +453,35 @@ mod tests {
     #[test]
     fn path_subject_is_manila() {
         let face = RowFace::Done { duration: None };
-        let line = final_row(&face, "Created worktree", Some("../x"), 16, PATH_ANN, true);
+        let line = final_row(
+            &face,
+            "Created worktree",
+            Some("feat/x"),
+            16,
+            PATH_ANN,
+            true,
+        );
         assert!(
-            line.contains(&format!("{MANILA}../x{}", styles::RESET)),
+            line.contains(&format!("{MANILA}feat/x{}", styles::RESET)),
             "got: {line:?}"
+        );
+    }
+
+    #[test]
+    fn worktree_subject_keeps_its_ink_on_the_plan_face() {
+        // #813: the worktree rows annotate with the worktree's *name*. An
+        // untyped annotation falls back to the pending tier's grey (see
+        // `pending_glyph_dims_but_the_label_stays_plain`), which would put
+        // the rail's most important noun in its dimmest ink — the one thing
+        // the identity-ink carve-out on this face exists to prevent.
+        let line = pending_row("Create worktree", Some("feat/x"), 16, PATH_ANN, true);
+        assert!(
+            line.contains(&format!("{MANILA}feat/x{}", styles::RESET)),
+            "the name must keep manila on the committed plan: {line:?}"
+        );
+        assert!(
+            !line.contains(&format!("{GREY}feat/x")),
+            "the name must not recede to the untyped tier: {line:?}"
         );
     }
 

--- a/tests/integration/test_branch_delete.sh
+++ b/tests/integration/test_branch_delete.sh
@@ -695,12 +695,11 @@ test_remove_dot_header_survives_validation_failure() {
     return 0
 }
 
-# #813: the row that removes the worktree annotated itself `.` whenever the
-# cwd sat inside the doomed directory — which is every `daft remove .`. A
-# relative path is only true while its anchor exists, and this row's anchor
-# is what the row deletes: once the rail closes and the shell has cd'd out,
-# `.` names a different directory.
-test_remove_dot_row_names_the_doomed_directory() {
+# #813: the row's label promises a worktree, so its subject is the worktree —
+# the branch it is for. It used to carry a path relative to the cwd, which
+# for every `daft remove .` (the way you delete the worktree you are standing
+# in) rendered as a bare `.`: the argument echoed back, naming nothing.
+test_remove_dot_row_names_the_worktree() {
     local remote_repo=$(create_test_remote "test-repo-bd-row" "main")
 
     git-worktree-clone --layout contained "$remote_repo" || return 1
@@ -721,12 +720,10 @@ test_remove_dot_row_names_the_doomed_directory() {
     # "Removed"; the pending/active faces say "Remove"/"Removing".
     local annotation
     annotation=$(_bd_rail_clean "$log" |
-        grep -o 'Removed worktree  *[^ ]*' | tail -1 |
+        grep -o 'Removed worktree  *[^ ]*' | head -1 |
         sed 's/Removed worktree  *//')
-    # Absolute (the suite's workdir is outside $HOME, so no `~` folding) and
-    # naming the directory that went away.
-    if [[ "$annotation" != /*/feature/annotation ]]; then
-        log_error "removal row annotated '$annotation', expected an absolute path ending in /feature/annotation"
+    if [[ "$annotation" != "feature/annotation" ]]; then
+        log_error "removal row annotated '$annotation', expected 'feature/annotation'"
         _bd_rail_clean "$log" | head -20
         return 1
     fi
@@ -1068,7 +1065,7 @@ run_branch_delete_tests() {
     run_test "branch_delete_by_dot" "test_branch_delete_by_dot"
     run_test "remove_dot_header_names_branch" "test_remove_dot_header_names_branch"
     run_test "remove_dot_header_survives_validation_failure" "test_remove_dot_header_survives_validation_failure"
-    run_test "remove_dot_row_names_the_doomed_directory" "test_remove_dot_row_names_the_doomed_directory"
+    run_test "remove_dot_row_names_the_worktree" "test_remove_dot_row_names_the_worktree"
     run_test "remove_unresolvable_path_echoes_verbatim" "test_remove_unresolvable_path_echoes_verbatim"
     run_test "remove_unresolvable_path_error_explains_the_miss" "test_remove_unresolvable_path_error_explains_the_miss"
 

--- a/tests/integration/test_branch_delete.sh
+++ b/tests/integration/test_branch_delete.sh
@@ -695,6 +695,44 @@ test_remove_dot_header_survives_validation_failure() {
     return 0
 }
 
+# #813: the row that removes the worktree annotated itself `.` whenever the
+# cwd sat inside the doomed directory — which is every `daft remove .`. A
+# relative path is only true while its anchor exists, and this row's anchor
+# is what the row deletes: once the rail closes and the shell has cd'd out,
+# `.` names a different directory.
+test_remove_dot_row_names_the_doomed_directory() {
+    local remote_repo=$(create_test_remote "test-repo-bd-row" "main")
+
+    git-worktree-clone --layout contained "$remote_repo" || return 1
+    cd "test-repo-bd-row"
+    local project_root
+    project_root=$(pwd -P)
+
+    git-worktree-checkout -b feature/annotation || return 1
+    cd "feature/annotation"
+
+    local log="$project_root/remove-dot-row.log"
+    local cd_file
+    cd_file=$(mktemp "${TMPDIR:-/tmp}/daft-cd-row.XXXXXX")
+    DAFT_CD_FILE="$cd_file" _bd_rail_daft "$BD_PTY_RUN" "$log" daft remove . >/dev/null 2>&1
+    rm -f "$cd_file"
+
+    # `✓  Removed worktree   <annotation>  (0.1s)`. Only the Done face spells
+    # "Removed"; the pending/active faces say "Remove"/"Removing".
+    local annotation
+    annotation=$(_bd_rail_clean "$log" |
+        grep -o 'Removed worktree  *[^ ]*' | tail -1 |
+        sed 's/Removed worktree  *//')
+    # Absolute (the suite's workdir is outside $HOME, so no `~` folding) and
+    # naming the directory that went away.
+    if [[ "$annotation" != /*/feature/annotation ]]; then
+        log_error "removal row annotated '$annotation', expected an absolute path ending in /feature/annotation"
+        _bd_rail_clean "$log" | head -20
+        return 1
+    fi
+    return 0
+}
+
 # #813 do-not-regress: an argument that resolves to nothing must still be
 # echoed exactly as typed. Replacing an unresolvable path with a guess is
 # worse than showing the path.
@@ -1030,6 +1068,7 @@ run_branch_delete_tests() {
     run_test "branch_delete_by_dot" "test_branch_delete_by_dot"
     run_test "remove_dot_header_names_branch" "test_remove_dot_header_names_branch"
     run_test "remove_dot_header_survives_validation_failure" "test_remove_dot_header_survives_validation_failure"
+    run_test "remove_dot_row_names_the_doomed_directory" "test_remove_dot_row_names_the_doomed_directory"
     run_test "remove_unresolvable_path_echoes_verbatim" "test_remove_unresolvable_path_echoes_verbatim"
     run_test "remove_unresolvable_path_error_explains_the_miss" "test_remove_unresolvable_path_error_explains_the_miss"
 

--- a/tests/integration/test_branch_delete.sh
+++ b/tests/integration/test_branch_delete.sh
@@ -717,6 +717,33 @@ test_remove_unresolvable_path_echoes_verbatim() {
     return 0
 }
 
+# #813: the same miss, one line further down. A path argument that matched no
+# worktree reaches git as `refs/heads/../feature/nope`, and git's refname
+# complaint used to surface verbatim behind "failed to check if branch
+# exists" — a diagnosis of the wrong failure.
+test_remove_unresolvable_path_error_explains_the_miss() {
+    local remote_repo=$(create_test_remote "test-repo-bd-miss-err" "main")
+
+    git-worktree-clone --layout contained "$remote_repo" || return 1
+    cd "test-repo-bd-miss-err/main"
+
+    local err
+    err=$(daft remove ../feature/nope 2>&1 || true)
+    if ! echo "$err" | grep -q "no worktree at that path, and not a valid branch name"; then
+        log_error "error did not explain the miss: $err"
+        return 1
+    fi
+    if echo "$err" | grep -q "failed to check if branch exists"; then
+        log_error "error still leaks git's refname complaint: $err"
+        return 1
+    fi
+    if ! echo "$err" | grep -q -- "../feature/nope"; then
+        log_error "error dropped the user's spelling: $err"
+        return 1
+    fi
+    return 0
+}
+
 # --- Tests for new git-worktree-branch -d/-D command ---
 
 # Test basic branch delete with -d flag
@@ -1004,6 +1031,7 @@ run_branch_delete_tests() {
     run_test "remove_dot_header_names_branch" "test_remove_dot_header_names_branch"
     run_test "remove_dot_header_survives_validation_failure" "test_remove_dot_header_survives_validation_failure"
     run_test "remove_unresolvable_path_echoes_verbatim" "test_remove_unresolvable_path_echoes_verbatim"
+    run_test "remove_unresolvable_path_error_explains_the_miss" "test_remove_unresolvable_path_error_explains_the_miss"
 
     log "Running git-worktree-branch -d/-D integration tests..."
 

--- a/tests/integration/test_branch_delete.sh
+++ b/tests/integration/test_branch_delete.sh
@@ -598,6 +598,125 @@ test_branch_delete_by_dot() {
     return 0
 }
 
+# --- #813: the rail header names the worktree, not the path argument ---
+
+BD_PTY_RUN="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/pty_run.py"
+
+# Run daft with the live rail enabled (pattern from test_checkout.sh): the
+# framework's DAFT_TESTING hides the interactive region — the subject of
+# these tests — so it comes off and the background spawns it suppresses are
+# turned off individually. TERM is pinned because indicatif hides its whole
+# draw target under an unset or `dumb` TERM, as on a bare CI runner.
+_bd_rail_daft() {
+    env -u DAFT_TESTING \
+        TERM=xterm-256color \
+        DAFT_NO_UPDATE_CHECK=1 \
+        DAFT_NO_TRUST_PRUNE=1 \
+        DAFT_NO_LOG_CLEAN=1 \
+        DAFT_NO_HINTS=1 \
+        "$@"
+}
+
+# Strip ANSI and split the pty's carriage-returned repaints into lines.
+_bd_rail_clean() {
+    sed -e 's/\x1b\[[0-9;]*[a-zA-Z]//g' -e 's/\r/\n/g' "$1"
+}
+
+# The planning face is the *first* thing painted, before any plan commits.
+# Grepping the whole log would pass on the committed header alone (which was
+# always right), so the assertion has to be pinned to the first `Removing`
+# line the terminal ever saw.
+_bd_first_removing_line() {
+    _bd_rail_clean "$1" | grep -o 'Removing [^ ]*' | head -1
+}
+
+# #813: `daft remove .` announced "Removing ." — the raw argument in the
+# slot that carries identity. The committed header resolved it, but the
+# planning face is what the user reads first, and on the runs that never
+# commit a plan it is all they read.
+test_remove_dot_header_names_branch() {
+    local remote_repo=$(create_test_remote "test-repo-bd-hdr" "main")
+
+    git-worktree-clone --layout contained "$remote_repo" || return 1
+    cd "test-repo-bd-hdr"
+    local project_root
+    project_root=$(pwd -P)
+
+    git-worktree-checkout -b feature/header || return 1
+    cd "feature/header"
+
+    local log="$project_root/remove-dot-rail.log"
+    local cd_file
+    cd_file=$(mktemp "${TMPDIR:-/tmp}/daft-cd-hdr.XXXXXX")
+    DAFT_CD_FILE="$cd_file" _bd_rail_daft "$BD_PTY_RUN" "$log" daft remove . >/dev/null 2>&1
+    rm -f "$cd_file"
+
+    local first
+    first=$(_bd_first_removing_line "$log")
+    if [[ "$first" != "Removing feature/header" ]]; then
+        log_error "first header line was '$first', expected 'Removing feature/header'"
+        _bd_rail_clean "$log" | head -20
+        return 1
+    fi
+    return 0
+}
+
+# #813: the header must agree with the error underneath it. A dirty worktree
+# aborts during validation, so no plan ever commits and the seed is the only
+# header the run will ever have — the case the PlanCommit replacement cannot
+# reach.
+test_remove_dot_header_survives_validation_failure() {
+    local remote_repo=$(create_test_remote "test-repo-bd-hdr-fail" "main")
+
+    git-worktree-clone --layout contained "$remote_repo" || return 1
+    cd "test-repo-bd-hdr-fail"
+    local project_root
+    project_root=$(pwd -P)
+
+    git-worktree-checkout -b feature/dirty-header || return 1
+    cd "feature/dirty-header"
+    echo "uncommitted" > scratch.txt
+
+    local log="$project_root/remove-dirty-rail.log"
+    _bd_rail_daft "$BD_PTY_RUN" "$log" daft remove . >/dev/null 2>&1
+
+    local first
+    first=$(_bd_first_removing_line "$log")
+    if [[ "$first" != "Removing feature/dirty-header" ]]; then
+        log_error "first header line was '$first', expected 'Removing feature/dirty-header'"
+        _bd_rail_clean "$log" | head -20
+        return 1
+    fi
+    # The worktree must survive — this is a display change only.
+    if [[ ! -d "$project_root/feature/dirty-header" ]]; then
+        log_error "dirty worktree was removed"
+        return 1
+    fi
+    return 0
+}
+
+# #813 do-not-regress: an argument that resolves to nothing must still be
+# echoed exactly as typed. Replacing an unresolvable path with a guess is
+# worse than showing the path.
+test_remove_unresolvable_path_echoes_verbatim() {
+    local remote_repo=$(create_test_remote "test-repo-bd-hdr-miss" "main")
+
+    git-worktree-clone --layout contained "$remote_repo" || return 1
+    cd "test-repo-bd-hdr-miss/main"
+    local log="$PWD/remove-miss-rail.log"
+
+    _bd_rail_daft "$BD_PTY_RUN" "$log" daft remove ../feature/nope >/dev/null 2>&1
+
+    local first
+    first=$(_bd_first_removing_line "$log")
+    if [[ "$first" != "Removing ../feature/nope" ]]; then
+        log_error "first header line was '$first', expected 'Removing ../feature/nope'"
+        _bd_rail_clean "$log" | head -20
+        return 1
+    fi
+    return 0
+}
+
 # --- Tests for new git-worktree-branch -d/-D command ---
 
 # Test basic branch delete with -d flag
@@ -882,6 +1001,9 @@ run_branch_delete_tests() {
     run_test "branch_delete_by_relative_path" "test_branch_delete_by_relative_path"
     run_test "branch_delete_by_absolute_path" "test_branch_delete_by_absolute_path"
     run_test "branch_delete_by_dot" "test_branch_delete_by_dot"
+    run_test "remove_dot_header_names_branch" "test_remove_dot_header_names_branch"
+    run_test "remove_dot_header_survives_validation_failure" "test_remove_dot_header_survives_validation_failure"
+    run_test "remove_unresolvable_path_echoes_verbatim" "test_remove_unresolvable_path_echoes_verbatim"
 
     log "Running git-worktree-branch -d/-D integration tests..."
 

--- a/tests/integration/test_checkout.sh
+++ b/tests/integration/test_checkout.sh
@@ -1106,6 +1106,40 @@ test_go_sandbox_header_names_dirname() {
     return 0
 }
 
+# #813: a sandbox pins HEAD to a commit and never touches a branch, but its
+# rail reused the branch journey's stage, so the row read "Checked out
+# branch" beside an annotation naming a commit — the row described something
+# that does not exist in the run being watched.
+test_go_sandbox_row_names_a_commit_not_a_branch() {
+    local remote_repo=$(create_test_remote "test-repo-sandbox-noun" "main")
+    git-worktree-clone --layout contained "$remote_repo" || return 1
+    cd "test-repo-sandbox-noun/main"
+
+    local full dirname
+    full=$(git rev-parse HEAD)
+    dirname="${full:0:12}"
+
+    local log="$PWD/go-sandbox-noun.log"
+    _rail_daft "$CHECKOUT_PTY_RUN" "$log" daft go "$full" --no-cd || return 1
+
+    # Scoped past the handover line: the branch attempt above it is a real
+    # branch checkout and keeps the branch noun.
+    local sandbox_rail
+    sandbox_rail=$(_rail_clean "$log" | sed -n '/opening detached sandbox/,$p')
+    if ! echo "$sandbox_rail" | grep -q "Checked out commit"; then
+        log_error "sandbox rail did not name a commit"
+        echo "$sandbox_rail" | head -20
+        return 1
+    fi
+    if echo "$sandbox_rail" | grep -q "Checked out branch"; then
+        log_error "sandbox rail still claims it checked out a branch"
+        echo "$sandbox_rail" | head -20
+        return 1
+    fi
+    assert_directory_exists "../$dirname" || return 1
+    return 0
+}
+
 # #812: the `-x` sequence is planned onto the creation rail and runs inside
 # the region's lifetime. None of that is reachable from the YAML suite —
 # `commit_plan` early-returns off Interactive and the runner captures stderr,
@@ -1281,6 +1315,7 @@ run_checkout_tests() {
 
     # Rail header names the sandbox, not the spelling (#813)
     run_test "go_sandbox_header_names_dirname" "test_go_sandbox_header_names_dirname"
+    run_test "go_sandbox_row_names_a_commit_not_a_branch" "test_go_sandbox_row_names_a_commit_not_a_branch"
 
     # `-x` rows on the creation rail under a PTY (#812)
     run_test "start_exec_rows_on_rail" "test_start_exec_rows_on_rail"

--- a/tests/integration/test_checkout.sh
+++ b/tests/integration/test_checkout.sh
@@ -1075,9 +1075,10 @@ test_go_fetch_on_rail_expands() {
 # Scoped to the sandbox rail on purpose. `daft go <sha>` first tries the
 # branch reading, and that attempt's collapsed face legitimately shows the
 # spelling — daft is trying to open a branch of that name and has not probed
-# yet. The "Branch '<sha>' not found; opening detached sandbox '<dirname>'"
-# line between the two is what marks the handover — and it names the sandbox,
-# so the spelling appears exactly once, before daft knows better.
+# yet. The "Branch '<sha>' not found; opening a detached sandbox" line between
+# the two is what marks the handover. It names no sandbox: which one this
+# lands in is not known until the visit resolves, and the header below it is
+# where that answer belongs.
 test_go_sandbox_header_names_dirname() {
     local remote_repo=$(create_test_remote "test-repo-sandbox-hdr" "main")
     git-worktree-clone --layout contained "$remote_repo" || return 1
@@ -1103,6 +1104,56 @@ test_go_sandbox_header_names_dirname() {
         return 1
     fi
     assert_directory_exists "../$dirname" || return 1
+    return 0
+}
+
+# #813: one commit has one sandbox, whatever spelling summoned it. A visit
+# that lands on an existing sandbox must name *that* worktree, not the name a
+# fresh one would have been given — seeding the header from the spelling's
+# derived name was wrong in the one case where being wrong looks most like
+# being right: `<12 hex>` is exactly the shape of a real sandbox name, so the
+# header asserted a directory that does not exist, four lines above the line
+# naming the one that does.
+test_go_sandbox_header_names_the_sandbox_it_lands_in() {
+    local remote_repo=$(create_test_remote "test-repo-sandbox-land" "main")
+    git-worktree-clone --layout contained "$remote_repo" || return 1
+    cd "test-repo-sandbox-land/main"
+
+    local full derived
+    full=$(git rev-parse HEAD)
+    derived="${full:0:12}"
+    git tag v1.0 HEAD || return 1
+
+    # Mint the canonical sandbox for this commit under the tag's name.
+    daft go v1.0 --no-cd >/dev/null 2>&1 || return 1
+    assert_directory_exists "../v1.0" || return 1
+
+    # Now reach the same commit by a spelling that derives a different name.
+    local log="$PWD/go-sandbox-land.log"
+    _rail_daft "$CHECKOUT_PTY_RUN" "$log" daft go "$full" --no-cd || return 1
+
+    # Read the planning face, not a `┌` frame: a visit that *navigates*
+    # commits no plan, so this rail never draws one — which is the same reason
+    # the seed has to be right in the first place. Scoped past the handover
+    # line for two reasons: the branch attempt above it legitimately shows the
+    # spelling, and the derived name is a prefix of that spelling, so an
+    # unscoped negative grep matches the branch rail and always "fails".
+    local sandbox_rail
+    sandbox_rail=$(_rail_clean "$log" | sed -n '/opening a detached sandbox/,$p')
+    if ! echo "$sandbox_rail" | grep -q "Opening v1.0"; then
+        log_error "header must name the sandbox the visit lands in ('v1.0')"
+        echo "$sandbox_rail" | head -20
+        return 1
+    fi
+    if echo "$sandbox_rail" | grep -q "Opening $derived"; then
+        log_error "header named '$derived', a directory the visit never creates"
+        echo "$sandbox_rail" | head -20
+        return 1
+    fi
+    if [[ -d "../$derived" ]]; then
+        log_error "the visit minted a second sandbox for one commit"
+        return 1
+    fi
     return 0
 }
 
@@ -1176,7 +1227,7 @@ test_go_sandbox_rows_name_the_sandbox() {
     # Scoped past the handover line: the branch attempt above it is a real
     # branch checkout and keeps the branch noun.
     local sandbox_rail
-    sandbox_rail=$(_rail_clean "$log" | sed -n '/opening detached sandbox/,$p')
+    sandbox_rail=$(_rail_clean "$log" | sed -n '/opening a detached sandbox/,$p')
     if ! echo "$sandbox_rail" | grep -q "Checked out commit"; then
         log_error "sandbox rail did not name a commit"
         echo "$sandbox_rail" | head -20
@@ -1376,6 +1427,7 @@ run_checkout_tests() {
 
     # Rail header names the sandbox, not the spelling (#813)
     run_test "go_sandbox_header_names_dirname" "test_go_sandbox_header_names_dirname"
+    run_test "go_sandbox_header_names_the_sandbox_it_lands_in" "test_go_sandbox_header_names_the_sandbox_it_lands_in"
     run_test "go_sandbox_rows_name_the_sandbox" "test_go_sandbox_rows_name_the_sandbox"
     run_test "go_row_names_the_worktree_not_its_path" "test_go_row_names_the_worktree_not_its_path"
     run_test "start_row_names_the_worktree_not_its_path" "test_start_row_names_the_worktree_not_its_path"

--- a/tests/integration/test_checkout.sh
+++ b/tests/integration/test_checkout.sh
@@ -1075,8 +1075,9 @@ test_go_fetch_on_rail_expands() {
 # Scoped to the sandbox rail on purpose. `daft go <sha>` first tries the
 # branch reading, and that attempt's collapsed face legitimately shows the
 # spelling — daft is trying to open a branch of that name and has not probed
-# yet. The "Branch '<sha>' not found; opening a detached sandbox" line
-# between the two is what marks the handover.
+# yet. The "Branch '<sha>' not found; opening detached sandbox '<dirname>'"
+# line between the two is what marks the handover — and it names the sandbox,
+# so the spelling appears exactly once, before daft knows better.
 test_go_sandbox_header_names_dirname() {
     local remote_repo=$(create_test_remote "test-repo-sandbox-hdr" "main")
     git-worktree-clone --layout contained "$remote_repo" || return 1

--- a/tests/integration/test_checkout.sh
+++ b/tests/integration/test_checkout.sh
@@ -1106,11 +1106,62 @@ test_go_sandbox_header_names_dirname() {
     return 0
 }
 
+# #813: the branch journey's `Created worktree` row carried a path relative
+# to the cwd, so the row's label promised a worktree and its subject was a
+# location — in the path colour, which said so twice. The subject is the
+# worktree: the branch it is for.
+test_go_row_names_the_worktree_not_its_path() {
+    local remote_repo=$(create_test_remote "test-repo-row-name" "main")
+    git-worktree-clone --layout contained "$remote_repo" || return 1
+    cd "test-repo-row-name/main"
+
+    local log="$PWD/go-row-name.log"
+    _rail_daft "$CHECKOUT_PTY_RUN" "$log" daft go develop || return 1
+
+    local annotation
+    annotation=$(_rail_clean "$log" |
+        grep -o 'Created worktree  *[^ ]*' | head -1 |
+        sed 's/Created worktree  *//')
+    if [[ "$annotation" != "develop" ]]; then
+        log_error "create row annotated '$annotation', expected 'develop'"
+        _rail_clean "$log" | head -20
+        return 1
+    fi
+    return 0
+}
+
+# #813: same row, the `daft start` journey — a separate plan builder, so a
+# separate render site.
+test_start_row_names_the_worktree_not_its_path() {
+    local remote_repo=$(create_test_remote "test-repo-row-start" "main")
+    git-worktree-clone --layout contained "$remote_repo" || return 1
+    cd "test-repo-row-start/main"
+    git config daft.checkout.push false
+
+    # Outside the repo: `daft start` carries untracked files into the new
+    # worktree, and a log written here would leave with them.
+    local log="$TEMP_BASE_DIR/start-row-name.log"
+    _rail_daft "$CHECKOUT_PTY_RUN" "$log" daft start feature/row-name || return 1
+
+    local annotation
+    annotation=$(_rail_clean "$log" |
+        grep -o 'Created worktree  *[^ ]*' | head -1 |
+        sed 's/Created worktree  *//')
+    if [[ "$annotation" != "feature/row-name" ]]; then
+        log_error "create row annotated '$annotation', expected 'feature/row-name'"
+        _rail_clean "$log" | head -20
+        return 1
+    fi
+    return 0
+}
+
 # #813: a sandbox pins HEAD to a commit and never touches a branch, but its
 # rail reused the branch journey's stage, so the row read "Checked out
 # branch" beside an annotation naming a commit — the row described something
-# that does not exist in the run being watched.
-test_go_sandbox_row_names_a_commit_not_a_branch() {
+# that does not exist in the run being watched. Its `Created worktree` row
+# has the same job as the branch journey's: name the worktree, which for a
+# sandbox is its directory name.
+test_go_sandbox_rows_name_the_sandbox() {
     local remote_repo=$(create_test_remote "test-repo-sandbox-noun" "main")
     git-worktree-clone --layout contained "$remote_repo" || return 1
     cd "test-repo-sandbox-noun/main"
@@ -1133,6 +1184,16 @@ test_go_sandbox_row_names_a_commit_not_a_branch() {
     fi
     if echo "$sandbox_rail" | grep -q "Checked out branch"; then
         log_error "sandbox rail still claims it checked out a branch"
+        echo "$sandbox_rail" | head -20
+        return 1
+    fi
+
+    local annotation
+    annotation=$(echo "$sandbox_rail" |
+        grep -o 'Created worktree  *[^ ]*' | head -1 |
+        sed 's/Created worktree  *//')
+    if [[ "$annotation" != "$dirname" ]]; then
+        log_error "create row annotated '$annotation', expected '$dirname'"
         echo "$sandbox_rail" | head -20
         return 1
     fi
@@ -1315,7 +1376,9 @@ run_checkout_tests() {
 
     # Rail header names the sandbox, not the spelling (#813)
     run_test "go_sandbox_header_names_dirname" "test_go_sandbox_header_names_dirname"
-    run_test "go_sandbox_row_names_a_commit_not_a_branch" "test_go_sandbox_row_names_a_commit_not_a_branch"
+    run_test "go_sandbox_rows_name_the_sandbox" "test_go_sandbox_rows_name_the_sandbox"
+    run_test "go_row_names_the_worktree_not_its_path" "test_go_row_names_the_worktree_not_its_path"
+    run_test "start_row_names_the_worktree_not_its_path" "test_start_row_names_the_worktree_not_its_path"
 
     # `-x` rows on the creation rail under a PTY (#812)
     run_test "start_exec_rows_on_rail" "test_start_exec_rows_on_rail"

--- a/tests/integration/test_checkout.sh
+++ b/tests/integration/test_checkout.sh
@@ -1066,6 +1066,45 @@ test_go_fetch_on_rail_expands() {
     return 0
 }
 
+# #813: `daft go <full-sha>` opens a sandbox whose directory is a 12-hex
+# prefix of the commit, but the sandbox rail's header was seeded with the
+# spelling — forty hex characters in the slot that carries identity. A
+# sandbox visit never commits a plan for the *branch* reading, so nothing
+# downstream corrects it: this seed is the whole sandbox run.
+#
+# Scoped to the sandbox rail on purpose. `daft go <sha>` first tries the
+# branch reading, and that attempt's collapsed face legitimately shows the
+# spelling — daft is trying to open a branch of that name and has not probed
+# yet. The "Branch '<sha>' not found; opening a detached sandbox" line
+# between the two is what marks the handover.
+test_go_sandbox_header_names_dirname() {
+    local remote_repo=$(create_test_remote "test-repo-sandbox-hdr" "main")
+    git-worktree-clone --layout contained "$remote_repo" || return 1
+    cd "test-repo-sandbox-hdr/main"
+
+    local full dirname
+    full=$(git rev-parse HEAD)
+    # `sandbox::derived_dirname` — DERIVED_DIRNAME_HEX = 12.
+    dirname="${full:0:12}"
+
+    local log="$PWD/go-sandbox-hdr.log"
+    _rail_daft "$CHECKOUT_PTY_RUN" "$log" daft go "$full" --no-cd || return 1
+
+    local clean
+    clean=$(_rail_clean "$log")
+    if ! echo "$clean" | grep -q "┌  Opening $dirname"; then
+        log_error "sandbox rail header did not name the sandbox '$dirname'"
+        echo "$clean" | head -20
+        return 1
+    fi
+    if echo "$clean" | grep -q "┌  Opening $full"; then
+        log_error "sandbox rail header still carries the full spelling"
+        return 1
+    fi
+    assert_directory_exists "../$dirname" || return 1
+    return 0
+}
+
 # #812: the `-x` sequence is planned onto the creation rail and runs inside
 # the region's lifetime. None of that is reachable from the YAML suite —
 # `commit_plan` early-returns off Interactive and the runner captures stderr,
@@ -1238,6 +1277,9 @@ run_checkout_tests() {
     # Rail behavior under a PTY (#782)
     run_test "go_fetch_hop_no_rail_receipt" "test_go_fetch_hop_no_rail_receipt"
     run_test "go_fetch_on_rail_expands" "test_go_fetch_on_rail_expands"
+
+    # Rail header names the sandbox, not the spelling (#813)
+    run_test "go_sandbox_header_names_dirname" "test_go_sandbox_header_names_dirname"
 
     # `-x` rows on the creation rail under a PTY (#812)
     run_test "start_exec_rows_on_rail" "test_start_exec_rows_on_rail"


### PR DESCRIPTION
Fixes #813

`daft remove ../feature/x` announced `Removing ../feature/x`; `daft go <sha>`
opened a worktree called `baddade12345` while announcing forty hex characters.
The rail named the spelling that summoned a worktree rather than the worktree
itself — and a relative path is only true while its anchor exists, which for a
removal is the directory being deleted.

Rows that create or destroy a worktree now annotate with its **name** — the
branch it is for, or a sandbox's directory name. `daft push`'s
`Resolved worktree` row keeps a real path on purpose: nothing is created or
destroyed there, and what the row records is *where* the pre-push hook will run.

## What changed

- **Four render sites had spelled the annotation out independently**
  (`checkout.rs`, `checkout_branch.rs`, `sandbox.rs`, `branch_delete.rs`), which
  is exactly why they could disagree. One source now answers.
- **`StageId::CheckOutDetached`** splits the sandbox rail off `CheckOut`, so it
  reads "Checked out **commit**" — a sandbox has no branch, and the rail says so
  a line later.
- **Resolution happens in the seed, not at plan commit.** A dirty worktree
  aborts while the seed is the only header on screen, and that run never commits
  a plan — so `PlanCommit::header` can never correct it. `start --fork` already
  resolved before `Timeline::new`; this follows it.
- **The name keeps manila.** The ink types the entity, not the spelling: a
  worktree is a filesystem entity whether a row names it or locates it. Dropping
  these rows to `Plain` looked like "uncoloured" but `render::row_body` resolves
  an untyped annotation through `pending_row`'s grey fallback — which put the
  rail's most important noun in its dimmest tier on the committed plan.
- **A visit names the sandbox it lands in.** Idempotence matches on the
  *commit*, so `daft go <sha>` navigates into the sandbox a tag minted earlier;
  the header was announcing the name a fresh one would have been given.

## Scope note

The last commit is `area:completions` and is not #813 work: `--hooks` (#821)
shipped with value completion in fish only, and in bash/zsh the flag fell
through to branch names rather than offering its four modes. Requested during
review of this branch; called out here so the extra zone on the auto-labeler
does not read as scope creep. It is self-contained and can be split out on
request.

## The ticket's third bullet has no referent

There is no path shorthand in `go`/`start` to fix: `daft go .` errors with
"Branch name cannot start with '.'", `daft go ../x` with "cannot contain '..'".
The real sibling defect was the commit-ish -> dirname gap, which is fixed.

## Verification

`mise run fmt`, `mise run clippy`, full unit suite (3815, 0 failures),
`test_checkout.sh` 43/43, `test_branch_delete.sh` 28/28, `completions:test`
35/35. The emitted bash/zsh completions were driven functionally under bash 5
and syntax-checked with `zsh -n`; both new guards were revert-verified against
the bug they exist to catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)