### PR TITLE
perf: defer worktree deletion to a background reaper

### DIFF
--- a/docs/about/troubleshooting.md
+++ b/docs/about/troubleshooting.md
@@ -68,6 +68,23 @@ over.
 `daft list` prints all worktrees. With `--format json` you get machine-readable
 output.
 
+## I removed a worktree but the disk space hasn't come back
+
+That is expected, briefly. `daft remove` and `daft prune` move the worktree
+aside and return as soon as the parts you are waiting on are done — the branch
+is gone, git is consistent, and the path is free to reuse immediately. The
+directory itself is deleted by a background process a moment later, which is why
+removing a worktree full of `node_modules` takes about as long as removing an
+empty one instead of tens of seconds.
+
+If space still has not returned after a while, `daft doctor` reports any
+worktrees that are still waiting, and `daft doctor --fix` reclaims them
+immediately. Removals also sweep leftovers on their way through, so the next
+`daft remove` or `daft prune` in that repo picks up anything stranded.
+
+To make removal reclaim space before it returns — for a script that checks free
+space straight afterwards, say — set `DAFT_NO_TRASH_REAP=1`.
+
 ## When in doubt
 
 Run `daft doctor`. It diagnoses install, shell integration, layout health, and

--- a/docs/about/troubleshooting.md
+++ b/docs/about/troubleshooting.md
@@ -82,6 +82,13 @@ worktrees that are still waiting, and `daft doctor --fix` reclaims them
 immediately. Removals also sweep leftovers on their way through, so the next
 `daft remove` or `daft prune` in that repo picks up anything stranded.
 
+`daft doctor` distinguishes two cases. A worktree still _waiting_ is one whose
+delete has not finished. A removal reported as _interrupted_ was cut short — by
+Ctrl-C, or the machine going down — after the directory moved but before git was
+told, so git may still expect a worktree that is no longer there. Nothing
+deletes those automatically, because they can hold ignored files that exist
+nowhere else. `daft doctor --fix` puts them back where git expects them.
+
 To make removal reclaim space before it returns — for a script that checks free
 space straight afterwards, say — set `DAFT_NO_TRASH_REAP=1`.
 

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -191,6 +191,7 @@ fn run_repository_checks(ctx: &repository::RepoContext) -> CheckCategory {
         repository::check_remote_head(ctx),
         repository::check_remote_sync_config(ctx),
         repository::check_reflink_support(ctx),
+        repository::check_pending_trash(ctx),
     ];
 
     // A project-level agent-skill copy (committed .claude/skills/) gets the

--- a/src/core/size_walk.rs
+++ b/src/core/size_walk.rs
@@ -287,6 +287,14 @@ fn scan_dir(
             continue;
         };
         if meta.is_dir() {
+            // Worktrees awaiting deletion are not part of what the repo
+            // occupies — they are on their way out, and counting them reports
+            // space that is already spoken for. This matters because the
+            // figure is persisted (`commands::size_cache`), so a walk that
+            // races a pending reap would cache the pre-removal size (#200).
+            if crate::core::worktree::trash::is_trash_path(&entry.path()) {
+                continue;
+            }
             subdirs.push(entry.path());
         } else if count_file(&meta, seen, hard_links) {
             bytes += meta.len();
@@ -379,6 +387,28 @@ mod tests {
         write(&root.join("sub/c.txt"), b"nested content");
         write(&root.join("sub/deep/d.txt"), &vec![7u8; 1234]);
         fs::create_dir_all(root.join("sub/empty")).unwrap();
+    }
+
+    /// Worktrees renamed into `.daft/trash/` are on their way out (#200), so
+    /// they must not inflate the repo's reported size — the figure is cached,
+    /// so a walk that races a pending reap would persist the pre-removal size.
+    #[test]
+    fn pending_deletions_do_not_count_toward_size() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("repo");
+        write(&root.join("kept.bin"), &vec![0u8; 1000]);
+        write(
+            &root.join(".git/.daft/trash/doomed-worktree/huge.bin"),
+            &vec![0u8; 50_000],
+        );
+
+        let sizes = walk_all(std::slice::from_ref(&root), None, 4);
+
+        assert_eq!(
+            sizes[0],
+            Some(1000),
+            "a worktree awaiting deletion must not be counted"
+        );
     }
 
     #[test]

--- a/src/core/worktree/branch_delete.rs
+++ b/src/core/worktree/branch_delete.rs
@@ -250,6 +250,11 @@ pub fn execute(
 ) -> Result<BranchDeleteResult> {
     let git = GitCommand::new(params.is_quiet).with_gitoxide(params.use_gitoxide);
     let git_dir = get_git_common_dir()?;
+    // Reclaim anything a previous reaper failed to finish (#200). This is what
+    // makes a failed background delete *delayed* rather than permanent, so
+    // deferring the delete is not a way to lose track of disk space. Cheap when
+    // the trash is empty, which is the ordinary case.
+    trash::sweep(&git_dir);
     let default_branch =
         get_default_branch_local(&git_dir, &params.remote_name, params.use_gitoxide)
             .context("Cannot determine default branch")?;

--- a/src/core/worktree/branch_delete.rs
+++ b/src/core/worktree/branch_delete.rs
@@ -2365,7 +2365,9 @@ fn delete_single_branch(
                     // claim more than it did.
                     let annotation = match disposition {
                         Disposition::Deferred => Some("reclaiming space in background".to_string()),
-                        Disposition::Declined => None,
+                        // Reclaimed and Declined both mean the space is
+                        // already back by the time this row settles.
+                        Disposition::Reclaimed | Disposition::Declined => None,
                     };
                     sink.on_stage(
                         &stage_key(StageId::RemoveWorktree),
@@ -2571,8 +2573,9 @@ fn remove_worktree_completing_orphans(
     // Declining is not a failure — it means the fast path did not apply, and
     // the ordinary removal below runs exactly as it always has, including
     // git's own refusal of a dirty worktree.
-    if trash::dispose(git, git_common_dir, wt_path, force) == Disposition::Deferred {
-        return Ok(Disposition::Deferred);
+    let disposition = trash::dispose(git, git_common_dir, wt_path, force);
+    if disposition != Disposition::Declined {
+        return Ok(disposition);
     }
 
     let orig = match git.worktree_remove(wt_path, force) {
@@ -3247,7 +3250,14 @@ mod tests {
         )
         .expect("a clean worktree must be removable");
 
-        assert_eq!(disposition, Disposition::Deferred, "expected the fast path");
+        // `Reclaimed`, not `Deferred`: tests never spawn a reaper, so the
+        // rename still happens but the delete completes inline. The point is
+        // that it is not `Declined` — the fast path applied.
+        assert_eq!(
+            disposition,
+            Disposition::Reclaimed,
+            "expected the fast path to apply"
+        );
         assert!(!wt.exists(), "the path must be free");
         let listed = git.worktree_list_porcelain().unwrap();
         assert!(

--- a/src/core/worktree/branch_delete.rs
+++ b/src/core/worktree/branch_delete.rs
@@ -2358,20 +2358,31 @@ fn delete_single_branch(
             match remove_worktree_completing_orphans(ctx.git, &ctx.git_dir, wt_path, force, sink) {
                 Ok(disposition) => {
                     result.worktree_removed = true;
-                    sink.on_step(&format!("Removed worktree '{}'", branch.name));
                     // Say so when the space is still coming back: the path is
                     // free and git is consistent, but `df` will not agree for
-                    // another moment. Silence here would make the command
-                    // claim more than it did.
-                    let annotation = match disposition {
-                        Disposition::Deferred => Some("reclaiming space in background".to_string()),
-                        // Reclaimed and Declined both mean the space is
-                        // already back by the time this row settles.
-                        Disposition::Reclaimed | Disposition::Declined => None,
-                    };
+                    // another moment.
+                    //
+                    // It goes in the step line, not the row's annotation. That
+                    // slot already carries the worktree's name (#813, set at
+                    // `:456`), `StageEvent::Completed`/`Note` *replace* rather
+                    // than append, and the slot is inked `SubjectInk::Path` —
+                    // so writing prose there costs the row its identity and
+                    // renders it as a path besides. The rail's row claims the
+                    // worktree was removed, which is true the moment it
+                    // settles; disk reclamation is reported by `daft doctor`
+                    // and documented in troubleshooting.
+                    match disposition {
+                        Some(Disposition::Deferred) => sink.on_step(&format!(
+                            "Removed worktree '{}' (reclaiming space in background)",
+                            branch.name
+                        )),
+                        // A reclaimed fast path and an ordinary removal both
+                        // mean the space is already back by now.
+                        _ => sink.on_step(&format!("Removed worktree '{}'", branch.name)),
+                    }
                     sink.on_stage(
                         &stage_key(StageId::RemoveWorktree),
-                        StageEvent::Completed { annotation },
+                        StageEvent::Completed { annotation: None },
                     );
                 }
                 Err(e) => {
@@ -2568,18 +2579,23 @@ fn remove_worktree_completing_orphans(
     wt_path: &Path,
     force: bool,
     sink: &mut dyn ProgressSink,
-) -> Result<Disposition> {
+) -> Result<Option<Disposition>> {
     // Try to get the directory out of the way without walking it (#200).
     // Declining is not a failure — it means the fast path did not apply, and
     // the ordinary removal below runs exactly as it always has, including
     // git's own refusal of a dirty worktree.
+    //
+    // `None` is what the ordinary path reports. It is deliberately not
+    // `Some(Declined)`: `Declined` means "the caller must remove this the
+    // ordinary way", and a value that also means "already removed the ordinary
+    // way" would make the obvious reading of the enum destructive.
     let disposition = trash::dispose(git, git_common_dir, wt_path, force);
     if disposition != Disposition::Declined {
-        return Ok(disposition);
+        return Ok(Some(disposition));
     }
 
     let orig = match git.worktree_remove(wt_path, force) {
-        Ok(()) => return Ok(Disposition::Declined),
+        Ok(()) => return Ok(None),
         Err(e) => e,
     };
     let target = std::fs::canonicalize(wt_path).unwrap_or_else(|_| wt_path.to_path_buf());
@@ -2599,7 +2615,7 @@ fn remove_worktree_completing_orphans(
         wt_path.display()
     ));
     match std::fs::remove_dir_all(wt_path) {
-        Ok(()) => Ok(Disposition::Declined),
+        Ok(()) => Ok(None),
         Err(e) => Err(orig.context(format!("the direct delete of the leftover failed too: {e}"))),
     }
 }
@@ -3255,7 +3271,7 @@ mod tests {
         // that it is not `Declined` — the fast path applied.
         assert_eq!(
             disposition,
-            Disposition::Reclaimed,
+            Some(Disposition::Reclaimed),
             "expected the fast path to apply"
         );
         assert!(!wt.exists(), "the path must be free");
@@ -3291,6 +3307,118 @@ mod tests {
 
         setup_worktree(tmp.path(), "feature-branch-2", &wt);
         assert!(wt.exists(), "the same path must be reusable straight away");
+    }
+
+    /// Git refuses to remove a worktree holding a checked-out submodule, and
+    /// that refusal is one the rename would silently retire: git looks for
+    /// submodule paths that *exist*, and after the rename none do. So the fast
+    /// path must decline and let git speak — verified end to end against a real
+    /// submodule rather than against the predicate alone.
+    #[test]
+    #[serial]
+    fn a_worktree_with_a_populated_submodule_keeps_gits_refusal() {
+        let _cwd = CwdGuard::new();
+        let tmp = tempfile::tempdir().unwrap();
+        let sub = tmp.path().join("sub");
+        std::fs::create_dir_all(&sub).unwrap();
+        init_repo(&sub);
+
+        let root = tmp.path().join("repo");
+        std::fs::create_dir_all(&root).unwrap();
+        init_repo(&root);
+        let wt = tmp.path().join("feature");
+        setup_worktree(&root, "feature-branch", &wt);
+        std::env::set_current_dir(&root).unwrap();
+
+        // `protocol.file.allow` per command, never in config: a global write
+        // is forbidden outright, and a local one would not reach the worktree.
+        let added = ShellCommand::new("git")
+            .args(["-c", "protocol.file.allow=always", "submodule", "add", "-q"])
+            .arg(&sub)
+            .arg("vendor/sub")
+            .current_dir(&wt)
+            .env("GIT_AUTHOR_NAME", "Test")
+            .env("GIT_AUTHOR_EMAIL", "test@test.com")
+            .env("GIT_COMMITTER_NAME", "Test")
+            .env("GIT_COMMITTER_EMAIL", "test@test.com")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .unwrap();
+        assert!(added.success(), "the fixture needs a real submodule");
+        git_quiet(&wt, &["add", "-A"]);
+        commit_empty(&wt, "add submodule");
+
+        let git = GitCommand::new(true);
+        let err = remove_worktree_completing_orphans(
+            &git,
+            &root.join(".git"),
+            &wt,
+            false,
+            &mut crate::core::NullSink,
+        )
+        .expect_err("git refuses a worktree containing submodules");
+
+        assert!(err.to_string().contains("Git worktree remove failed"));
+        assert!(wt.exists(), "the worktree must be untouched");
+        assert!(
+            crate::core::worktree::trash::pending(&root.join(".git")).is_empty(),
+            "a submodule-bearing worktree must never reach the trash"
+        );
+    }
+
+    /// The recovery contract for the one window this design cannot close: the
+    /// tree is renamed aside and the process dies before git is told. No reaper
+    /// may take that entry, and `doctor --fix` must put it back where git still
+    /// expects it — deleting it would destroy ignored files (`.env`,
+    /// `node_modules/`) that the dirty probe deliberately never sees.
+    #[test]
+    #[serial]
+    fn an_interrupted_removal_is_restored_rather_than_reaped() {
+        use crate::core::worktree::trash;
+
+        let _cwd = CwdGuard::new();
+        let tmp = tempfile::tempdir().unwrap();
+        init_repo(tmp.path());
+        let wt = tmp.path().join("feature");
+        setup_worktree(tmp.path(), "feature-branch", &wt);
+        std::env::set_current_dir(tmp.path()).unwrap();
+        // Ignored content: invisible to `git status`, and irreplaceable.
+        std::fs::create_dir_all(wt.join("node_modules")).unwrap();
+        std::fs::write(wt.join("node_modules/dep.js"), "x").unwrap();
+
+        // Reproduce the crash state by hand: renamed in, sidecar still there,
+        // git's record untouched.
+        let git_dir = tmp.path().join(".git");
+        let trash = trash::trash_dir(&git_dir);
+        std::fs::create_dir_all(&trash).unwrap();
+        let entry = trash.join("feature-1-2");
+        let canonical = std::fs::canonicalize(&wt).unwrap();
+        trash::write_origin_sidecar_for_test(&entry, &canonical);
+        std::fs::rename(&wt, &entry).unwrap();
+
+        // Every ordinary sweep must pass straight over it.
+        trash::sweep(&git_dir);
+        assert!(
+            entry.join("node_modules/dep.js").exists(),
+            "a sweep must not touch an interrupted removal"
+        );
+
+        let git = GitCommand::new(true);
+        trash::reclaim(&git, &git_dir).expect("doctor --fix must resolve it");
+
+        assert!(
+            wt.exists(),
+            "the worktree must be back where git expects it"
+        );
+        assert!(
+            wt.join("node_modules/dep.js").exists(),
+            "its ignored content must come back with it"
+        );
+        assert!(
+            trash::pending(&git_dir).is_empty(),
+            "and nothing may be left waiting"
+        );
     }
 
     /// A still-registered worktree whose removal fails keeps the original

--- a/src/core/worktree/branch_delete.rs
+++ b/src/core/worktree/branch_delete.rs
@@ -5,6 +5,7 @@
 use crate::core::stage::{PlanCommit, Row, StageEvent, StageId, StepKey, StepSpec};
 use crate::core::worktree::ports::{ForgeMergedWitness, NoopStageRunner};
 use crate::core::worktree::push::{PushAction, push_with_hooks, resolve_delete_pre_push};
+use crate::core::worktree::trash::{self, Disposition};
 use crate::core::{
     ConflictSide, ConsolidationChoice, ConsolidationPrompter, ConsolidationRequest, HookRunner,
     ProgressSink, RefinedFileSummary,
@@ -2349,13 +2350,21 @@ fn delete_single_branch(
         } else if wt_path.exists() {
             sink.on_step(&format!("Removing worktree at {}...", wt_path.display()));
             sink.on_stage(&stage_key(StageId::RemoveWorktree), StageEvent::Started);
-            match remove_worktree_completing_orphans(ctx.git, wt_path, force, sink) {
-                Ok(()) => {
+            match remove_worktree_completing_orphans(ctx.git, &ctx.git_dir, wt_path, force, sink) {
+                Ok(disposition) => {
                     result.worktree_removed = true;
                     sink.on_step(&format!("Removed worktree '{}'", branch.name));
+                    // Say so when the space is still coming back: the path is
+                    // free and git is consistent, but `df` will not agree for
+                    // another moment. Silence here would make the command
+                    // claim more than it did.
+                    let annotation = match disposition {
+                        Disposition::Deferred => Some("reclaiming space in background".to_string()),
+                        Disposition::Declined => None,
+                    };
                     sink.on_stage(
                         &stage_key(StageId::RemoveWorktree),
-                        StageEvent::Completed { annotation: None },
+                        StageEvent::Completed { annotation },
                     );
                 }
                 Err(e) => {
@@ -2548,12 +2557,21 @@ fn parse_worktree_list(git: &GitCommand) -> Result<Vec<WorktreeListEntry>> {
 /// error stands untouched.
 fn remove_worktree_completing_orphans(
     git: &GitCommand,
+    git_common_dir: &Path,
     wt_path: &Path,
     force: bool,
     sink: &mut dyn ProgressSink,
-) -> Result<()> {
+) -> Result<Disposition> {
+    // Try to get the directory out of the way without walking it (#200).
+    // Declining is not a failure — it means the fast path did not apply, and
+    // the ordinary removal below runs exactly as it always has, including
+    // git's own refusal of a dirty worktree.
+    if trash::dispose(git, git_common_dir, wt_path, force) == Disposition::Deferred {
+        return Ok(Disposition::Deferred);
+    }
+
     let orig = match git.worktree_remove(wt_path, force) {
-        Ok(()) => return Ok(()),
+        Ok(()) => return Ok(Disposition::Declined),
         Err(e) => e,
     };
     let target = std::fs::canonicalize(wt_path).unwrap_or_else(|_| wt_path.to_path_buf());
@@ -2573,7 +2591,7 @@ fn remove_worktree_completing_orphans(
         wt_path.display()
     ));
     match std::fs::remove_dir_all(wt_path) {
-        Ok(()) => Ok(()),
+        Ok(()) => Ok(Disposition::Declined),
         Err(e) => Err(orig.context(format!("the direct delete of the leftover failed too: {e}"))),
     }
 }
@@ -3184,9 +3202,80 @@ mod tests {
         assert!(wt.exists());
 
         let git = GitCommand::new(true);
-        remove_worktree_completing_orphans(&git, &wt, false, &mut crate::core::NullSink)
-            .expect("a disowned directory must still get deleted");
+        remove_worktree_completing_orphans(
+            &git,
+            &tmp.path().join(".git"),
+            &wt,
+            false,
+            &mut crate::core::NullSink,
+        )
+        .expect("a disowned directory must still get deleted");
         assert!(!wt.exists(), "the leftover directory must be gone");
+    }
+
+    /// The #200 fast path: a clean worktree is renamed aside rather than
+    /// walked, and git's admin record goes with it. Asserts the *observable*
+    /// contract — path free, worktree unregistered — not the rename itself.
+    #[test]
+    #[serial]
+    fn a_clean_worktree_is_disposed_without_walking_it() {
+        let _cwd = CwdGuard::new();
+        let tmp = tempfile::tempdir().unwrap();
+        init_repo(tmp.path());
+        let wt = tmp.path().join("feature");
+        setup_worktree(tmp.path(), "feature-branch", &wt);
+        std::env::set_current_dir(tmp.path()).unwrap();
+        // A populated but *clean* tree: the case the fast path is for. Leaving
+        // these untracked would (correctly) make `dispose` decline.
+        std::fs::create_dir_all(wt.join("deps/pkg")).unwrap();
+        std::fs::write(wt.join("deps/pkg/index.js"), "x").unwrap();
+        git_quiet(&wt, &["add", "."]);
+        commit_empty(&wt, "deps");
+
+        let git = GitCommand::new(true);
+        let disposition = remove_worktree_completing_orphans(
+            &git,
+            &tmp.path().join(".git"),
+            &wt,
+            false,
+            &mut crate::core::NullSink,
+        )
+        .expect("a clean worktree must be removable");
+
+        assert_eq!(disposition, Disposition::Deferred, "expected the fast path");
+        assert!(!wt.exists(), "the path must be free");
+        let listed = git.worktree_list_porcelain().unwrap();
+        assert!(
+            !listed.contains("feature"),
+            "git must no longer register the worktree: {listed}"
+        );
+    }
+
+    /// The acceptance test for #200: whatever the fast path does to the admin
+    /// record, the freed name must be immediately reusable. This is what fails
+    /// if the record drop only appeared to work.
+    #[test]
+    #[serial]
+    fn a_disposed_worktree_path_is_immediately_reusable() {
+        let _cwd = CwdGuard::new();
+        let tmp = tempfile::tempdir().unwrap();
+        init_repo(tmp.path());
+        let wt = tmp.path().join("feature");
+        setup_worktree(tmp.path(), "feature-branch", &wt);
+        std::env::set_current_dir(tmp.path()).unwrap();
+
+        let git = GitCommand::new(true);
+        remove_worktree_completing_orphans(
+            &git,
+            &tmp.path().join(".git"),
+            &wt,
+            true,
+            &mut crate::core::NullSink,
+        )
+        .expect("removal must succeed");
+
+        setup_worktree(tmp.path(), "feature-branch-2", &wt);
+        assert!(wt.exists(), "the same path must be reusable straight away");
     }
 
     /// A still-registered worktree whose removal fails keeps the original
@@ -3205,10 +3294,24 @@ mod tests {
         std::fs::write(wt.join("junk.txt"), "x").unwrap();
 
         let git = GitCommand::new(true);
-        let err = remove_worktree_completing_orphans(&git, &wt, false, &mut crate::core::NullSink)
-            .expect_err("a registered dirty worktree must keep refusing");
+        let err = remove_worktree_completing_orphans(
+            &git,
+            &tmp.path().join(".git"),
+            &wt,
+            false,
+            &mut crate::core::NullSink,
+        )
+        .expect_err("a registered dirty worktree must keep refusing");
         assert!(err.to_string().contains("Git worktree remove failed"));
         assert!(wt.exists(), "the worktree must be untouched");
+        // The fast path must not have moved it aside either: renaming a dirty
+        // tree would retire git's own refusal, which is the last guard between
+        // validation and an irreversible delete (#200).
+        assert!(
+            !crate::core::worktree::trash::trash_dir(&tmp.path().join(".git")).exists()
+                || crate::core::worktree::trash::pending(&tmp.path().join(".git")).is_empty(),
+            "a dirty worktree must never reach the trash"
+        );
     }
 
     #[test]

--- a/src/core/worktree/mod.rs
+++ b/src/core/worktree/mod.rs
@@ -43,6 +43,7 @@ pub mod rename;
 pub mod sandbox;
 pub mod sync_dag;
 pub mod temp_worktree;
+pub mod trash;
 pub mod warm;
 
 /// Configuration for worktree operations.

--- a/src/core/worktree/prune.rs
+++ b/src/core/worktree/prune.rs
@@ -927,16 +927,29 @@ fn remove_worktree(
         // failure — it means the fast path did not apply, and the ordinary
         // removal below runs unchanged, including git's refusal of a dirty
         // worktree.
-        let handled = crate::core::worktree::trash::dispose(ctx.git, &ctx.git_dir, wt_path, force)
-            != crate::core::worktree::trash::Disposition::Declined;
-        if !handled && let Err(e) = ctx.git.worktree_remove(wt_path, force) {
+        use crate::core::worktree::trash::Disposition;
+        let disposition =
+            crate::core::worktree::trash::dispose(ctx.git, &ctx.git_dir, wt_path, force);
+        if disposition == Disposition::Declined
+            && let Err(e) = ctx.git.worktree_remove(wt_path, force)
+        {
             sink.on_warning(&format!(
                 "Failed to remove worktree {}: {e}. Skipping deletion of branch {branch_name}.",
                 wt_path.display()
             ));
             return RemoveOutcome::Failed;
         }
-        sink.on_step(&format!("Removed worktree '{branch_name}'"));
+        // `prune` clears many worktrees at once, so the gap between "removed"
+        // and "the space is back" is the widest here of anywhere. Saying so
+        // costs a clause and stops `df` from contradicting us.
+        match disposition {
+            Disposition::Deferred => sink.on_step(&format!(
+                "Removed worktree '{branch_name}' (reclaiming space in background)"
+            )),
+            Disposition::Reclaimed | Disposition::Declined => {
+                sink.on_step(&format!("Removed worktree '{branch_name}'"));
+            }
+        }
     } else {
         sink.on_warning(&format!(
             "Worktree directory {} not found. Attempting to force remove record.",

--- a/src/core/worktree/prune.rs
+++ b/src/core/worktree/prune.rs
@@ -134,6 +134,9 @@ pub fn execute(
         git = git.with_cancel(std::sync::Arc::clone(cancel));
     }
     let git_dir = get_git_common_dir()?;
+    // Reclaim leftovers from a reaper that died (#200): a failed background
+    // delete must be delayed, never permanent. Cheap when the trash is empty.
+    crate::core::worktree::trash::sweep(&git_dir);
     let default_branch =
         get_default_branch_local(&git_dir, &params.remote_name, params.use_gitoxide).ok();
     let ctx = PruneContext {
@@ -920,7 +923,13 @@ fn remove_worktree(
 
     if wt_path.exists() {
         sink.on_step("Removing worktree...");
-        if let Err(e) = ctx.git.worktree_remove(wt_path, force) {
+        // Rename aside rather than walking the tree (#200). Declining is not a
+        // failure — it means the fast path did not apply, and the ordinary
+        // removal below runs unchanged, including git's refusal of a dirty
+        // worktree.
+        let deferred = crate::core::worktree::trash::dispose(ctx.git, &ctx.git_dir, wt_path, force)
+            == crate::core::worktree::trash::Disposition::Deferred;
+        if !deferred && let Err(e) = ctx.git.worktree_remove(wt_path, force) {
             sink.on_warning(&format!(
                 "Failed to remove worktree {}: {e}. Skipping deletion of branch {branch_name}.",
                 wt_path.display()

--- a/src/core/worktree/prune.rs
+++ b/src/core/worktree/prune.rs
@@ -927,9 +927,9 @@ fn remove_worktree(
         // failure — it means the fast path did not apply, and the ordinary
         // removal below runs unchanged, including git's refusal of a dirty
         // worktree.
-        let deferred = crate::core::worktree::trash::dispose(ctx.git, &ctx.git_dir, wt_path, force)
-            == crate::core::worktree::trash::Disposition::Deferred;
-        if !deferred && let Err(e) = ctx.git.worktree_remove(wt_path, force) {
+        let handled = crate::core::worktree::trash::dispose(ctx.git, &ctx.git_dir, wt_path, force)
+            != crate::core::worktree::trash::Disposition::Declined;
+        if !handled && let Err(e) = ctx.git.worktree_remove(wt_path, force) {
             sink.on_warning(&format!(
                 "Failed to remove worktree {}: {e}. Skipping deletion of branch {branch_name}.",
                 wt_path.display()

--- a/src/core/worktree/trash.rs
+++ b/src/core/worktree/trash.rs
@@ -42,6 +42,15 @@ use std::time::{SystemTime, UNIX_EPOCH};
 /// trash directory there as a worktree.
 const TRASH_SUBDIR: &str = "trash";
 
+/// Shared prefix for every "the fast path did not apply" line, so that
+/// `--verbose` output can be grepped for the reason with one pattern.
+///
+/// Worth the constant: a decline is otherwise indistinguishable from a fast
+/// removal — same exit code, same rows, only a missing annotation — so a
+/// removal that quietly walks the tree looks exactly like one that did not.
+/// Diagnosing that from the outside is guesswork, and was.
+const DECLINED: &str = "fast removal declined";
+
 /// What [`dispose`] actually did. The distinction between the first two is
 /// user-facing: only `Deferred` may claim the space is still coming back.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -100,6 +109,7 @@ pub fn dispose(
     // A main working tree has a `.git` *directory*; a linked worktree has a
     // `.git` file. Never rename the former — it holds the repo itself.
     if worktree_path.join(".git").is_dir() {
+        crate::log_debug!("{DECLINED}: main working tree");
         return Disposition::Declined;
     }
 
@@ -111,7 +121,14 @@ pub fn dispose(
             // Dirty, or we could not tell: decline and let git refuse. Failing
             // closed matters here — a status probe that errors must not be
             // read as "clean".
-            _ => return Disposition::Declined,
+            Ok(true) => {
+                crate::log_debug!("{DECLINED}: worktree has uncommitted changes");
+                return Disposition::Declined;
+            }
+            Err(e) => {
+                crate::log_debug!("{DECLINED}: could not check for changes: {e}");
+                return Disposition::Declined;
+            }
         }
     }
 
@@ -122,7 +139,7 @@ pub fn dispose(
 
     let trash = trash_dir(git_common_dir);
     if let Err(e) = std::fs::create_dir_all(&trash) {
-        crate::log_debug!("trash dir creation failed at {}: {e}", trash.display());
+        crate::log_debug!("{DECLINED}: cannot create {}: {e}", trash.display());
         return Disposition::Declined;
     }
 
@@ -131,11 +148,12 @@ pub fn dispose(
         // EXDEV (worktree on another filesystem — the `centralized` layout, or
         // `--at` pointing off-volume) lands here, as does any permission
         // problem. Both are ordinary-path territory.
-        crate::log_debug!("worktree rename to trash failed: {e}");
+        crate::log_debug!("{DECLINED}: rename into the trash failed: {e}");
         return Disposition::Declined;
     }
 
     if !drop_worktree_record(git, worktree_path, &canonical) {
+        crate::log_debug!("{DECLINED}: git would not drop the worktree record");
         // The directory is already gone from its original path, so the
         // ordinary path cannot run any more. Recover by putting it back.
         if let Err(e) = std::fs::rename(&dest, worktree_path) {
@@ -202,26 +220,43 @@ pub fn run_reap_trash(trash: &Path) -> anyhow::Result<()> {
         anyhow::bail!("refusing to reap {}: not a daft trash dir", trash.display());
     }
 
-    // Single-flight, mirroring `log_clean::run_clean_logs`. Two reapers racing
-    // over the same directory would each see the other's half-deleted trees and
-    // log spurious failures. The lock sits beside the trash dir rather than
-    // inside it, so draining the trash does not delete the lock.
+    reap_locked(trash);
+    Ok(())
+}
+
+/// Drain `trash` while holding the single-flight lock, mirroring
+/// `log_clean::run_clean_logs`. Returns `false` when another reaper already
+/// holds it, meaning the trash is being drained but not by us.
+///
+/// Every reap goes through here, including the inline one: two reapers racing
+/// over the same directory would each see the other's half-deleted trees and
+/// log spurious failures, and back-to-back removals are exactly when a
+/// foreground sweep meets a still-running detached reaper.
+///
+/// The lock sits beside the trash dir rather than inside it, so draining the
+/// trash does not delete the lock.
+fn reap_locked(trash: &Path) -> bool {
     let lock_path = trash.with_extension("lock");
     if let Some(parent) = lock_path.parent() {
         std::fs::create_dir_all(parent).ok();
     }
-    let lock_file = std::fs::OpenOptions::new()
+    let opened = std::fs::OpenOptions::new()
         .write(true)
         .create(true)
         .truncate(false)
-        .open(&lock_path)?;
+        .open(&lock_path);
+    let Ok(lock_file) = opened else {
+        // No lock file to be had. Reaping unlocked risks a noisy race; not
+        // reaping at all risks trash that never drains. Prefer the noise.
+        reap_now(trash);
+        return true;
+    };
     use fs2::FileExt;
     if lock_file.try_lock_exclusive().is_err() {
-        return Ok(()); // another reaper is already draining this trash
+        return false;
     }
-
     reap_now(trash);
-    Ok(())
+    true
 }
 
 /// Worktrees still awaiting deletion, for `daft doctor`.
@@ -293,14 +328,28 @@ fn schedule_reap(trash: &Path) -> Disposition {
         || crate::should_skip_background_tasks(crate::cli::argv())
         || std::env::var_os("DAFT_NO_TRASH_REAP").is_some()
     {
-        reap_now(trash);
-        return Disposition::Reclaimed;
+        crate::log_debug!("reclaiming inline: background reaping is suppressed");
+        return reap_inline(trash);
     }
-    if spawn_reaper(trash).is_err() {
-        reap_now(trash);
-        return Disposition::Reclaimed;
+    if let Err(e) = spawn_reaper(trash) {
+        crate::log_debug!("reclaiming inline: could not spawn a reaper: {e}");
+        return reap_inline(trash);
     }
+    crate::log_debug!("deferred: a detached reaper is reclaiming the space");
     Disposition::Deferred
+}
+
+/// Drain the trash on the critical path, reporting what actually happened.
+///
+/// Losing the lock race is not `Reclaimed`: another reaper holds the trash and
+/// may not be finished, so claiming the space is already back would overstate
+/// it in exactly the direction that hides a slow removal.
+fn reap_inline(trash: &Path) -> Disposition {
+    if reap_locked(trash) {
+        Disposition::Reclaimed
+    } else {
+        Disposition::Deferred
+    }
 }
 
 #[cfg(unix)]
@@ -422,6 +471,38 @@ mod tests {
     fn sweep_without_a_trash_dir_is_a_no_op() {
         let tmp = tempfile::tempdir().unwrap();
         sweep(&tmp.path().join(".git"));
+    }
+
+    /// Every reap takes the single-flight lock, the inline one included — a
+    /// foreground sweep must not race a detached reaper that is still walking
+    /// the same tree. Back-to-back removals are when that actually happens.
+    #[test]
+    fn an_inline_reap_yields_to_a_reaper_already_holding_the_lock() {
+        use fs2::FileExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let git_dir = tmp.path().join(".git");
+        let trash = trash_dir(&git_dir);
+        std::fs::create_dir_all(trash.join("busy")).unwrap();
+
+        // Stand in for a live reaper holding the lock.
+        let held = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(trash.with_extension("lock"))
+            .unwrap();
+        held.try_lock_exclusive().unwrap();
+
+        // Deferred, not Reclaimed: someone else owns the drain, and it may not
+        // be finished. Claiming the space is back would be the overstatement
+        // that hides a still-running walk.
+        assert_eq!(reap_inline(&trash), Disposition::Deferred);
+        assert!(trash.join("busy").exists(), "must not touch a locked trash");
+
+        FileExt::unlock(&held).unwrap();
+        assert_eq!(reap_inline(&trash), Disposition::Reclaimed);
+        assert!(!trash.join("busy").exists());
     }
 
     #[test]

--- a/src/core/worktree/trash.rs
+++ b/src/core/worktree/trash.rs
@@ -18,22 +18,48 @@
 //! evict job logs (rename to `.deleting-…`, then `remove_dir_all`), and the
 //! same owned-scratch-dir-plus-stale-sweep shape as [`super::temp_worktree`].
 //!
-//! Two properties worth stating because they are easy to lose in a refactor:
+//! # What keeps this from losing a worktree
 //!
-//! - **A dirty worktree is never renamed.** Without `force`, `git worktree
-//!   remove` performs its own uncommitted-changes check immediately before
-//!   deleting — a guard distinct from, and much later than, daft's validation
-//!   pass. Renaming first would silently retire it. [`dispose`] therefore
-//!   re-checks and declines the fast path when the tree is dirty, so the caller
-//!   falls through to git and the user sees git's own refusal, unchanged.
-//! - **Reaping is convergent, not fire-and-forget.** A reaper that dies leaves
-//!   a directory in the trash, and the next removal in the repo sweeps it. A
-//!   failed reap is therefore delayed, never permanent, which is what keeps
-//!   deferred deletion from being a silent failure.
+//! **Nothing is deleted until git has disowned it.** The rename happens before
+//! the record drop, so there is a window in which the tree sits in the trash
+//! while git still points at its old path — a `SIGINT` or a crash lands
+//! squarely in it. A [sidecar file](origin_sidecar) written *before* the rename
+//! marks the entry as not-yet-committed, and [`dispose`] deletes that sidecar
+//! only once the record drop is verified. Reapers skip any entry that still has
+//! one, so an interrupted removal costs disk space, never data. Resolving those
+//! entries — restoring the worktree, or clearing it once git no longer wants it
+//! — is [`reclaim`]'s job, driven by `daft doctor --fix`, which has a
+//! `GitCommand` and a place to report.
+//!
+//! This protects against process death, not power loss: the sidecar is not
+//! fsynced, because a barrier would cost more than the entire fast path.
+//!
+//! **Git's own refusals are preserved, not retired.** Without `force`, `git
+//! worktree remove` runs two checks immediately before deleting, both much
+//! later than daft's validation pass, and renaming first would silently retire
+//! both. So [`dispose`] re-runs them and declines the fast path if either
+//! fires, leaving the caller to invoke git and the user to see git's own
+//! wording:
+//!
+//! - uncommitted changes ([`crate::git::GitCommand::has_uncommitted_changes_in`]);
+//! - a populated submodule, which git refuses with "working trees containing
+//!   submodules cannot be moved or removed" ([`has_populated_submodules`]).
+//!
+//! Both are gated on `force`, matching git: `git worktree remove --force`
+//! removes a submodule-bearing worktree, so daft's forced path may too. A
+//! *locked* worktree needs no check here — git wants `--force --force` for one
+//! and [`drop_worktree_record`] only ever passes a single `--force`, so the
+//! record survives, the restore fires, and git issues the refusal itself.
+//!
+//! **Reaping is convergent, not fire-and-forget.** A reaper that dies leaves a
+//! directory in the trash, and the next removal in the repo sweeps it. A failed
+//! reap is therefore delayed, never permanent, which is what keeps deferred
+//! deletion from being a silent failure.
 
 use crate::git::GitCommand;
+use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 /// Directory under `<git-common-dir>/.daft/` holding worktrees awaiting
 /// deletion. Inside the git dir deliberately: several code paths classify
@@ -41,6 +67,12 @@ use std::time::{SystemTime, UNIX_EPOCH};
 /// config scanners, `daft repo remove`'s is-empty probe) and would read a
 /// trash directory there as a worktree.
 const TRASH_SUBDIR: &str = "trash";
+
+/// Suffix marking the sidecar that protects a not-yet-committed trash entry.
+/// Appended to the entry's full name rather than set with `Path::set_extension`
+/// — a worktree called `feature.v2` trashes as `feature.v2-…`, and setting an
+/// extension there would *replace* `v2` and produce a sidecar guarding nothing.
+const ORIGIN_SUFFIX: &str = ".origin";
 
 /// Shared prefix for every "the fast path did not apply" line, so that
 /// `--verbose` output can be grepped for the reason with one pattern.
@@ -73,8 +105,17 @@ pub enum Disposition {
 #[derive(Debug, Clone)]
 pub struct PendingEntry {
     pub path: PathBuf,
-    /// How long ago the entry was renamed in, when that can be determined.
-    pub age: Option<std::time::Duration>,
+    /// How long ago the entry was renamed in, read from the timestamp
+    /// [`entry_name`] encodes. Deliberately *not* the directory's mtime, which
+    /// `rename(2)` carries over from the worktree and so measures when the user
+    /// last edited a file — a week-old checkout would look a week stranded the
+    /// instant it was removed.
+    pub age: Option<Duration>,
+    /// True when the entry still has its [sidecar](origin_sidecar): the rename
+    /// happened but the record drop never confirmed, so this is an interrupted
+    /// removal rather than a reap in flight. No reaper will touch it; only
+    /// [`reclaim`] resolves it.
+    pub interrupted: bool,
 }
 
 /// Where this repo's pending deletions live.
@@ -91,15 +132,61 @@ pub fn is_trash_path(path: &Path) -> bool {
         && matches!(parts.next(), Some(c) if c.as_os_str() == ".daft")
 }
 
+/// The sidecar guarding `dest` until its removal is committed.
+fn origin_sidecar(dest: &Path) -> PathBuf {
+    let mut name = dest.as_os_str().to_os_string();
+    name.push(ORIGIN_SUFFIX);
+    PathBuf::from(name)
+}
+
+/// Reproduce, from another module's tests, the state a removal leaves behind
+/// when it dies between the rename and the record drop. Deliberately test-only:
+/// in production the write happens inside [`dispose`], where its *ordering*
+/// relative to the rename is the whole point.
+#[cfg(test)]
+pub fn write_origin_sidecar_for_test(dest: &Path, origin: &Path) {
+    std::fs::write(origin_sidecar(dest), path_bytes(origin)).unwrap();
+}
+
+fn is_sidecar(path: &Path) -> bool {
+    path.file_name()
+        .and_then(OsStr::to_str)
+        .is_some_and(|n| n.ends_with(ORIGIN_SUFFIX))
+}
+
+#[cfg(unix)]
+fn path_bytes(path: &Path) -> Vec<u8> {
+    use std::os::unix::ffi::OsStrExt;
+    path.as_os_str().as_bytes().to_vec()
+}
+
+#[cfg(unix)]
+fn path_from_bytes(bytes: &[u8]) -> PathBuf {
+    use std::os::unix::ffi::OsStrExt;
+    PathBuf::from(OsStr::from_bytes(bytes))
+}
+
+// Off unix the fast path never runs (see `spawn_reaper`), so a lossy round-trip
+// here is unreachable in practice; it exists to keep the module compiling.
+#[cfg(not(unix))]
+fn path_bytes(path: &Path) -> Vec<u8> {
+    path.to_string_lossy().into_owned().into_bytes()
+}
+
+#[cfg(not(unix))]
+fn path_from_bytes(bytes: &[u8]) -> PathBuf {
+    PathBuf::from(String::from_utf8_lossy(bytes).into_owned())
+}
+
 /// Move `worktree_path` out of the way and drop git's admin record for it,
 /// leaving the actual deletion to a background reaper.
 ///
 /// Returns [`Disposition::Declined`] — not an error — whenever the fast path
-/// does not apply: a dirty tree without `force`, a main working tree, a rename
-/// that cannot happen (`EXDEV` for a worktree on another filesystem, a
-/// permission problem), or a git record that will not budge. The caller then
-/// performs the ordinary removal, so declining costs correctness nothing and
-/// the user sees git's own diagnostics rather than ours.
+/// does not apply: a dirty tree or a populated submodule without `force`, a
+/// main working tree, a rename that cannot happen (`EXDEV` for a worktree on
+/// another filesystem, a permission problem), or a git record that will not
+/// budge. The caller then performs the ordinary removal, so declining costs
+/// correctness nothing and the user sees git's own diagnostics rather than ours.
 pub fn dispose(
     git: &GitCommand,
     git_common_dir: &Path,
@@ -113,8 +200,8 @@ pub fn dispose(
         return Disposition::Declined;
     }
 
-    // Preserve the guard git would have applied. Only `force` removals skip
-    // it, exactly as `git worktree remove` does.
+    // Preserve the two guards git would have applied. Only `force` removals
+    // skip them, exactly as `git worktree remove` does.
     if !force {
         match git.has_uncommitted_changes_in(worktree_path) {
             Ok(false) => {}
@@ -130,6 +217,10 @@ pub fn dispose(
                 return Disposition::Declined;
             }
         }
+        if has_populated_submodules(worktree_path) {
+            crate::log_debug!("{DECLINED}: worktree contains a populated submodule");
+            return Disposition::Declined;
+        }
     }
 
     // Capture identity before the rename: `canonicalize` on a path that no
@@ -144,11 +235,22 @@ pub fn dispose(
     }
 
     let dest = trash.join(entry_name(worktree_path));
+    let sidecar = origin_sidecar(&dest);
+
+    // Write the guard *before* the rename, so that every moment in which the
+    // tree is in the trash without git having disowned it is a moment in which
+    // reapers can see that it must not be touched.
+    if let Err(e) = std::fs::write(&sidecar, path_bytes(&canonical)) {
+        crate::log_debug!("{DECLINED}: cannot mark the trash entry: {e}");
+        return Disposition::Declined;
+    }
+
     if let Err(e) = std::fs::rename(worktree_path, &dest) {
         // EXDEV (worktree on another filesystem — the `centralized` layout, or
         // `--at` pointing off-volume) lands here, as does any permission
         // problem. Both are ordinary-path territory.
         crate::log_debug!("{DECLINED}: rename into the trash failed: {e}");
+        let _ = std::fs::remove_file(&sidecar);
         return Disposition::Declined;
     }
 
@@ -156,34 +258,88 @@ pub fn dispose(
         crate::log_debug!("{DECLINED}: git would not drop the worktree record");
         // The directory is already gone from its original path, so the
         // ordinary path cannot run any more. Recover by putting it back.
-        if let Err(e) = std::fs::rename(&dest, worktree_path) {
-            crate::log_debug!("failed to restore worktree after record drop: {e}");
-            // Restoring failed too. The directory is in the trash and git
-            // still has a record; the reaper would delete the user's tree
-            // while git believes it exists. Leave it alone — the sweep will
-            // not touch it because the record still names it, and `daft
-            // doctor` will report it.
-            return Disposition::Declined;
+        match std::fs::rename(&dest, worktree_path) {
+            Ok(()) => {
+                let _ = std::fs::remove_file(&sidecar);
+            }
+            Err(e) => {
+                // Restoring failed too. The tree stays in the trash *with* its
+                // sidecar, which is exactly the state that keeps reapers off
+                // it; `daft doctor` reports it and `reclaim` resolves it.
+                crate::log_debug!("failed to restore worktree after record drop: {e}");
+            }
         }
+        return Disposition::Declined;
+    }
+
+    // Git has disowned the path. Dropping the sidecar is the commit point:
+    // from here the entry is ordinary garbage and any reaper may take it.
+    if let Err(e) = std::fs::remove_file(&sidecar) {
+        // The tree is safe either way — it simply will not be reaped until
+        // `daft doctor --fix` resolves it, so say so rather than claiming
+        // background reclamation.
+        crate::log_debug!("could not commit the trash entry, leaving it for doctor: {e}");
         return Disposition::Declined;
     }
 
     schedule_reap(&trash)
 }
 
+/// Does this worktree hold a submodule that is actually checked out?
+///
+/// Git's refusal is keyed on a gitlink in the index whose directory exists, so
+/// a `.gitmodules` listing submodules nobody ran `submodule update` for does
+/// *not* block removal — verified against git 2.55. Cheap in the common case:
+/// one `stat` for the `.gitmodules` that almost never exists.
+///
+/// Fails closed. An unreadable or malformed `.gitmodules` reports `true`, which
+/// costs a fast path and never a worktree.
+fn has_populated_submodules(worktree_path: &Path) -> bool {
+    if !worktree_path.join(".gitmodules").exists() {
+        return false;
+    }
+    let output = crate::utils::git_command_at(worktree_path)
+        .args([
+            "config",
+            "--file",
+            ".gitmodules",
+            "--get-regexp",
+            r"^submodule\..*\.path$",
+        ])
+        .stderr(std::process::Stdio::null())
+        .output();
+    let Ok(output) = output else {
+        return true;
+    };
+    // 0 = matches, 1 = no matches. Anything else (a malformed file, say) is a
+    // question we could not answer.
+    if !matches!(output.status.code(), Some(0 | 1)) {
+        return true;
+    }
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| line.split_once(' '))
+        .any(|(_, path)| worktree_path.join(path.trim()).join(".git").exists())
+}
+
 /// Reap anything left in this repo's trash: leftovers from a reaper that died,
-/// or from a `dispose` whose spawn failed. Cheap when the trash is empty, which
-/// is the common case, so callers can run it unconditionally at command start.
+/// or from a `dispose` whose spawn failed. Cheap when there is nothing to do,
+/// which is the common case, so callers can run it unconditionally at command
+/// start.
 pub fn sweep(git_common_dir: &Path) {
     let trash = trash_dir(git_common_dir);
-    if !has_entries(&trash) {
+    if !has_reapable_entries(&trash) {
         return;
     }
     schedule_reap(&trash);
 }
 
-/// Reap everything in `trash` right now. This is the reaper's body; it also
-/// runs inline when background work is suppressed.
+/// Reap everything in `trash` that git has already disowned. This is the
+/// reaper's body; it also runs inline when background work is suppressed.
+///
+/// Entries still carrying a [sidecar](origin_sidecar) are left strictly alone:
+/// their removal never committed, so the worktree may still be the only copy of
+/// the user's ignored files and git may still point at its old path.
 pub fn reap_now(trash: &Path) {
     if !is_trash_path(trash) {
         return;
@@ -192,13 +348,36 @@ pub fn reap_now(trash: &Path) {
         return;
     };
     for entry in entries.flatten() {
-        if let Err(e) = std::fs::remove_dir_all(entry.path()) {
+        let path = entry.path();
+        if is_sidecar(&path) {
+            // A sidecar whose entry is gone guards nothing; anything else is
+            // still doing its job.
+            if !guarded_entry(&path).exists() {
+                let _ = std::fs::remove_file(&path);
+            }
+            continue;
+        }
+        if origin_sidecar(&path).exists() {
+            crate::log_debug!(
+                "leaving {}: its removal never completed",
+                path.file_name().unwrap_or_default().to_string_lossy()
+            );
+            continue;
+        }
+        if let Err(e) = std::fs::remove_dir_all(&path) {
             // Leave it for the next sweep rather than retrying here.
-            crate::log_debug!("reap of {} failed: {e}", entry.path().display());
+            crate::log_debug!("reap of {} failed: {e}", path.display());
         }
     }
-    // Best-effort; fails harmlessly while another reaper still holds entries.
-    let _ = std::fs::remove_dir(trash);
+    // The trash directory itself stays. Removing it would let a reaper pull the
+    // floor out from under a concurrent `dispose` between its `create_dir_all`
+    // and its `rename`, which costs that removal the fast path for no reason.
+}
+
+/// The entry a sidecar guards: its own path minus the suffix.
+fn guarded_entry(sidecar: &Path) -> PathBuf {
+    let name = sidecar.as_os_str().to_string_lossy();
+    PathBuf::from(name.trim_end_matches(ORIGIN_SUFFIX).to_string())
 }
 
 /// Entry point for the `daft __reap-trash <dir>` background process: drain one
@@ -220,43 +399,67 @@ pub fn run_reap_trash(trash: &Path) -> anyhow::Result<()> {
         anyhow::bail!("refusing to reap {}: not a daft trash dir", trash.display());
     }
 
-    reap_locked(trash);
+    // Wait for the lock rather than giving up on it. Nobody is blocked on this
+    // process, and a reaper that exits on contention would strand the very
+    // entry it was spawned for: the reaper already running enumerated the trash
+    // before that entry was renamed in, so it will never see it.
+    reap_locked(trash, Wait::Block);
     Ok(())
 }
 
+/// Whether a reap may wait for the single-flight lock.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Wait {
+    /// Detached reapers wait: nothing is blocked on them, and giving up would
+    /// strand the entry they were spawned for.
+    Block,
+    /// Foreground reaps do not — the user is waiting, and another process
+    /// already draining the trash is a perfectly good outcome.
+    Give,
+}
+
 /// Drain `trash` while holding the single-flight lock, mirroring
-/// `log_clean::run_clean_logs`. Returns `false` when another reaper already
-/// holds it, meaning the trash is being drained but not by us.
+/// `log_clean::run_clean_logs`. Returns `false` when another reaper holds it
+/// and we chose not to wait, meaning the trash is being drained but not by us.
 ///
-/// Every reap goes through here, including the inline one: two reapers racing
-/// over the same directory would each see the other's half-deleted trees and
-/// log spurious failures, and back-to-back removals are exactly when a
-/// foreground sweep meets a still-running detached reaper.
+/// Every reap goes through here, including the inline one and `daft doctor
+/// --fix`: two reapers racing over the same directory would each see the
+/// other's half-deleted trees and log spurious failures, and back-to-back
+/// removals are exactly when a foreground sweep meets a still-running detached
+/// reaper.
 ///
 /// The lock sits beside the trash dir rather than inside it, so draining the
 /// trash does not delete the lock.
-fn reap_locked(trash: &Path) -> bool {
-    let lock_path = trash.with_extension("lock");
-    if let Some(parent) = lock_path.parent() {
-        std::fs::create_dir_all(parent).ok();
-    }
-    let opened = std::fs::OpenOptions::new()
-        .write(true)
-        .create(true)
-        .truncate(false)
-        .open(&lock_path);
-    let Ok(lock_file) = opened else {
+fn reap_locked(trash: &Path, wait: Wait) -> bool {
+    let Some(lock_file) = open_lock(trash) else {
         // No lock file to be had. Reaping unlocked risks a noisy race; not
         // reaping at all risks trash that never drains. Prefer the noise.
         reap_now(trash);
         return true;
     };
     use fs2::FileExt;
-    if lock_file.try_lock_exclusive().is_err() {
+    let acquired = match wait {
+        Wait::Block => lock_file.lock_exclusive().is_ok(),
+        Wait::Give => lock_file.try_lock_exclusive().is_ok(),
+    };
+    if !acquired {
         return false;
     }
     reap_now(trash);
     true
+}
+
+fn open_lock(trash: &Path) -> Option<std::fs::File> {
+    let lock_path = trash.with_extension("lock");
+    if let Some(parent) = lock_path.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+    std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock_path)
+        .ok()
 }
 
 /// Worktrees still awaiting deletion, for `daft doctor`.
@@ -267,38 +470,99 @@ pub fn pending(git_common_dir: &Path) -> Vec<PendingEntry> {
     };
     entries
         .flatten()
-        .map(|entry| {
-            let age = entry
-                .metadata()
-                .and_then(|m| m.modified())
-                .ok()
-                .and_then(|t| SystemTime::now().duration_since(t).ok());
-            PendingEntry {
-                path: entry.path(),
-                age,
-            }
+        .map(|entry| entry.path())
+        // Sidecars describe an entry rather than being one; listing them would
+        // report every interrupted removal twice.
+        .filter(|path| !is_sidecar(path))
+        .map(|path| PendingEntry {
+            age: entry_age(&path),
+            interrupted: origin_sidecar(&path).exists(),
+            path,
         })
         .collect()
 }
 
+/// Resolve everything waiting in this repo's trash, on the caller's thread.
+///
+/// This is `daft doctor --fix`. Unlike a reaper it can act on interrupted
+/// removals, because it has a `GitCommand` and somewhere to report: an entry
+/// git still points at is *restored* to where git expects it, so a removal cut
+/// short becomes a no-op rather than a wedge; one git no longer wants is
+/// deleted like any other garbage.
+///
+/// Returns an error naming what could not be reclaimed, so a fix that did not
+/// fix anything cannot report success.
+pub fn reclaim(git: &GitCommand, git_common_dir: &Path) -> anyhow::Result<()> {
+    let trash = trash_dir(git_common_dir);
+    if !trash.exists() {
+        return Ok(());
+    }
+    let lock = open_lock(&trash);
+    if let Some(file) = &lock {
+        use fs2::FileExt;
+        let _ = file.lock_exclusive();
+    }
+
+    let mut failures: Vec<String> = Vec::new();
+    let entries = std::fs::read_dir(&trash)
+        .map(|d| d.flatten().map(|e| e.path()).collect::<Vec<_>>())
+        .unwrap_or_default();
+
+    for path in entries {
+        if is_sidecar(&path) {
+            if !guarded_entry(&path).exists() {
+                let _ = std::fs::remove_file(&path);
+            }
+            continue;
+        }
+        let sidecar = origin_sidecar(&path);
+        let origin = std::fs::read(&sidecar).ok().map(|b| path_from_bytes(&b));
+        // An interrupted removal that git still points at belongs back where
+        // git expects it — deleting it would destroy ignored files the
+        // cancelled removal was supposed to leave alone.
+        if let Some(origin) = origin
+            && !origin.as_os_str().is_empty()
+            && !origin.exists()
+            && still_registered(git, &origin)
+        {
+            match std::fs::rename(&path, &origin) {
+                Ok(()) => {
+                    let _ = std::fs::remove_file(&sidecar);
+                }
+                Err(e) => failures.push(format!("{}: {e}", origin.display())),
+            }
+            continue;
+        }
+        match std::fs::remove_dir_all(&path) {
+            Ok(()) => {
+                let _ = std::fs::remove_file(&sidecar);
+            }
+            Err(e) => failures.push(format!("{}: {e}", path.display())),
+        }
+    }
+
+    if let Some(file) = &lock {
+        let _ = fs2::FileExt::unlock(file);
+    }
+
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        anyhow::bail!("could not reclaim {}", failures.join("; "))
+    }
+}
+
 /// Drop git's admin entry for a worktree whose directory is already gone.
 ///
-/// `git worktree remove --force` handles this directly; `git worktree prune` is
-/// the documented mechanism and stands behind it. Either way the record is
-/// verified gone rather than trusted from an exit code, because `prune` is
-/// repo-wide and will also clear records for *other* worktrees that happen to
-/// be missing — a green exit says nothing about ours specifically.
+/// `git worktree remove --force` handles this directly, and the record is
+/// verified gone rather than trusted from an exit code. There is deliberately
+/// no `git worktree prune` fallback: prune is repo-wide and immediately drops
+/// the record of *every* worktree whose directory is currently missing, so a
+/// removal here could deregister a colleague's worktree on an unmounted volume.
+/// Failing instead costs one slow removal, which the caller handles by
+/// restoring the tree and letting git remove it the ordinary way.
 fn drop_worktree_record(git: &GitCommand, worktree_path: &Path, canonical: &Path) -> bool {
-    if git.worktree_remove(worktree_path, true).is_ok() && !still_registered(git, canonical) {
-        return true;
-    }
-    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    let _ = crate::utils::git_command_at(&cwd)
-        .args(["worktree", "prune"])
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status();
-    !still_registered(git, canonical)
+    git.worktree_remove(worktree_path, true).is_ok() && !still_registered(git, canonical)
 }
 
 fn still_registered(git: &GitCommand, canonical: &Path) -> bool {
@@ -345,7 +609,7 @@ fn schedule_reap(trash: &Path) -> Disposition {
 /// may not be finished, so claiming the space is already back would overstate
 /// it in exactly the direction that hides a slow removal.
 fn reap_inline(trash: &Path) -> Disposition {
-    if reap_locked(trash) {
+    if reap_locked(trash, Wait::Give) {
         Disposition::Reclaimed
     } else {
         Disposition::Deferred
@@ -378,12 +642,22 @@ fn spawn_reaper(_trash: &Path) -> anyhow::Result<()> {
     anyhow::bail!("background reaping is unix-only")
 }
 
-fn has_entries(dir: &Path) -> bool {
-    std::fs::read_dir(dir).is_ok_and(|mut d| d.next().is_some())
+/// Is there anything a reaper could actually take? Entries still guarded by a
+/// sidecar do not count: spawning a process to walk past them every command
+/// would be pure noise.
+fn has_reapable_entries(trash: &Path) -> bool {
+    let Ok(entries) = std::fs::read_dir(trash) else {
+        return false;
+    };
+    entries
+        .flatten()
+        .map(|e| e.path())
+        .any(|p| !is_sidecar(&p) && !origin_sidecar(&p).exists())
 }
 
 /// A collision-free name for a trashed worktree. The original name leads so a
-/// human reading `daft doctor` output can tell what is waiting to be deleted.
+/// human reading `daft doctor` output can tell what is waiting to be deleted,
+/// and the trailing nanosecond stamp is what [`entry_age`] reads back.
 fn entry_name(worktree_path: &Path) -> String {
     let base = worktree_path
         .file_name()
@@ -396,9 +670,36 @@ fn entry_name(worktree_path: &Path) -> String {
     format!("{base}-{}-{nanos}", std::process::id())
 }
 
+/// How long ago an entry was trashed, from the stamp [`entry_name`] wrote.
+///
+/// The stamp is read from the right, so a worktree whose own name contains
+/// hyphens (most of them) parses correctly.
+fn entry_age(path: &Path) -> Option<Duration> {
+    let name = path.file_name()?.to_str()?;
+    let (_, nanos) = name.rsplit_once('-')?;
+    let nanos: u64 = nanos.parse().ok()?;
+    let trashed = UNIX_EPOCH.checked_add(Duration::from_nanos(nanos))?;
+    SystemTime::now().duration_since(trashed).ok()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Stand in for `dispose`'s output without needing a real repo: a trashed
+    /// directory whose removal has been committed (no sidecar).
+    fn committed_entry(trash: &Path, name: &str) -> PathBuf {
+        let entry = trash.join(name);
+        std::fs::create_dir_all(entry.join("payload")).unwrap();
+        entry
+    }
+
+    /// …and one whose removal was interrupted after the rename.
+    fn interrupted_entry(trash: &Path, name: &str, origin: &Path) -> PathBuf {
+        let entry = committed_entry(trash, name);
+        std::fs::write(origin_sidecar(&entry), path_bytes(origin)).unwrap();
+        entry
+    }
 
     #[test]
     fn trash_lives_under_the_git_dir() {
@@ -415,6 +716,21 @@ mod tests {
         assert!(!is_trash_path(Path::new("/Users/someone")));
         // A directory merely *named* trash is not ours.
         assert!(!is_trash_path(Path::new("/tmp/trash")));
+    }
+
+    /// A dotted worktree name is why the sidecar is a suffix and not an
+    /// extension: `set_extension` would eat the `v2` and guard nothing.
+    #[test]
+    fn a_sidecar_guards_a_dotted_entry_name() {
+        let entry = Path::new("/t/.daft/trash/feature.v2-991-17");
+        let sidecar = origin_sidecar(entry);
+        assert_eq!(
+            sidecar,
+            PathBuf::from("/t/.daft/trash/feature.v2-991-17.origin")
+        );
+        assert!(is_sidecar(&sidecar));
+        assert!(!is_sidecar(entry));
+        assert_eq!(guarded_entry(&sidecar), entry);
     }
 
     #[test]
@@ -445,6 +761,59 @@ mod tests {
         assert!(!trash.join("wt-2").exists());
     }
 
+    /// The invariant the whole design rests on: an entry whose removal never
+    /// committed is not garbage. Git may still point at its old path, and it
+    /// may hold ignored files — `.env`, `node_modules/` — that exist nowhere
+    /// else, which the dirty probe deliberately does not see.
+    #[test]
+    fn a_reaper_never_takes_an_uncommitted_entry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let trash = trash_dir(&tmp.path().join(".git"));
+        std::fs::create_dir_all(&trash).unwrap();
+        let doomed = committed_entry(&trash, "committed-1-2");
+        let spared = interrupted_entry(&trash, "interrupted-1-3", &tmp.path().join("feature"));
+
+        reap_now(&trash);
+
+        assert!(!doomed.exists(), "a committed entry must be reaped");
+        assert!(
+            spared.join("payload").exists(),
+            "an interrupted removal must survive every sweep"
+        );
+        assert!(
+            origin_sidecar(&spared).exists(),
+            "its guard must survive too"
+        );
+    }
+
+    /// A sidecar outliving its entry protects nothing and would otherwise
+    /// accumulate forever.
+    #[test]
+    fn an_orphan_sidecar_is_cleaned_up() {
+        let tmp = tempfile::tempdir().unwrap();
+        let trash = trash_dir(&tmp.path().join(".git"));
+        std::fs::create_dir_all(&trash).unwrap();
+        let orphan = origin_sidecar(&trash.join("gone-1-2"));
+        std::fs::write(&orphan, path_bytes(Path::new("/nowhere"))).unwrap();
+
+        reap_now(&trash);
+
+        assert!(!orphan.exists());
+    }
+
+    /// Removing the trash dir would let a reaper pull the floor out from under
+    /// a concurrent `dispose` between its `create_dir_all` and its `rename`.
+    #[test]
+    fn reaping_leaves_the_trash_dir_in_place() {
+        let tmp = tempfile::tempdir().unwrap();
+        let trash = trash_dir(&tmp.path().join(".git"));
+        committed_entry(&trash, "wt-1-2");
+
+        reap_now(&trash);
+
+        assert!(trash.exists(), "the trash dir must outlive its contents");
+    }
+
     #[test]
     fn reap_on_an_absent_trash_dir_is_a_no_op() {
         let tmp = tempfile::tempdir().unwrap();
@@ -465,6 +834,19 @@ mod tests {
         sweep(&git_dir);
 
         assert!(!trash.join("stranded").exists());
+    }
+
+    /// A trash holding only uncommitted entries has nothing a reaper may take,
+    /// so a sweep must not spawn one on every command for the rest of time.
+    #[test]
+    fn sweep_ignores_a_trash_of_only_uncommitted_entries() {
+        let tmp = tempfile::tempdir().unwrap();
+        let git_dir = tmp.path().join(".git");
+        let trash = trash_dir(&git_dir);
+        std::fs::create_dir_all(&trash).unwrap();
+        interrupted_entry(&trash, "interrupted-1-2", &tmp.path().join("feature"));
+
+        assert!(!has_reapable_entries(&trash));
     }
 
     #[test]
@@ -513,6 +895,89 @@ mod tests {
         assert!(a.starts_with("feature-"), "{a}");
     }
 
+    /// Age comes from the stamp in the name, not the directory's mtime —
+    /// `rename(2)` carries mtime over from the worktree, so a checkout last
+    /// edited a week ago would read as a week stranded the moment it was
+    /// removed.
+    #[test]
+    fn age_is_measured_from_when_the_entry_was_trashed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let trash = trash_dir(&tmp.path().join(".git"));
+        let entry = trash.join(entry_name(Path::new("/repo/my-feature-branch")));
+        std::fs::create_dir_all(&entry).unwrap();
+
+        let age = entry_age(&entry).expect("a freshly stamped entry has a readable age");
+        assert!(age < Duration::from_secs(5), "{age:?}");
+
+        // A week-old stamp reads as a week, whatever the directory's mtime is.
+        let old = trash.join(format!(
+            "old-1-{}",
+            (SystemTime::now() - Duration::from_secs(7 * 86_400))
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&old).unwrap();
+        assert!(entry_age(&old).unwrap() > Duration::from_secs(6 * 86_400));
+    }
+
+    #[test]
+    fn an_unstamped_entry_has_no_age() {
+        assert!(entry_age(Path::new("/t/.daft/trash/handmade")).is_none());
+    }
+
+    /// Write a `.gitmodules` declaring `path`, optionally checking it out.
+    fn declare_submodule(worktree: &Path, path: &str, populated: bool) {
+        std::fs::create_dir_all(worktree).unwrap();
+        std::fs::write(
+            worktree.join(".gitmodules"),
+            format!("[submodule \"s\"]\n\tpath = {path}\n\turl = ./s\n"),
+        )
+        .unwrap();
+        let checkout = worktree.join(path);
+        std::fs::create_dir_all(&checkout).unwrap();
+        if populated {
+            std::fs::write(checkout.join(".git"), "gitdir: ../../.git/modules/s").unwrap();
+        }
+    }
+
+    /// The overwhelmingly common case, and the one that must stay cheap: no
+    /// `.gitmodules`, so the probe is a single `stat` and no subprocess.
+    #[test]
+    fn a_worktree_without_gitmodules_has_no_submodules() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(!has_populated_submodules(tmp.path()));
+    }
+
+    /// Git's refusal is keyed on a gitlink whose directory is checked out, so
+    /// a `.gitmodules` nobody ran `submodule update` for must not cost the
+    /// fast path.
+    #[test]
+    fn a_declared_but_uninitialized_submodule_does_not_block_the_fast_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        declare_submodule(tmp.path(), "vendor/lib", false);
+        assert!(!has_populated_submodules(tmp.path()));
+    }
+
+    /// This is the case git dies on with "working trees containing submodules
+    /// cannot be moved or removed". Renaming aside would defeat that check —
+    /// git looks for paths that exist, and after the rename none do.
+    #[test]
+    fn a_populated_submodule_blocks_the_fast_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        declare_submodule(tmp.path(), "vendor/lib", true);
+        assert!(has_populated_submodules(tmp.path()));
+    }
+
+    /// A `.gitmodules` git cannot parse is a question we could not answer, and
+    /// the safe answer costs a fast path rather than a worktree.
+    #[test]
+    fn an_unparseable_gitmodules_fails_closed() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join(".gitmodules"), "[submodule \"s\"\n\tpath\n").unwrap();
+        assert!(has_populated_submodules(tmp.path()));
+    }
+
     #[test]
     fn pending_reports_nothing_when_the_trash_is_absent() {
         let tmp = tempfile::tempdir().unwrap();
@@ -520,16 +985,20 @@ mod tests {
     }
 
     #[test]
-    fn pending_reports_each_waiting_worktree() {
+    fn pending_reports_each_waiting_worktree_once() {
         let tmp = tempfile::tempdir().unwrap();
         let git_dir = tmp.path().join(".git");
         let trash = trash_dir(&git_dir);
-        std::fs::create_dir_all(trash.join("wt-1")).unwrap();
-        std::fs::create_dir_all(trash.join("wt-2")).unwrap();
+        std::fs::create_dir_all(&trash).unwrap();
+        committed_entry(&trash, "wt-1-2");
+        interrupted_entry(&trash, "wt-1-3", &tmp.path().join("feature"));
 
         let entries = pending(&git_dir);
 
+        // Two entries, not three: the sidecar describes one of them rather
+        // than being one itself.
         assert_eq!(entries.len(), 2);
         assert!(entries.iter().all(|e| e.age.is_some()));
+        assert_eq!(entries.iter().filter(|e| e.interrupted).count(), 1);
     }
 }

--- a/src/core/worktree/trash.rs
+++ b/src/core/worktree/trash.rs
@@ -1,0 +1,424 @@
+//! Fast worktree disposal: rename the directory aside, drop git's admin
+//! record, and leave the unlink walk to a detached reaper.
+//!
+//! `git worktree remove` deletes the directory itself, with a serial unlink
+//! walk that is O(files) on the critical path — seconds to tens of seconds for
+//! a worktree carrying `node_modules/` or `target/`. That walk is the whole of
+//! the command's perceived cost, and none of it is work the user is waiting on
+//! for a *correct* result: once the directory is out of the way and git's admin
+//! entry is gone, the user-visible contract is discharged (branch gone, git
+//! consistent, path free for a fresh `daft start`). Only disk reclamation is
+//! left, and that can happen after the process exits.
+//!
+//! So: [`dispose`] renames the worktree into `<git-common-dir>/.daft/trash/`
+//! (one syscall, O(1)), drops the record, and hands the tree to
+//! `daft __reap-trash`.
+//!
+//! This is the same shape [`crate::coordinator::log_store`] already uses to
+//! evict job logs (rename to `.deleting-…`, then `remove_dir_all`), and the
+//! same owned-scratch-dir-plus-stale-sweep shape as [`super::temp_worktree`].
+//!
+//! Two properties worth stating because they are easy to lose in a refactor:
+//!
+//! - **A dirty worktree is never renamed.** Without `force`, `git worktree
+//!   remove` performs its own uncommitted-changes check immediately before
+//!   deleting — a guard distinct from, and much later than, daft's validation
+//!   pass. Renaming first would silently retire it. [`dispose`] therefore
+//!   re-checks and declines the fast path when the tree is dirty, so the caller
+//!   falls through to git and the user sees git's own refusal, unchanged.
+//! - **Reaping is convergent, not fire-and-forget.** A reaper that dies leaves
+//!   a directory in the trash, and the next removal in the repo sweeps it. A
+//!   failed reap is therefore delayed, never permanent, which is what keeps
+//!   deferred deletion from being a silent failure.
+
+use crate::git::GitCommand;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Directory under `<git-common-dir>/.daft/` holding worktrees awaiting
+/// deletion. Inside the git dir deliberately: several code paths classify
+/// directories under the *project root* by shape (layout transform, the hook
+/// config scanners, `daft repo remove`'s is-empty probe) and would read a
+/// trash directory there as a worktree.
+const TRASH_SUBDIR: &str = "trash";
+
+/// Whether [`dispose`] deferred the delete or the caller must do it itself.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Disposition {
+    /// Renamed aside and handed to a reaper. The path is free; the disk space
+    /// is not yet back.
+    Deferred,
+    /// The fast path did not apply. The caller must remove the worktree the
+    /// ordinary way — this is not an error, and carries no diagnosis with it.
+    Declined,
+}
+
+/// A worktree still sitting in the trash, for `daft doctor` to report.
+#[derive(Debug, Clone)]
+pub struct PendingEntry {
+    pub path: PathBuf,
+    /// How long ago the entry was renamed in, when that can be determined.
+    pub age: Option<std::time::Duration>,
+}
+
+/// Where this repo's pending deletions live.
+pub fn trash_dir(git_common_dir: &Path) -> PathBuf {
+    git_common_dir.join(".daft").join(TRASH_SUBDIR)
+}
+
+/// True when `path` is inside some repo's `.daft/trash/`. The reaper deletes
+/// recursively from a path it was handed, so it verifies this before touching
+/// anything.
+pub fn is_trash_path(path: &Path) -> bool {
+    let mut parts = path.components().rev();
+    matches!(parts.next(), Some(c) if c.as_os_str() == TRASH_SUBDIR)
+        && matches!(parts.next(), Some(c) if c.as_os_str() == ".daft")
+}
+
+/// Move `worktree_path` out of the way and drop git's admin record for it,
+/// leaving the actual deletion to a background reaper.
+///
+/// Returns [`Disposition::Declined`] — not an error — whenever the fast path
+/// does not apply: a dirty tree without `force`, a main working tree, a rename
+/// that cannot happen (`EXDEV` for a worktree on another filesystem, a
+/// permission problem), or a git record that will not budge. The caller then
+/// performs the ordinary removal, so declining costs correctness nothing and
+/// the user sees git's own diagnostics rather than ours.
+pub fn dispose(
+    git: &GitCommand,
+    git_common_dir: &Path,
+    worktree_path: &Path,
+    force: bool,
+) -> Disposition {
+    // A main working tree has a `.git` *directory*; a linked worktree has a
+    // `.git` file. Never rename the former — it holds the repo itself.
+    if worktree_path.join(".git").is_dir() {
+        return Disposition::Declined;
+    }
+
+    // Preserve the guard git would have applied. Only `force` removals skip
+    // it, exactly as `git worktree remove` does.
+    if !force {
+        match git.has_uncommitted_changes_in(worktree_path) {
+            Ok(false) => {}
+            // Dirty, or we could not tell: decline and let git refuse. Failing
+            // closed matters here — a status probe that errors must not be
+            // read as "clean".
+            _ => return Disposition::Declined,
+        }
+    }
+
+    // Capture identity before the rename: `canonicalize` on a path that no
+    // longer exists falls back to the input, which would make the
+    // still-registered check below compare the wrong thing.
+    let canonical = std::fs::canonicalize(worktree_path).unwrap_or_else(|_| worktree_path.into());
+
+    let trash = trash_dir(git_common_dir);
+    if let Err(e) = std::fs::create_dir_all(&trash) {
+        crate::log_debug!("trash dir creation failed at {}: {e}", trash.display());
+        return Disposition::Declined;
+    }
+
+    let dest = trash.join(entry_name(worktree_path));
+    if let Err(e) = std::fs::rename(worktree_path, &dest) {
+        // EXDEV (worktree on another filesystem — the `centralized` layout, or
+        // `--at` pointing off-volume) lands here, as does any permission
+        // problem. Both are ordinary-path territory.
+        crate::log_debug!("worktree rename to trash failed: {e}");
+        return Disposition::Declined;
+    }
+
+    if !drop_worktree_record(git, worktree_path, &canonical) {
+        // The directory is already gone from its original path, so the
+        // ordinary path cannot run any more. Recover by putting it back.
+        if let Err(e) = std::fs::rename(&dest, worktree_path) {
+            crate::log_debug!("failed to restore worktree after record drop: {e}");
+            // Restoring failed too. The directory is in the trash and git
+            // still has a record; the reaper would delete the user's tree
+            // while git believes it exists. Leave it alone — the sweep will
+            // not touch it because the record still names it, and `daft
+            // doctor` will report it.
+            return Disposition::Declined;
+        }
+        return Disposition::Declined;
+    }
+
+    schedule_reap(&trash);
+    Disposition::Deferred
+}
+
+/// Reap anything left in this repo's trash: leftovers from a reaper that died,
+/// or from a `dispose` whose spawn failed. Cheap when the trash is empty, which
+/// is the common case, so callers can run it unconditionally at command start.
+pub fn sweep(git_common_dir: &Path) {
+    let trash = trash_dir(git_common_dir);
+    if !has_entries(&trash) {
+        return;
+    }
+    schedule_reap(&trash);
+}
+
+/// Reap everything in `trash` right now. This is the reaper's body; it also
+/// runs inline when background work is suppressed.
+pub fn reap_now(trash: &Path) {
+    if !is_trash_path(trash) {
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(trash) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        if let Err(e) = std::fs::remove_dir_all(entry.path()) {
+            // Leave it for the next sweep rather than retrying here.
+            crate::log_debug!("reap of {} failed: {e}", entry.path().display());
+        }
+    }
+    // Best-effort; fails harmlessly while another reaper still holds entries.
+    let _ = std::fs::remove_dir(trash);
+}
+
+/// Entry point for the `daft __reap-trash <dir>` background process: drain one
+/// repo's trash and exit.
+///
+/// Errors go nowhere — the process is detached with null stdio, so there is no
+/// channel to report on, exactly as [`crate::commands::forge_cache::run_refresh_forge`]
+/// describes. That is tolerable here because the failure mode is benign and
+/// self-correcting: whatever this process fails to delete stays in the trash,
+/// the next removal in the repo sweeps it again, and `daft doctor` reports
+/// anything that outlives several attempts. A directory that persists *is* the
+/// error report.
+pub fn run_reap_trash(trash: &Path) -> anyhow::Result<()> {
+    // Detach from the parent's session/TTY per the spawn-self contract.
+    #[cfg(unix)]
+    nix::unistd::setsid().ok();
+
+    if !is_trash_path(trash) {
+        anyhow::bail!("refusing to reap {}: not a daft trash dir", trash.display());
+    }
+
+    // Single-flight, mirroring `log_clean::run_clean_logs`. Two reapers racing
+    // over the same directory would each see the other's half-deleted trees and
+    // log spurious failures. The lock sits beside the trash dir rather than
+    // inside it, so draining the trash does not delete the lock.
+    let lock_path = trash.with_extension("lock");
+    if let Some(parent) = lock_path.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+    let lock_file = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock_path)?;
+    use fs2::FileExt;
+    if lock_file.try_lock_exclusive().is_err() {
+        return Ok(()); // another reaper is already draining this trash
+    }
+
+    reap_now(trash);
+    Ok(())
+}
+
+/// Worktrees still awaiting deletion, for `daft doctor`.
+pub fn pending(git_common_dir: &Path) -> Vec<PendingEntry> {
+    let trash = trash_dir(git_common_dir);
+    let Ok(entries) = std::fs::read_dir(&trash) else {
+        return Vec::new();
+    };
+    entries
+        .flatten()
+        .map(|entry| {
+            let age = entry
+                .metadata()
+                .and_then(|m| m.modified())
+                .ok()
+                .and_then(|t| SystemTime::now().duration_since(t).ok());
+            PendingEntry {
+                path: entry.path(),
+                age,
+            }
+        })
+        .collect()
+}
+
+/// Drop git's admin entry for a worktree whose directory is already gone.
+///
+/// `git worktree remove --force` handles this directly; `git worktree prune` is
+/// the documented mechanism and stands behind it. Either way the record is
+/// verified gone rather than trusted from an exit code, because `prune` is
+/// repo-wide and will also clear records for *other* worktrees that happen to
+/// be missing — a green exit says nothing about ours specifically.
+fn drop_worktree_record(git: &GitCommand, worktree_path: &Path, canonical: &Path) -> bool {
+    if git.worktree_remove(worktree_path, true).is_ok() && !still_registered(git, canonical) {
+        return true;
+    }
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let _ = crate::utils::git_command_at(&cwd)
+        .args(["worktree", "prune"])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+    !still_registered(git, canonical)
+}
+
+fn still_registered(git: &GitCommand, canonical: &Path) -> bool {
+    let Ok(porcelain) = git.worktree_list_porcelain() else {
+        // Cannot tell — assume it is, so the caller restores and falls back.
+        return true;
+    };
+    super::porcelain::parse_worktree_list_porcelain(&porcelain)
+        .iter()
+        .any(|e| std::fs::canonicalize(&e.path).unwrap_or_else(|_| e.path.clone()) == canonical)
+}
+
+/// Hand `trash` to a detached reaper, or drain it inline when background work
+/// is suppressed.
+///
+/// Inline is not merely a test convenience: the manual suite runs ~2000 daft
+/// invocations, and a spawn per removal would either pile up orphaned processes
+/// or leave unreaped directories that change `read_dir`-based assertions.
+/// [`crate::should_skip_background_tasks`] is the same gate the other
+/// background tasks use.
+fn schedule_reap(trash: &Path) {
+    // `cfg!(test)` is not redundant with the env gates: under `cargo test`
+    // `current_exe()` is the *test* binary, so a spawn would fork the test
+    // harness with `__reap-trash` as a filter argument rather than starting a
+    // reaper — a stray process per removal, and trash that never drains.
+    if cfg!(test)
+        || crate::should_skip_background_tasks(crate::cli::argv())
+        || std::env::var_os("DAFT_NO_TRASH_REAP").is_some()
+    {
+        reap_now(trash);
+        return;
+    }
+    if spawn_reaper(trash).is_err() {
+        reap_now(trash);
+    }
+}
+
+#[cfg(unix)]
+fn spawn_reaper(trash: &Path) -> anyhow::Result<()> {
+    // canonicalize() is load-bearing: removal is reached through symlinks
+    // (`git-worktree-branch-delete`, `git-worktree-prune`, …) and dispatch is
+    // by argv[0], so spawning the symlink would route the child into that
+    // command's arm, where clap rejects `__reap-trash` — silently, since the
+    // child's stderr is /dev/null.
+    let exe = std::env::current_exe()?.canonicalize()?;
+    std::process::Command::new(exe)
+        .arg("__reap-trash")
+        .arg(trash)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn spawn_reaper(_trash: &Path) -> anyhow::Result<()> {
+    // No detached reaper off unix: there is no session to leave, and Windows
+    // refuses to rename a directory any process holds open, so the fast path
+    // is unreliable there anyway. Callers drain inline.
+    anyhow::bail!("background reaping is unix-only")
+}
+
+fn has_entries(dir: &Path) -> bool {
+    std::fs::read_dir(dir).is_ok_and(|mut d| d.next().is_some())
+}
+
+/// A collision-free name for a trashed worktree. The original name leads so a
+/// human reading `daft doctor` output can tell what is waiting to be deleted.
+fn entry_name(worktree_path: &Path) -> String {
+    let base = worktree_path
+        .file_name()
+        .map(|n| n.to_string_lossy().replace(['/', '\\'], "-"))
+        .unwrap_or_else(|| "worktree".to_string());
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    format!("{base}-{}-{nanos}", std::process::id())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trash_lives_under_the_git_dir() {
+        let dir = trash_dir(Path::new("/repo/.git"));
+        assert_eq!(dir, PathBuf::from("/repo/.git/.daft/trash"));
+    }
+
+    #[test]
+    fn only_a_daft_trash_path_is_reapable() {
+        assert!(is_trash_path(Path::new("/repo/.git/.daft/trash")));
+        assert!(!is_trash_path(Path::new("/repo/.git/.daft")));
+        assert!(!is_trash_path(Path::new("/repo/.git")));
+        assert!(!is_trash_path(Path::new("/")));
+        assert!(!is_trash_path(Path::new("/Users/someone")));
+        // A directory merely *named* trash is not ours.
+        assert!(!is_trash_path(Path::new("/tmp/trash")));
+    }
+
+    #[test]
+    fn reap_refuses_a_path_outside_the_trash() {
+        let tmp = tempfile::tempdir().unwrap();
+        let victim = tmp.path().join("not-trash");
+        std::fs::create_dir_all(victim.join("payload")).unwrap();
+
+        reap_now(&victim);
+
+        assert!(
+            victim.join("payload").exists(),
+            "reap_now must refuse a path that is not a .daft/trash dir"
+        );
+    }
+
+    #[test]
+    fn reap_drains_the_trash_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let trash = trash_dir(&tmp.path().join(".git"));
+        std::fs::create_dir_all(trash.join("wt-1/nested")).unwrap();
+        std::fs::create_dir_all(trash.join("wt-2")).unwrap();
+        std::fs::write(trash.join("wt-1/nested/f.txt"), "x").unwrap();
+
+        reap_now(&trash);
+
+        assert!(!trash.join("wt-1").exists());
+        assert!(!trash.join("wt-2").exists());
+    }
+
+    #[test]
+    fn reap_on_an_absent_trash_dir_is_a_no_op() {
+        let tmp = tempfile::tempdir().unwrap();
+        reap_now(&trash_dir(&tmp.path().join(".git")));
+    }
+
+    #[test]
+    fn entry_names_do_not_collide() {
+        let a = entry_name(Path::new("/repo/feature"));
+        let b = entry_name(Path::new("/repo/feature"));
+        assert_ne!(a, b);
+        assert!(a.starts_with("feature-"), "{a}");
+    }
+
+    #[test]
+    fn pending_reports_nothing_when_the_trash_is_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(pending(&tmp.path().join(".git")).is_empty());
+    }
+
+    #[test]
+    fn pending_reports_each_waiting_worktree() {
+        let tmp = tempfile::tempdir().unwrap();
+        let git_dir = tmp.path().join(".git");
+        let trash = trash_dir(&git_dir);
+        std::fs::create_dir_all(trash.join("wt-1")).unwrap();
+        std::fs::create_dir_all(trash.join("wt-2")).unwrap();
+
+        let entries = pending(&git_dir);
+
+        assert_eq!(entries.len(), 2);
+        assert!(entries.iter().all(|e| e.age.is_some()));
+    }
+}

--- a/src/core/worktree/trash.rs
+++ b/src/core/worktree/trash.rs
@@ -274,12 +274,16 @@ pub fn dispose(
 
     // Git has disowned the path. Dropping the sidecar is the commit point:
     // from here the entry is ordinary garbage and any reaper may take it.
+    //
+    // Failing to drop it is emphatically *not* a failed removal, so this must
+    // not decline — the worktree is gone and git has been told, and sending the
+    // caller down the ordinary path would have it delete an absent directory
+    // and report an error for work that succeeded. The only cost is that no
+    // reaper will take this particular entry: `daft doctor` reports it, and
+    // `reclaim` clears it, since git no longer names the origin the guard
+    // points at.
     if let Err(e) = std::fs::remove_file(&sidecar) {
-        // The tree is safe either way — it simply will not be reaped until
-        // `daft doctor --fix` resolves it, so say so rather than claiming
-        // background reclamation.
-        crate::log_debug!("could not commit the trash entry, leaving it for doctor: {e}");
-        return Disposition::Declined;
+        crate::log_debug!("trash entry left for doctor, its guard did not clear: {e}");
     }
 
     schedule_reap(&trash)
@@ -516,7 +520,18 @@ pub fn reclaim(git: &GitCommand, git_common_dir: &Path) -> anyhow::Result<()> {
             continue;
         }
         let sidecar = origin_sidecar(&path);
-        let origin = std::fs::read(&sidecar).ok().map(|b| path_from_bytes(&b));
+        let origin = match std::fs::read(&sidecar) {
+            Ok(bytes) => Some(path_from_bytes(&bytes)),
+            // No sidecar: the removal committed, so this is ordinary garbage.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+            // A sidecar we cannot read is a guard we cannot evaluate. Report
+            // it and move on: refusing to act keeps the space occupied, where
+            // acting could delete a worktree git is still pointing at.
+            Err(e) => {
+                failures.push(format!("{}: unreadable guard: {e}", sidecar.display()));
+                continue;
+            }
+        };
         // An interrupted removal that git still points at belongs back where
         // git expects it — deleting it would destroy ignored files the
         // cancelled removal was supposed to leave alone.

--- a/src/core/worktree/trash.rs
+++ b/src/core/worktree/trash.rs
@@ -394,6 +394,28 @@ mod tests {
         reap_now(&trash_dir(&tmp.path().join(".git")));
     }
 
+    /// The convergence guarantee: whatever a dead reaper left behind is
+    /// reclaimed by the next removal in the repo. This is what makes a failed
+    /// background delete delayed rather than permanent.
+    #[test]
+    fn sweep_reclaims_what_a_dead_reaper_left() {
+        let tmp = tempfile::tempdir().unwrap();
+        let git_dir = tmp.path().join(".git");
+        let trash = trash_dir(&git_dir);
+        std::fs::create_dir_all(trash.join("stranded/deep")).unwrap();
+        std::fs::write(trash.join("stranded/deep/f.txt"), "x").unwrap();
+
+        sweep(&git_dir);
+
+        assert!(!trash.join("stranded").exists());
+    }
+
+    #[test]
+    fn sweep_without_a_trash_dir_is_a_no_op() {
+        let tmp = tempfile::tempdir().unwrap();
+        sweep(&tmp.path().join(".git"));
+    }
+
     #[test]
     fn entry_names_do_not_collide() {
         let a = entry_name(Path::new("/repo/feature"));

--- a/src/core/worktree/trash.rs
+++ b/src/core/worktree/trash.rs
@@ -42,12 +42,19 @@ use std::time::{SystemTime, UNIX_EPOCH};
 /// trash directory there as a worktree.
 const TRASH_SUBDIR: &str = "trash";
 
-/// Whether [`dispose`] deferred the delete or the caller must do it itself.
+/// What [`dispose`] actually did. The distinction between the first two is
+/// user-facing: only `Deferred` may claim the space is still coming back.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Disposition {
-    /// Renamed aside and handed to a reaper. The path is free; the disk space
-    /// is not yet back.
+    /// Renamed aside and handed to a detached reaper. The path is free; the
+    /// disk space is not yet back.
     Deferred,
+    /// Renamed aside and reclaimed before returning, because background work
+    /// was suppressed. Indistinguishable from `Deferred` to the caller's
+    /// control flow, but *not* to the user: the space is already back, so
+    /// saying "reclaiming in background" here would be a lie — and one that
+    /// hides the cost, since the walk did happen on the critical path.
+    Reclaimed,
     /// The fast path did not apply. The caller must remove the worktree the
     /// ordinary way — this is not an error, and carries no diagnosis with it.
     Declined,
@@ -143,8 +150,7 @@ pub fn dispose(
         return Disposition::Declined;
     }
 
-    schedule_reap(&trash);
-    Disposition::Deferred
+    schedule_reap(&trash)
 }
 
 /// Reap anything left in this repo's trash: leftovers from a reaper that died,
@@ -278,7 +284,7 @@ fn still_registered(git: &GitCommand, canonical: &Path) -> bool {
 /// or leave unreaped directories that change `read_dir`-based assertions.
 /// [`crate::should_skip_background_tasks`] is the same gate the other
 /// background tasks use.
-fn schedule_reap(trash: &Path) {
+fn schedule_reap(trash: &Path) -> Disposition {
     // `cfg!(test)` is not redundant with the env gates: under `cargo test`
     // `current_exe()` is the *test* binary, so a spawn would fork the test
     // harness with `__reap-trash` as a filter argument rather than starting a
@@ -288,11 +294,13 @@ fn schedule_reap(trash: &Path) {
         || std::env::var_os("DAFT_NO_TRASH_REAP").is_some()
     {
         reap_now(trash);
-        return;
+        return Disposition::Reclaimed;
     }
     if spawn_reaper(trash).is_err() {
         reap_now(trash);
+        return Disposition::Reclaimed;
     }
+    Disposition::Deferred
 }
 
 #[cfg(unix)]

--- a/src/doctor/repository.rs
+++ b/src/doctor/repository.rs
@@ -141,20 +141,25 @@ pub fn check_reflink_support(ctx: &RepoContext) -> CheckResult {
 /// stopped pruning can sit on the space indefinitely, silently. This check is
 /// the surface that makes it visible, and `--fix` reclaims it on demand.
 ///
-/// A young entry is a reap still in flight, which is ordinary and passes.
-/// Entries that have outlived several sweeps are the ones worth reporting.
+/// Two states get reported, and they are not the same problem. A *stale* entry
+/// is one whose reap should have finished long ago — the space is simply still
+/// there. An *interrupted* one never had its removal committed: the tree was
+/// renamed aside but git was never told, so no reaper will ever touch it and
+/// git may still point at a path that no longer exists. That is worth saying at
+/// any age, so it is not gated on the threshold.
 pub fn check_pending_trash(ctx: &RepoContext) -> CheckResult {
     /// Below this a pending entry is almost certainly a reap still running.
     const STALE_AFTER: std::time::Duration = std::time::Duration::from_secs(60 * 60);
 
     let pending = crate::core::worktree::trash::pending(&ctx.git_common_dir);
-    let stale = stale_pending(&pending, STALE_AFTER);
+    let reportable = reportable_pending(&pending, STALE_AFTER);
 
-    if stale.is_empty() {
+    if reportable.is_empty() {
         return CheckResult::pass("Pending deletions", "no worktrees awaiting reclamation");
     }
 
-    let labels: Vec<String> = stale
+    let interrupted = reportable.iter().filter(|e| e.interrupted).count();
+    let labels: Vec<String> = reportable
         .iter()
         .map(|e| {
             let name = e
@@ -162,50 +167,72 @@ pub fn check_pending_trash(ctx: &RepoContext) -> CheckResult {
                 .file_name()
                 .map(|n| n.to_string_lossy().into_owned())
                 .unwrap_or_else(|| e.path.display().to_string());
-            match e.age {
-                Some(age) => format!("{name} — waiting {}", humanize_age(age)),
-                None => name,
-            }
+            let state = if e.interrupted {
+                "removal interrupted".to_string()
+            } else {
+                match e.age {
+                    Some(age) => format!("waiting {}", humanize_age(age)),
+                    None => "waiting".to_string(),
+                }
+            };
+            format!("{name} — {state}")
         })
         .collect();
 
-    let trash = crate::core::worktree::trash::trash_dir(&ctx.git_common_dir);
-    let dry_labels = labels.clone();
-    CheckResult::warning(
-        "Pending deletions",
-        &format!(
+    let headline = if interrupted == reportable.len() {
+        format!("{interrupted} interrupted removal(s) awaiting resolution")
+    } else if interrupted > 0 {
+        format!(
+            "{} removed worktree(s) still occupying disk space, {interrupted} interrupted",
+            reportable.len()
+        )
+    } else {
+        format!(
             "{} removed worktree(s) still occupying disk space",
-            stale.len()
-        ),
-    )
-    .with_details(labels)
-    .with_suggestion("run with --fix to reclaim the space now")
-    .with_fix(Box::new(move || {
-        crate::core::worktree::trash::reap_now(&trash);
-        Ok(())
-    }))
-    .with_dry_run_fix(Box::new(move || {
-        dry_labels
-            .iter()
-            .map(|label| FixAction {
-                description: format!("Reclaim: {label}"),
-                would_succeed: true,
-                failure_reason: None,
-            })
-            .collect()
-    }))
+            reportable.len()
+        )
+    };
+
+    let git_common_dir = ctx.git_common_dir.clone();
+    let dry_labels = labels.clone();
+    CheckResult::warning("Pending deletions", &headline)
+        .with_details(labels)
+        .with_suggestion("run with --fix to resolve them now")
+        .with_fix(Box::new(move || {
+            // `reclaim` takes the single-flight lock and reports what it could
+            // not do, so a fix that freed nothing cannot print as fixed — and
+            // it restores an interrupted removal rather than completing it,
+            // since git still expects that worktree to be there.
+            let git = GitCommand::new(true);
+            crate::core::worktree::trash::reclaim(&git, &git_common_dir)
+                .map_err(|e| format!("{e:#}"))
+        }))
+        .with_dry_run_fix(Box::new(move || {
+            dry_labels
+                .iter()
+                .map(|label| FixAction {
+                    description: format!("Resolve: {label}"),
+                    would_succeed: true,
+                    failure_reason: None,
+                })
+                .collect()
+        }))
 }
 
-/// Pending entries old enough to be worth reporting. An entry whose age cannot
-/// be read is treated as *not* stale: an unreadable timestamp is no evidence a
-/// reap failed, and guessing would turn a healthy repo into a standing warning.
-fn stale_pending(
+/// Pending entries worth telling the user about: anything whose removal was
+/// interrupted, plus anything that has outlived several sweeps.
+///
+/// An entry of unknown age is treated as *not* stale: an unreadable timestamp
+/// is no evidence a reap failed, and guessing would turn a healthy repo into a
+/// standing warning. An interrupted entry is reported regardless — there its
+/// age says nothing, because no reaper is coming for it either way.
+fn reportable_pending(
     pending: &[crate::core::worktree::trash::PendingEntry],
     threshold: std::time::Duration,
 ) -> Vec<&crate::core::worktree::trash::PendingEntry> {
     pending
         .iter()
-        .filter(|e| e.age.is_some_and(|age| age > threshold))
+        .filter(|e| e.interrupted || e.age.is_some_and(|age| age > threshold))
         .collect()
 }
 
@@ -557,6 +584,7 @@ mod tests {
         PendingEntry {
             path: std::path::PathBuf::from(name),
             age,
+            interrupted: false,
         }
     }
 
@@ -565,7 +593,7 @@ mod tests {
     #[test]
     fn a_young_pending_entry_is_not_reported() {
         let pending = vec![entry("just-removed", Some(Duration::from_secs(5)))];
-        assert!(stale_pending(&pending, Duration::from_secs(3600)).is_empty());
+        assert!(reportable_pending(&pending, Duration::from_secs(3600)).is_empty());
     }
 
     /// An entry outliving the threshold means sweeps are not reaching it.
@@ -575,7 +603,7 @@ mod tests {
             entry("fresh", Some(Duration::from_secs(5))),
             entry("stuck", Some(Duration::from_secs(90_000))),
         ];
-        let stale = stale_pending(&pending, Duration::from_secs(3600));
+        let stale = reportable_pending(&pending, Duration::from_secs(3600));
         assert_eq!(stale.len(), 1);
         assert_eq!(stale[0].path, std::path::PathBuf::from("stuck"));
     }
@@ -585,7 +613,20 @@ mod tests {
     #[test]
     fn a_pending_entry_of_unknown_age_is_not_reported() {
         let pending = vec![entry("unknown", None)];
-        assert!(stale_pending(&pending, Duration::from_secs(3600)).is_empty());
+        assert!(reportable_pending(&pending, Duration::from_secs(3600)).is_empty());
+    }
+
+    /// An interrupted removal is never healthy, however young: no reaper will
+    /// ever take it, so waiting for a threshold only delays the report.
+    #[test]
+    fn an_interrupted_removal_is_reported_at_any_age() {
+        let pending = vec![PendingEntry {
+            path: std::path::PathBuf::from("cut-short"),
+            age: Some(Duration::from_secs(2)),
+            interrupted: true,
+        }];
+        let reportable = reportable_pending(&pending, Duration::from_secs(3600));
+        assert_eq!(reportable.len(), 1);
     }
 
     #[test]

--- a/src/doctor/repository.rs
+++ b/src/doctor/repository.rs
@@ -132,6 +132,91 @@ pub fn check_reflink_support(ctx: &RepoContext) -> CheckResult {
     }
 }
 
+/// Worktrees renamed aside by a removal but not yet reclaimed (#200).
+///
+/// A removal hands the directory to a detached reaper and returns; if that
+/// reaper dies, the space stays occupied until the next removal in the repo
+/// sweeps it. That self-healing is what keeps deferred deletion honest, but it
+/// only fires when the user removes something again — so a repo they have
+/// stopped pruning can sit on the space indefinitely, silently. This check is
+/// the surface that makes it visible, and `--fix` reclaims it on demand.
+///
+/// A young entry is a reap still in flight, which is ordinary and passes.
+/// Entries that have outlived several sweeps are the ones worth reporting.
+pub fn check_pending_trash(ctx: &RepoContext) -> CheckResult {
+    /// Below this a pending entry is almost certainly a reap still running.
+    const STALE_AFTER: std::time::Duration = std::time::Duration::from_secs(60 * 60);
+
+    let pending = crate::core::worktree::trash::pending(&ctx.git_common_dir);
+    let stale = stale_pending(&pending, STALE_AFTER);
+
+    if stale.is_empty() {
+        return CheckResult::pass("Pending deletions", "no worktrees awaiting reclamation");
+    }
+
+    let labels: Vec<String> = stale
+        .iter()
+        .map(|e| {
+            let name = e
+                .path
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_else(|| e.path.display().to_string());
+            match e.age {
+                Some(age) => format!("{name} — waiting {}", humanize_age(age)),
+                None => name,
+            }
+        })
+        .collect();
+
+    let trash = crate::core::worktree::trash::trash_dir(&ctx.git_common_dir);
+    let dry_labels = labels.clone();
+    CheckResult::warning(
+        "Pending deletions",
+        &format!(
+            "{} removed worktree(s) still occupying disk space",
+            stale.len()
+        ),
+    )
+    .with_details(labels)
+    .with_suggestion("run with --fix to reclaim the space now")
+    .with_fix(Box::new(move || {
+        crate::core::worktree::trash::reap_now(&trash);
+        Ok(())
+    }))
+    .with_dry_run_fix(Box::new(move || {
+        dry_labels
+            .iter()
+            .map(|label| FixAction {
+                description: format!("Reclaim: {label}"),
+                would_succeed: true,
+                failure_reason: None,
+            })
+            .collect()
+    }))
+}
+
+/// Pending entries old enough to be worth reporting. An entry whose age cannot
+/// be read is treated as *not* stale: an unreadable timestamp is no evidence a
+/// reap failed, and guessing would turn a healthy repo into a standing warning.
+fn stale_pending(
+    pending: &[crate::core::worktree::trash::PendingEntry],
+    threshold: std::time::Duration,
+) -> Vec<&crate::core::worktree::trash::PendingEntry> {
+    pending
+        .iter()
+        .filter(|e| e.age.is_some_and(|age| age > threshold))
+        .collect()
+}
+
+fn humanize_age(age: std::time::Duration) -> String {
+    let hours = age.as_secs() / 3600;
+    if hours < 24 {
+        return format!("{hours}h");
+    }
+    format!("{}d", hours / 24)
+}
+
 /// Check that the repository uses a daft-compatible worktree layout.
 pub fn check_worktree_layout(ctx: &RepoContext) -> CheckResult {
     let git = GitCommand::new(true);
@@ -464,7 +549,50 @@ pub fn dry_run_remote_head() -> Vec<FixAction> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::worktree::trash::PendingEntry;
     use crate::doctor::CheckStatus;
+    use std::time::Duration;
+
+    fn entry(name: &str, age: Option<Duration>) -> PendingEntry {
+        PendingEntry {
+            path: std::path::PathBuf::from(name),
+            age,
+        }
+    }
+
+    /// A reap in flight is the ordinary case; reporting it would make every
+    /// removal look like a problem for as long as the delete takes.
+    #[test]
+    fn a_young_pending_entry_is_not_reported() {
+        let pending = vec![entry("just-removed", Some(Duration::from_secs(5)))];
+        assert!(stale_pending(&pending, Duration::from_secs(3600)).is_empty());
+    }
+
+    /// An entry outliving the threshold means sweeps are not reaching it.
+    #[test]
+    fn an_old_pending_entry_is_reported() {
+        let pending = vec![
+            entry("fresh", Some(Duration::from_secs(5))),
+            entry("stuck", Some(Duration::from_secs(90_000))),
+        ];
+        let stale = stale_pending(&pending, Duration::from_secs(3600));
+        assert_eq!(stale.len(), 1);
+        assert_eq!(stale[0].path, std::path::PathBuf::from("stuck"));
+    }
+
+    /// An unreadable timestamp is not evidence of failure — treating it as
+    /// stale would leave a healthy repo permanently warning.
+    #[test]
+    fn a_pending_entry_of_unknown_age_is_not_reported() {
+        let pending = vec![entry("unknown", None)];
+        assert!(stale_pending(&pending, Duration::from_secs(3600)).is_empty());
+    }
+
+    #[test]
+    fn age_reads_in_hours_then_days() {
+        assert_eq!(humanize_age(Duration::from_secs(3600)), "1h");
+        assert_eq!(humanize_age(Duration::from_secs(3600 * 25)), "1d");
+    }
 
     #[test]
     fn test_is_common_dir_bare_true() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -134,6 +134,14 @@ fn main() -> Result<()> {
                         let _ = commands::forge_cache::run_refresh_forge();
                         return Ok(());
                     }
+                    "__reap-trash" => {
+                        if let Some(dir) = args.get(2) {
+                            let _ = daft::core::worktree::trash::run_reap_trash(
+                                std::path::Path::new(dir),
+                            );
+                        }
+                        return Ok(());
+                    }
                     "__dump-store" => {
                         if let Err(e) = commands::dump_store::run() {
                             eprintln!("daft __dump-store: {e:#}");

--- a/tests/integration/test_branch_delete.sh
+++ b/tests/integration/test_branch_delete.sh
@@ -1041,6 +1041,124 @@ test_daft_remove_default_force_worktree_only() {
     return 0
 }
 
+# --- #200: the deferred reclamation path, exercised for real ---
+
+# The deferred path only exists when background work is allowed, so DAFT_TESTING
+# comes off — and every *other* spawn it was suppressing is turned off
+# individually, leaving the reaper as the only background process in play.
+_bd_daft_with_background() {
+    env -u DAFT_TESTING \
+        DAFT_NO_UPDATE_CHECK=1 \
+        DAFT_NO_TRUST_PRUNE=1 \
+        DAFT_NO_LOG_CLEAN=1 \
+        DAFT_NO_HINTS=1 \
+        "$@"
+}
+
+# #200: `daft remove` renames the worktree aside and hands the unlink walk to a
+# detached `daft __reap-trash`. The YAML suite cannot cover that: its runner
+# injects DAFT_TESTING=1, which makes the reap run inline, so a scenario
+# asserting "nothing is left in the trash" passes even when the spawn is
+# completely broken — and a broken spawn puts the whole O(files) walk back on
+# the critical path, which is the one thing this feature exists to prevent.
+#
+# So: assert the diagnostic that distinguishes the two paths *first* (the inline
+# fallback says "reclaiming inline", never "deferred"), and only then wait for a
+# real detached process to finish the job.
+test_remove_defers_reclamation_to_a_detached_reaper() {
+    local remote_repo=$(create_test_remote "test-repo-bd-defer" "main")
+
+    git-worktree-clone --layout contained "$remote_repo" || return 1
+    cd "test-repo-bd-defer"
+    local project_root
+    project_root=$(pwd -P)
+
+    git-worktree-checkout -b feature/deferred || return 1
+
+    # Ignore the payload through info/exclude rather than a committed
+    # .gitignore: a tracked file would leave the branch unpushed and an
+    # untracked one would leave the worktree dirty, and either would
+    # (correctly) decline the fast path, testing nothing.
+    echo 'payload/' >> "$project_root/.git/info/exclude"
+    mkdir -p "$project_root/feature/deferred/payload/deep"
+    echo x > "$project_root/feature/deferred/payload/deep/f.txt"
+
+    cd "$project_root/main"
+    local log="$project_root/defer.log"
+    if ! _bd_daft_with_background daft remove --verbose feature/deferred > "$log" 2>&1; then
+        log_error "removal failed"
+        cat "$log"
+        return 1
+    fi
+
+    if ! grep -q "deferred: a detached reaper is reclaiming the space" "$log"; then
+        log_error "removal did not defer — the detached spawn is not being taken"
+        grep -iE "declined|inline|deferred" "$log" | head -5
+        return 1
+    fi
+
+    if [[ -e "$project_root/feature/deferred" ]]; then
+        log_error "the worktree path was not freed"
+        return 1
+    fi
+
+    # Convergence: a real process, in its own session, finishes the delete.
+    local trash="$project_root/.git/.daft/trash"
+    local waited=0
+    while [[ -n "$(ls -A "$trash" 2>/dev/null)" ]]; do
+        sleep 0.2
+        waited=$((waited + 1))
+        if (( waited > 150 )); then
+            log_error "the detached reaper never drained $trash"
+            ls -la "$trash"
+            return 1
+        fi
+    done
+
+    return 0
+}
+
+# #200: the guard that keeps deferral from being a way to lose a worktree. A
+# removal that dies between the rename and the record drop leaves the tree in
+# the trash while git still points at its old path; no sweep may take it, since
+# its ignored files may exist nowhere else. Simulated here by hand, because the
+# window is a crash — but the sidecar that marks it is written by production
+# code, and a reaper that ignored the mark would delete this tree.
+test_remove_sweep_spares_an_interrupted_removal() {
+    local remote_repo=$(create_test_remote "test-repo-bd-interrupt" "main")
+
+    git-worktree-clone --layout contained "$remote_repo" || return 1
+    cd "test-repo-bd-interrupt"
+    local project_root
+    project_root=$(pwd -P)
+
+    git-worktree-checkout -b feature/interrupted || return 1
+    git-worktree-checkout -b feature/bystander || return 1
+
+    local trash="$project_root/.git/.daft/trash"
+    local entry="$trash/feature-interrupted-1-2"
+    mkdir -p "$trash"
+    # The sidecar names where the tree came from; its presence is what says
+    # "git was never told". Written before the move, exactly as dispose does.
+    printf '%s' "$project_root/feature/interrupted" > "$entry.origin"
+    mv "$project_root/feature/interrupted" "$entry"
+    echo irreplaceable > "$entry/secret.env"
+
+    # Any removal in the repo sweeps the trash at command start.
+    cd "$project_root/main"
+    _bd_daft_with_background daft remove feature/bystander > /dev/null 2>&1 || {
+        log_error "the bystander removal failed"
+        return 1
+    }
+    sleep 1
+
+    if [[ ! -f "$entry/secret.env" ]]; then
+        log_error "a sweep destroyed a worktree whose removal never completed"
+        return 1
+    fi
+    return 0
+}
+
 run_branch_delete_tests() {
     log "Running git-worktree-branch-delete integration tests..."
 
@@ -1068,6 +1186,8 @@ run_branch_delete_tests() {
     run_test "remove_dot_row_names_the_worktree" "test_remove_dot_row_names_the_worktree"
     run_test "remove_unresolvable_path_echoes_verbatim" "test_remove_unresolvable_path_echoes_verbatim"
     run_test "remove_unresolvable_path_error_explains_the_miss" "test_remove_unresolvable_path_error_explains_the_miss"
+    run_test "remove_defers_reclamation_to_a_detached_reaper" "test_remove_defers_reclamation_to_a_detached_reaper"
+    run_test "remove_sweep_spares_an_interrupted_removal" "test_remove_sweep_spares_an_interrupted_removal"
 
     log "Running git-worktree-branch -d/-D integration tests..."
 

--- a/tests/manual/scenarios/branch-delete/remove-frees-the-path-immediately.yml
+++ b/tests/manual/scenarios/branch-delete/remove-frees-the-path-immediately.yml
@@ -1,0 +1,57 @@
+name: Removal frees the path for immediate reuse
+description: >
+  #200 defers the worktree delete: the directory is renamed aside and git's
+  admin record dropped, with the unlink walk left to a background reaper. The
+  contract that must survive that is the name becoming free straight away — if
+  the record drop only appeared to work, recreating the same branch fails.
+
+repos:
+  - name: test-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone the repository
+    run: daft clone --layout contained $REMOTE_TEST_REPO
+    expect:
+      exit_code: 0
+
+  - name: Create a feature branch with a populated worktree
+    run: daft start feature/reuse
+    cwd: "$WORK_DIR/test-repo"
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-repo/feature/reuse"
+
+  - name: Fill it with committed build output
+    run: |
+      cd $WORK_DIR/test-repo/feature/reuse
+      mkdir -p node_modules/pkg
+      for i in 1 2 3 4 5; do echo "module $i" > node_modules/pkg/f$i.js; done
+      git add -A
+      git commit -m "deps"
+    expect:
+      exit_code: 0
+
+  - name: Remove the branch
+    run: daft remove -f feature/reuse
+    cwd: "$WORK_DIR/test-repo"
+    expect:
+      exit_code: 0
+      files_not_exist:
+        - "$WORK_DIR/test-repo/feature/reuse"
+
+  - name: The same branch name is immediately reusable
+    run: daft start feature/reuse
+    cwd: "$WORK_DIR/test-repo"
+    expect:
+      exit_code: 0
+      dirs_exist:
+        - "$WORK_DIR/test-repo/feature/reuse"
+
+  - name: Nothing is left waiting in the trash
+    run: |
+      cd $WORK_DIR/test-repo
+      test -z "$(find .git/.daft/trash -mindepth 1 -maxdepth 1 2>/dev/null)"
+    expect:
+      exit_code: 0

--- a/tests/manual/scenarios/branch-delete/remove-frees-the-path-immediately.yml
+++ b/tests/manual/scenarios/branch-delete/remove-frees-the-path-immediately.yml
@@ -5,6 +5,11 @@ description: >
   contract that must survive that is the name becoming free straight away — if
   the record drop only appeared to work, recreating the same branch fails.
 
+  Scope: the runner injects DAFT_TESTING=1, which makes the reap run inline, so
+  this proves the contract but not the deferral. The detached spawn itself is
+  covered by test_remove_defers_reclamation_to_a_detached_reaper in
+  tests/integration/test_branch_delete.sh, which runs with DAFT_TESTING off.
+
 repos:
   - name: test-repo
     use_fixture: standard-remote

--- a/tests/manual/scenarios/branch-delete/remove-sweeps-stranded-deletions.yml
+++ b/tests/manual/scenarios/branch-delete/remove-sweeps-stranded-deletions.yml
@@ -6,6 +6,12 @@ description: >
   the trash first. This seeds a stranded entry by hand — standing in for a
   reaper killed mid-flight — and asserts the next removal reclaims it.
 
+  The seeded entry carries no `.origin` sidecar, which is what makes it garbage:
+  its removal committed, and only the delete was left. An entry that *does* have
+  one is an interrupted removal and must survive every sweep — covered by
+  test_remove_sweep_spares_an_interrupted_removal in
+  tests/integration/test_branch_delete.sh.
+
 repos:
   - name: test-repo
     use_fixture: standard-remote

--- a/tests/manual/scenarios/branch-delete/remove-sweeps-stranded-deletions.yml
+++ b/tests/manual/scenarios/branch-delete/remove-sweeps-stranded-deletions.yml
@@ -1,0 +1,42 @@
+name: Removal reclaims what a dead reaper left behind
+description: >
+  #200 hands the actual delete to a detached reaper, so a reaper that dies
+  leaves an occupied directory nobody is watching. The guarantee that keeps that
+  from being a silent leak is convergence: the next removal in the repo sweeps
+  the trash first. This seeds a stranded entry by hand — standing in for a
+  reaper killed mid-flight — and asserts the next removal reclaims it.
+
+repos:
+  - name: test-repo
+    use_fixture: standard-remote
+
+steps:
+  - name: Clone the repository
+    run: daft clone --layout contained $REMOTE_TEST_REPO
+    expect:
+      exit_code: 0
+
+  - name: Strand a directory in the trash, as a killed reaper would
+    run: |
+      cd $WORK_DIR/test-repo
+      mkdir -p .git/.daft/trash/stranded-worktree/node_modules
+      echo "leaked" > .git/.daft/trash/stranded-worktree/node_modules/big.js
+    expect:
+      exit_code: 0
+      files_exist:
+        - "$WORK_DIR/test-repo/.git/.daft/trash/stranded-worktree/node_modules/big.js"
+
+  - name: Create and remove an unrelated branch
+    run: daft start feature/unrelated
+    cwd: "$WORK_DIR/test-repo"
+    expect:
+      exit_code: 0
+
+  - name: The removal sweeps the stranded entry on its way through
+    run: daft remove -f feature/unrelated
+    cwd: "$WORK_DIR/test-repo"
+    expect:
+      exit_code: 0
+      files_not_exist:
+        - "$WORK_DIR/test-repo/.git/.daft/trash/stranded-worktree/node_modules/big.js"
+        - "$WORK_DIR/test-repo/feature/unrelated"


### PR DESCRIPTION
`git worktree remove` deletes the directory itself, with a serial unlink walk
that is O(files) on the critical path. On a worktree carrying `node_modules/` or
`target/` that walk is essentially the whole of the command's perceived cost —
and none of it is work the user is waiting on for a *correct* result. Once the
directory is out of the way and git's admin entry is gone, the contract is
discharged: branch gone, git consistent, path free for a fresh `daft start`.

So the fast path is not a faster walk. `dispose` renames the worktree into
`<git-common-dir>/.daft/trash/` (one syscall, O(1)), drops the record, and hands
the tree to a detached `daft __reap-trash`.

## Measured

Released binary (brew `daft` 1.26.0) vs this branch, on a genuine 74,839-entry /
901 MB `node_modules`, gitignored, clonefiled in fresh per iteration:

| | master (1.26.0) | this branch |
| --- | --- | --- |
| run 1 | 4.12s | 0.12s |
| run 2 | 4.54s | 0.13s |

**~34x.** Same 0.12s when invoked as `daft remove .` from inside the doomed
worktree. Background reclamation finishes ~4-5s after the command returns.

Ceiling check: plain `rm -rf` on that tree is 6.7s — the entire theoretical win.
The feature converts essentially all of it.

## What keeps this from losing a worktree

Deferred deletion is more vulnerable to silent failure than a synchronous walk,
so the safety properties are the design rather than a postscript.

**Nothing is deleted until git has disowned it.** The rename happens before the
record drop, so there is a window in which the tree sits in the trash while git
still points at its old path — a Ctrl-C lands squarely in it. An `.origin`
sidecar, written *before* the rename and removed only once the record drop is
verified, is the commit point. Reapers skip any entry that still has one, so an
interrupted removal costs disk space and never data. `daft doctor --fix`
resolves those: a tree git still points at goes back where git expects it, so a
cancelled removal is a no-op rather than a wedge.

**Git's own refusals are preserved, not retired.** Without `--force`, `git
worktree remove` runs two checks immediately before deleting — both much later
than daft's validation pass, and renaming first would silently retire both. So
`dispose` re-runs them and declines the fast path if either fires, leaving the
caller to invoke git and the user to see git's own wording: uncommitted changes,
and a populated submodule ("working trees containing submodules cannot be moved
or removed"). Both are gated on `force`, matching git.

**Reaping is convergent, not fire-and-forget.** Three tiers: the opportunistic
spawn, a sweep at the start of every removal-ish command in the repo, and a
`daft doctor` surface with `--fix`. A failed reap is *delayed*, never permanent
— which is what keeps a deferred delete from being a silent leak. Because tier 2
retries, a trash entry that persists *is* the error report; no separate error
channel is needed for a detached process with nowhere to write.

**The filesystem is the queue.** No state-dir registry, no config stamp, no
dual-write — pending work is exactly what is in the trash dir, self-describing
and crash-safe.

## Placement

The trash lives inside `.git`, not under the project root, because six code
paths classify project-root directories by *shape* and would read a trash
directory there as a worktree (`layout/transform/legacy.rs`, the hook config
scanners, `daft repo remove`'s is-empty probe). It also preserves
`cleanup_empty_parent_dirs` exactly — a same-parent `.deleting-*` sibling would
leave the parent non-empty and silently regress it.

`size_walk.rs` has no `.git` skip and no dotfile skip, so `daft repo list
--columns +size` would have counted pending trash into a *persisted* cache. The
exclusion is part of the mechanism, not a nicety.

## Not converted

- **`daft repo remove`** cannot use this design: its trash would sit inside the
  bare git dir that `remove_bare_directory` then deletes wholesale, so deferring
  buys nothing and adds a rename per worktree. Making that fast needs a trash
  *outside* the project root — a different placement question.
- `temp_worktree.rs` (`.daft-tmp` trees are small), `layout/transform/*`
  (transform must leave the tree in a known state between steps), and the two
  already-gone-directory arms that only drop a record.
- `merge.rs`'s squash cleanup — `merge --remove-*` already benefits through
  `branch_delete`.

## Notes

- `DAFT_NO_TRASH_REAP=1` drains inline, for a script that checks free space
  immediately afterwards. It is also the single-binary A/B lever: it reproduces
  the pre-change cost with every other variable held fixed.
- The rail's `RemoveWorktree` annotation is deliberately left alone. That slot
  carries the worktree's name (#813), `StageEvent::Completed` replaces rather
  than appends, and it is inked `SubjectInk::Path` — so prose there costs the
  row its identity. Deferral is reported on the step line, by `daft doctor`, and
  in `docs/about/troubleshooting.md`.
- The reaper is *event*-triggered, not startup-triggered, so it does not touch
  the startup task block in `main.rs` and does not inherit the latent
  startup-symlink bug there. Worth a separate look, not fixed here.
- `cfg!(test)` in `schedule_reap` is load-bearing: under `cargo test`,
  `current_exe()` is the test binary, so a spawn would fork the harness with
  `__reap-trash` as a filter argument.

## Testing

Unit tests for the sidecar protocol, the submodule and dirty declines, age
parsing, the lock, and `reclaim`'s restore. Two YAML scenarios for the path-reuse
contract and the stranded sweep.

The YAML runner injects `DAFT_TESTING=1`, which forces the reap inline — so a
scenario asserting "nothing is left in the trash" passes even with the detached
spawn completely broken. Two bash tests therefore run with it *off*:
`remove_defers_reclamation_to_a_detached_reaper` asserts the `--verbose`
diagnostic that distinguishes the two paths before waiting for a real detached
process to converge, and `remove_sweep_spares_an_interrupted_removal` proves a
sweep leaves an uncommitted entry alone.

Fixes #200
